### PR TITLE
fix: setting ollama host in conftest

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,11 +37,17 @@ def _check_ollama_available():
     """
     import socket
 
+    host_str = os.environ.get("OLLAMA_HOST", "127.0.0.1:11434")
+    # OLLAMA_HOST may be "host:port" or just "host" (bare IP without port)
+    if ":" in host_str:
+        host, port = host_str.rsplit(":", 1)
+        port = int(port)
+    else:
+        host, port = host_str, 11434
     try:
-        # Try to connect to Ollama's default port
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)
-        result = sock.connect_ex(("localhost", 11434))
+        result = sock.connect_ex((host, port))
         sock.close()
         return result == 0
     except Exception:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,7 @@ def _check_ollama_available():
         host, port = host_str.rsplit(":", 1)
         port = int(port)
     else:
-        host, port = host_str, 11434
+        host, port = host_str, int(os.environ.get("OLLAMA_PORT", 11434))
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description

The PR just ensures that conftest inherits `OLLAMA_URL` and `OLLAMA_PORT` from env variables if it is set. 



### Testing
- [X] Tests added to the respective file if code was changed
- [X] New code has 100% coverage if code as added
- [X] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)