### PR TITLE
chore: fix free-disk-space action

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -15,11 +15,14 @@ runs:
           /usr/share/dotnet /usr/local/lib/android /opt/ghc \
           /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
           /usr/lib/jvm || true
+        sudo apt update >/dev/null 2>&1
         sudo apt install aptitude -y >/dev/null 2>&1
         sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
         sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
         sudo apt-get autoremove -y >/dev/null 2>&1
         sudo apt-get autoclean -y >/dev/null 2>&1
+        sudo apt-get clean >/dev/null 2>&1
+        sudo rm -rf /var/lib/apt/lists/* || true
       shell: bash
     - name: Print disk space after cleanup
       run: |


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 

<!-- Brief description of the change being made along with an explanation. -->

Yesterdays GitHub Actions outage ended with a reset/update to the runners which surfaced a bug in our free-disk-space action, this addresses it

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)