### PR TITLE
fix-43: Refactoring import statements for faster startup time

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -12,12 +12,11 @@ import inspect
 import json
 import os
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import outlines
 import outlines_core
 import torch
-from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # type: ignore
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -26,7 +25,6 @@ from transformers import (
     PreTrainedTokenizer,
     set_seed,
 )
-from transformers.generation import GenerateDecoderOnlyOutput
 
 from mellea.backends import BaseModelSubclass
 from mellea.backends.aloras import Alora, AloraBackendMixin
@@ -51,6 +49,9 @@ from mellea.stdlib.base import (
 )
 from mellea.stdlib.chat import Message
 from mellea.stdlib.requirement import ALoraRequirement, LLMaJRequirement, Requirement
+
+if TYPE_CHECKING:
+    from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # type: ignore
 
 assert outlines, "outlines needs to be present to make outlines_core work"
 
@@ -160,17 +161,17 @@ class LocalHFBackend(FormatterBackend, AloraBackendMixin):
         self._cache = cache if cache is not None else SimpleLRUCache(3)
 
         # Used when running aLoRAs with this backend.
-        self._alora_model: aLoRAPeftModelForCausalLM | None = None
+        self._alora_model: "aLoRAPeftModelForCausalLM | None" = None  # noqa: UP037
         # ALoras that have been loaded for this model.
         self._aloras: dict[str, HFAlora] = {}
 
     @property
-    def alora_model(self) -> aLoRAPeftModelForCausalLM | None:
+    def alora_model(self) -> "aLoRAPeftModelForCausalLM | None":  # noqa: UP037
         """The ALora model."""
         return self._alora_model
 
     @alora_model.setter
-    def alora_model(self, model: aLoRAPeftModelForCausalLM | None):
+    def alora_model(self, model: "aLoRAPeftModelForCausalLM | None"):  # noqa: UP037
         """Sets the ALora model. This should only happen once in a backend's lifetime."""
         assert self._alora_model is None
         self._alora_model = model
@@ -624,6 +625,8 @@ class LocalHFBackend(FormatterBackend, AloraBackendMixin):
         Args:
             alora (str): identifier for the ALora adapter
         """
+        from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # type: ignore
+
         assert issubclass(alora.__class__, HFAlora), (
             f"cannot add an ALora of type {alora.__class__} to model; must inherit from {HFAlora.__class__}"
         )

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from mellea.backends import Backend, BaseModelSubclass
-from mellea.backends.aloras.huggingface.granite_aloras import add_granite_aloras
 from mellea.backends.formatter import FormatterBackend
-from mellea.backends.huggingface import LocalHFBackend
 from mellea.backends.model_ids import (
     IBM_GRANITE_3_2_8B,
     IBM_GRANITE_3_3_8B,
@@ -15,7 +13,6 @@ from mellea.backends.model_ids import (
 )
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
-from mellea.backends.watsonx import WatsonxAIBackend
 from mellea.helpers.fancy_logger import FancyLogger
 from mellea.stdlib.base import (
     CBlock,
@@ -40,10 +37,14 @@ def backend_name_to_class(name: str) -> Any:
     if name == "ollama":
         return OllamaModelBackend
     elif name == "hf" or name == "huggingface":
+        from mellea.backends.huggingface import LocalHFBackend
+
         return LocalHFBackend
     elif name == "openai":
         return OpenAIBackend
     elif name == "watsonx":
+        from mellea.backends.watsonx import WatsonxAIBackend
+
         return WatsonxAIBackend
     else:
         return None
@@ -332,9 +333,15 @@ class MelleaSession:
 
     def load_default_aloras(self):
         """Loads the default Aloras for this model, if they exist and if the backend supports."""
+        from mellea.backends.huggingface import LocalHFBackend
+
         if self.backend.model_id == IBM_GRANITE_3_2_8B and isinstance(
             self.backend, LocalHFBackend
         ):
+            from mellea.backends.aloras.huggingface.granite_aloras import (
+                add_granite_aloras,
+            )
+
             add_granite_aloras(self.backend)
             return
         self._session_logger.warning(


### PR DESCRIPTION
## Summary
Initial startup time for an import statement was taking too long for a fresh install as shown in #43  and also here:

<img width="1450" height="821" alt="Screenshot 2025-08-12 at 1 30 39 PM" src="https://github.com/user-attachments/assets/502faf43-f4fa-431f-aeaf-f7cc9774c397" />

After the refactor, we have a faster startup time:

<img width="1439" height="876" alt="Screenshot 2025-08-13 at 11 49 59 AM" src="https://github.com/user-attachments/assets/823f4072-5de9-440d-a3a9-c31998c53f4d" />

## Related Issue
- #43 
- #23 

## Changes
- Refactors imports to not load libraries that take a lot of time during a fresh install
- Moving type hinting to use `TYPE_CHECK` to avoid importing torch at startup.