### PR TITLE
fix: flag more tests that require ollama

### DIFF
--- a/test/backends/test_tool_calls.py
+++ b/test/backends/test_tool_calls.py
@@ -13,6 +13,8 @@ from mellea.stdlib.components.docs.richdocument import Table
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.session import MelleaSession
 
+pytestmark = [pytest.mark.ollama, pytest.mark.llm]
+
 
 @pytest.fixture(scope="module")
 def m() -> MelleaSession:

--- a/test/core/test_model_output_thunk.py
+++ b/test/core/test_model_output_thunk.py
@@ -6,6 +6,8 @@ from mellea.backends import ModelOption
 from mellea.core import ModelOutputThunk
 from mellea.stdlib.session import MelleaSession, start_session
 
+pytestmark = [pytest.mark.ollama, pytest.mark.llm]
+
 
 # Use generated ModelOutputThunks to fully test copying. This can technically be done without a
 # backend, but it simplifies test setup.

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -8,6 +8,8 @@ from mellea.stdlib.session import start_session
 ctx = ChatContext()
 ctx = ctx.add(ModelOutputThunk("test"))
 
+pytestmark = [pytest.mark.ollama, pytest.mark.llm]
+
 
 async def test_llmaj_validation_req_output_field():
     m = start_session(ctx=ctx)

--- a/test/stdlib/test_functional.py
+++ b/test/stdlib/test_functional.py
@@ -7,6 +7,8 @@ from mellea.stdlib.functional import aact, ainstruct, avalidate, instruct
 from mellea.stdlib.requirements import req
 from mellea.stdlib.session import start_session
 
+pytestmark = [pytest.mark.ollama, pytest.mark.llm]
+
 
 @pytest.fixture(scope="module")
 def m_session(gh_run):


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: #419 

Flags a few more tests as requiring ollama (this skips the tests in question, but not 100% sure this is the ideal way to do it)

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)