### PR TITLE
small fixes 

### DIFF
--- a/docs/examples/generative_slots/inter_module_composition/summarizers.py
+++ b/docs/examples/generative_slots/inter_module_composition/summarizers.py
@@ -13,4 +13,4 @@ def summarize_contract(contract_text: str) -> str:
 
 @generative
 def summarize_short_story(story: str) -> str:
-    """Summarize a short story, with one paragraph on plot and one paragraph on braod themes."""
+    """Summarize a short story, with one paragraph on plot and one paragraph on broad themes."""

--- a/docs/examples/notebooks/compositionality_with_generative_slots.ipynb
+++ b/docs/examples/notebooks/compositionality_with_generative_slots.ipynb
@@ -95,7 +95,7 @@
     "\n",
     "@generative\n",
     "def summarize_short_story(story: str) -> str:\n",
-    "    \"\"\"Summarize a short story, with one paragraph on plot and one paragraph on braod themes.\"\"\""
+    "    \"\"\"Summarize a short story, with one paragraph on plot and one paragraph on broad themes.\"\"\""
    ]
   },
   {

--- a/docs/examples/notebooks/georgia_tech.ipynb
+++ b/docs/examples/notebooks/georgia_tech.ipynb
@@ -451,7 +451,6 @@
     "    )\n",
     "    if isinstance(table2, Table):\n",
     "        print(table2.to_markdown())\n",
-    "        break\n",
     "    else:\n",
     "        print(\"==== TRYING AGAIN after non-useful output.====\")"
    ]

--- a/docs/examples/notebooks/georgia_tech.ipynb
+++ b/docs/examples/notebooks/georgia_tech.ipynb
@@ -36,7 +36,7 @@
     "!curl -fsSL https://ollama.com/install.sh | sh > /dev/null\n",
     "!nohup ollama serve >/dev/null 2>&1 &\n",
     "\n",
-    "# Download the granite:3.38b weights.\n",
+    "# Download the granite:3.3:8b weights.\n",
     "!ollama pull granite3.3:8b\n",
     "!ollama pull llama3.2:3b\n",
     "\n",
@@ -193,7 +193,7 @@
     "\n",
     "@generative\n",
     "def summarize_short_story(story: str) -> str:\n",
-    "    \"\"\"Summarize a short story, with one paragraph on plot and one paragraph on braod themes.\"\"\"\n",
+    "    \"\"\"Summarize a short story, with one paragraph on plot and one paragraph on broad themes.\"\"\"\n",
     "\n",
     "\n",
     "################################################################################\n",
@@ -441,16 +441,17 @@
     "from mellea.backends.types import ModelOption\n",
     "\n",
     "# You can use multiple different models at the same time!\n",
-    "m_mistral = mellea.MelleaSession(backend=OllamaModelBackend(model_id=META_LLAMA_3_2_3B))\n",
+    "m_llama = mellea.MelleaSession(backend=OllamaModelBackend(model_id=META_LLAMA_3_2_3B))\n",
     "\n",
     "for seed in [x * 12 for x in range(5)]:\n",
-    "    table2 = m_mistral.transform(\n",
+    "    table2 = m_llama.transform(\n",
     "        table1,\n",
-    "        \"Add a column 'Model' that extracts which model was used or 'None' if none.\",\n",
+    "        \"Add a 'Model' column as the last column that extracts which model was used for that feature or 'None' if none.\",\n",
     "        model_options={ModelOption.SEED: seed},\n",
     "    )\n",
     "    if isinstance(table2, Table):\n",
     "        print(table2.to_markdown())\n",
+    "        break\n",
     "    else:\n",
     "        print(\"==== TRYING AGAIN after non-useful output.====\")"
    ]
@@ -474,7 +475,7 @@
     "\n",
     "**The MObject Pattern**: You should store data alongside its relevant operations (tools). This allows LLMs to interact with both the data and methods in a unified, structured manner. It also simplifies the process of exposing only the specific fields and methods you want the LLM to access.\n",
     "\n",
-    "The MOBject pattern also provides a way of evolving existing classical codebases into generative programs. Mellea's @mify decorator lets you turn any class into an MObject. If needed, you can specify which fields and methods are included, and provide a template for how the object should be represented to the LLM."
+    "The MObject pattern also provides a way of evolving existing classical codebases into generative programs. Mellea's @mify decorator lets you turn any class into an MObject. If needed, you can specify which fields and methods are included, and provide a template for how the object should be represented to the LLM."
    ]
   },
   {
@@ -544,9 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "Co662BJtBYBt"
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/docs/examples/tutorial/compositionality_with_generative_slots.py
+++ b/docs/examples/tutorial/compositionality_with_generative_slots.py
@@ -14,7 +14,7 @@ def summarize_contract(contract_text: str) -> str:
 
 @generative
 def summarize_short_story(story: str) -> str:
-    """Summarize a short story, with one paragraph on plot and one paragraph on braod themes."""
+    """Summarize a short story, with one paragraph on plot and one paragraph on broad themes."""
 
 
 # The Decision Aides Library


### PR DESCRIPTION
Also changes the table add column prompt. Looks like the ollama version or jupyter notebook environment causes different behavior with the table. This new prompt will fail 3 times and then create the correct table:
```
=== 16:15:16-INFO ======
Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
INFO:fancy_logger:Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
==== TRYING AGAIN after non-useful output.====
=== 16:15:20-INFO ======
Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
INFO:fancy_logger:Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
==== TRYING AGAIN after non-useful output.====
=== 16:15:25-INFO ======
Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
INFO:fancy_logger:Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
==== TRYING AGAIN after non-useful output.====
=== 16:15:29-INFO ======
Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
INFO:fancy_logger:Tools for call: dict_keys(['from_markdown', 'to_markdown', 'transpose'])
=== 16:15:32-WARNING ======
added a tool message from transform to the context as well.
WARNING:fancy_logger:added a tool message from transform to the context as well.
| Feature                              | AUC         | Model            |
|--------------------------------------|-------------|------------------|
| Bag of Words                         | 0.63 ± 0.11 | None             |
| (Test 1 - GPT-2) Average Probability | 0.71 ± 0.25 | (Test 1 - GPT-2) |
| (Test 2 - GPT-2) Top-K Buckets       | 0.87 ± 0.07 | (Test 2 - GPT-2) |
| (Test 1 - BERT) Average Probability  | 0.70 ± 0.27 | (Test 1 - BERT)  |
| (Test 2 - BERT) Top-K Buckets        | 0.85 ± 0.09 | (Test 2 - BERT)  |
```