### PR TITLE
fix: add missing type annotations to public API functions

### DIFF
--- a/mellea/backends/cache.py
+++ b/mellea/backends/cache.py
@@ -12,7 +12,7 @@ class Cache(abc.ABC):
     # Whenever PEP 695 generics are supported by mypy, we should use them here.
 
     @abc.abstractmethod
-    def put(self, key: str | int, value: Any):
+    def put(self, key: str | int, value: Any) -> None:
         """Inserts into the cache. May result in eviction of other cached values."""
         ...
 
@@ -44,7 +44,7 @@ class SimpleLRUCache(Cache):
         self.cache: OrderedDict = OrderedDict()
         self.on_evict = on_evict
 
-    def current_size(self):
+    def current_size(self) -> int:
         """Just return the size of the key set. This isn't necessarily safe."""
         return len(self.cache.keys())
 
@@ -58,7 +58,7 @@ class SimpleLRUCache(Cache):
             self.cache[key] = value
             return value
 
-    def put(self, key: str | int, value: Any):
+    def put(self, key: str | int, value: Any) -> None:
         """Put a value into the cache."""
         if self.capacity <= 0:
             return

--- a/mellea/backends/kv_block_helpers.py
+++ b/mellea/backends/kv_block_helpers.py
@@ -5,6 +5,7 @@ from functools import reduce
 from typing import Any
 
 import torch
+from transformers import PreTrainedModel
 from transformers.cache_utils import DynamicCache
 from transformers.tokenization_utils_base import BatchEncoding
 
@@ -30,7 +31,7 @@ def merge_dynamic_caches(caches: Iterable[DynamicCache]) -> DynamicCache:
 
 
 def tokens_to_legacy_cache(
-    model, device: str, tokens_or_cache: BatchEncoding | DynamicCache
+    model: PreTrainedModel, device: str, tokens_or_cache: BatchEncoding | DynamicCache
 ) -> Iterable[LegacyCache]:
     """Prefills and returns Ks and Vs as a LegacyCache."""
     if type(tokens_or_cache) is DynamicCache:

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -92,7 +92,7 @@ class ModelOption:
         return new_options
 
     @staticmethod
-    def remove_special_keys(model_options) -> dict[str, Any]:
+    def remove_special_keys(model_options: dict[str, Any]) -> dict[str, Any]:
         """Removes all sentiel-valued keys (i.e., those that start with @@@)."""
         new_options = {}
         for k, v in model_options.items():

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -53,15 +53,15 @@ class CBlock:
         return self._underlying_value
 
     @value.setter
-    def value(self, v: str):
+    def value(self, v: str) -> None:
         """Sets the value of the block."""
         self._underlying_value = v
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Stringifies the block."""
         return self.value if self.value else ""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Provides a python-parsable representation of the block (usually)."""
         return f"CBlock({self.value}, {self._meta.__repr__()})"
 
@@ -120,7 +120,7 @@ class ImageBlock(CBlock):
         image_base64 = cls.pil_to_base64(image)
         return cls(image_base64, meta)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Provides a python-parsable representation of the block (usually)."""
         return f"ImageBlock({self.value}, {self._meta.__repr__()})"
 
@@ -235,7 +235,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._thinking = other._thinking
         self._generate_log = other._generate_log
 
-    def is_computed(self):
+    def is_computed(self) -> bool:
         """Returns true only if this Thunk has already been filled."""
         return self._computed
 
@@ -247,7 +247,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         return self._underlying_value
 
     @value.setter
-    def value(self, v: str):
+    def value(self, v: str) -> None:
         """Sets the value of the block."""
         self._underlying_value = v
 
@@ -409,14 +409,14 @@ class ModelOutputThunk(CBlock, Generic[S]):
             else self._underlying_value[beginning_length:]  # type: ignore
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Provides a python-parsable representation (usually).
 
         Differs from CBlock because `._meta` can be very large for ModelOutputThunks.
         """
         return f"ModelOutputThunk({self.value})"
 
