### PR TITLE
fix: use tuple instead of generator for DropDuplicates dictionary key

### DIFF
--- a/mellea/formatters/granite/intrinsics/output.py
+++ b/mellea/formatters/granite/intrinsics/output.py
@@ -724,7 +724,7 @@ class DropDuplicates(InPlaceTransformation):
                         f"deduplication be present in all rows. "
                         f"Element is: {element}"
                     )
-            key = (element[t] for t in self.target_fields)
+            key = tuple(element[t] for t in self.target_fields)
             key_to_record[key] = element
         return list(key_to_record.values())
 

--- a/test/formatters/granite/testdata/test_canned_output/model_output/citations.json
+++ b/test/formatters/granite/testdata/test_canned_output/model_output/citations.json
@@ -6,7 +6,7 @@
       "index": 0,
       "logprobs": null,
       "message": {
-        "content": " [{\"r\": 0, \"c\": [8, 11, 13]}, {\"r\": 1, \"c\": []}]",
+        "content": " [{\"r\": 0, \"c\": [8, 8, 11, 13]}, {\"r\": 0, \"c\": [8, 8, 11, 13]}, {\"r\": 1, \"c\": []}]",
         "refusal": null,
         "role": "assistant",
         "annotations": null,


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes https://github.com/generative-computing/mellea/issues/651

The DropDuplicates rule was not dropping duplicates because the dictionary keys were generators and not tuples. This PR includes the following changes:
- Fixes the DropDuplicates rule, by ensuring that the dictionary keys are tuples
- Adds duplicates to the citations canned output test to catch regressions

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)