### PR TITLE
fix: guarding optional imports for hooks

### DIFF
--- a/mellea/formatters/granite/retrievers/util.py
+++ b/mellea/formatters/granite/retrievers/util.py
@@ -10,8 +10,8 @@ import urllib.request
 import zipfile
 
 # Third Party
-import pyarrow as pa
-import pyarrow.json as pj
+import pyarrow as pa  # type: ignore[import-not-found]
+import pyarrow.json as pj  # type: ignore[import-not-found]
 
 
 def download_mtrag_corpus(target_dir: str, corpus_name: str) -> pathlib.Path:

--- a/mellea/plugins/base.py
+++ b/mellea/plugins/base.py
@@ -112,6 +112,13 @@ try:
 
     _HAS_PLUGIN_FRAMEWORK = True
 except ImportError:
+    from pydantic import BaseModel as _BaseModel
+
+    class PluginPayload(_BaseModel):  # type: ignore[no-redef]
+        """Fallback frozen base when cpex is not installed."""
+
+        model_config = {"frozen": True}
+
     _HAS_PLUGIN_FRAMEWORK = False
 
 if TYPE_CHECKING:

--- a/mellea/plugins/base.py
+++ b/mellea/plugins/base.py
@@ -112,13 +112,6 @@ try:
 
     _HAS_PLUGIN_FRAMEWORK = True
 except ImportError:
-    from pydantic import BaseModel as _BaseModel
-
-    class PluginPayload(_BaseModel):  # type: ignore[no-redef]
-        """Fallback frozen base when cpex is not installed."""
-
-        model_config = {"frozen": True}
-
     _HAS_PLUGIN_FRAMEWORK = False
 
 if TYPE_CHECKING:
@@ -141,23 +134,22 @@ class PluginViolationError(Exception):
         super().__init__(f"Plugin blocked {hook_type}: {detail}{reason}")
 
 
-class MelleaBasePayload(PluginPayload):
-    """Frozen base — all payloads are immutable by design.
-
-    Plugins must use ``model_copy(update={...})`` to propose modifications
-    and return the copy via ``PluginResult.modified_payload``.  The plugin
-    manager applies the hook's ``HookPayloadPolicy`` to filter changes to
-    writable fields only.
-    """
-
-    session_id: str | None = None
-    request_id: str = ""
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    hook: str = ""
-    user_metadata: dict[str, Any] = Field(default_factory=dict)
-
-
 if _HAS_PLUGIN_FRAMEWORK:
+
+    class MelleaBasePayload(PluginPayload):
+        """Frozen base — all payloads are immutable by design.
+
+        Plugins must use ``model_copy(update={...})`` to propose modifications
+        and return the copy via ``PluginResult.modified_payload``.  The plugin
+        manager applies the hook's ``HookPayloadPolicy`` to filter changes to
+        writable fields only.
+        """
+
+        session_id: str | None = None
+        request_id: str = ""
+        timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+        hook: str = ""
+        user_metadata: dict[str, Any] = Field(default_factory=dict)
 
     class MelleaPlugin(_CpexPlugin):
         """Base class for Mellea plugins with lifecycle hooks and typed accessors.
@@ -237,13 +229,23 @@ if _HAS_PLUGIN_FRAMEWORK:
 
 else:
     # Provide a stub when the plugin framework is not installed.
-    class MelleaPlugin:  # type: ignore[no-redef]
-        """Stub — install ``mcp-contextforge-gateway`` for full plugin support."""
+    class MelleaBasePayload:  # type: ignore[no-redef]
+        """Stub — install ``"mellea[hooks]"`` for full plugin support."""
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D107
             raise ImportError(
                 "MelleaPlugin requires the ContextForge plugin framework. "
-                "Install it with: pip install 'mellea[contextforge]'"
+                "Install it with: pip install 'mellea[hooks]'"
+            )
+
+    # Provide a stub when the plugin framework is not installed.
+    class MelleaPlugin:  # type: ignore[no-redef]
+        """Stub — install ``"mellea[hooks]"`` for full plugin support."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D107
+            raise ImportError(
+                "MelleaPlugin requires the ContextForge plugin framework. "
+                "Install it with: pip install 'mellea[hooks]'"
             )
 
     # Provide an alias when the plugin framework is not installed.

--- a/mellea/plugins/manager.py
+++ b/mellea/plugins/manager.py
@@ -57,7 +57,7 @@ def ensure_plugin_manager() -> Any:
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "Plugin system requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
 
     if _plugin_manager is None:
