### PR TITLE
fix: include fixes issue in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -3,7 +3,7 @@
 Use this template when adding or modifying components in `mellea/stdlib/components/`.
 
 ## Description
-- [ ] Link to Issue: 
+- [ ] Link to Issue: Fixes <!-- issue number -->
 
 <!-- Brief description of the component being added/modified along with an explanation for why it should be in the standard library. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/misc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/misc.md
@@ -8,7 +8,7 @@
 - [ ] Other
 
 ## Description
-- [ ] Link to Issue: 
+- [ ] Link to Issue: Fixes <!-- issue number -->
 
 <!-- Brief description of the change being made along with an explanation. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/requirement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/requirement.md
@@ -3,7 +3,7 @@
 Use this template when adding or modifying requirements in `mellea/stdlib/requirements/`.
 
 ## Description
-- [ ] Link to Issue: 
+- [ ] Link to Issue: Fixes <!-- issue number -->
 
 <!-- Brief description of the requirement being added/modified along with an explanation for why it should be in the standard library. -->
 
@@ -17,7 +17,7 @@ Use this template when adding or modifying requirements in `mellea/stdlib/requir
 ### Validation Logic
 - [ ] `validation_fn` defined (if using Python-based validation)
     - [ ] re-usable functionality within the validation_fn should be separated out into `mellea/stdlib/tools/`
-- [ ] `validate` returns a `ValidationResult` with 
+- [ ] `validate` returns a `ValidationResult` with
     - [ ] a `thunk` and `context` if using a backend to generate
     - [ ] a specific `reason` and `score` when possible
 

--- a/.github/PULL_REQUEST_TEMPLATE/sampling.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sampling.md
@@ -3,7 +3,7 @@
 Use this template when adding or modifying sampling strategies in `mellea/stdlib/sampling/`.
 
 ## Description
-- [ ] Link to Issue: 
+- [ ] Link to Issue: Fixes <!-- issue number -->
 
 <!-- Brief description of the sampling strategy being added/modified along with an explanation for why it should be in the standard library. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tool.md
@@ -3,7 +3,7 @@
 Use this template when adding or modifying components in `mellea/stdlib/tools/`.
 
 ## Description
-- [ ] Link to Issue: 
+- [ ] Link to Issue: Fixes <!-- issue number -->
 
 <!-- Brief description of the tool being added/modified along with an explanation for why it should be in the standard library. -->
 


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: 

This is admittedly a minor annoyance, but I keep forgetting to type `Fixes` in my PRs (which results in issues not getting autoclosed when the PR merges). This PR adds that text to the PR templates for a not-so-subtle reminder 😄 

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)