### PR TITLE
chore: enforce commit formatting on PR titles

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -31,10 +31,11 @@ jobs:
             };
 
             const match = title.match(/^(\w+)[\(!\:]/);
-            if (!match) return;
+            if (!match) { core.setFailed(`PR title "${title}" does not match conventional commit format.`); return; }
 
             const prefix = match[1];
             const label = labelMap[prefix];
+            if (label === undefined) { core.setFailed(`PR title prefix "${prefix}" is not a recognized conventional commit type.`); return; }
             if (!label) return;
 
             await github.rest.issues.addLabels({


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [x] Link to Issue: Fixes #681 

Enforces mergify rule on PR titles via existing github action that adds labels. 
Once this merges, we can disable the mergify action

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)