### PR TITLE
fix: skip pytest collection of qiskit validation_helpers module (#683)

### DIFF
--- a/docs/examples/instruct_validate_repair/qiskit_code_validation/validation_helpers.py
+++ b/docs/examples/instruct_validate_repair/qiskit_code_validation/validation_helpers.py
@@ -1,3 +1,4 @@
+# pytest: skip
 """Helper functions for Qiskit code validation.
 
 This module provides utilities for extracting code from markdown and validating


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue:

Fixes #683

`validation_helpers.py` is a helper module, not a runnable example, but was being collected and executed by pytest. It failed immediately due to a missing optional dependency. Add `# pytest: skip` consistent with the existing conftest mechanism and with the adjacent `qiskit_code_validation.py` entry point.

### Testing
- [ ] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)