### PR TITLE
Think budget-forcing

### DIFF
--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -37,6 +37,7 @@ from mellea.stdlib.base import (
 )
 from mellea.stdlib.chat import Message
 from mellea.stdlib.requirement import ALoraRequirement, LLMaJRequirement, Requirement
+import re
 
 if TYPE_CHECKING:
     from transformers.tokenization_utils import PreTrainedTokenizer
@@ -471,21 +472,21 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
         self,
         action: CBlock,
         *,
-        think_max_tokens: int = 3072,
+        think_max_tokens: int = 4096,
         answer_max_tokens: int | None = None,
-        start_think_token: str | None = "<think>",
-        end_think_token: str | None = "</think>",
-        begin_response_token: str | None = None,
-        end_response_token: str | None = None,
-        think_wait_suffix: str | None = None,
-        answer_suffix: str | None = "The final answer is:",
-        answer_token: str | None = "boxed",
+        start_think_token: str = "<think>",
+        end_think_token: str = "</think>",
+        begin_response_token: str = "",
+        end_response_token: str = "",
+        think_wait_suffix: str = "",
+        answer_suffix: str = "The final answer is:",
+        answer_regex: str = "boxed",
         model_options: dict | None = None,
     ) -> list[ModelOutputThunk]:
-        """Generate with budget forcing using the completions APIs. This relies on raw autocompletion and assumes the model's output is structued in the following form: '<think> ... </think> summary answer'
+        """Generate with budget forcing using the completions APIs. This relies on raw autocompletion and assumes the model's output is structured in the following form: '<think> ... </think> summary answer'
         The budget forcing method is proposed in the paper: https://arxiv.org/abs/2501.19393
         This implementation tries to follow the key outlines in the paper while ensuring stable and fail-safe operation.
-        This is performed via multi-step generation. The model will be called multiple times until requirements are met, in other words, the response will be assembeled conditionally.
+        This is performed via multi-step generation. The model will be called multiple times until requirements are met, in other words, the response will be assembled conditionally.
 
         Args:
             think_max_tokens: Budget in number of tokens allocated for the think block
@@ -496,7 +497,7 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
             end_response_token: Used by certain models, string indicating end of response block, e.g. "</response>", default None
             think_wait_suffix: String to append to force continued thinking, e.g. "\nWait" if set to None we will not force additional thinking. Use None for upper-bound budget case
             answer_suffix: String to append to force a final answer
-            answer_token: Token that indicates an answer is generated
+            answer_regex: Answer regex which indicates an answer is generated
 
         Assumptions:
             -  The chat template is applied on prompt, with think mode enabled
@@ -511,24 +512,33 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
 
         responses = []
         prompt = self.formatter.print(action)
-        if start_think_token is not None:
+        if start_think_token:
             prompt += start_think_token
             responses.append(start_think_token)
+
         backend_opts = self._make_backend_specific_and_remove(
             model_opts, is_chat_context=False
         )
         # Generate thinking portion
-        max_tok_thd = 0.8
-        backend_opts["max_tokens"] = think_max_tokens
+        max_tok_thd = 1.0
         # backend_opts["echo"] = True
         # backend_opts["logprobs"] = 1
         backend_opts["n"] = 1
+        rem_toks = think_max_tokens
         gen_tok_count = 0
         curr_prompt = prompt
         min_step_len = 10  # minimum character length of step to be considered valid
 
         # think block indefinite multi-step operation to satisfy user's budget
         while True:
