### PR TITLE
fix: hf metrics tests run out of memory

### DIFF
--- a/test/stdlib/test_spans.py
+++ b/test/stdlib/test_spans.py
@@ -8,7 +8,12 @@ from mellea.stdlib.components import SimpleComponent
 from mellea.stdlib.session import MelleaSession, start_session
 
 # Module-level markers for all tests using Granite 4 hybrid micro (3B model)
-pytestmark = [pytest.mark.huggingface, pytest.mark.requires_gpu, pytest.mark.llm]
+pytestmark = [
+    pytest.mark.huggingface,
+    pytest.mark.requires_gpu,
+    pytest.mark.requires_heavy_ram,
+    pytest.mark.llm,
+]
 
 
 # We edit the context type in the async tests below. Don't change the scope here.

--- a/test/telemetry/test_metrics_backend.py
+++ b/test/telemetry/test_metrics_backend.py
@@ -324,6 +324,7 @@ async def test_litellm_token_metrics_integration(
 @pytest.mark.asyncio
 @pytest.mark.llm
 @pytest.mark.huggingface
+@pytest.mark.requires_heavy_ram
 @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
 async def test_huggingface_token_metrics_integration(
     enable_metrics, metric_reader, stream, hf_metrics_backend


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: #620

<!-- Brief description of the change being made along with an explanation. -->

Previous huggingface tests all fell under the high GPU/RAM usage flags and were run in isolation. So we were not aware that by default there is no cleanup happening, causing each test to import a model into memory and leave it there until tests were finished.

This adds a fixture to only load the model once and clean up after the test file finishes.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)