### PR TITLE
fix: ensure enough tokens for structured output in vLLM test (#591)

### DIFF
--- a/test/backends/test_openai_vllm.py
+++ b/test/backends/test_openai_vllm.py
@@ -222,6 +222,7 @@ async def test_generate_from_raw_with_format(m_session: MelleaSession) -> None:
         actions=[CBlock(value=prompt) for prompt in prompts],
         format=Answer,
         ctx=m_session.ctx,
+        model_options={ModelOption.MAX_NEW_TOKENS: 256},
     )
 
     assert len(results) == len(prompts)


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Ensure enough tokens for structured output in vLLM test

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #591

Fixes #591

Flaky `test_generate_from_raw_with_format` in `test/backends/test_openai_vllm.py` caused by vLLM's low default token limit, resulting in truncated JSON objects. This PR sets `MAX_NEW_TOKENS` to 256. 

Note: While this change is independent for merge, successful execution in isolated environments depends on the associated PYTHONPATH fix (#592). Combined, these fixes result in 100% pass rate for vLLM tests on LSF.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
