### PR TITLE
docs: note virtual environment requirement for pre-commit hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,10 @@ to melleaadmin@ibm.com.
    ```bash
    pre-commit install
    ```
+   > **Note:** Some hooks require tools in dev dependency groups to be on your PATH. Activate the virtual environment before committing to ensure they are available:
+   > ```bash
+   > source .venv/bin/activate
+   > ```
 
 ### Installation with `conda`/`mamba`
 
@@ -430,7 +434,7 @@ CICD=1 uv run pytest
 | Output is wrong/None | Model too small or needs better prompt. Try larger model or add `reasoning` field. |
 | `error: can't find Rust compiler` | Python 3.13+ requires Rust for outlines. Install [Rust](https://www.rust-lang.org/tools/install) or use Python 3.12. |
 | Tests fail on Intel Mac | Use conda: `conda install 'torchvision>=0.22.0'` then `uv pip install mellea`. |
-| Pre-commit hooks fail | Run `pre-commit run --all-files` to see specific issues. Fix or use `git commit -n` to bypass. |
+| Pre-commit hooks fail | Run `pre-commit run --all-files` to see specific issues. Fix or use `git commit -n` to bypass. If a tool reports `command not found`, activate the virtual environment before committing: `source .venv/bin/activate`. |
 
 ### Debugging Tips
 


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #744

Adds a note to the installation steps and common issues table clarifying that some pre-commit hooks require dev tools (from the `lint` and `typecheck` dependency groups) to be on PATH, and directs contributors to activate the virtual environment before committing.

This was introduced in #709 which moved the ruff hooks to `language: system`, requiring the tools to be available outside the virtualenv.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
