### PR TITLE
fix: async overhaul; create global event loop; add client cache

### DIFF
--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -18,7 +18,11 @@ from mellea.backends.tools import (
     add_tools_from_model_options,
 )
 from mellea.backends.types import ModelOption
-from mellea.helpers.async_helpers import send_to_queue
+from mellea.helpers.async_helpers import (
+    ClientCache,
+    get_current_event_loop,
+    send_to_queue,
+)
 from mellea.helpers.fancy_logger import FancyLogger
 from mellea.stdlib.base import (
     CBlock,
@@ -68,6 +72,10 @@ class OllamaModelBackend(FormatterBackend):
         # Setup the client and ensure that we have the model available.
         self._base_url = base_url
         self._client = ollama.Client(base_url)
+
+        _async_client = ollama.AsyncClient(self._base_url)
+        self._client_cache = ClientCache(2)
+        self._client_cache.put(id(get_current_event_loop()), _async_client)
 
         if not self._check_ollama_server():
             err = f"could not create OllamaModelBackend: ollama server not running at {base_url}"
@@ -180,6 +188,17 @@ class OllamaModelBackend(FormatterBackend):
             return True
         except ollama.ResponseError:
             return False
+
+    @property
+    def _async_client(self) -> ollama.AsyncClient:
+        """Ollama's client gets tied to a specific event loop. Reset it if needed here."""
+        key = id(get_current_event_loop())
+
+        _async_client = self._client_cache.get(key)
+        if _async_client is None:
+            _async_client = ollama.AsyncClient(self._base_url)
+            self._client_cache.put(key, _async_client)
+        return _async_client
 
     def _simplify_and_merge(
         self, model_options: dict[str, Any] | None
@@ -318,13 +337,10 @@ class OllamaModelBackend(FormatterBackend):
                 add_tools_from_context_actions(tools, [action])
             FancyLogger.get_logger().info(f"Tools for call: {tools.keys()}")
 
-        # Ollama ties its async client to an event loop so we have to create it here.
-        async_client = ollama.AsyncClient(self._base_url)
-
         # Generate a chat response from ollama, using the chat messages. Can be either type since stream is passed as a model option.
         chat_response: Coroutine[
             Any, Any, AsyncIterator[ollama.ChatResponse] | ollama.ChatResponse
-        ] = async_client.chat(
+        ] = self._async_client.chat(
             model=self._get_ollama_model_id(),
             messages=conversation,
             tools=list(tools.values()),

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -22,7 +22,11 @@ from mellea.backends.tools import (
     convert_tools_to_json,
 )
 from mellea.backends.types import ModelOption
-from mellea.helpers.async_helpers import send_to_queue
+from mellea.helpers.async_helpers import (
+    ClientCache,
+    get_current_event_loop,
+    send_to_queue,
+)
 from mellea.helpers.fancy_logger import FancyLogger
 from mellea.helpers.openai_compatible_helpers import (
     chat_completion_delta_merge,
@@ -94,14 +98,18 @@ class WatsonxAIBackend(FormatterBackend):
 
         self._creds = Credentials(url=base_url, api_key=api_key)
         _client = APIClient(credentials=self._creds)
-        self._model_inference = ModelInference(
+        self._kwargs = kwargs
+        _model_inference = ModelInference(
             model_id=self._get_watsonx_model_id(),
             api_client=_client,
             credentials=self._creds,
             project_id=self._project_id,
             params=self.model_options,
-            **kwargs,
+            **self._kwargs,
         )
+
+        self._client_cache = ClientCache(2)
+        self._client_cache.put(id(get_current_event_loop()), _model_inference)
 
         # A mapping of common options for this backend mapped to their Mellea ModelOptions equivalent.
         # These are usually values that must be extracted before hand or that are common among backend providers.
@@ -134,16 +142,22 @@ class WatsonxAIBackend(FormatterBackend):
 
     @property
     def _model(self) -> ModelInference:
-        """Watsonx's client gets tied to a specific event loop. Reset it here."""
-        _client = APIClient(credentials=self._creds)
-        self._model_inference = ModelInference(
-            model_id=self._get_watsonx_model_id(),
-            api_client=_client,
-            credentials=self._creds,
-            project_id=self._project_id,
-            params=self.model_options,
-        )
-        return self._model_inference
+        """Watsonx's client gets tied to a specific event loop. Reset it if needed here."""
+        key = id(get_current_event_loop())
+
+        _model_inference = self._client_cache.get(key)
+        if _model_inference is None:
+            _client = APIClient(credentials=self._creds)
+            _model_inference = ModelInference(
+                model_id=self._get_watsonx_model_id(),
+                api_client=_client,
+                credentials=self._creds,
+                project_id=self._project_id,
+                params=self.model_options,
+                **self._kwargs,
+            )
+            self._client_cache.put(key, _model_inference)
+        return _model_inference
 
     def _get_watsonx_model_id(self) -> str:
         """Gets the watsonx model id from the model_id that was provided in the constructor. Raises AssertionError if the ModelIdentifier does not provide a watsonx_name."""

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -1,8 +1,9 @@
 """Async helper functions."""
 
 import asyncio
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Coroutine
-from typing import Any
+from typing import Any, TypeVar
 
 from mellea.stdlib.base import ModelOutputThunk
 
@@ -46,3 +47,53 @@ async def wait_for_all_mots(mots: list[ModelOutputThunk]):
         coroutines.append(mot.avalue())
 
     await asyncio.gather(*coroutines)
+
+
+def get_current_event_loop() -> None | asyncio.AbstractEventLoop:
+    """Get the current event loop without having to catch exceptions."""
+    loop = None
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    return loop
+
+
+class ClientCache:
+    """A simple [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_(LRU)) cache.
+
+    Used to keep track of clients for backends where the client is tied to a specific event loop.
+    """
+
+    def __init__(self, capacity: int):
+        """Initializes the LRU cache with a certain capacity.
+
+        The `ClientCache` either contains a value or it doesn't.
+        """
+        self.capacity = capacity
+        self.cache: OrderedDict = OrderedDict()
+
+    def current_size(self):
+        """Just return the size of the key set. This isn't necessarily safe."""
+        return len(self.cache.keys())
+
+    def get(self, key: int) -> Any | None:
+        """Gets a value from the cache."""
+        if key not in self.cache:
+            return None
+        else:
+            # Move the accessed item to the end (most recent)
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+
+    def put(self, key: int, value: Any):
+        """Put a value into the cache."""
+        if key in self.cache:
+            # If the key exists, move it to the end (most recent)
+            self.cache.pop(key)
+        elif len(self.cache) >= self.capacity:
+            # If the cache is full, remove the least recently used item
+            self.cache.popitem(last=False)
+        # Add the new key-value pair to the end (most recent)
+        self.cache[key] = value

--- a/mellea/helpers/event_loop_helper.py
+++ b/mellea/helpers/event_loop_helper.py
@@ -1,0 +1,86 @@
+"""Helper for event loop management. Allows consistently running async generate requests in sync code."""
+
+import asyncio
+import threading
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+R = TypeVar("R")
+
+
+class _EventLoopHandler:
+    """A class that handles the event loop for Mellea code. Do not directly instantiate this. Use `_run_async_in_thread`."""
+
+    def __init__(self):
+        """Instantiates an EventLoopHandler. Used to ensure consistency when calling async code from sync code in Mellea.
+
+        Do not instantiate this class. Rely on the exported `_run_async_in_thread` function.
+        """
+        self._event_loop = asyncio.new_event_loop()
+        self._thread: threading.Thread = threading.Thread(
+            target=self._event_loop.run_forever, daemon=True
+        )
+        self._thread.start()
+
+    def __del__(self):
+        """Delete the event loop handler."""
+        self._close_event_loop()
+
+    def _close_event_loop(self) -> None:
+        """Called when deleting the event loop handler. Cleans up the event loop and thread."""
+        if self._event_loop:
+            try:
+                tasks = asyncio.all_tasks(self._event_loop)
+                for task in tasks:
+                    task.cancel()
+
+                async def finalize_tasks():
+                    # TODO: We can log errors here if needed.
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+                out = asyncio.run_coroutine_threadsafe(
+                    finalize_tasks(), self._event_loop
+                )
+
+                # Timeout if needed.
+                out.result(5)
+            except Exception:
+                pass
+
+            # Finally stop the event loop for this session.
+            self._event_loop.stop()
+
+    def __call__(self, co: Coroutine[Any, Any, R]) -> R:
+        """Runs the coroutine in the event loop."""
+        return asyncio.run_coroutine_threadsafe(co, self._event_loop).result()
+
+
+# Instantiate this class once. It will not be re-instantiated.
+__event_loop_handler = _EventLoopHandler()
+
+
+def _run_async_in_thread(co: Coroutine[Any, Any, R]) -> R:
+    """Call to run async code from synchronous code in Mellea.
+
+    In Mellea, we utilize async code underneath sync code to speed up
+    inference requests. This puts us in a difficult situation since most
+    api providers and sdks use async clients that get bound to a specific event
+    loop to make requests. These clients are typically long-lasting and sometimes
+    cannot be easily reinstantiated on demand to avoid these issues.
+    By declaring a single event loop for these async requests,
+    Mellea avoids these client issues.
+
+    Note: This implementation requires that sessions/backends be run only through
+    the top-level / session sync or async interfaces, not both. You will need to
+    reinstantiate your backend if switching between the two.
+
+    Args:
+        co: coroutine to run
+
+    Returns:
+        output of the coroutine
+    """
+    return __event_loop_handler(co)
+
+
+__all__ = ["_run_async_in_thread"]

--- a/test/backends/test_litellm_watsonx.py
+++ b/test/backends/test_litellm_watsonx.py
@@ -1,0 +1,51 @@
+import asyncio
+import pytest
+
+from mellea import MelleaSession
+from mellea.backends.litellm import LiteLLMBackend
+
+@pytest.fixture(scope="function")
+def session():
+    """Fresh Ollama session for each test."""
+    session = MelleaSession(
+        LiteLLMBackend(
+            model_id="watsonx/ibm/granite-4-h-small",
+        ), 
+    )
+    yield session
+    session.reset()
+
+def test_has_potential_event_loop_errors(session):
+    """This test is specific to litellm backends that use watsonx/. It can be removed once that bug is fixed."""
+
+    backend: LiteLLMBackend = session.backend
+    potential_err = backend._has_potential_event_loop_errors()
+    assert not potential_err, "first invocation in an event loop shouldn't flag errors"
+
+    potential_err = backend._has_potential_event_loop_errors()
+    assert not potential_err, "second invocation in the same event loop shouldn't flag errors"
+
+
+    async def new_event_loop() -> bool:
+        return backend._has_potential_event_loop_errors()
+
+    err_expected = asyncio.run(new_event_loop())
+    assert err_expected, "invocation in a new event loop should flag an error"
+
+@pytest.mark.qualitative
+def test_multiple_sync_funcs(session):
+    session.chat("first")
+    session.chat("second")
+
+@pytest.mark.qualitative
+@pytest.mark.xfail(reason="litellm has a bug with watsonx; once that is fixed, this should pass.")
+async def test_multiple_async_funcs(session):
+    """If this test passes, remove the _has_potential_event_loop_errors func from litellm."""
+    session.chat("first sync")  # Do one sync first in this function so that it should always fail.
+    await session.achat("first async")
+    await session.achat("second async")
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -6,6 +6,7 @@ import pytest
 from typing_extensions import Annotated
 
 from mellea import start_session
+from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.types import ModelOption
 from mellea.stdlib.base import CBlock, SimpleContext
 from mellea.stdlib.requirement import Requirement, simple_validate
@@ -165,6 +166,27 @@ async def test_async_avalue(session):
     m1_final_val = await mot1.avalue()
     assert m1_final_val is not None
     assert m1_final_val == mot1.value
+
+def test_multiple_asyncio_runs(session):
+    async def test():
+        session.achat("hello")
+    
+    asyncio.run(test())
+    asyncio.run(test())
+
+def test_client_cache(session):
+    backend: OllamaModelBackend = session.backend
+    first_client = backend._async_client
+
+    async def get_second_client():
+        return backend._async_client
+    
+    second_client = asyncio.run(get_second_client())
+
+    items_in_cache = backend._client_cache.cache.values()
+    assert len(items_in_cache) == 2, "should be two clients in the cache since _async_client was called from two event loops"
+    assert first_client in items_in_cache
+    assert second_client in items_in_cache
 
 
 if __name__ == "__main__":

--- a/test/backends/test_watsonx.py
+++ b/test/backends/test_watsonx.py
@@ -4,7 +4,6 @@ import os
 
 import pydantic
 import pytest
-from typing_extensions import Annotated
 
 from mellea import MelleaSession
 from mellea.backends.formatter import TemplateFormatter
@@ -132,6 +131,19 @@ async def test_async_avalue(session):
     m1_final_val = await mot1.avalue()
     assert m1_final_val is not None
     assert m1_final_val == mot1.value
+
+def test_client_cache(backend):
+    first_client = backend._model
+
+    async def get_second_client():
+        return backend._model
+    
+    second_client = asyncio.run(get_second_client())
+
+    items_in_cache = backend._client_cache.cache.values()
+    assert len(items_in_cache) == 2, "should be two clients in the cache since _async_client was called from two event loops"
+    assert first_client in items_in_cache
+    assert second_client in items_in_cache
 
 if __name__ == "__main__":
     import pytest

--- a/test/stdlib_basics/test_event_loop_helper.py
+++ b/test/stdlib_basics/test_event_loop_helper.py
@@ -1,0 +1,35 @@
+import pytest
+
+import mellea.helpers.event_loop_helper as elh
+import mellea.helpers.event_loop_helper as elh2
+
+def test_event_loop_handler_singleton():
+    assert elh.__event_loop_handler is not None
+    assert elh.__event_loop_handler == elh2.__event_loop_handler
+
+def test_run_async_in_thread():
+    async def testing() -> bool:
+        return True
+    
+    assert elh._run_async_in_thread(testing()), "somehow the wrong value was returned"
+
+def test_event_loop_handler_init_and_del():
+    # Do not ever instantiate this manually. Only doing here for testing.
+    new_event_loop_handler = elh._EventLoopHandler()
+
+    async def testing() -> int:
+        return 1
+
+    out = new_event_loop_handler(testing())
+    assert out == 1, "somehow the wrong value was returned"
+
+    del(new_event_loop_handler)
+
+    # Make sure this didn't delete the actual singleton.
+    assert elh.__event_loop_handler is not None
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])

--- a/test/stdlib_basics/test_funcs.py
+++ b/test/stdlib_basics/test_funcs.py
@@ -3,7 +3,7 @@
 import pytest
 
 from mellea.backends.types import ModelOption
-from mellea.stdlib.base import CBlock, ModelOutputThunk
+from mellea.stdlib.base import ModelOutputThunk
 from mellea.stdlib.chat import Message
 from mellea.stdlib.funcs import instruct, aact, avalidate, ainstruct
 from mellea.stdlib.requirement import req


### PR DESCRIPTION
Added an event loop that all synchronous code uses to run the async code in. For backends where clients get tied to specific event loops, I added a client cache so that they can re-instantiate clients when needed.

Litellm still has a bug with Watsonx clients. I opened an issue for that, but there's nothing we can do on our end to force litellm to recreate that client. We might be able to manually pass in async httpx / aiohttp client, but for now I simply added a warning message. You won't have any issues as long as you either:
1. run everything synchronously
2. run everything in the same `asyncio.run()` call

I added a few more tests to test for these specific watsonx litellm issues.

Notes:
- We should keep the client cache, even if other changes in this PR get rejected.
- The event loop singleton is only truly necessary for the litellm backend, but it prevents us from having to use new threads for each sync call which is slightly more performant.