@@ -93,7 +93,7 @@ async def initialize_plugins(
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "Plugin system requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
 
     register_mellea_hooks()

--- a/mellea/plugins/policies.py
+++ b/mellea/plugins/policies.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    from cpex.framework.hooks.policies import HookPayloadPolicy
+    from cpex.framework.hooks.policies import (
+        HookPayloadPolicy,  # type: ignore[import-not-found]
+    )
 
     _HAS_PLUGIN_FRAMEWORK = True
 except ImportError:

--- a/mellea/plugins/registry.py
+++ b/mellea/plugins/registry.py
@@ -68,7 +68,7 @@ def modify(payload: Any, **field_updates: Any) -> Any:
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "modify() requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
     return PluginResult(
         continue_processing=True,
@@ -94,7 +94,7 @@ def block(
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "block() requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
     return PluginResult(
         continue_processing=False,
@@ -123,7 +123,7 @@ def register(
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "register() requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
 
     from mellea.plugins.manager import ensure_plugin_manager
@@ -343,6 +343,27 @@ if _HAS_PLUGIN_FRAMEWORK:
                 return PluginResult(continue_processing=True)
             return result
 
+else:
+    # Provide a stub when the plugin framework is not installed.
+    class _FunctionHookAdapter:  # type: ignore[no-redef]
+        """Stub — install ``"mellea[hooks]"`` for full plugin support."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "MelleaPlugin requires the ContextForge plugin framework. "
+                "Install it with: pip install 'mellea[hooks]'"
+            )
+
+    # Provide a stub when the plugin framework is not installed.
+    class _MethodHookAdapter:  # type: ignore[no-redef]
+        """Stub — install ``"mellea[hooks]"`` for full plugin support."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "MelleaPlugin requires the ContextForge plugin framework. "
+                "Install it with: pip install 'mellea[hooks]'"
+            )
+
 
 class _PluginScope:
     """Context manager returned by :func:`plugin_scope`.
@@ -441,7 +462,7 @@ def unregister(
     if not _HAS_PLUGIN_FRAMEWORK:
         raise ImportError(
             "unregister() requires the ContextForge plugin framework. "
-            "Install it with: pip install 'mellea[contextforge]'"
+            "Install it with: pip install 'mellea[hooks]'"
         )
 
     from mellea.plugins.manager import get_plugin_manager

--- a/mellea/plugins/registry.py
+++ b/mellea/plugins/registry.py
@@ -232,115 +232,116 @@ def _register_single(
         )
 
 
-class _FunctionHookAdapter(Plugin):
-    """Adapts a standalone ``@hook``-decorated function into a ContextForge Plugin."""
+if _HAS_PLUGIN_FRAMEWORK:
 
-    def __init__(
-        self,
-        fn: Callable,
-        session_id: str | None = None,
-        priority_override: int | None = None,
-    ):
-        meta: HookMeta = fn._mellea_hook_meta  # type: ignore[attr-defined]
-        priority = (
-            priority_override
-            if priority_override is not None
-            else (meta.priority if meta.priority is not None else 50)
-        )
-        config = PluginConfig(
-            name=f"{fn.__module__}.{fn.__qualname__}",
-            kind=f"{fn.__module__}.{fn.__qualname__}",
-            hooks=[meta.hook_type],
-            mode=_map_mode(meta.mode),
-            priority=priority,
-            on_error=_CFOnError.IGNORE,
-        )
-        super().__init__(config)
-        self._fn = fn
-        self._session_id = session_id
+    class _FunctionHookAdapter(Plugin):
+        """Adapts a standalone ``@hook``-decorated function into a ContextForge Plugin."""
 
-    async def initialize(self) -> None:
-        pass
+        def __init__(
+            self,
+            fn: Callable,
+            session_id: str | None = None,
+            priority_override: int | None = None,
+        ):
+            meta: HookMeta = fn._mellea_hook_meta  # type: ignore[attr-defined]
+            priority = (
+                priority_override
+                if priority_override is not None
+                else (meta.priority if meta.priority is not None else 50)
+            )
+            config = PluginConfig(
+                name=f"{fn.__module__}.{fn.__qualname__}",
+                kind=f"{fn.__module__}.{fn.__qualname__}",
+                hooks=[meta.hook_type],
+                mode=_map_mode(meta.mode),
+                priority=priority,
+                on_error=_CFOnError.IGNORE,
+            )
+            super().__init__(config)
+            self._fn = fn
+            self._session_id = session_id
 
-    async def shutdown(self) -> None:
-        pass
+        async def initialize(self) -> None:
+            pass
 
-    # The hook method is discovered by convention: method name == hook_type.
-    # We dynamically add it so ContextForge's HookRef can find it.
-    def __getattr__(self, name: str) -> Any:
-        meta: HookMeta | None = getattr(self._fn, "_mellea_hook_meta", None)
-        if meta and name == meta.hook_type:
-            return self._invoke
-        raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'"
-        )
+        async def shutdown(self) -> None:
+            pass
 
-    async def _invoke(self, payload: Any, context: Any) -> Any:
-        result = await self._fn(payload, context)
-        if result is None:
-            return PluginResult(continue_processing=True)
-        return result
+        # The hook method is discovered by convention: method name == hook_type.
+        # We dynamically add it so ContextForge's HookRef can find it.
+        def __getattr__(self, name: str) -> Any:
+            meta: HookMeta | None = getattr(self._fn, "_mellea_hook_meta", None)
+            if meta and name == meta.hook_type:
+                return self._invoke
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
 
+        async def _invoke(self, payload: Any, context: Any) -> Any:
+            result = await self._fn(payload, context)
+            if result is None:
+                return PluginResult(continue_processing=True)
+            return result
 
-class _MethodHookAdapter(Plugin):
-    """Adapts a single ``@hook``-decorated bound method from a ``Plugin`` class.
+    class _MethodHookAdapter(Plugin):
+        """Adapts a single ``@hook``-decorated bound method from a ``Plugin`` class.
 
-    Each ``@hook`` method on a ``@plugin``-decorated class gets its own adapter
-    so that per-method execution modes (``SEQUENTIAL``, ``FIRE_AND_FORGET``, etc.)
-    are respected.  The adapter name is ``"<plugin_name>.<hook_type>"``.
+        Each ``@hook`` method on a ``@plugin``-decorated class gets its own adapter
+        so that per-method execution modes (``SEQUENTIAL``, ``FIRE_AND_FORGET``, etc.)
+        are respected.  The adapter name is ``"<plugin_name>.<hook_type>"``.
 
-    Note: ``initialize()`` and ``shutdown()`` delegate to the underlying class
-    instance and may be called once per registered hook method.  Make them
-    idempotent when using the ``Plugin`` base class with multiple hook methods.
-    """
+        Note: ``initialize()`` and ``shutdown()`` delegate to the underlying class
+        instance and may be called once per registered hook method.  Make them
+        idempotent when using the ``Plugin`` base class with multiple hook methods.
+        """
 
-    def __init__(
-        self,
-        instance: Any,
-        bound_method: Callable,
-        hook_meta: HookMeta,
-        plugin_name: str,
-        plugin_module: str,
-        priority: int,
-        session_id: str | None = None,
-    ):
-        hook_val = getattr(hook_meta.hook_type, "value", hook_meta.hook_type)
-        adapter_name = f"{plugin_name}.{hook_val}"
-        config = PluginConfig(
-            name=adapter_name,
-            kind=f"{plugin_module}.{hook_val}",
-            hooks=[hook_meta.hook_type],
-            mode=_map_mode(hook_meta.mode),
-            priority=priority,
-            on_error=_CFOnError.IGNORE,
-        )
-        super().__init__(config)
-        self._instance = instance
-        self._bound_method = bound_method
-        self._session_id = session_id
+        def __init__(
+            self,
+            instance: Any,
+            bound_method: Callable,
+            hook_meta: HookMeta,
+            plugin_name: str,
+            plugin_module: str,
+            priority: int,
+            session_id: str | None = None,
+        ):
+            hook_val = getattr(hook_meta.hook_type, "value", hook_meta.hook_type)
+            adapter_name = f"{plugin_name}.{hook_val}"
+            config = PluginConfig(
+                name=adapter_name,
+                kind=f"{plugin_module}.{hook_val}",
+                hooks=[hook_meta.hook_type],
+                mode=_map_mode(hook_meta.mode),
+                priority=priority,
+                on_error=_CFOnError.IGNORE,
+            )
+            super().__init__(config)
+            self._instance = instance
+            self._bound_method = bound_method
+            self._session_id = session_id
 
-    async def initialize(self) -> None:
-        init = getattr(self._instance, "initialize", None)
-        if init and callable(init):
-            await init()
+        async def initialize(self) -> None:
+            init = getattr(self._instance, "initialize", None)
+            if init and callable(init):
+                await init()
 
-    async def shutdown(self) -> None:
-        shut = getattr(self._instance, "shutdown", None)
-        if shut and callable(shut):
-            await shut()
+        async def shutdown(self) -> None:
+            shut = getattr(self._instance, "shutdown", None)
+            if shut and callable(shut):
+                await shut()
 
-    def __getattr__(self, name: str) -> Any:
-        if self._config.hooks and name == self._config.hooks[0]:
-            return self._invoke
-        raise AttributeError(
-            f"'{type(self).__name__}' object has no attribute '{name}'"
-        )
+        def __getattr__(self, name: str) -> Any:
+            if self._config.hooks and name == self._config.hooks[0]:
+                return self._invoke
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
 
-    async def _invoke(self, payload: Any, context: Any) -> Any:
-        result = await self._bound_method(payload, context)
-        if result is None:
-            return PluginResult(continue_processing=True)
-        return result
+        async def _invoke(self, payload: Any, context: Any) -> Any:
+            result = await self._bound_method(payload, context)
+            if result is None:
+                return PluginResult(continue_processing=True)
+            return result
 
 
 class _PluginScope:

--- a/test/backends/test_mellea_tool.py
+++ b/test/backends/test_mellea_tool.py
@@ -129,7 +129,7 @@ def test_from_smolagents_basic():
     4. The tool can be executed with arguments
     """
     try:
-        from smolagents import Tool
+        from smolagents import Tool  # type: ignore[import-not-found]
     except ImportError:
         pytest.skip(
             "smolagents not installed - install with: uv pip install 'mellea[smolagents]'"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -601,6 +601,12 @@ async def register_acceptance_sets(request):
         # If plugins are enabled, we don't need to re-enable them for this specific test.
         return
 
+    from mellea.plugins.registry import _HAS_PLUGIN_FRAMEWORK
+
+    if not _HAS_PLUGIN_FRAMEWORK:
+        yield
+        return
+
     from mellea.plugins import register
     from mellea.plugins.manager import shutdown_plugins
     from test.plugins._acceptance_sets import ALL_ACCEPTANCE_SETS
@@ -618,6 +624,12 @@ async def auto_register_acceptance_sets(request):
         "--disable-default-mellea-plugins", default=False
     )
     if disable_plugins:
+        yield
+        return
+
+    from mellea.plugins.registry import _HAS_PLUGIN_FRAMEWORK
+
+    if not _HAS_PLUGIN_FRAMEWORK:
         yield
         return
 

--- a/test/plugins/test_payloads.py
+++ b/test/plugins/test_payloads.py
@@ -7,6 +7,7 @@ from mellea.plugins.base import MelleaBasePayload
 from mellea.plugins.hooks.component import ComponentPreExecutePayload
 from mellea.plugins.hooks.generation import GenerationPreCallPayload
 from mellea.plugins.hooks.session import SessionPreInitPayload
+from mellea.plugins.registry import _HAS_PLUGIN_FRAMEWORK
 
 
 class TestMelleaBasePayload:
@@ -94,6 +95,7 @@ class TestPayloadFieldsAreStrongRefs:
         assert modified.action.name == "replaced"
         assert payload.action.name == "original"
 
+    @pytest.mark.skipif(not _HAS_PLUGIN_FRAMEWORK, reason="cpex not installed")
     def test_writable_fields_in_policies(self):
         """Writable fields should be listed in their hook policies."""
         from mellea.plugins.policies import MELLEA_HOOK_PAYLOAD_POLICIES

--- a/test/plugins/test_policies.py
+++ b/test/plugins/test_policies.py
@@ -1,5 +1,9 @@
 """Tests for hook payload policies."""
 
+import pytest
+
+pytest.importorskip("cpex", reason="cpex not installed")
+
 from mellea.plugins.policies import MELLEA_HOOK_PAYLOAD_POLICIES
 
 

--- a/test/stdlib/requirements/test_reqlib_python.py
+++ b/test/stdlib/requirements/test_reqlib_python.py
@@ -3,7 +3,7 @@
 import pytest
 
 try:
-    import llm_sandbox
+    import llm_sandbox  # type: ignore[import-not-found]
 
     try:
         with llm_sandbox.SandboxSession(


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 

The cpex package (cpex.framework) provides the ContextForge plugin framework — base classes (Plugin, PluginPayload, PluginResult) and infrastructure (hook registry, payload policies) that Mellea's plugin system builds on. It's an optional dependency.

The bug: two files defined classes that inherit from cpex types at module level, outside the if _HAS_PLUGIN_FRAMEWORK: guard:
  - base.py: class MelleaBasePayload(PluginPayload) — base for all 17 hook payloads
  - registry.py: class _FunctionHookAdapter(Plugin) and class _MethodHookAdapter(Plugin) — adapters for registering hooks

When cpex isn't installed, those names don't exist, so import mellea raises NameError and the entire package is broken. The fix was to provide a frozen pydantic.BaseModel fallback for PluginPayload and wrap the two adapter classes inside the existing if _HAS_PLUGIN_FRAMEWORK: guard (they're only ever instantiated through already-guarded code paths).


<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)