-    def __copy__(self):
+    def __copy__(self) -> ModelOutputThunk:
         """Returns a shallow copy of the ModelOutputThunk. A copied ModelOutputThunk cannot be used for generation; don't copy over fields associated with generating."""
         copied = ModelOutputThunk(
             self._underlying_value, self._meta, self.parsed_repr, self.tool_calls
@@ -436,7 +436,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         copied._model_options = self._model_options
         return copied
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict) -> ModelOutputThunk:
         """Returns a deep copy of the ModelOutputThunk. A copied ModelOutputThunk cannot be used for generation; don't copy over fields associated with generation. Similar to __copy__ but creates deepcopies of _meta, parsed_repr, and most other fields that are objects."""
         # Use __init__ to initialize all fields. Modify the fields that need to be copied/deepcopied below.
         deepcopied = ModelOutputThunk(self._underlying_value)
@@ -488,7 +488,7 @@ class Context(abc.ABC):
     _is_root: bool
     _is_chat_context: bool = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Constructs a new root context with no content."""
         self._previous = None
         self._data = None
@@ -590,7 +590,7 @@ class Context(abc.ABC):
                 return c
         return None
 
-    def last_turn(self):
+    def last_turn(self) -> ContextTurn | None:
         """The last input/output turn of the context.
 
         This can be partial. If the last event is an input, then the output is None.
@@ -632,7 +632,7 @@ class AbstractMelleaTool(abc.ABC):
     """Name of the tool."""
 
     @abc.abstractmethod
-    def run(self, *args, **kwargs) -> Any:
+    def run(self, *args: Any, **kwargs: Any) -> Any:
         """Runs the tool on the given arguments."""
 
     @property

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -149,7 +149,7 @@ class Requirement(Component[str]):
                 context=val_ctx,
             )
 
-    def parts(self):
+    def parts(self) -> list[Component | CBlock]:
         """Returns all of the constituent parts of a Requirement."""
         return []
 

--- a/mellea/core/utils.py
+++ b/mellea/core/utils.py
@@ -11,14 +11,16 @@ import requests
 class RESTHandler(logging.Handler):
     """RESTHandler for logging."""
 
-    def __init__(self, api_url, method="POST", headers=None):
+    def __init__(
+        self, api_url: str, method: str = "POST", headers: dict[str, str] | None = None
+    ) -> None:
         """Initializes a RESTHandler; uses application/json by default."""
         super().__init__()
         self.api_url = api_url
         self.method = method
         self.headers = headers or {"Content-Type": "application/json"}
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         """Attempts to emit a record to FLOG, or silently fails."""
         if os.environ.get("FLOG"):
             log_data = self.format(record)
@@ -74,7 +76,7 @@ class CustomFormatter(logging.Formatter):
         logging.CRITICAL: bold_red + _format_string + reset,
     }
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         """The format fn."""
         log_fmt = self.FORMATS.get(record.levelno)
         formatter = logging.Formatter(log_fmt, datefmt="%H:%M:%S")
@@ -96,7 +98,7 @@ class FancyLogger:
     NOTSET = 0
 
     @staticmethod
