### PR TITLE
fix: decomp subtask regex

### DIFF
--- a/cli/decompose/prompt_modules/subtask_list/_subtask_list.py
+++ b/cli/decompose/prompt_modules/subtask_list/_subtask_list.py
@@ -20,7 +20,7 @@ from ._types import SubtaskItem
 T = TypeVar("T")
 
 RE_SUBTASK_AND_TAG = re.compile(
-    r"(.*\S)\s*-\s*Variable\s*:\s*(\w+)", flags=re.IGNORECASE
+    r"(.*\S)\s*.\s*Variable\s*:\s*(\w+)", flags=re.IGNORECASE
 )
 RE_FINAL_SUBTASK_LIST = re.compile(
     r"<subtask_list>(.+?)</subtask_list>", flags=re.IGNORECASE | re.DOTALL


### PR DESCRIPTION
It just changes the `-` character for a wildcard for any single character, which is `.`