### PR TITLE
fix: use device_map for HF model loading (#581)

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -270,8 +270,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 )
                 # Get the model and tokenizer.
                 self._model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-                    self._hf_model_id
-                ).to(self._device)  # type: ignore
+                    self._hf_model_id, device_map=str(self._device)
+                )
                 self._tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
                     self._hf_model_id
                 )


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# fix: use device_map for HF model loading (#581)

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: #581

Fixes #581

Use `device_map=str(self._device)` instead of `.to(self._device)` in `LocalHFBackend.__init__` to stream model weights directly to the target device, avoiding the 2x CPU memory spike (model is loaded, then copied) that causes OOMs on constrained systems. `str()` ensures MPS compatibility (see PR #227).

Also adds `attr-defined` to the vLLM mypy override in [pyproject.toml](cci:7://file:///Users/jonesn/src/mellea/pyproject.toml:0:0-0:0) to unblock pre-commit — these are pre-existing type errors from a vLLM version mismatch (0.9.1 vs >=0.13.0), unrelated to this fix. See #548/#549 -- this may be temporary. 

### vLLM version mismatch (WIP)

Keeping as draft until I get this resolved -- it came up with the latest pypy updates... 

The BlueVela conda env has vLLM `0.9.1`, but [pyproject.toml](cci:7://file:///Users/jonesn/src/mellea/pyproject.toml:0:0-0:0) requires `>=0.13.0`. 

I previously ran a few weeks ago and vllm ran clean but since then we've had some changes:
- `05f0a91` — fix: avoid instantiating an additional tokenizer (#548)
- `5ac4b2f` — fix: self._tokenizer is unset (#549)

* A number of failures, but includes for example calls to `shutdown()` which doesn't exist in 0.9.1...

**Next steps:** Either adapt code to accomodate older version, or update BlueVela conda env (or create own copy?) to vLLM >=0.13.0 and re-run, then revisit the [pyproject.toml](cci:7://file:///Users/jonesn/src/mellea/pyproject.toml:0:0-0:0) mypy `attr-defined` override -- this relates to the version discrepancy

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

- ✅ Verified on MPS with `sshleifer/tiny-gpt2`; pre-commit passes
- ✅  HuggingFace GPU tests on BlueVela pending
