### PR TITLE
ci: drop mergify, add release entry to pr-labels action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,9 +1,0 @@
-merge_protections:
-  - name: Enforce conventional commit
-    description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
-    if:
-      - base = main
-    success_conditions:
-      - "title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert|release)(?:\\(.+\
-        \\))?:"

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -28,6 +28,7 @@ jobs:
               'build':    null,
               'style':    null,
               'revert':   null,
+              'release':  null,
             };
 
             const match = title.match(/^(\w+)[\(!\:]/);


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

After #750, we no longer need the mergify rule to validate PR titles. So this PR drops that rule and also catches a missed prefix (`release`) from the previous PR.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)