### PR TITLE
fix: lock granite-common version to avoid arg changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "mistletoe>=1.4.0",
     "huggingface-hub>=0.33.4",
     "pillow",
-    "granite-common>=0.3.5", # Needed for Intrinsics.
+    "granite-common==0.3.5", # Needed for Intrinsics.
     "math_verify", # Needed for Majority Voting Sampling Strategies.
     "rouge_score", # Needed for Majority Voting Sampling Strategies.
     "llm-sandbox[docker]>=0.3.23",


### PR DESCRIPTION
Granite common made a breaking api change. Lock the package version for now until we change our code.