### PR TITLE
ci: fix to make pr label job required check

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -3,6 +3,7 @@ name: "Label PR by conventional commit prefix"
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
+  merge_group:
 
 jobs:
   label:
@@ -45,3 +46,10 @@ jobs:
               issue_number: context.payload.pull_request.number,
               labels: [label],
             });
+  conventional-commit:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR title already validated at PR open/edit time"
+
+

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   label:
-    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write
     steps:
       - name: Apply label based on PR title prefix
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
           script: |
@@ -47,10 +47,8 @@ jobs:
               issue_number: context.payload.pull_request.number,
               labels: [label],
             });
-  conventional-commit:
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "PR title already validated at PR open/edit time"
+      - name: Skip label in merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "PR title already validated at PR open/edit time"
 
 

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   label:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

This PR adds a small fix to the add labels / PR title action to enable us to use it as a required check.
Currently actions need to pass twice, once on the actual PR and then again when in the merge queue.
To make a check required, it has to pass in both phases.
The problem we had was the job would not return a result in the merge queue, meaning that if it was required it would prevent merging.
Here we add a small fix so that the job will pass in both phases.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)