### PR TITLE
fix: use __repr__ for helpful debug display in Message/ToolMessage

### DIFF
--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -79,7 +79,7 @@ class Message(Component["Message"]):
             template_order=["*", "Message"],
         )
 
-    def __str__(self):
+    def __repr__(self) -> str:
         """Pretty representation of messages, because they are a special case."""
         images = []
         if self.images is not None:
@@ -176,9 +176,9 @@ class ToolMessage(Message):
             obj=self, args=args, template_order=["*", "Message"]
         )
 
-    def __str__(self):
+    def __repr__(self) -> str:
         """Pretty representation of messages, because they are a special case."""
-        return f'mellea.Message(role="{self.role}", content="{self.content}", name="{self.name}")'
+        return f'mellea.ToolMessage(role="{self.role}", content="{self.content}", name="{self.name}")'
 
 
 def as_chat_history(ctx: Context) -> list[Message]:


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: 

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Fixes #338 