### PR TITLE
fix: watsonx project id bug

### DIFF
--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -96,8 +96,10 @@ class WatsonxAIBackend(FormatterBackend):
             base_url = f"{os.environ.get('WATSONX_URL')}"
         if api_key is None:
             api_key = os.environ.get("WATSONX_API_KEY")
+
         if project_id is None:
-            self._project_id = os.environ.get("WATSONX_PROJECT_ID")
+            project_id = os.environ.get("WATSONX_PROJECT_ID")
+        self._project_id = project_id
 
         self._creds = Credentials(url=base_url, api_key=api_key)
         self._kwargs = kwargs


### PR DESCRIPTION
`project_id` was only being set during initialization if it was grabbed from the env. Change so that it's always set.

Tested:
- replicated the issue by setting the project_id as a paramter
- tested that the code change allowed requests to go through 