### PR TITLE
fix(tools): correct args validation in langchain tool wrapper

### DIFF
--- a/mellea/backends/tools.py
+++ b/mellea/backends/tools.py
@@ -95,7 +95,7 @@ class MelleaTool(AbstractMelleaTool):
 
                 def parameter_remapper(*args, **kwargs):
                     """Langchain tools expect their first argument to be 'tool_input'."""
-                    if args is not None or len(args) != 0:
+                    if args:
                         # This shouldn't happen. Our ModelToolCall.call_func actually passes in everything as kwargs.
                         FancyLogger.get_logger().warning(
                             f"ignoring unexpected args while calling langchain tool ({tool_name}): ({args})"

--- a/test/backends/test_mellea_tool.py
+++ b/test/backends/test_mellea_tool.py
@@ -99,6 +99,30 @@ def test_from_langchain():
     assert t.run(input=2) == "2"
 
 
+def test_from_langchain_args_handling(caplog):
+    """Test that langchain tools handle args correctly.
+
+    Verifies that:
+    1. Tools work correctly when called with kwargs only (normal case)
+    2. A warning is logged if positional args are passed (shouldn't happen)
+    """
+    t = MelleaTool.from_langchain(langchain_tool)
+
+    # Normal case: kwargs only (no warning expected)
+    caplog.clear()
+    result = t.run(input=5)
+    assert result == "5"
+    assert "ignoring unexpected args" not in caplog.text
+
+    # Edge case: positional args passed (warning expected)
+    # This shouldn't happen in practice since ModelToolCall.call_func uses **kwargs
+    caplog.clear()
+    result = t.run(42, input=5)  # Pass both positional and keyword args
+    assert result == "5"  # Should still work, using kwargs
+    assert "ignoring unexpected args" in caplog.text
+    assert "langchain_tool" in caplog.text
+
+
 @pytest.mark.qualitative
 @pytest.mark.ollama
 @pytest.mark.llm


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #760 

Fixed logic error in MelleaTool.from_langchain() where the condition `if args is not None or len(args) != 0:` was always True, causing false positive warnings on every tool call.

Changed to `if args:` which correctly checks for non-empty tuples, since *args is always a tuple (never None) in Python.

Added test_from_langchain_args_handling() to verify:
- No warning when called with kwargs only (normal case)
- Warning logged when positional args passed (edge case)

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)