### PR TITLE
fix model-id error caused by previous refactor

### DIFF
--- a/mellea/backends/formatter.py
+++ b/mellea/backends/formatter.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from collections.abc import Iterable, Mapping
+from dataclasses import fields
 from typing import Any
 
 import jinja2
@@ -396,14 +397,13 @@ class TemplateFormatter(Formatter, abc.ABC):
             "model_id was neither a `str` nor `ModelIdentifier`"
         )
 
-        # Go through the ModelIdentifier's fields, find one that isn't `"None"` or `""`.
-        ids = [model_id.hf_model_name, model_id.ollama_name]
-        model_id = ""
-        for val in ids:
-            if val != "None" and val != "":
-                model_id = val  # type: ignore
-                break
-        return model_id
+        # Go through the ModelIdentifier's fields, find one that can be matched against.
+        for field in fields(model_id):
+            val = getattr(model_id, field.name)
+            if val is not None and val != "":
+                return val
+
+        return ""  # Cannot match against any model identifiers. Will ultimately use default.
 
 
 def _simplify_model_string(input: str) -> str:

--- a/test/test_formatter_baseclasses.py
+++ b/test/test_formatter_baseclasses.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pytest
 
 from mellea.backends.formatter import TemplateFormatter
-from mellea.backends.model_ids import IBM_GRANITE_3_2_8B
+from mellea.backends.model_ids import ModelIdentifier, IBM_GRANITE_3_2_8B
 from mellea.stdlib.base import (
     BasicContext,
     CBlock,
@@ -278,6 +278,22 @@ def test_load_with_model_id(instr: Instruction):
 
 def test_fake_model_id(instr: Instruction):
     tf = TemplateFormatter("fake-model")
+    tmpl = tf._load_template(instr.format_for_llm())
+    assert tmpl.name is not None
+    assert (
+        "default" in tmpl.name
+    ), "there should always be a default instruction template"
+
+def test_custom_model_id():
+    model_id = ModelIdentifier(mlx_name="new-model-here")
+    tf = TemplateFormatter(model_id=model_id)
+    assert tf._get_model_id() == "new-model-here", "getting the model id should always give a string if one exists"
+
+def test_empty_model_id(instr: Instruction):
+    model_id = ModelIdentifier()
+    tf = TemplateFormatter(model_id=model_id)
+    assert tf._get_model_id() == ""
+
     tmpl = tf._load_template(instr.format_for_llm())
     assert tmpl.name is not None
     assert (


### PR DESCRIPTION
in a previous version of the code, the model_id was always being stringified here before being checked; this is not the case now, which would cause the check to incorrectly pass even though the value was `None`

all formatter tests still passed, and I added two new tests to check for similar situations