### PR TITLE
feat: add codeowners for the granite-common part of mellea intrinsics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@
 
 # Mellea Core requires special review
 /mellea/core/ @nrfulton @jakelorocco
+
+# Mellea Intrinsics
+/mellea/formatters/granite @generative-computing/mellea-intrinsics
+/test/formatters/granite @generative-computing/mellea-intrinsics


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes N/A

Now that granite common is a part of Mellea, there are portions of the code that are best owned by the team that heads that work. I've created a new team `mellea-intrinsics` to delegate responsibility to. If this restriction becomes too burdensome, we can remove this; it's main goal is to notify those contributors when a change is going in / needs to be reviewed.
<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)