### PR TITLE
fix: exclude tooling from mypy check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: mypy
         name: MyPy
-        entry: uv run --no-sync mypy --install-types --non-interactive . --exclude scratchpad/ --exclude tmp/
+        entry: uv run --no-sync mypy --install-types --non-interactive . 
         pass_filenames: false
         language: system
         types_or: [python, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,11 @@ install_types = true
 non_interactive = true
 disable_error_code = ["empty-body", "import-untyped"]
 python_version = "3.11"
+exclude = [
+"^tooling/",
+"^scratchpad/",
+"^tmp/"
+]
 
 [[tool.mypy.overrides]]
 # Keep import-not-found suppressed for optional dependencies


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

Updates mypy configuration to exclude doc tooling

Fixes #747 

<!-- Brief description of the change being made along with an explanation. -->

Our pre-commit runs mypy which validates types and therefore needs to have all dependencies available for the code it is checking. Since griffe (used by docs pipeline) is only in the 'dev' group, and we only use 'uv run' for mypy, it will not have access to those dependencies.

An alternative option is  ensuring mypy check installs/syncs all optional dependencies including dev. However this is a bigger decision - it has more impact, so I am not proposing that here (aside: this mypy issue may occur in other areas .. we may need to consider this in future)

Additionally I've moved the exclusion into pyproject.toml which allows the invocation in pre-commit to not have to specify additional excludes & keeps the config consistent

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)