### PR TITLE
fix: always populate mot.usage in HuggingFace backend

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1133,18 +1133,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         span = mot._meta.get("_telemetry_span")
-        from ..telemetry.metrics import is_metrics_enabled
 
-        metrics_enabled = is_metrics_enabled()
-
-        # Extract token counts only if needed
+        # Derive token counts from the output sequences (HF models have no usage object).
         hf_output = mot._meta.get("hf_output")
         n_prompt, n_completion = None, None
-        if (span is not None or metrics_enabled) and isinstance(
-            hf_output, GenerateDecoderOnlyOutput
-        ):
-            # HuggingFace local models don't provide usage objects, but we can
-            # calculate token counts from sequences
+        if isinstance(hf_output, GenerateDecoderOnlyOutput):
             try:
                 if input_ids is not None and hf_output.sequences is not None:
                     n_prompt = input_ids.shape[1]
@@ -1152,7 +1145,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             except Exception:
                 pass
 
-        # Populate standardized usage field (convert to OpenAI format)
         if n_prompt is not None and n_completion is not None:
             mot.usage = {
                 "prompt_tokens": n_prompt,


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description

Fixes #694

Token count extraction in `_post_process_async` was gated behind `span is not None or metrics_enabled`, so `mot.usage` was always `None` in plain (non-telemetry) runs. Extraction is now unconditional — usage is a standard mot field, not a telemetry concern.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)