### PR TITLE
fix: Document.parts() returns [] instead of raising NotImplementedError

### DIFF
--- a/mellea/stdlib/components/docs/document.py
+++ b/mellea/stdlib/components/docs/document.py
@@ -15,7 +15,7 @@ class Document(Component[str]):
 
     def parts(self) -> list[Component | CBlock]:
         """The set of all the constituent parts of the `Component`."""
-        raise NotImplementedError("parts isn't implemented by default")
+        return []
 
     def format_for_llm(self) -> str:
         """Formats the `Document` into a string.

--- a/test/stdlib/components/docs/test_document.py
+++ b/test/stdlib/components/docs/test_document.py
@@ -1,0 +1,19 @@
+from mellea.stdlib.components.docs.document import Document
+
+
+def test_document_parts_returns_empty_list():
+    doc = Document("some text", title="Test", doc_id="1")
+    assert doc.parts() == [], "Document.parts() should return an empty list"
+
+
+def test_document_format_for_llm():
+    doc = Document("hello world", title="Greeting", doc_id="abc")
+    result = doc.format_for_llm()
+    assert "abc" in result
+    assert "Greeting" in result
+    assert "hello world" in result
+
+
+def test_document_format_for_llm_no_title():
+    doc = Document("just text")
+    assert doc.format_for_llm() == "just text"


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description

`Document.parts()` raises `NotImplementedError` instead of returning an empty list, causing crashes when a `Document` is passed inside a `Message` to `act()`/`aact()` via `generate_walk()`.

Returns `[]` to match the pattern used by `RichDocument` and `Table`.

Closes #636

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)