### PR TITLE
fix: import times by not exporting RichDocument at module level

### DIFF
--- a/docs/examples/mify/mify.py
+++ b/docs/examples/mify/mify.py
@@ -1,4 +1,4 @@
-from mellea.stdlib.components.docs import TableQuery
+from mellea.stdlib.components.docs.richdocument import TableQuery
 from mellea.stdlib.components.mify import MifiedProtocol, mify
 from mellea.stdlib.session import start_session
 

--- a/docs/examples/mify/rich_document_advanced.py
+++ b/docs/examples/mify/rich_document_advanced.py
@@ -35,7 +35,7 @@ print(response.content)  # > The paper introduces...
 
 # 4. `Mellea` also provides a basic wrapper around this functionality to make
 # basic processing of documents easier.
-from mellea.stdlib.components.docs import RichDocument
+from mellea.stdlib.components.docs.richdocument import RichDocument
 
 # This creates a new `Mellea` RichDocument component that encapsulates all
 # the logic above along with some convenient helpers.

--- a/docs/examples/mify/rich_table_execute_basic.py
+++ b/docs/examples/mify/rich_table_execute_basic.py
@@ -5,7 +5,7 @@ from mellea import start_session
 from mellea.backends import model_ids
 from mellea.backends import ModelOption
 from mellea.core import FancyLogger
-from mellea.stdlib.components.docs import RichDocument, Table
+from mellea.stdlib.components.docs.richdocument import RichDocument, Table
 
 FancyLogger.get_logger().setLevel("ERROR")
 

--- a/docs/examples/notebooks/document_mobject.ipynb
+++ b/docs/examples/notebooks/document_mobject.ipynb
@@ -80,11 +80,7 @@
     "id": "3j-Se7PpfMqV"
    },
    "outputs": [],
-   "source": [
-    "from mellea.stdlib.components.docs import RichDocument\n",
-    "\n",
-    "rd = RichDocument.from_document_file(\"https://arxiv.org/pdf/1906.04043\")"
-   ]
+   "source": "from mellea.stdlib.components.docs.richdocument import RichDocument\n\nrd = RichDocument.from_document_file(\"https://arxiv.org/pdf/1906.04043\")"
   },
   {
    "cell_type": "markdown",
@@ -101,12 +97,7 @@
     "id": "kcBb3g_BfMqV"
    },
    "outputs": [],
-   "source": [
-    "from mellea.stdlib.components.docs import Table\n",
-    "\n",
-    "table1: Table = rd.get_tables()[0]\n",
-    "print(table1.to_markdown())"
-   ]
+   "source": "from mellea.stdlib.components.docs.richdocument import Table\n\ntable1: Table = rd.get_tables()[0]\nprint(table1.to_markdown())"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/rag/mellea_pdf.py
+++ b/docs/examples/rag/mellea_pdf.py
@@ -1,5 +1,5 @@
 import mellea
-from mellea.stdlib.components.docs import RichDocument
+from mellea.stdlib.components.docs.richdocument import RichDocument
 
 m = mellea.start_session()
 

--- a/docs/examples/tutorial/document_mobject.py
+++ b/docs/examples/tutorial/document_mobject.py
@@ -1,10 +1,10 @@
 from mellea.backends import model_ids
 from mellea.backends.model_ids import IBM_GRANITE_3_3_8B
-from mellea.stdlib.components.docs import RichDocument
+from mellea.stdlib.components.docs.richdocument import RichDocument
 
 rd = RichDocument.from_document_file("https://arxiv.org/pdf/1906.04043")
 
