### PR TITLE
fix: pin trl to version 0.19.0 to avoid deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ hf = [
     "outlines<1.0.0",
     "peft>=0.16.0",
     "transformers>=4.53.2",
-    "trl>=0.19.0",
+    "trl==0.19.1",
 ]
 
 litellm = [

--- a/uv.lock
+++ b/uv.lock
@@ -2477,7 +2477,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rouge-score" },
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.53.2" },
-    { name = "trl", marker = "extra == 'hf'", specifier = ">=0.19.0" },
+    { name = "trl", marker = "extra == 'hf'", specifier = "==0.19.1" },
     { name = "typer" },
     { name = "types-requests" },
     { name = "types-tqdm" },
@@ -5834,16 +5834,16 @@ wheels = [
 
 [[package]]
 name = "trl"
-version = "0.22.2"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
     { name = "datasets" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/70/cf4f7936669457103d10aaa235fcf17d58f902f389acef93cb392118e019/trl-0.22.2.tar.gz", hash = "sha256:343203711339cb4f200b78fee35efa39655b2e6a0f8a63ce0b077973e689c12a", size = 497063, upload-time = "2025-09-03T14:41:58.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/69/303db8941a08edd646f658d18a0f00a5b83df523ae8967bbc6cce3a81466/trl-0.19.1.tar.gz", hash = "sha256:545592462ed985f4b77c9b1dbc0957efb17c43262648bb147abf3250ad3ff100", size = 397181, upload-time = "2025-07-08T00:48:40.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/89/b10851fcad71e9ff7a6e74c5981476a7a3aa4efc0e9ef24176eb859990c9/trl-0.22.2-py3-none-any.whl", hash = "sha256:b5b058bc2b876f3b9d04e3ac54c6ad085b09f5583becefefd10d88a7cd150e21", size = 544789, upload-time = "2025-09-03T14:41:56.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/42df113377d440f2a5a0a45ffa617db03c4a25b1e4cd171b018649845eb0/trl-0.19.1-py3-none-any.whl", hash = "sha256:8a2d4277b4ba7221eaab545a35ee89b6fbb8721fa3709ac01876a8c1bd7fd78a", size = 376159, upload-time = "2025-07-08T00:48:38.843Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/generative-computing/mellea/issues/196

Will open an issue for unpinning this library with info I found once this is merged.