### PR TITLE
fix: Adding pillow as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "click<8.2.0", # Newer versions will cause errors with --help in typer CLIs.
     "mistletoe>=1.4.0",
     "huggingface-hub>=0.33.4",
+    "pillow",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -2322,6 +2322,7 @@ dependencies = [
     { name = "mistletoe" },
     { name = "ollama" },
     { name = "openai" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "typer" },
@@ -2406,6 +2407,7 @@ requires-dist = [
     { name = "openai" },
     { name = "outlines", marker = "extra == 'hf'", specifier = "<1.0.0" },
     { name = "peft", marker = "extra == 'hf'", specifier = ">=0.16.0" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.53.2" },


### PR DESCRIPTION
Fixes issue #146 

Testing:
======
git clone https://github.com/jbusche/mellea.git -b jbusche-add-pillow
cd mellea
python3.12 -m venv venv
source venv/bin/activate
pip install .
pip list |grep pill
```
Returns:
```
pillow             11.3.0
```

Now when I run, I can import mellea:
```
python
import mellea
m = mellea.start_session()
print(m.chat("How many letters in the English alphabet?").content)
```
Returns with:
```
There are 26 letters in the English alphabet.
```