### PR TITLE
fix: restrict transformers version to 4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ hf = [
     "outlines-core==0.1.26",
     "outlines",                 # intentionally un-versioned, expecting a minor update. coutlines-core version should be enough to specify it
     "peft>=0.18.0", # aLoRA support was added in Peft 0.18.0
-    "transformers>=4.53.2",
+    "transformers>=4.53.2,<5",
     "trl==0.19.1",
     "granite-common[transformers]",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3453,7 +3453,7 @@ requires-dist = [
     { name = "pydantic" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rouge-score" },
-    { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.53.2" },
+    { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.53.2,<5" },
     { name = "transformers", marker = "extra == 'vllm'", specifier = "<4.54.0" },
     { name = "trl", marker = "extra == 'hf'", specifier = "==0.19.1" },
     { name = "typer" },


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [X] Link to Issue: #367 

Restricting transformers library to v4.x  due to a dependency in the Hugging Face backend on `DynamicCache.to_legacy_cache`  (which is removed in transformers v5)

Pinning to v4.57.6 as mentioned in the issue opened a can of worms: it required a vllm bump, which required a bump to outlines, which would've required code changes in the backends.

For now, just putting an upper cap on the version to prevent problems with removing legacy cache. Can work on a bigger update as a follow on (though it might be better to put effort on finding the new method you're supposed to use for getting tensors out of DynamicCache instead)

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)