### PR TITLE
feat: allow BaseSamplingStrategy to specify a concurrency budget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ combine-as-imports = true
 split-on-trailing-comma = false
 
 [tool.codespell]
-ignore-words-list = 'mellea,hashi,noo,Asai,asai,nd,mot,rouge,Rouge'
+ignore-words-list = 'mellea,hashi,noo,Asai,asai,nd,mot,rouge,Rouge,strat'
 check-filenames = true
 check-hidden = false
 regex = "(?<![a-z])[a-z'`]+|[A-Z][a-z'`]*|[a-z]+'[a-z]*|[a-z]+(?=[_-])|[a-z]+(?=[A-Z])|\\d+"

--- a/test/stdlib_basics/test_sampling_ctx.py
+++ b/test/stdlib_basics/test_sampling_ctx.py
@@ -1,13 +1,17 @@
+import asyncio
+from unittest.mock import Mock
 import pytest
 from mellea import start_session
-from mellea.backends import ModelOption
-from mellea.stdlib.base import ChatContext, ModelOutputThunk, Context
-from mellea.stdlib.requirement import Requirement
+from mellea.backends import Backend, ModelOption
+from mellea.stdlib.base import ChatContext, GenerateLog, ModelOutputThunk, Context
+from mellea.stdlib.instruction import Instruction
+from mellea.stdlib.requirement import Requirement, ValidationResult
 from mellea.stdlib.sampling import (
     MultiTurnStrategy,
     RejectionSamplingStrategy,
     SamplingResult,
 )
+from mellea.stdlib.sampling.base import _SamplingResultSlice, RepairTemplateStrategy
 
 
 class TestSamplingCtxCase:
@@ -78,6 +82,147 @@ class TestSamplingCtxCase:
         assert len(self.m.last_prompt()) == len(res.sample_generations) * 2 - 1, (
             "For n sampling iterations there should be 2n-1 prompt conversation elements in the last prompt."
         )
