### PR TITLE
fix: correct type annotations and improve CI cache invalidation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml', 'uv.lock') }}
       - name: Install dependencies
         run: uv sync --frozen --all-extras --group dev
       - name: Check style and run tests

--- a/mellea/formatters/granite/retrievers/elasticsearch.py
+++ b/mellea/formatters/granite/retrievers/elasticsearch.py
@@ -2,11 +2,13 @@
 
 """Classes and functions that implement the ElasticsearchRetriever."""
 
+from typing import Any
+
 
 class ElasticsearchRetriever:
     """Retriever for documents hosted on an ElasticSearch server."""
 
-    def __init__(self, corpus_name: str, host: str, **kwargs: dict[str, int]):
+    def __init__(self, corpus_name: str, host: str, **kwargs: Any):
         """Initialize ElasticsearchRetriever.
 
         :param hosts: Full url:port to the Elasticsearch server.


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 

<!-- Brief description of the change being made along with an explanation. -->

# Fix MyPy Type Errors and CI Cache Invalidation

## Problem

MyPy type errors were occurring locally but not caught in CI:
```
mellea/formatters/granite/retrievers/elasticsearch.py:25: error: Argument 2 to "Elasticsearch" has incompatible type "**dict[str, dict[str, int]]"
```

## Root Cause

1. **Type Error**: Incorrect `**kwargs` annotation (`dict[str, int]` instead of `Any`) in `elasticsearch.py`
2. **CI Cache Issue**: Pre-commit cache key didn't include `uv.lock`, so MyPy used stale cached results when dependencies changed

The bug was introduced when PR #571 (code) and PR #570 (dependencies) were merged separately. CI never re-checked the files with the new type information because the cache wasn't invalidated.

## Changes

### Type Fix
- Fixed `**kwargs: dict[str, int]` → `**kwargs: Any` in `elasticsearch.py`

### CI Fix
- Updated pre-commit cache key to include `uv.lock` hash
- Ensures MyPy re-checks files whenever dependencies change

## Testing

✅ `pre-commit run --all-files` passes locally
✅ All MyPy type checks pass

## Impact

Prevents future type errors from being masked by stale CI cache when dependencies are added or updated.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)