### PR TITLE
chore: use github tooling to build release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: "New Features"
+      labels:
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Documentation"
+      labels:
+        - documentation
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -13,13 +13,30 @@ CHGLOG_FILE="${CHGLOG_FILE:-CHANGELOG.md}"
 uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version "${TARGET_VERSION}"
 UV_FROZEN=0 uv lock --upgrade-package mellea
 
-# collect release notes
+# push changes
+git config --global user.name 'github-actions[bot]'
+git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+# Configure the remote with the token
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+TARGET_TAG_NAME="v${TARGET_VERSION}"
+
+# Commit and push version bump first so the tag has the right base
+git add pyproject.toml uv.lock
+COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
+git commit -m "${COMMIT_MSG}"
+git push origin main
+
+# create GitHub release (incl. Git tag) with GitHub-native generated notes
+gh release create "${TARGET_TAG_NAME}" --generate-notes
+
+# pull the generated notes back locally to update the changelog
 REL_NOTES=$(mktemp)
-uv run --no-sync semantic-release changelog --unreleased >> "${REL_NOTES}"
+gh release view "${TARGET_TAG_NAME}" --json body -q ".body" >> "${REL_NOTES}"
 
 # update changelog
 TMP_CHGLOG=$(mktemp)
-TARGET_TAG_NAME="v${TARGET_VERSION}"
 RELEASE_URL="$(gh repo view --json url -q ".url")/releases/tag/${TARGET_TAG_NAME}"
 printf "## [${TARGET_TAG_NAME}](${RELEASE_URL}) - $(date -Idate)\n\n" >> "${TMP_CHGLOG}"
 cat "${REL_NOTES}" >> "${TMP_CHGLOG}"
@@ -28,17 +45,6 @@ if [ -f "${CHGLOG_FILE}" ]; then
 fi
 mv "${TMP_CHGLOG}" "${CHGLOG_FILE}"
 
-# push changes
-git config --global user.name 'github-actions[bot]'
-git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-
-# Configure the remote with the token
-git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-git add pyproject.toml uv.lock "${CHGLOG_FILE}"
-COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
-git commit -m "${COMMIT_MSG}"
+git add "${CHGLOG_FILE}"
+git commit -m "docs: update changelog for ${TARGET_TAG_NAME} [skip ci]"
 git push origin main
-
-# create GitHub release (incl. Git tag)
-gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -26,6 +26,7 @@ jobs:
               'chore':    null,
               'build':    null,
               'style':    null,
+              'revert':   null,
             };
 
             const match = title.match(/^(\w+)[\(!\:]/);

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,43 @@
+name: "Label PR by conventional commit prefix"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply label based on PR title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labelMap = {
+              'feat':     'enhancement',
+              'fix':      'bug',
+              'docs':     'documentation',
+              'test':     'testing',
+              'perf':     'enhancement',
+              'refactor': 'enhancement',
+              'ci':       'integrations',
+              'chore':    null,
+              'build':    null,
+              'style':    null,
+            };
+
+            const match = title.match(/^(\w+)[\(!\:]/);
+            if (!match) return;
+
+            const prefix = match[1];
+            const label = labelMap[prefix];
+            if (!label) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

<!-- Brief description of the change being made along with an explanation. -->

Uses github native tooling to create release notes instead of semantic-version
Also adds auto-labeling for PRs (which is needed for GH to categorize PR for the notes)

Benefit is we'll get a list of contributors in the release notes, and it also calls out first time contributors (which is nice for community building)

If we want to keep the current way we do it, that's fine too.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)