### PR TITLE
move all m.* functions to use `m.act`

### DIFF
--- a/mellea/stdlib/genslot.py
+++ b/mellea/stdlib/genslot.py
@@ -9,7 +9,7 @@ from typing import Any, Generic, ParamSpec, TypedDict, TypeVar, get_type_hints
 from pydantic import BaseModel, Field, create_model
 
 from mellea.stdlib.base import Component, TemplateRepresentation
-from mellea.stdlib.session import get_session
+from mellea.stdlib.session import MelleaSession, get_session
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -154,7 +154,7 @@ class GenerativeSlot(Component, Generic[P, R]):
 
     def __call__(
         self,
-        m=None,
+        m: MelleaSession | None = None,
         model_options: dict | None = None,
         *args: P.args,
         **kwargs: P.kwargs,
@@ -180,13 +180,11 @@ class GenerativeSlot(Component, Generic[P, R]):
 
         response_model = create_response_format(self._function._func)
 
-        response = m.genslot(
-            slot_copy, model_options=model_options, format=response_model
-        )
+        response = m.act(slot_copy, format=response_model, model_options=model_options)
 
         function_response: FunctionResponse[R] = response_model.model_validate_json(
-            response.value
-        )  # type: ignore
+            response.value  # type: ignore
+        )
 
         return function_response.result
 

