### PR TITLE
fix: add missing requires_gpu and requires_heavy_ram markers to Huggi…

### DIFF
--- a/test/telemetry/test_metrics_backend.py
+++ b/test/telemetry/test_metrics_backend.py
@@ -297,6 +297,12 @@ async def test_litellm_token_metrics_integration(
 @pytest.mark.asyncio
 @pytest.mark.llm
 @pytest.mark.huggingface
+@pytest.mark.requires_gpu
+@pytest.mark.requires_heavy_ram
+@pytest.mark.skipif(
+    int(os.environ.get("CICD", 0)) == 1,
+    reason="Skipping HuggingFace metrics test in CI - requires GPU and model download",
+)
 @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
 async def test_huggingface_token_metrics_integration(
     enable_metrics, metric_reader, stream, gh_run


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #620

`test_huggingface_token_metrics_integration` was added in #563 without `requires_gpu` or `requires_heavy_ram` markers. All other HuggingFace tests carry both markers, which are enforced by `conftest.py` at collection time — `requires_heavy_ram` skips on systems with < 48 GB RAM, `requires_gpu` skips without a GPU. Without them the test ran unconditionally on any machine with OpenTelemetry installed, triggering a full model download and load that consumed 10–15 minutes and exhausted available memory.

On my macbook m1 32GB this stalled the system for 15 mins before i aborted it, very high memory pressure (>40GB) led to audio breakup/stuttering, and finally had to be terminated.

### Testing
- [ ] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
