### PR TITLE
docs: condense README to elevator pitch (#478)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ uv pip install mellea
 See [installation docs](https://docs.mellea.ai/getting-started/installation) for additional options, such as installing all extras via `uv pip install 'mellea[all]'`.
 For source installation directly from this repo, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-
-
 ## Example
 
 The `@generative` decorator turns a typed Python function into a structured LLM call.


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: 
Fixes #478

Condenses the root README from 206 lines to ~80 lines, replacing detailed installation notes, example walkthroughs, and a verbose contributing section with a focused elevator pitch and links out to the docs site for deeper reading.

Key changes:
- Opening paragraph names the "generative programs" paradigm and frames the problem/solution, aligned with the mellea.ai landing page vision
- Adds explicit badges and links for both `mellea.ai` (website) and `docs.mellea.ai` (docs)
- Single accurate `@generative` + Pydantic code example replacing two examples and the Colab table
- Contributing section links directly to `CONTRIBUTING.md`, building-extensions docs, and mellea-contribs
- Fixes pre-existing GitHub License badge link (was pointing to badge image URL, not the LICENSE file)
- Adds Apache-2.0 license footer

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