--- a/mellea/stdlib/sampling.py
+++ b/mellea/stdlib/sampling.py
@@ -153,7 +153,7 @@ class BaseSamplingStrategy(SamplingStrategy):
         sampled_actions: list[Component],
         sampled_results: list[ModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
-    ):
+    ) -> int:
         """This function returns the index of the result that should be selected as `.value` iff the loop budget is exhausted and no success.
 
         Args:
@@ -356,17 +356,17 @@ class MultiTurnStrategy(BaseSamplingStrategy):
 
     @staticmethod
     def repair(
-        context: Context,
+        ctx: Context,
         past_actions: list[Component],
         past_results: list[ModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> Component:
-        assert isinstance(context, LinearContext), (
+        assert isinstance(ctx, LinearContext), (
             " Need linear context to run agentic sampling."
         )
 
         # add failed execution to chat history
-        context.insert_turn(ContextTurn(past_actions[-1], past_results[-1]))
+        ctx.insert_turn(ContextTurn(past_actions[-1], past_results[-1]))
 
         last_failed_reqs: list[Requirement] = [s[0] for s in past_val[-1] if not s[1]]
         last_failed_reqs_str = "* " + "\n* ".join(

--- a/mellea/stdlib/sampling.py
+++ b/mellea/stdlib/sampling.py
@@ -48,6 +48,7 @@ class SamplingResult(CBlock):
         self.success = success
         self.sample_generations = sample_generations
         self.sample_validations = sample_validations
+        self.sample_actions = sample_actions
 
 
 class SamplingStrategy(abc.ABC):

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import contextvars
-from collections.abc import Generator
-from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Literal, Optional
+from typing import Any, Literal, overload
 
 from mellea.backends import Backend, BaseModelSubclass
 from mellea.backends.formatter import FormatterBackend
@@ -224,11 +222,171 @@ class MelleaSession:
         self.reset()
         self._backend_stack.clear()
         if hasattr(self.backend, "close"):
-            self.backend.close()
+            self.backend.close()  # type: ignore
 
     def summarize(self) -> ModelOutputThunk:
         """Summarizes the current context."""
         raise NotImplementedError()
+
+    @overload
+    def act(
+        self,
+        action: Component,
+        *,
+        strategy: SamplingStrategy | None = None,
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> ModelOutputThunk: ...
+
+    @overload
+    def act(
+        self,
+        action: Component,
+        *,
+        strategy: SamplingStrategy | None = None,
+        return_sampling_results: Literal[True],
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> SamplingResult: ...
+
+    def act(
+        self,
+        action: Component,
+        *,
+        requirements: list[Requirement] | None = None,
+        strategy: SamplingStrategy | None = None,
+        return_sampling_results: bool = False,
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> ModelOutputThunk | SamplingResult:
+        """Runs a generic action, and adds both the action and the result to the context.
+
+        Args:
+            action: the Component from which to generate.
+            requirements: used as additional requirements when a sampling strategy is provided
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
+            return_sampling_results: attach the (successful and failed) sampling attempts to the results.
+            format: if set, the BaseModel to use for constrained decoding.
+            model_options: additional model options, which will upsert into the model/backend's defaults.
+            tool_calls: if true, tool calling is enabled.
+
+        Returns:
+            A ModelOutputThunk if `return_sampling_results` is `False`, else returns a `SamplingResult`.
+        """
+        sampling_result: SamplingResult | None = None
+        generate_logs: list[GenerateLog] = []
+
+        if return_sampling_results:
+            assert strategy is not None, (
+                "Must provide a SamplingStrategy when return_sampling_results==True"
+            )
+
+        if strategy is None:
+            result = self.backend.generate_from_context(
+                action,
+                ctx=self.ctx,
+                format=format,
+                model_options=model_options,
+                generate_logs=generate_logs,
+                tool_calls=tool_calls,
+            )
+            assert len(generate_logs) == 1, "Simple call can only add one generate_log"
+            generate_logs[-1].is_final_result = True
+
+        else:
+            # Default validation strategy just validates all of the provided requirements.
+            if strategy.validate is None:
+                strategy.validate = lambda reqs, val_ctx, output: self.validate(
+                    reqs, output=output
+                )
+
+            # Default generation strategy just generates from context.
+            if strategy.generate is None:
+                strategy.generate = (
+                    lambda sample_action,
+                    gen_ctx,
+                    g_logs: self.backend.generate_from_context(
+                        sample_action,
+                        ctx=gen_ctx,
+                        format=format,
+                        model_options=model_options,
+                        generate_logs=g_logs,
+                        tool_calls=tool_calls,
+                    )
+                )
+
+            if requirements is None:
+                requirements = []
+
+            sampling_result = strategy.sample(
+                action, self.ctx, requirements=requirements, generate_logs=generate_logs
+            )
+
+            # make sure that one Log is marked as the one related to sampling_result.result
+            if sampling_result.success:
+                # if successful, the last log is the one related
+                generate_logs[-1].is_final_result = True
+            else:
+                # Find the log where log.result and sampling_result.result match
+                selected_log = [
+                    log for log in generate_logs if log.result == sampling_result.result
+                ]
+                assert len(selected_log) == 1, (
+                    "There should only be exactly one log corresponding to the single result. "
+                )
+                selected_log[0].is_final_result = True
+
+            result = sampling_result.result
+
+        self.ctx.insert_turn(ContextTurn(action, result), generate_logs=generate_logs)
+
+        if return_sampling_results:
+            assert (
+                sampling_result is not None
+            )  # Needed for the type checker but should never happen.
+            return sampling_result
+        else:
+            return result
+
+    @overload
+    def instruct(
+        self,
+        description: str,
+        *,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: SamplingStrategy | None = None,
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> ModelOutputThunk: ...
+
+    @overload
+    def instruct(
+        self,
+        description: str,
+        *,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: SamplingStrategy | None = None,
+        return_sampling_results: Literal[True],
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> SamplingResult: ...
 
     def instruct(
         self,
@@ -265,7 +423,8 @@ class MelleaSession:
         requirements = [] if requirements is None else requirements
         icl_examples = [] if icl_examples is None else icl_examples
         grounding_context = dict() if grounding_context is None else grounding_context
-        # all instruction options are forwarded to create a new Instruction object
+
+        # All instruction options are forwarded to create a new Instruction object.
         i = Instruction(
             description=description,
             requirements=requirements,
@@ -276,69 +435,15 @@ class MelleaSession:
             output_prefix=output_prefix,
         )
 
-        res = None
-        generate_logs: list[GenerateLog] = []
-        if strategy is None:
-            result = self.backend.generate_from_context(
-                i,
-                ctx=self.ctx,
-                format=format,
-                model_options=model_options,
-                generate_logs=generate_logs,
-                tool_calls=tool_calls,
-            )
-
-            # make sure that one Log is marked as the one related to result
-            assert len(generate_logs) == 1, "Simple call can only add one generate_log"
-            generate_logs[0].is_final_result = True
-        else:
-            if strategy.validate is None:
-                strategy.validate = lambda reqs, val_ctx, output: self.validate(  # type: ignore
-                    reqs,
-                    output=output,  # type: ignore
-                )  # type: ignore
-            if strategy.generate is None:
-                strategy.generate = (
-                    lambda instruction,
-                    gen_ctx,
-                    g_logs: self.backend.generate_from_context(
-                        instruction,
-                        ctx=gen_ctx,
-                        format=format,
-                        model_options=model_options,
-                        generate_logs=g_logs,
-                        tool_calls=tool_calls,
-                    )
-                )
-
-            # sample
-            res = strategy.sample(
-                i, self.ctx, i.requirements, generate_logs=generate_logs
-            )
-
-            # make sure that one Log is marked as the one related to res.result
-            if res.success:
-                # if successful, the last log is the one related
-                generate_logs[-1].is_final_result = True
-            else:
-                # find the one where log.result and res.result match
-                selected_log = [
-                    log for log in generate_logs if log.result == res.result
-                ]
-                assert len(selected_log) == 1, (
-                    "There should only be exactly one log corresponding to the single result. "
-                )
-                selected_log[0].is_final_result = True
-
-            result = res.result
-
-        self.ctx.insert_turn(ContextTurn(i, result), generate_logs=generate_logs)
-
-        if return_sampling_results:
-            assert res is not None, "Asking for sampling results without sampling."
-            return res
-        else:
-            return result
+        return self.act(
+            i,
+            requirements=i.requirements,
+            strategy=strategy,
+            return_sampling_results=return_sampling_results,
+            format=format,
+            model_options=model_options,
+            tool_calls=tool_calls,
+        )  # type: ignore[call-overload]
 
     def chat(
         self,
@@ -358,34 +463,17 @@ class MelleaSession:
         else:
             content_resolved = content
         user_message = Message(role=role, content=content_resolved)
-        generate_logs: list[GenerateLog] = []
-        output_thunk = self.backend.generate_from_context(
-            action=user_message,
-            ctx=self.ctx,
+
+        result = self.act(
+            user_message,
             format=format,
             model_options=model_options,
-            generate_logs=generate_logs,
             tool_calls=tool_calls,
         )
-        # make sure that the last and only Log is marked as the one related to result
-        assert len(generate_logs) == 1, "Simple call can only add one generate_log"
-        generate_logs[0].is_final_result = True
+        parsed_assistant_message = result.parsed_repr
+        assert isinstance(parsed_assistant_message, Message)
 
-        parsed_assistant_message = output_thunk.parsed_repr
-        assert type(parsed_assistant_message) is Message
-        self.ctx.insert_turn(
-            ContextTurn(user_message, output_thunk), generate_logs=generate_logs
-        )
         return parsed_assistant_message
-
-    def act(self, c: Component, tool_calls: bool = False) -> Any:
-        """Runs a generic action, and adds both the action and the result to the context."""
-        generate_logs: list[GenerateLog] = []
-        result: ModelOutputThunk = self.backend.generate_from_context(
-            c, self.ctx, generate_logs=generate_logs, tool_calls=tool_calls
-        )
-        self.ctx.insert_turn(turn=ContextTurn(c, result), generate_logs=generate_logs)
-        return result
 
     def validate(
         self,
@@ -418,40 +506,6 @@ class MelleaSession:
 
         return rvs
 
-    def genslot(
-        self,
-        gen_slot: Component,
-        model_options: dict | None = None,
-        format: type[BaseModelSubclass] | None = None,
-        tool_calls: bool = False,
-    ) -> ModelOutputThunk:
-        """Call generative Slot on a GenerativeSlot Component.
-
-        Args:
-            gen_slot (GenerativeSlot Component): A generative slot
-
-        Returns:
-            ModelOutputThunk: Output thunk
-        """
-        generate_logs: list[GenerateLog] = []
-        result: ModelOutputThunk = self.backend.generate_from_context(
-            action=gen_slot,
-            ctx=self.ctx,
-            model_options=model_options,
-            format=format,
-            generate_logs=generate_logs,
-            tool_calls=tool_calls,
-        )
-        # make sure that the last and only Log is marked as the one related to result
-        assert len(generate_logs) == 1, "Simple call can only add one generate_log"
-        generate_logs[0].is_final_result = True
-
-        self.ctx.insert_turn(
-            ContextTurn(deepcopy(gen_slot), result), generate_logs=generate_logs
-        )
-
-        return result
-
     def query(
         self,
         obj: Any,
@@ -479,32 +533,9 @@ class MelleaSession:
         assert isinstance(obj, MObjectProtocol)
         q = obj.get_query_object(query)
 
-        generate_logs: list[GenerateLog] = []
-        answer = self.backend.generate_from_context(
-            q,
-            self.ctx,
-            format=format,
-            model_options=model_options,
-            generate_logs=generate_logs,
-            tool_calls=tool_calls,
+        answer = self.act(
+            q, format=format, model_options=model_options, tool_calls=tool_calls
         )
-        # make sure that the last and only Log is marked as the one related to result
-        assert len(generate_logs) == 1, "Simple call can only add one generate_log"
-        generate_logs[0].is_final_result = True
-
-        if isinstance(self.ctx, SimpleContext):
-            self.ctx.insert_turn(ContextTurn(q, answer), generate_logs=generate_logs)
-        elif isinstance(self.ctx, LinearContext) and len(self.ctx._ctx) == 0:
-            FancyLogger.get_logger().info(
-                "Adding the Object Query and its answer as first turn to a Linear Context (Chat History). "
-                "You can now run more .chat() or .instruct() with the object as reference."
-            )
-            self.ctx.insert_turn(ContextTurn(q, answer), generate_logs=generate_logs)
-        else:
-            FancyLogger.get_logger().info(
-                "The Linear Context has not been modified by this query."
-            )
-
         return answer
 
     def transform(
@@ -532,42 +563,11 @@ class MelleaSession:
         assert isinstance(obj, MObjectProtocol)
         t = obj.get_transform_object(transformation)
 
-        generate_logs: list[GenerateLog] = []
-
         # Check that your model / backend supports tool calling.
         # This might throw an error when tools are provided but can't be handled by one or the other.
-        transformed = self.backend.generate_from_context(
-            t,
-            self.ctx,
-            format=format,
-            model_options=model_options,
-            generate_logs=generate_logs,
-            tool_calls=True,
+        transformed = self.act(
+            t, format=format, model_options=model_options, tool_calls=True
         )
-
-        assert len(generate_logs) == 1, "Simple call can only add one generate_log"
-        generate_logs[0].is_final_result = True
-
-        # Insert the new turn into the context. Tool calls are handled afterwards.
-        insert = False
-        if isinstance(self.ctx, SimpleContext):
-            insert = True
-            self.ctx.insert_turn(
-                ContextTurn(t, transformed), generate_logs=generate_logs
-            )
-        elif isinstance(self.ctx, LinearContext) and len(self.ctx._ctx) == 0:
-            insert = True
-            FancyLogger.get_logger().info(
-                "Adding the Object Transform and its result as first turn to a Linear Context (Chat History). "
-                "You can now run more .chat() or .instruct() with the object as reference."
-            )
-            self.ctx.insert_turn(
-                ContextTurn(t, transformed), generate_logs=generate_logs
-            )
-        else:
-            FancyLogger.get_logger().info(
-                "The Linear Context has not been modified by this query."
-            )
 
         tools = self._call_tools(transformed)
 
@@ -597,11 +597,11 @@ class MelleaSession:
                 FancyLogger.get_logger().warning(
                     f"the transform of {obj} with transformation description '{transformation}' resulted in a tool call with no generated arguments; consider calling the function `{chosen_tool._tool.name}` directly"
                 )
-            if insert:
-                self.ctx.insert(chosen_tool)
-                FancyLogger.get_logger().warning(
-                    "added a tool message from transform to the context as well."
-                )
+
+            self.ctx.insert(chosen_tool)
+            FancyLogger.get_logger().info(
+                "added a tool message from transform to the context"
+            )
             return chosen_tool._tool_output
 
         return transformed


### PR DESCRIPTION
`m.act` is the default implementation of how a session interacts with a backend. All other `m.*` functions (besides validate) will call that function and do pre/post processing to get the same results as before.

Notes:
- m.validate can't use act since requirements directly call the backend.generate functions; we can "fix" this if we have requirements take MelleaSession objects
- act handles context additions; this means that query and transform no longer handle adding to context differently depending on the context
- tool calling for transform will get moved in a future PR (there are no regressions here)

All tests pass.
