### PR TITLE
Fix missing Docling Import in `document_mobject.ipynb`

### DIFF
--- a/docs/examples/notebooks/document_mobject.ipynb
+++ b/docs/examples/notebooks/document_mobject.ipynb
@@ -60,8 +60,7 @@
    },
    "outputs": [],
    "source": [
-    "!uv pip install mellea -q \n",
-    "!uv pip install docling"
+    "!uv pip install mellea[docling]"
    ]
   },
   {

--- a/docs/examples/notebooks/document_mobject.ipynb
+++ b/docs/examples/notebooks/document_mobject.ipynb
@@ -61,7 +61,8 @@
    "outputs": [],
    "source": [
     "!uv pip install mellea -q",
-    "!uv pip install docling"
+    "!uv pip install docling",
+    ""
    ]
   },
   {

--- a/docs/examples/notebooks/document_mobject.ipynb
+++ b/docs/examples/notebooks/document_mobject.ipynb
@@ -60,7 +60,8 @@
    },
    "outputs": [],
    "source": [
-    "!uv pip install mellea -q"
+    "!uv pip install mellea -q",
+    "!uv pip install docling"
    ]
   },
   {

--- a/docs/examples/notebooks/document_mobject.ipynb
+++ b/docs/examples/notebooks/document_mobject.ipynb
@@ -60,9 +60,8 @@
    },
    "outputs": [],
    "source": [
-    "!uv pip install mellea -q",
-    "!uv pip install docling",
-    ""
+    "!uv pip install mellea -q \n",
+    "!uv pip install docling"
    ]
   },
   {


### PR DESCRIPTION
Hello!

I'm a Georgia Tech Student (and former OSPO Intern) - I'm very interested in this project, but I found a minor bug in the docling python notebook. The notebook appears to not properly download and install docling alongside mellea - I've added `!uv pip install docling` to fix the issue.

Thank you for your time! :-)