### PR TITLE
fix: add explicit exports to __init__.py

### DIFF
--- a/mellea/backends/__init__.py
+++ b/mellea/backends/__init__.py
@@ -6,3 +6,12 @@ from .backend import FormatterBackend
 from .cache import SimpleLRUCache
 from .model_ids import ModelIdentifier
 from .model_options import ModelOption
+
+__all__ = [
+    "Backend",
+    "BaseModelSubclass",
+    "FormatterBackend",
+    "ModelIdentifier",
+    "ModelOption",
+    "SimpleLRUCache",
+]

--- a/mellea/backends/adapters/__init__.py
+++ b/mellea/backends/adapters/__init__.py
@@ -9,3 +9,13 @@ from .adapter import (
     fetch_intrinsic_metadata,
     get_adapter_for_intrinsic,
 )
+
+__all__ = [
+    "AdapterMixin",
+    "AdapterType",
+    "GraniteCommonAdapter",
+    "LocalHFAdapter",
+    "OpenAIAdapter",
+    "fetch_intrinsic_metadata",
+    "get_adapter_for_intrinsic",
+]

--- a/mellea/core/__init__.py
+++ b/mellea/core/__init__.py
@@ -21,3 +21,30 @@ from .formatter import Formatter
 from .requirement import Requirement, ValidationResult, default_output_to_bool
 from .sampling import SamplingResult, SamplingStrategy
 from .utils import FancyLogger
+
+__all__ = [
+    "Backend",
+    "BaseModelSubclass",
+    "C",
+    "CBlock",
+    "Component",
+    "ComponentParseError",
+    "Context",
+    "ContextTurn",
+    "FancyLogger",
+    "Formatter",
+    "GenerateLog",
+    "GenerateType",
+    "ImageBlock",
+    "ModelOutputThunk",
+    "ModelToolCall",
+    "Requirement",
+    "S",
+    "SamplingResult",
+    "SamplingStrategy",
+    "TemplateRepresentation",
+    "ValidationResult",
+    "blockify",
+    "default_output_to_bool",
+    "generate_walk",
+]

--- a/mellea/formatters/__init__.py
+++ b/mellea/formatters/__init__.py
@@ -4,3 +4,5 @@
 from ..core import Formatter
 from .chat_formatter import ChatFormatter
 from .template_formatter import TemplateFormatter
+
+__all__ = ["ChatFormatter", "Formatter", "TemplateFormatter"]

--- a/mellea/helpers/__init__.py
+++ b/mellea/helpers/__init__.py
@@ -14,3 +14,17 @@ from .openai_compatible_helpers import (
     messages_to_docs,
 )
 from .server_type import _server_type, _ServerType
+
+__all__ = [
+    "ClientCache",
+    "_ServerType",
+    "_run_async_in_thread",
+    "_server_type",
+    "chat_completion_delta_merge",
+    "extract_model_tool_requests",
+    "get_current_event_loop",
+    "message_to_openai_message",
+    "messages_to_docs",
+    "send_to_queue",
+    "wait_for_all_mots",
+]

--- a/mellea/stdlib/components/__init__.py
+++ b/mellea/stdlib/components/__init__.py
@@ -17,3 +17,25 @@ from .intrinsic import Intrinsic
 from .mify import mify
 from .mobject import MObject, MObjectProtocol, Query, Transform
 from .simple import SimpleComponent
+
+__all__ = [
+    "CBlock",
+    "Component",
+    "ComponentParseError",
+    "Document",
+    "ImageBlock",
+    "Instruction",
+    "Intrinsic",
+    "MObject",
+    "MObjectProtocol",
+    "Message",
+    "ModelOutputThunk",
+    "Query",
+    "SimpleComponent",
+    "TemplateRepresentation",
+    "ToolMessage",
+    "Transform",
+    "as_chat_history",
+    "blockify",
+    "mify",
+]

--- a/mellea/stdlib/components/docs/__init__.py
+++ b/mellea/stdlib/components/docs/__init__.py
@@ -1,3 +1,5 @@
 """Classes and functions for working with document-like objects."""
 
 from .richdocument import RichDocument, Table, TableQuery, TableTransform
+
+__all__ = ["RichDocument", "Table", "TableQuery", "TableTransform"]

--- a/mellea/stdlib/components/intrinsic/__init__.py
+++ b/mellea/stdlib/components/intrinsic/__init__.py
@@ -1,3 +1,5 @@
 """Module for working with intrinsics."""
 
 from .intrinsic import Intrinsic
+
+__all__ = ["Intrinsic"]

--- a/mellea/stdlib/requirements/__init__.py
+++ b/mellea/stdlib/requirements/__init__.py
@@ -14,3 +14,22 @@ from .requirement import (
     simple_validate,
 )
 from .tool_reqs import tool_arg_validator, uses_tool
+
+__all__ = [
+    "ALoraRequirement",
+    "LLMaJRequirement",
+    "PythonExecutionReq",
+    "Requirement",
+    "ValidationResult",
+    "as_markdown_list",
+    "check",
+    "default_output_to_bool",
+    "is_markdown_list",
+    "is_markdown_table",
+    "req",
+    "reqify",
+    "requirement_check_to_bool",
+    "simple_validate",
+    "tool_arg_validator",
+    "uses_tool",
+]

--- a/mellea/stdlib/sampling/__init__.py
+++ b/mellea/stdlib/sampling/__init__.py
@@ -8,3 +8,12 @@ from .base import (
     RejectionSamplingStrategy,
     RepairTemplateStrategy,
 )
+
+__all__ = [
+    "BaseSamplingStrategy",
+    "MultiTurnStrategy",
+    "RejectionSamplingStrategy",
+    "RepairTemplateStrategy",
+    "SamplingResult",
+    "SamplingStrategy",
+]

--- a/mellea/stdlib/sampling/sampling_algos/__init__.py
+++ b/mellea/stdlib/sampling/sampling_algos/__init__.py
@@ -1,3 +1,5 @@
 """Module for Sampling Algorithms."""
 
 from .budget_forcing_alg import think_budget_forcing
+
+__all__ = ["think_budget_forcing"]

--- a/mellea/stdlib/tools/__init__.py
+++ b/mellea/stdlib/tools/__init__.py
@@ -1,3 +1,5 @@
 """Implementations of tools."""
 
 from .interpreter import code_interpreter, local_code_interpreter
+
+__all__ = ["code_interpreter", "local_code_interpreter"]


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: N/A

The implicit exports work but IDEs show errors. Added explicit exports here so that no red squiggly lines appear when using the simplified exports like `from mellea.stdlib.requirements import Requirement, simple_validate`.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)