### PR TITLE
make requirements thread safe

### DIFF
--- a/test/stdlib_basics/test_requirement.py
+++ b/test/stdlib_basics/test_requirement.py
@@ -1,10 +1,18 @@
 import pytest
 from mellea.stdlib.base import ModelOutputThunk
-from mellea.stdlib.requirement import simple_validate
-from mellea.stdlib.session import SimpleContext
+from mellea.stdlib.requirement import Requirement, simple_validate
+from mellea.stdlib.session import SimpleContext, start_session
 
 ctx = SimpleContext()
 ctx.insert(ModelOutputThunk("test"))
+
+def test_llmaj_validation_req_output_field():
+    m = start_session(ctx=ctx)
+    req = Requirement("Must output test.")
+    assert req._output is None
+
+    _ = req.validate(m.backend,ctx=ctx)
+    assert req._output is None, "requirement's output shouldn't be updated during/after validation"
 
 def test_simple_validate_bool():
     validation_func = simple_validate(lambda x: False, reason="static reason")


### PR DESCRIPTION
Closes: https://github.com/generative-computing/mellea/issues/20

Ended up being a relatively small change. And added a test to make sure we weren't editing the original requirement.

Previously, we would append the output directly to the requirement that was being used for validation. Now, we create a copy of that action (this is similar to what we do for genslots and sampling already).

I considered switching back to the old `Validation` object and having that store the output from the llmaj / requirement, but that no longer works with how we are handling aloras. Since backends now detect alora requirements and do specific actions based on the class type, we must pass an alora requirement in those situations. I didn't want to add another level of complexity and force requirement contributors to always write two components (a requirement and a validation).

If we switch back to having requirements handle their own processing / routing, then we should switch to having a Validation object.

All tests pass.