-from mellea.stdlib.components.docs import Table  # noqa: E402
+from mellea.stdlib.components.docs.richdocument import Table  # noqa: E402
 
 table1: Table = rd.get_tables()[0]
 print(table1.to_markdown())

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -617,7 +617,7 @@ Let's create a RichDocument from an arxiv paper:
 
 ```python
 # file: https://github.com/generative-computing/mellea/blob/main/docs/examples/tutorial/document_mobject.py#L1-L3
-from mellea.stdlib.components.docs import RichDocument
+from mellea.stdlib.components.docs.richdocument import RichDocument
 rd = RichDocument.from_document_file("https://arxiv.org/pdf/1906.04043")
 ```
 this loads the PDF file and parses it using the Docling parser into an
@@ -627,7 +627,7 @@ From the rich document we can extract some document content, e.g. the
 first table:
 ```python
 # file: https://github.com/generative-computing/mellea/blob/main/docs/examples/tutorial/document_mobject.py#L5-L8
-from mellea.stdlib.components.docs import Table
+from mellea.stdlib.components.docs.richdocument import Table
 table1: Table = rd.get_tables()[0]
 print(table1.to_markdown())
 ```

--- a/mellea/stdlib/components/docs/__init__.py
+++ b/mellea/stdlib/components/docs/__init__.py
@@ -1,5 +1,9 @@
 """Classes and functions for working with document-like objects."""
 
-from .richdocument import RichDocument, Table, TableQuery, TableTransform
+from .document import Document
 
-__all__ = ["RichDocument", "Table", "TableQuery", "TableTransform"]
+# Note: RichDocument, Table, TableQuery, TableTransform are not imported here
+# by default to avoid heavy docling/torch/transformers imports at module load time.
+# Import them explicitly from mellea.stdlib.components.docs.richdocument when needed.
+
+__all__ = ["Document"]

--- a/mellea/stdlib/requirements/md.py
+++ b/mellea/stdlib/requirements/md.py
@@ -1,14 +1,32 @@
 """This file contains various requirements for Markdown-formatted files."""
 
-import mistletoe
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ...core import Context, Requirement
+
+if TYPE_CHECKING:
+    import mistletoe
+
+_mistletoe = None
+
+
+def _get_mistletoe():
+    global _mistletoe
+    if _mistletoe is None:
+        import mistletoe as mt
+
+        _mistletoe = mt
+    return _mistletoe
+
 
 # region lists
 
 
 def as_markdown_list(ctx: Context) -> list[str] | None:
     """Attempts to format the last_output of the given context as a markdown list."""
+    mistletoe = _get_mistletoe()
     xs = list()
     raw_output = ctx.last_output()
     assert raw_output is not None
@@ -44,6 +62,7 @@ is_markdown_list = Requirement(
 
 
 def _md_table(ctx: Context):
+    mistletoe = _get_mistletoe()
     raw_output = ctx.last_output()
     assert raw_output is not None
     try:

--- a/test/backends/test_tool_calls.py
+++ b/test/backends/test_tool_calls.py
@@ -9,7 +9,7 @@ from mellea.backends import ModelOption
 from mellea.core import ModelOutputThunk
 from mellea.stdlib.context import ChatContext
 
-from mellea.stdlib.components.docs import Table
+from mellea.stdlib.components.docs.richdocument import Table
 from mellea.stdlib.session import MelleaSession
 
 

--- a/test/stdlib/components/docs/test_richdocument.py
+++ b/test/stdlib/components/docs/test_richdocument.py
@@ -1,6 +1,6 @@
 import os
 from mellea.core import TemplateRepresentation
-from mellea.stdlib.components.docs import RichDocument, Table
+from mellea.stdlib.components.docs.richdocument import RichDocument, Table
 import mellea
 from docling_core.types.doc.document import DoclingDocument
 import tempfile

--- a/test/stdlib/components/test_transform.py
+++ b/test/stdlib/components/test_transform.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mellea.core import TemplateRepresentation
-from mellea.stdlib.components.docs import TableTransform
+from mellea.stdlib.components.docs.richdocument import TableTransform
 from mellea.stdlib.components import MObject, Query, Transform
 
 custom_mobject_description = "custom mobject description"


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 

Move rich document imports so that they aren't imported by default.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)