+
+            if rem_toks <= 0:  # zero-think case
+                break
+
+            if rem_toks <= min_step_len:  # minimum step length reached
+                break
+
+            backend_opts["max_tokens"] = rem_toks
             try:
                 completion_response: Completion = self._client.completions.create(
                     model=self._hf_model_id, prompt=curr_prompt, **backend_opts
@@ -536,23 +546,27 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
             except openai.BadRequestError as e:
                 if openai_ollama_batching_error in e.message:
                     FancyLogger.get_logger().error(
-                        "If you are trying to call `OpenAIBackend._generate_from_raw while targeting an ollama server, "
+                        "If you are trying to call `OpenAIBackend.generate_with_budget_forcing while targeting an ollama server, "
                         "your requests will fail since ollama doesn't support batching requests."
                     )
                 raise e
 
             gen_tok_count += completion_response.usage.completion_tokens
+            rem_toks = think_max_tokens - gen_tok_count
             response = completion_response.choices[0].text
-            if think_wait_suffix is None:
+
+            if think_wait_suffix == "":
+                # non-strict budget form
                 responses.append(response)
                 break
 
-            if gen_tok_count >= max_tok_thd * think_max_tokens:
+            if rem_toks <= 0:
                 responses.append(response)
                 break
 
             else:
-                step = response.split(end_think_token)[0]
+                if end_think_token:
+                    step = response.split(end_think_token)[0]
                 # model fails to produce thoughts, let's exit
                 if len(step.strip()) <= min_step_len:
                     responses.append(response)
@@ -564,11 +578,7 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
                 curr_prompt += step
 
         response = "".join(responses)
-        ### debug obtaining final answer
-        # response = response.split(end_think_token)[0]
-        # response = response.replace(answer_token, "")
-        ###
-        if answer_token is None or answer_suffix is None:
+        if answer_regex is None or answer_suffix is None:
             return response, gen_tok_count
 
         # Now get a final answer if we need to
@@ -577,28 +587,31 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
         # Consider a strict structural approach in the future.
         # e.g.
         # ans_portion = response.split(end_think_token)[-1]
-        # if answer_token in ans_portion:
+        # if answer_regex in ans_portion:
         #     return response, gen_tok_count
 
-        if answer_token in response:
+        # Check if answer in response
+        matches = re.findall(answer_regex, response, re.DOTALL)
+        if len(matches) > 0:
             return response, gen_tok_count
 
         # Answer is not in response, let's force an answer
-        if end_think_token not in response:
-            response = (
-                f"{response} {end_think_token}{begin_response_token} {answer_suffix}"
-            )
+        if end_think_token and end_think_token not in response:
+            response += f" {end_think_token}"
 
-        else:
-            response = f"{response} {begin_response_token}{answer_suffix}"
+        if begin_response_token and begin_response_token not in response:
+            response += f" {begin_response_token}"
 
-        # update original prompt with assembled  response
+        if answer_suffix:
+            response += f" {answer_suffix}"
+
+        # update original prompt with assembled response
         prompt += response
         if answer_max_tokens is not None:
             backend_opts["max_tokens"] = answer_max_tokens
 
         else:
-            del backend_opts["max_tokens"]
+            backend_opts.pop("max_tokens", None)   # generate unconditionally
 
         try:
             completion_response: Completion = self._client.completions.create(
@@ -607,7 +620,7 @@ class OpenAIBackend(FormatterBackend, AloraBackendMixin):
         except openai.BadRequestError as e:
             if openai_ollama_batching_error in e.message:
                 FancyLogger.get_logger().error(
-                    "If you are trying to call `OpenAIBackend._generate_from_raw while targeting an ollama server, "
+                    "If you are trying to call `OpenAIBackend.generate_with_budget_forcing while targeting an ollama server, "
                     "your requests will fail since ollama doesn't support batching requests."
                 )
             raise e

--- a/test/backends/test_think_budget_forcing/.gitignore
+++ b/test/backends/test_think_budget_forcing/.gitignore
@@ -1,0 +1,2 @@
+vllm.err
+vllm.log

--- a/test/backends/test_think_budget_forcing/README.md
+++ b/test/backends/test_think_budget_forcing/README.md
@@ -1,0 +1,23 @@
+
+# Test for OpenAI API served by VLLM
+
+## Requirement
+
+anaconda / miniconda / miniforge.
+
+Make sure to run the test with multiple cores available (e.g. in a cloud instance / cluster job).
+Although you may think 1 core is enough,
+vllm could get stuck due to deadlock if so.
+
+## Installation
+
+Needs to be done only once.
+I creates a new conda environment named "mallea_tbf" only for the purposes of testing or contributing to the think budget-forcing feature.
+
+Run `./install.sh`
+
+## Testing
+
+``` shell
+./run_test.sh
+```

--- a/test/backends/test_think_budget_forcing/environment.yml
+++ b/test/backends/test_think_budget_forcing/environment.yml
@@ -1,0 +1,7 @@
+
+name: mellea_tbf
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12                 # note: at the time of writing, xformer (< vllm) has a broken wheel for 3.13. https://github.com/facebookresearch/xformers/issues/740#issuecomment-2753869337
+  - uv

--- a/test/backends/test_think_budget_forcing/install.sh
+++ b/test/backends/test_think_budget_forcing/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -xe
+
+ENV_NAME=mellea_tbf
+conda env remove -y -n $ENV_NAME || true
+conda env create -f $(readlink -ef $(dirname $0))/environment.yml
+
+in-conda (){
+    conda run -n $ENV_NAME $@
+}
+
+
+cd ../../../
+in-conda uv pip install -e .
+cd -
+in-conda uv pip install pre-commit
+in-conda uv pip install pytest
+in-conda uv pip install vllm==0.10.0
+in-conda uv pip install outlines

--- a/test/backends/test_think_budget_forcing/run_test.sh
+++ b/test/backends/test_think_budget_forcing/run_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+ENV_NAME=mellea_tbf
+eval "$(conda shell.bash hook)"
+conda activate $ENV_NAME
+
+dir=$(readlink -ef $(dirname $0))
+rm $dir/vllm.log $dir/vllm.err
+
+bash $dir/serve.sh &
+vllm_pid=$!
+
+trap "kill -SIGINT $vllm_pid ; wait" EXIT
+
+while sleep 1 ; do
+    if grep -q "Application startup complete." $dir/vllm.err
+    then
+        break
+    fi
+done
+
+python test_think_budget_forcing.py
+
+

--- a/test/backends/test_think_budget_forcing/serve.sh
+++ b/test/backends/test_think_budget_forcing/serve.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# @Masa note:
+# the following code is a bash snippet Kristian gave me
+# for how to run vllm with lora adapter loaded.
+
+# HF_GRANITE_ALORA_SNAPSHOT=${HF_HOME:-$HOME/.cache/huggingface}
+# HF_GRANITE_ALORA_SNAPSHOT+=/hub/
+# HF_GRANITE_ALORA_SNAPSHOT+=models--ibm-granite--granite-3.2-8b-alora-requirement-check/
+# HF_GRANITE_ALORA_SNAPSHOT+=snapshots/d55a7a7f5796609bc938c5c151a864cfcc6ab54e
+
+# vllm serve ibm-granite/granite-3.2-8b-instruct \
+#       --enable-lora \
+#       --lora-modules "{\"name\": \"ibm-granite/granite-3.2-8b-alora-requirement-check\", \"path\": \"${HF_GRANITE_ALORA_SNAPSHOT}\", \"base_model_name\": \"ibm-granite/granite-3.2-8b-instruct\"}" \
+#       --dtype bfloat16 \
+#       --max-lora-rank 64 \
+#       --enable-prefix-caching
+
+# However, in our test, we do not load the alora when we serve.
+# In this test, we use the dynamic loading interface from
+# https://docs.vllm.ai/en/stable/features/lora.html#dynamically-serving-lora-adapters
+
+# Using this feature requires the following environment variable.
+# If you use conda/miniforge,
+# this variable must have been set already when you set up the environment.
+# see environment.yml.
+export VLLM_ALLOW_RUNTIME_LORA_UPDATING=True
+
+echo "launching a vllm server. Logs are found in $(readlink -ef $(dirname $0))/vllm.log"
+      # At the time of writing this code, Granite 4.4 vLLM serving did not support prefix-caching
+      # --enable-prefix-caching \
+vllm serve ibm-granite/granite-4.0-tiny-preview \
+      --dtype bfloat16 \
+      > $(readlink -ef $(dirname $0))/vllm.log \
+      2> $(readlink -ef $(dirname $0))/vllm.err
+
+

--- a/test/backends/test_think_budget_forcing/test_think_budget_forcing.py
+++ b/test/backends/test_think_budget_forcing/test_think_budget_forcing.py
@@ -1,0 +1,84 @@
+from mellea import MelleaSession
+from mellea.stdlib.base import CBlock, SimpleContext
+from mellea.backends.openai import OpenAIBackend
+from transformers import AutoTokenizer
+import pytest
+import os
+
+class TestOpenAIBackend:
+    model_id = "ibm-granite/granite-4.0-tiny-preview"
+    backend = OpenAIBackend(
+        model_id=model_id,
+        base_url="http://0.0.0.0:8000/v1",
+        api_key="EMPTY",
+    )
+    m = MelleaSession(backend, ctx=SimpleContext())
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+    def prepare_prmpt_for_math(self, query):
+        # Preparing prompt for math reasoning tasks
+        system_prompt = None  # Use default of chat template
+        prompt_suffix = "\nPlease reason step by step, use \n\n to end each step, and put your final answer within \\boxed{}."
+
+        if prompt_suffix:
+            query += prompt_suffix
+
+        msg = []
+        if system_prompt is not None:
+            msg.append({"role": "system", "content": system_prompt})
+
+        msg.append({"role": "user", "content": query})
+        prompt = self.tokenizer.apply_chat_template(
+            msg,
+            tokenize=False,
+            thinking=True,
+            add_generation_prompt=True,
+        )
+
+        return prompt
+
+    def test_generate_from_raw_small(self):
+        prompt = "what is 1+1?"
+        prompt = self.prepare_prmpt_for_math(prompt)
+        action = CBlock(value=prompt)
+        results = []
+        THINK_MAX_TOKENS = 64
+        ANSWER_MAX_TOKENS = 16
+        result, gen_tok_cnt = self.m.backend.generate_with_budget_forcing(
+            action=action,
+            think_max_tokens=THINK_MAX_TOKENS,
+            answer_max_tokens=ANSWER_MAX_TOKENS,
+            start_think_token = "<think>",
+            end_think_token="</think>",
+            think_wait_suffix="Wait",
+            answer_suffix="The final answer is:",
+            # answer_suffix="",
+            answer_token="boxed",
+        )
+
+        assert gen_tok_cnt <= 2 * THINK_MAX_TOKENS
+
+
+    def test_generate_from_raw_large(self):
+        prompt = "what is 1+1?"
+        prompt = self.prepare_prmpt_for_math(prompt)
+        action = CBlock(value=prompt)
+        results = []
+        THINK_MAX_TOKENS = 1024
+        ANSWER_MAX_TOKENS = 256
+        result, gen_tok_cnt = self.m.backend.generate_with_budget_forcing(
+            action=action,
+            think_max_tokens=THINK_MAX_TOKENS,
+            answer_max_tokens=ANSWER_MAX_TOKENS,
+            start_think_token = "<think>",
+            end_think_token="</think>",
+            think_wait_suffix="Wait",
+            answer_suffix="The final answer is:",
+            answer_token="boxed",
+        )
+
+        assert gen_tok_cnt >= 0.5 * THINK_MAX_TOKENS
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])


### PR DESCRIPTION
Implements think budget-forcing techniques
Generates response with budget forcing using the completions APIs. 
This relies on multi-step raw autocompletion and assumes the model's output is structured in the following form:
` <think> ... </think> summary answer`
The budget forcing method is proposed in the paper: https://arxiv.org/abs/2501.19393
This implementation tries to follow the key outlines in the paper while ensuring stable and fail-safe operation.
This is performed via multi-step generation. The model will be called multiple times until requirements are met, in other words, the response will be assembled conditionally.

unit tests provided
Install and execute instructions are in: `test//backends/test_think_budget_forcing/README.md`