### PR TITLE
fix: add support for cblocks to act and sampling

### DIFF
--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -298,7 +298,7 @@ class MelleaSession:
     @overload
     def act(
         self,
-        action: Component,
+        action: Component | CBlock,
         *,
         strategy: SamplingStrategy | None = None,
         return_sampling_results: Literal[False] = False,
@@ -310,7 +310,7 @@ class MelleaSession:
     @overload
     def act(
         self,
-        action: Component,
+        action: Component | CBlock,
         *,
         strategy: SamplingStrategy | None = None,
         return_sampling_results: Literal[True],
@@ -321,7 +321,7 @@ class MelleaSession:
 
     def act(
         self,
-        action: Component,
+        action: Component | CBlock,
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy | None = None,
@@ -363,7 +363,7 @@ class MelleaSession:
 
     async def _act(
         self,
-        action: Component,
+        action: Component | CBlock,
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ combine-as-imports = true
 split-on-trailing-comma = false
 
 [tool.codespell]
-ignore-words-list = 'mellea,hashi,noo,Asai,asai,nd,mot'
+ignore-words-list = 'mellea,hashi,noo,Asai,asai,nd,mot,strat'
 check-filenames = true
 check-hidden = false
 regex = "(?<![a-z])[a-z'`]+|[A-Z][a-z'`]*|[a-z]+'[a-z]*|[a-z]+(?=[_-])|[a-z]+(?=[A-Z])|\\d+"

--- a/test/stdlib_basics/test_sampling_ctx.py
+++ b/test/stdlib_basics/test_sampling_ctx.py
@@ -1,6 +1,8 @@
 import pytest
 from mellea import LinearContext, start_session
 from mellea.backends import ModelOption
+from mellea.stdlib.base import CBlock
+from mellea.stdlib.requirement import req
 from mellea.stdlib.sampling import (
     MultiTurnStrategy,
     RejectionSamplingStrategy,
@@ -62,6 +64,19 @@ class TestSamplingCtxCase:
         self._run_asserts_for_ctx_testing(res)
 
         assert len(self.m.last_prompt()) == len(res.sample_generations)*2-1, "For n sampling iterations there should be 2n-1 prompt conversation elements in the last prompt."
+
+def test_sampling_with_cblocks():
+    m = start_session(
+        model_options={ModelOption.MAX_NEW_TOKENS: 10}, ctx=LinearContext()
+    )
+
+    strat = RejectionSamplingStrategy(
+        loop_budget=2,
+        requirements=[req("It should be a fairytale."), req("It should have a happy end.")]
+    )
+
+    out = m.act(CBlock("Write a short story."), strategy=strat)
+    assert out.value is not None
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
We already supported this, but the types weren't correctly there. I just changed those types and added an explicit test for this behavior.