### PR TITLE
docs: fixes version detection logic

### DIFF
--- a/tooling/docs-autogen/generate-ast.py
+++ b/tooling/docs-autogen/generate-ast.py
@@ -64,7 +64,11 @@ REPO_URL = "https://github.com/generative-computing/mellea"
 def normalize_version(v: str | None) -> str | None:
     if not v:
         return None
-    return v[1:] if v.startswith("v") else v
+    v = v[1:] if v.startswith("v") else v
+    # Return None for branch names or non-version strings (must start with digit)
+    if not v or not v[0].isdigit():
+        return None
+    return v
 
 
 def yaml_quote(value: str | None) -> str:


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [X] Bug Fix
- [ ] New Feature
- [X] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 

<!-- Brief description of the change being made along with an explanation. -->

**The Problem:**
The GitHub Action is passing --pypi-version main to the script. The `normalize_version` function in `tooling/docs-autogen/generate-ast.py` at L64-L67, only strips a leading "v" from versions but doesn't handle branch names like "main".

This results in pip_install constructing `mellea==main` at `tooling/docs-autogen/generate-ast.py` at L171, which is invalid pip syntax. Pip expects a semver version like 0.3.0, not a git branch name.

The normalize_version function doesn't validate that the version is actually a valid version number. When "main" is passed, it's passed through unchanged, creating the invalid requirement mellea==main.

**The Fix:**
Update normalize_version to return None for non-version strings like "main" (or any value that doesn't look like a valid version). When normalize_version returns None, pip_install already handles it correctly by installing without a version pin (i.e., latest from PyPI).

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Manually tested with this snippet
```
def normalize_version(v):
    if not v:
        return None
    v = v[1:] if v.startswith('v') else v
    if not v or not v[0].isdigit():
        return None
    return v

tests = [
    ('main', None),
    ('master', None),
    ('v0.3.0', '0.3.0'),
    ('0.3.0', '0.3.0'),
    (None, None),
    ('', None),
]

for input_val, expected in tests:
    result = normalize_version(input_val)
    status = '✓' if result == expected else '✗'
    print(f'{status} normalize_version({input_val!r}) = {result!r} (expected {expected!r})')
```