### PR TITLE
Make pbars respect logging levels

### DIFF
--- a/mellea/stdlib/sampling.py
+++ b/mellea/stdlib/sampling.py
@@ -150,6 +150,10 @@ class RejectionSamplingStrategy(SamplingStrategy):
 
         flog = FancyLogger.get_logger()
 
+        # The `logging_redirect_tqdm` approach did not work, so instead we will use the show_progress
+        # flag to determine whether we should show the pbar.
+        show_progress = show_progress and flog.getEffectiveLevel() <= FancyLogger.INFO
+
         failed_results: list[ModelOutputThunk] = []
         failed_scores: list[list[tuple[Requirement, ValidationResult]]] = []
         failed_instructions: list[Instruction] = []


### PR DESCRIPTION
This PR addresses #100 and #101 by disabling pbars in sampling if the logging level is greater than `INFO`.

I did try `logging_redirect_tqdm` but it does not address the desired behavior, and in any case we already have `show_progress` for this purpose.

The main downside of this approach is that `logging_level` overrides `show_progress`.

We also use pbars for ollama downloads. I argue **against** disabling those pbars because in that case the user will observe "hanging" if a model needs to be downloaded. Also, this should happen only rarely and only for local inference users, so the typical situations where you want quiet `STDOUT` do not apply.

