### PR TITLE
small code fixes: remove unused funcs and skip a memory heavy test

### DIFF
--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -414,31 +414,6 @@ class MelleaSession:
 
         return rvs
 
-    def req(self, *args, **kwargs):
-        """Shorthand for Requirement.__init__(...)."""
-        return req(*args, **kwargs)
-
-    def check(self, *args, **kwargs):
-        """Shorthand for Requirement.__init__(..., check_only=True)."""
-        return check(*args, **kwargs)
-
-    def load_default_aloras(self):
-        """Loads the default Aloras for this model, if they exist and if the backend supports."""
-        from mellea.backends.huggingface import LocalHFBackend
-
-        if self.backend.model_id == IBM_GRANITE_3_2_8B and isinstance(
-            self.backend, LocalHFBackend
-        ):
-            from mellea.backends.aloras.huggingface.granite_aloras import (
-                add_granite_aloras,
-            )
-
-            add_granite_aloras(self.backend)
-            return
-        self._session_logger.warning(
-            "This model/backend combination does not support any aloras."
-        )
-
     def genslot(
         self,
         gen_slot: Component,

--- a/test/stdlib_basics/test_richdocument.py
+++ b/test/stdlib_basics/test_richdocument.py
@@ -93,6 +93,7 @@ def test_empty_table():
     assert table is None, "table should be empty when supplied string is empty"
 
 
+@pytest.mark.skip # Test requires too much memory for smaller machines.
 def test_richdocument_generation(rd: RichDocument):
     m = mellea.start_session(backend_name="hf")
     response = m.chat(rd.to_markdown()[:500] + "\nSummarize the provided document.")


### PR DESCRIPTION
Skips the rich document test that causes github runners (and my computer) to crash. 

Removes unused session level functions (and req / check shouldn't be session funcs anyways). There's no code / references to these functions anywhere else in the code base.