-    def get_logger():
+    def get_logger() -> logging.Logger:
         """Returns a FancyLogger.logger and sets level based upon env vars."""
         if FancyLogger.logger is None:
             logger = logging.getLogger("fancy_logger")

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -36,7 +36,7 @@ async def send_to_queue(
         await aqueue.put(e)
 
 
-async def wait_for_all_mots(mots: list[ModelOutputThunk]):
+async def wait_for_all_mots(mots: list[ModelOutputThunk]) -> None:
     """Helper function to make waiting for multiple ModelOutputThunks to be computed easier.
 
     All ModelOutputThunks must be from the same event loop. This should always be the case in sampling
@@ -73,7 +73,7 @@ class ClientCache:
         self.capacity = capacity
         self.cache: OrderedDict = OrderedDict()
 
-    def current_size(self):
+    def current_size(self) -> int:
         """Just return the size of the key set. This isn't necessarily safe."""
         return len(self.cache.keys())
 
@@ -87,7 +87,7 @@ class ClientCache:
             self.cache[key] = value
             return value
 
-    def put(self, key: int, value: Any):
+    def put(self, key: int, value: Any) -> None:
         """Put a value into the cache."""
         if key in self.cache:
             # If the key exists, move it to the end (most recent)

--- a/mellea/helpers/event_loop_helper.py
+++ b/mellea/helpers/event_loop_helper.py
@@ -13,7 +13,7 @@ R = TypeVar("R")
 class _EventLoopHandler:
     """A class that handles the event loop for Mellea code. Do not directly instantiate this. Use `_run_async_in_thread`."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Instantiates an EventLoopHandler. Used to ensure consistency when calling async code from sync code in Mellea.
 
         Do not instantiate this class. Rely on the exported `_run_async_in_thread` function.
@@ -25,7 +25,7 @@ class _EventLoopHandler:
         )
         self._thread.start()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Delete the event loop handler."""
         self._close_event_loop()
 
@@ -37,7 +37,7 @@ class _EventLoopHandler:
                 for task in tasks:
                     task.cancel()
 
-                async def finalize_tasks():
+                async def finalize_tasks() -> None:
                     # TODO: We can log errors here if needed.
                     await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/mellea/stdlib/components/simple.py
+++ b/mellea/stdlib/components/simple.py
@@ -1,12 +1,14 @@
 """SimpleComponent."""
 
+from typing import Any
+
 from ...core import CBlock, Component, ModelOutputThunk
 
 
 class SimpleComponent(Component[str]):
     """A Component that is make up of named spans."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         """Initialized a simple component of the constructor's kwargs."""
         for key in kwargs.keys():
             if type(kwargs[key]) is str:
@@ -14,11 +16,11 @@ class SimpleComponent(Component[str]):
         self._kwargs_type_check(kwargs)
         self._kwargs = kwargs
 
-    def parts(self):
+    def parts(self) -> list[Component | CBlock]:
         """Returns the values of the kwargs."""
         return list(self._kwargs.values())
 
-    def _kwargs_type_check(self, kwargs):
+    def _kwargs_type_check(self, kwargs: dict[str, Any]) -> bool:
         for key in kwargs.keys():
             value = kwargs[key]
             assert issubclass(type(value), Component) or issubclass(
@@ -28,14 +30,14 @@ class SimpleComponent(Component[str]):
         return True
 
     @staticmethod
-    def make_simple_string(kwargs):
+    def make_simple_string(kwargs: dict[str, Any]) -> str:
         """Uses <|key|>value</|key|> to represent a simple component."""
         return "\n".join(
             [f"<|{key}|>{value}</|{key}|>" for (key, value) in kwargs.items()]
         )
 
     @staticmethod
-    def make_json_string(kwargs):
+    def make_json_string(kwargs: dict[str, Any]) -> str:
         """Uses json."""
         str_args = dict()
         for key in kwargs.keys():
@@ -48,7 +50,7 @@ class SimpleComponent(Component[str]):
 
         return json.dumps(str_args)
 
-    def format_for_llm(self):
+    def format_for_llm(self) -> str:
         """Uses a string rep."""
         return SimpleComponent.make_json_string(self._kwargs)
 

--- a/mellea/stdlib/components/unit_test_eval.py
+++ b/mellea/stdlib/components/unit_test_eval.py
@@ -35,7 +35,7 @@ class TestData(BaseModel):
 
     @field_validator("examples")
     @classmethod
-    def validate_examples(cls, v):
+    def validate_examples(cls, v: list[Example]) -> list[Example]:
         """Ensure examples list is not empty."""
         if not v:
             raise ValueError("examples list cannot be empty")
@@ -82,7 +82,7 @@ class TestBasedEval(Component[str]):
 
     def set_judge_context(
         self, input_text: str, prediction: str, targets_for_input: list[str]
-    ):
+    ) -> None:
         """Set context for judge evaluation."""
         if len(targets_for_input) == 0:  # no reference
             target_text = "N/A"

--- a/mellea/stdlib/requirements/md.py
+++ b/mellea/stdlib/requirements/md.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from ...core import Context, Requirement
+from ...core import Context, Requirement, ValidationResult
 
 if TYPE_CHECKING:
     import mistletoe
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 _mistletoe = None
 
 
-def _get_mistletoe():
+def _get_mistletoe() -> Any:
     global _mistletoe
     if _mistletoe is None:
         import mistletoe as mt
@@ -46,8 +46,8 @@ def as_markdown_list(ctx: Context) -> list[str] | None:
         return None
 
 
-def _md_list(ctx: Context):
-    return as_markdown_list(ctx) is not None
+def _md_list(ctx: Context) -> ValidationResult:
+    return ValidationResult(result=as_markdown_list(ctx) is not None)
 
 
 is_markdown_list = Requirement(
@@ -61,7 +61,7 @@ is_markdown_list = Requirement(
 # region tables
 
 
-def _md_table(ctx: Context):
+def _md_table(ctx: Context) -> ValidationResult:
     mistletoe = _get_mistletoe()
     raw_output = ctx.last_output()
     assert raw_output is not None
@@ -71,10 +71,10 @@ def _md_table(ctx: Context):
         assert parsed.children is not None
         children = list(parsed.children)
         if len(children) != 1:
-            return False
-        return type(children[0]) is mistletoe.block_token.Table
+            return ValidationResult(result=False)
+        return ValidationResult(result=type(children[0]) is mistletoe.block_token.Table)
     except Exception:
-        return False
+        return ValidationResult(result=False)
 
 
 is_markdown_table = Requirement(

--- a/mellea/stdlib/requirements/tool_reqs.py
+++ b/mellea/stdlib/requirements/tool_reqs.py
@@ -15,7 +15,7 @@ def _name2str(tool_name: str | Callable) -> str:
             raise TypeError(f"Expected Callable or str but found: {type(tool_name)}")
 
 
-def uses_tool(tool_name: str | Callable, check_only=False):
+def uses_tool(tool_name: str | Callable, check_only: bool = False) -> Requirement:
     """Forces the model to call a given tool.
 
     Args:
@@ -26,7 +26,7 @@ def uses_tool(tool_name: str | Callable, check_only=False):
     """
     tool_name = _name2str(tool_name)
 
-    def _validate(ctx: Context):
+    def _validate(ctx: Context) -> ValidationResult:
         output = ctx.last_output()
         assert output is not None
         if output.tool_calls is None:
@@ -65,7 +65,7 @@ def tool_arg_validator(
     if tool_name:
         tool_name = _name2str(tool_name)
 
-    def _validate(ctx: Context):
+    def _validate(ctx: Context) -> ValidationResult:
         output = ctx.last_output()
         assert output is not None
 

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -45,7 +45,7 @@ class ExecutionResult:
     """ Used for returning results from static analyses. """
     analysis_result: Any | None = None
 
-    def to_validationresult_reason(self):
+    def to_validationresult_reason(self) -> str:
         """Maps an ExecutionResult to a ValidationResult reason.
 
         TODO: Downstream use of this method is really hacky. A far better solution is for `ExecutionResult` to implement the `ValidationResult` interface.
@@ -59,8 +59,10 @@ class ExecutionResult:
             reason = self.skip_message
         else:
             if self.success:
+                assert self.stdout is not None
                 reason = self.stdout
             else:
+                assert self.stderr is not None
                 reason = self.stderr
         return reason
 

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -15,6 +15,7 @@ Configuration via environment variables:
 """
 
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
 from importlib.metadata import version
 from typing import Any
@@ -50,7 +51,7 @@ _CONSOLE_EXPORT = os.getenv("MELLEA_TRACE_CONSOLE", "false").lower() in (
 )
 
 
-def _setup_tracer_provider():
+def _setup_tracer_provider() -> Any:
     """Set up the global tracer provider with OTLP exporter if configured."""
     if not _OTEL_AVAILABLE:
         return None
@@ -101,7 +102,7 @@ def is_backend_tracing_enabled() -> bool:
 
 
 @contextmanager
-def trace_application(name: str, **attributes: Any):
+def trace_application(name: str, **attributes: Any) -> Generator[Any, None, None]:
     """Create an application trace span if application tracing is enabled.
 
     Args:
@@ -122,7 +123,7 @@ def trace_application(name: str, **attributes: Any):
 
 
 @contextmanager
-def trace_backend(name: str, **attributes: Any):
+def trace_backend(name: str, **attributes: Any) -> Generator[Any, None, None]:
     """Create a backend trace span if backend tracing is enabled.
 
     Follows Gen-AI semantic conventions for LLM operations.
@@ -147,7 +148,7 @@ def trace_backend(name: str, **attributes: Any):
         yield None
 
 
-def start_backend_span(name: str, **attributes: Any):
+def start_backend_span(name: str, **attributes: Any) -> Any:
     """Start a backend trace span without auto-closing (for async operations).
 
     Use this when you need to manually control span lifecycle, such as for


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #615

Adds missing return-type and parameter annotations to ~75 functions across 14 public API files. Griffe (the doc pipeline) requires annotations to generate correct return-type cross-references in the API reference; without them it emits `no_returns` audit failures and renders stubs with no linked types. Two latent bugs were also surfaced: `_md_list`/`_md_table` were returning bare `bool` where `Requirement.validation_fn` expects `ValidationResult`, and `to_validationresult_reason` had a narrowing gap that mypy could not verify. Both are fixed here.

### Testing
- [ ] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)