### PR TITLE
fix: modifications to granite formatter tests

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -73,15 +73,17 @@ class YamlJsonCombo(pydantic.BaseModel):
     """Base model on which the target adapter was trained. Should be small enough to
     run on the CI server."""
 
-    @pydantic.model_validator(mode="after")
-    def _maybe_download_yaml(self):
+    def _resolve_yaml(self):
         """
         If YAML file is not provided, download one based on other attributes of this
-        object.
+        object. Called at fixture creation (execution time) to prevent collection time errors.
         """
         if not self.yaml_file:
             self.yaml_file = intrinsics_util.obtain_io_yaml(
-                self.task, self.base_model_id, self.repo_id, revision=self.revision
+                self.task,
+                self.base_model_id,
+                self.repo_id,
+                revision=self.revision,  # type: ignore
             )
         return self
 
@@ -290,7 +292,7 @@ def _yaml_json_combo(request: pytest.FixtureRequest) -> YamlJsonCombo:
 
     Returns test configuration.
     """
-    return _YAML_JSON_COMBOS[request.param]
+    return _YAML_JSON_COMBOS[request.param]._resolve_yaml()
 
 
 @pytest.fixture(
@@ -306,7 +308,7 @@ def _yaml_json_combo_no_alora(request: pytest.FixtureRequest) -> YamlJsonCombo:
     Returns tuple of short name, YAML file, JSON file, model directory, and
     arguments file.
     """
-    return _YAML_JSON_COMBOS_NO_ALORA[request.param]
+    return _YAML_JSON_COMBOS_NO_ALORA[request.param]._resolve_yaml()
 
 
 @pytest.fixture(
@@ -318,7 +320,7 @@ def _yaml_json_combo_with_model(request: pytest.FixtureRequest) -> YamlJsonCombo
     """Version of :func:`_yaml_json_combo()` fixture with only the inputs that have
     models.
     """
-    return _YAML_JSON_COMBOS_WITH_MODEL[request.param]
+    return _YAML_JSON_COMBOS_WITH_MODEL[request.param]._resolve_yaml()
 
 
 @pytest.fixture(
@@ -330,7 +332,7 @@ def _yaml_json_combo_with_lora_model(request: pytest.FixtureRequest) -> YamlJson
     """Version of :func:`_yaml_json_combo()` fixture with only the inputs that have
     non-aLoRA models.
     """
-    return _YAML_JSON_COMBOS_WITH_LORA_MODEL[request.param]
+    return _YAML_JSON_COMBOS_WITH_LORA_MODEL[request.param]._resolve_yaml()
 
 
 @pytest.fixture(
@@ -342,7 +344,7 @@ def _yaml_json_combo_for_ollama(request: pytest.FixtureRequest) -> YamlJsonCombo
     """Version of :func:`_yaml_json_combo()` fixture with only inputs suitable
     for an Ollama backend.
     """
-    return _YAML_JSON_COMBOS_FOR_OLLAMA[request.param]
+    return _YAML_JSON_COMBOS_FOR_OLLAMA[request.param]._resolve_yaml()
 
 
 def test_no_orphan_files():
@@ -685,8 +687,6 @@ def test_run_transformers(yaml_json_combo_with_model, gh_run):
         raise e
 
 
-@pytest.mark.ollama
-@pytest.mark.llm
 def test_run_ollama(yaml_json_combo_for_ollama):
     """
     Run the target model end-to-end with a mock Ollama backend.


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes N/A

Added pytest markers for the LLM based tests. Changed when yaml collection is done so that tests don't fail at collection time.

Tested the changes and am able to run the tests even with an unavailable adapter; tests now fail during execution and other tests can run:
```
================================================================================== short test summary info ==================================================================================
ERROR test/formatters/granite/test_intrinsics_formatters.py::test_canned_input[answer_relevance_classifier] - ValueError: Intrinsic 'answer_relevance_classifier' as LoRA adapter on base model 'granite-4.0-micro' not found in ibm-granite/granite-lib-rag-r1.0 repository on Hugging Face Hub. Sear...
ERROR test/formatters/granite/test_intrinsics_formatters.py::test_openai_compat[answer_relevance_classifier] - ValueError: Intrinsic 'answer_relevance_classifier' as LoRA adapter on base model 'granite-4.0-micro' not found in ibm-granite/granite-lib-rag-r1.0 repository on Hugging Face Hub. Sear...
ERROR test/formatters/granite/test_intrinsics_formatters.py::test_canned_output[answer_relevance_classifier] - ValueError: Intrinsic 'answer_relevance_classifier' as LoRA adapter on base model 'granite-4.0-micro' not found in ibm-granite/granite-lib-rag-r1.0 repository on Hugging Face Hub. Sear...
ERROR test/formatters/granite/test_intrinsics_formatters.py::test_run_transformers[answer_relevance_classifier] - ValueError: Intrinsic 'answer_relevance_classifier' as LoRA adapter on base model 'granite-4.0-micro' not found in ibm-granite/granite-lib-rag-r1.0 repository on Hugging Face Hub. Sear...
ERROR test/formatters/granite/test_intrinsics_formatters.py::test_run_ollama[answer_relevance_classifier] - ValueError: Intrinsic 'answer_relevance_classifier' as LoRA adapter on base model 'granite-4.0-micro' not found in ibm-granite/granite-lib-rag-r1.0 repository on Hugging Face Hub. Sear...
==================================================================== 74 passed, 1 xfailed, 5 errors in 234.83s (0:03:54) ====================================================================
```

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)