### PR TITLE
fix: marks span tests as qualitative & removes chat error message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [v0.2.3](https://github.com/generative-computing/mellea/releases/tag/v0.2.3) - 2026-01-07
+
+### Feature
+
+* Allow forcing a release through test failures ([#292](https://github.com/generative-computing/mellea/issues/292)) ([`14b55a3`](https://github.com/generative-computing/mellea/commit/14b55a38550581e5b0e0ea05cf5cc8b45a2cd5e5))
+* Lazy Spans and KV Blocks ([#249](https://github.com/generative-computing/mellea/issues/249)) ([`b9e4a33`](https://github.com/generative-computing/mellea/commit/b9e4a33d4a7c79bfe3655aaf10a957947e78d04f))
+* Switch to new RAG intrinsics repo ([#289](https://github.com/generative-computing/mellea/issues/289)) ([`94c35ad`](https://github.com/generative-computing/mellea/commit/94c35adff9d44376a9357e06b20dafd09314b29b))
+
+### Fix
+
+* OpenAI `base_url` default and reasoning effort model option. ([#271](https://github.com/generative-computing/mellea/issues/271)) ([`9733df8`](https://github.com/generative-computing/mellea/commit/9733df8fc2e3a81a0f5ba7c35e1cf468d9eb622f))
+* Unpin granite_commons version from 0.3.5 ([#287](https://github.com/generative-computing/mellea/issues/287)) ([`0b402bd`](https://github.com/generative-computing/mellea/commit/0b402bdc8f73d7543ff56bdbe1a5c304182fcbb5))
+
 ## [v0.2.2](https://github.com/generative-computing/mellea/releases/tag/v0.2.2) - 2025-12-18
 
 ### Feature

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "mellea"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
     { name = "Nathan Fulton", email = "nathan@ibm.com" },
     { name = "Hendrik Strobelt", email = "hendrik.strobelt@ibm.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and python_full_version < '4' and sys_platform == 'darwin'",
@@ -3211,7 +3211,7 @@ wheels = [
 
 [[package]]
 name = "mellea"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansicolors" },


### PR DESCRIPTION
I introduced some really annoying things into 0.2.3. This PR fixes those issues.

- [x] Marking these tests and qualitative so that they don't run on CICD.
- [x] Right now, generating from a chat Message results in an error message. I mute that error message for now. @HendrikStrobelt will need to update `Message.parts()` when he changes ImageBlocks to be CBlocks.