### PR TITLE
release: bump minor version

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,5 +5,5 @@ merge_protections:
       - base = main
     success_conditions:
       - "title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert|release)(?:\\(.+\
         \\))?:"


### PR DESCRIPTION
We want to explicitly bump the minor version to signal that there were some api changes but didn't want to bump the major version since mellea is still early in development.