+
+
+@pytest.fixture(scope="function")
+def mocked_context_backend(sleep_time: float = 1) -> Backend:
+    backend = Mock()
+
+    async def mock_generate(*args, **kwargs):
+        # We know that these will be passed as kwargs since we are invoking the generate call.
+        action = kwargs.pop("action")
+        ctx = kwargs.pop("ctx")
+
+        await asyncio.sleep(sleep_time)
+        output = ModelOutputThunk("mocked")
+        output._generate_log = GenerateLog()
+        return output, ctx.add(action).add(output)
+
+    backend.generate_from_context = mock_generate
+    return backend
+
+
+# Have to define this globally for ease of use.
+counter = 1
+
+
+async def test_rejection_sampling_with_concurrency_early_success(
+    mocked_context_backend,
+):
+    backend = mocked_context_backend
+
+    ctx = ChatContext()
+
+    def sometimes_pass(ctx: Context) -> ValidationResult:
+        global counter
+        if counter % 5 == 0:
+            val_result = ValidationResult(True)
+        else:
+            val_result = ValidationResult(False)
+
+        counter += 1
+        return val_result
+
+    sometimes_pass_req = Requirement("sometimes_pass", validation_fn=sometimes_pass)
+
+    loop_budget = 3
+    concurrency_budget = 3
+    sampling_strat = RejectionSamplingStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    result = await sampling_strat.sample(
+        action=Instruction(""),
+        context=ctx,
+        backend=backend,
+        requirements=[sometimes_pass_req],
+    )
+
+    # Note: we can't necessarily assert that the 4th index has the successful result since items may be added to the
+    # queue in a somewhat random order.
+    assert len(result.sample_actions) < loop_budget * concurrency_budget, (
+        "success on the 5th request means the total samples should be less than the budget"
+    )
+
+
+async def test_subsample_iteration(mocked_context_backend):
+    backend = mocked_context_backend
+
+    ctx = ChatContext()
+    always_pass_req = Requirement(
+        "always pass", validation_fn=lambda x: ValidationResult(result=True)
+    )
+
+    loop_budget = 5
+    concurrency_budget = 5
+    sampling_strat = RejectionSamplingStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    generator = sampling_strat._subsample_iteration(
+        iterations=2,
+        action=Instruction(""),
+        context=ctx,
+        backend=backend,
+        requirements=[always_pass_req],
+    )
+
+    slice = await generator.__anext__()
+    assert isinstance(slice, _SamplingResultSlice)
+
+    # Generator should stop after the first successful
+    with pytest.raises(StopAsyncIteration):
+        await generator.__anext__()
+
+
+async def test_repair_strategy_with_concurrency(mocked_context_backend):
+    backend = mocked_context_backend
+
+    ctx = ChatContext()
+    req = Requirement(
+        "always fail", validation_fn=lambda x: ValidationResult(result=False)
+    )
+
+    loop_budget = 5
+    concurrency_budget = 5
+    sampling_strat = RepairTemplateStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    result = await sampling_strat.sample(
+        action=Instruction(""), context=ctx, backend=backend, requirements=[req]
+    )
+
+    assert len(result.sample_actions) == loop_budget * concurrency_budget, (
+        "forced failures mean we should exhaust the loop"
+    )
+    assert (
+        result.sample_contexts[-1].view_for_generation()[0]._repair_string is not None  # type: ignore
+    ), "last batch of retries should have a repair string with `RepairTemplateStrategy`"  
+
+
+async def test_mulit_turn_strategy_with_concurrency(mocked_context_backend):
+    backend = mocked_context_backend
+
+    ctx = ChatContext()
+    req = Requirement(
+        "always fail", validation_fn=lambda x: ValidationResult(result=False)
+    )
+
+    loop_budget = 2
+    concurrency_budget = 3
+    sampling_strat = MultiTurnStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+    result = await sampling_strat.sample(
+        action=Instruction(""), context=ctx, backend=backend, requirements=[req]
+    )
+    assert len(result.sample_actions) == loop_budget * concurrency_budget, (
+        "forced failures mean we should exhaust the loop"
+    )
+    assert len(result.sample_contexts[-1].view_for_generation()) == loop_budget * 2, (  # type: ignore
+        "last batch of retries should have a context length of `2*loop_budget` with `MultiTurnStrategy`"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Investigated adding a concurrency budget to base sampling strategy (and its subclasses). By increasing concurrency, you increase the number of sampling iterations that happen concurrently (ie generate/validate pairs).

I looked into some other solutions of how to add this concurrency parameter (like creating a total_budget, etc...), but none of them kept the meaning of loop_budget as what it is now while being intelligible. I think specifying a separate concurrency budget makes the most sense since it keeps existing sampling strategies the same while allowing for an easy way to improve the rate of sampling.

For example:
- loop_budget = 2, concurrency_budget = 2 -> can generate at most 4 samples; at any point in time, only two samples can be in progress

Changes:
- had to modify the output slightly. Example output of several sampling strategies being run:
```
output looks something like:
RejectionSamplingStrategy: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.63s/it]
=== 13:15:53-INFO ======
Invoking select_from_failure after 3 failed attempts.
MultiTurnStrategy: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:02<00:00,  1.20it/s]
=== 13:15:56-INFO ======
Invoking select_from_failure after 3 failed attempts.
RejectionSamplingStrategy:  67%|██████████████████████████████████████████████████████████████████▋                                 | 6/9 [00:02<00:01,  2.99it/s]
=== 13:15:58-INFO ======
Sampling was successful.
RepairTemplateStrategy: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [00:05<00:00,  4.98it/s]
=== 13:16:04-INFO ======
Invoking select_from_failure after 25 failed attempts.
MultiTurnStrategy: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:02<00:00,  2.99it/s]
=== 13:16:06-INFO ======
Invoking select_from_failure after 6 failed attempts.
```
- had to create a sub-function to hold a sampling iteration; this function yields slices of sampling results that can be combined into a single sampling result

Tests:
- added a bunch of tests to make sure the new methods worked as expected
- tests and examples pass