### PR TITLE
fix: evict Ollama models between test modules to prevent memory starvation

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -214,7 +214,7 @@ Utility functions used across examples.
 - **Agent Guidelines**: [../../AGENTS.md](../../AGENTS.md)
 - **Dev Docs**: [../dev/](../dev/)
 
-## Running Examples
+## 🏃 Running Examples
 
 ```bash
 # Run any Python example
@@ -226,8 +226,8 @@ uv run docs/examples/tutorial/simple_email.py
 # Run notebooks
 jupyter notebook docs/examples/notebooks/
 
-# Run examples as tests
-uv run pytest docs/examples/
+# Run tests
+uv run pytest test/
 ```
 
 ## 💡 Tips

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -214,7 +214,7 @@ Utility functions used across examples.
 - **Agent Guidelines**: [../../AGENTS.md](../../AGENTS.md)
 - **Dev Docs**: [../dev/](../dev/)
 
-## 🏃 Running Examples
+## Running Examples
 
 ```bash
 # Run any Python example
@@ -226,8 +226,8 @@ uv run docs/examples/tutorial/simple_email.py
 # Run notebooks
 jupyter notebook docs/examples/notebooks/
 
-# Run tests
-uv run pytest test/
+# Run examples as tests
+uv run pytest docs/examples/
 ```
 
 ## 💡 Tips

--- a/docs/examples/conftest.py
+++ b/docs/examples/conftest.py
@@ -603,6 +603,56 @@ def pytest_runtest_setup(item):
             )
 
 
+def pytest_runtest_teardown(item, nextitem):
+    """Evict Ollama models after each ollama-marked example.
+
+    Examples run as subprocesses, so Ollama's default keep_alive keeps
+    models resident after exit. Evict after every example to prevent
+    heavyweight models from starving subsequent examples of memory (#798).
+    """
+    if not isinstance(item, ExampleItem):
+        return
+    if not item.get_closest_marker("ollama"):
+        return
+
+    _evict_ollama_models()
+
+
+def _evict_ollama_models() -> None:
+    """Evict all currently loaded Ollama models (best-effort)."""
+    import requests
+
+    host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
+    if ":" in host:
+        host, port = host.rsplit(":", 1)
+    else:
+        port = os.environ.get("OLLAMA_PORT", "11434")
+
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
+
+    base_url = f"http://{host}:{port}"
+
+    try:
+        resp = requests.get(f"{base_url}/api/ps", timeout=5)
+        resp.raise_for_status()
+        loaded = resp.json().get("models", [])
+    except Exception:
+        return
+
+    for entry in loaded:
+        model_name = entry.get("name") or entry.get("model", "unknown")
+        try:
+            requests.post(
+                f"{base_url}/api/generate",
+                json={"model": model_name, "keep_alive": 0},
+                timeout=10,
+            )
+            print(f"ollama-evict: evicted {model_name}", file=sys.stderr)
+        except Exception:
+            pass
+
+
 def pytest_collection_modifyitems(items):
     """Apply markers from example files to ExampleItem objects.
 

--- a/test/README.md
+++ b/test/README.md
@@ -19,10 +19,31 @@ uv run pytest -m slow
 
 - `CICD=1` - Enable CI mode (skips qualitative tests)
 - `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` - Helps with GPU memory fragmentation
-- `OLLAMA_KEEP_ALIVE=1m` - Reduce Ollama model idle window from the default 5 minutes to 1 minute.
-  Useful when running without `--group-by-backend`: limits how long a loaded Ollama model occupies
-  unified memory while HF/torch tests are running. Has no effect mid-run (timer resets per request),
-  but reduces the overlap window when switching between backend groups.
+
+## Ollama Model Eviction
+
+When pytest orchestrates many Ollama-backed tests in sequence, the default 5-minute
+keep-alive means models from earlier tests stay resident and accumulate, eventually
+starving later tests of memory.
+
+Two mechanisms in `test/conftest.py` handle this:
+
+- **Per-module eviction** (`pytest_runtest_teardown`) — when crossing a file
+  boundary between Ollama-marked tests, queries `/api/ps` for all loaded models
+  and evicts them with `keep_alive=0`. Covers both `test/` and `docs/examples/`.
+  Always active, no flags required.
+- **Group warm-up/eviction** (`pytest_runtest_setup`) — warms up a fixed set of CI
+  models (`keep_alive=-1`) when entering the Ollama backend group and evicts them
+  when leaving. Requires `--group-by-backend`.
+
+**Trade-off:** if two consecutive test files use the same model, it will be unloaded
+and reloaded (~5-15 s overhead). Predictable memory behaviour is more important
+than saving a reload, especially on constrained CI runners. Tests within a single
+file share the loaded model with no overhead.
+
+**Caveat:** eviction targets *all* loaded Ollama models, not just those loaded by
+the test. If you are using Ollama interactively while the suite runs, your model
+will be evicted between test modules.
 
 ## GPU Testing on CUDA Systems
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -549,6 +549,20 @@ def pytest_runtest_setup(item):
     # to prevent fixture setup errors
 
 
+def pytest_runtest_teardown(item, nextitem):
+    """Evict Ollama models when crossing a module boundary.
+
+    Prevents models from accumulating across test files while avoiding
+    redundant unload/reload within a single module (where tests typically
+    share a model). Also evicts after the very last test.
+    """
+    if not item.get_closest_marker("ollama"):
+        return
+
+    if nextitem is None or nextitem.path != item.path:
+        evict_ollama_models()
+
+
 def memory_cleaner():
     """Lightweight memory cleanup — safety net for per-test GPU leaks."""
     yield
@@ -564,6 +578,53 @@ def memory_cleaner():
             torch.cuda.synchronize()
     except ImportError:
         pass
+
+
+def evict_ollama_models() -> None:
+    """Evict all currently loaded Ollama models to free memory.
+
+    Queries /api/ps to discover loaded models, then sends keep_alive=0
+    to each via /api/generate. Prevents heavyweight models from starving
+    subsequent tests of memory (see #798).
+
+    Best-effort: errors are logged but never raised.
+    """
+    logger = FancyLogger.get_logger()
+
+    # Parse OLLAMA_HOST which may be "host", "host:port", or absent.
+    host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
+    if ":" in host:
+        host, port = host.rsplit(":", 1)
+    else:
+        port = os.environ.get("OLLAMA_PORT", "11434")
+
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
+
+    base_url = f"http://{host}:{port}"
+
+    try:
+        resp = requests.get(f"{base_url}/api/ps", timeout=5)
+        resp.raise_for_status()
+        loaded = resp.json().get("models", [])
+    except Exception as e:
+        logger.warning("ollama-evict: could not query loaded models: %s", e)
+        return
+
+    if not loaded:
+        return
+
+    for entry in loaded:
+        model_name = entry.get("name") or entry.get("model", "unknown")
+        try:
+            requests.post(
+                f"{base_url}/api/generate",
+                json={"model": model_name, "keep_alive": 0},
+                timeout=10,
+            )
+            logger.info("ollama-evict: evicted %s", model_name)
+        except Exception as e:
+            logger.warning("ollama-evict: failed to evict %s: %s", model_name, e)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/test/core/test_computed_model_output_thunk.py
+++ b/test/core/test_computed_model_output_thunk.py
@@ -1,7 +1,5 @@
 """Tests for ComputedModelOutputThunk."""
 
-# pytest: ollama, llm
-
 import pytest
 
 from mellea.core import ComputedModelOutputThunk, ModelOutputThunk
@@ -72,6 +70,8 @@ def test_computed_thunk_with_parsed_repr():
     assert computed_thunk.parsed_repr == "parsed value"
 
 
+@pytest.mark.ollama
+@pytest.mark.e2e
 def test_sync_functions_return_computed_thunks():
     """Test that synchronous session functions return ComputedModelOutputThunk."""
     with start_session() as session:
@@ -83,6 +83,8 @@ def test_sync_functions_return_computed_thunks():
         assert result.value is not None
 
 
+@pytest.mark.ollama
+@pytest.mark.e2e
 def test_sync_functions_with_sampling_return_computed_thunks():
     """Test that synchronous functions with sampling return ComputedModelOutputThunk."""
     from mellea.stdlib.sampling import RejectionSamplingStrategy
@@ -98,6 +100,8 @@ def test_sync_functions_with_sampling_return_computed_thunks():
         assert result.value is not None
 
 
+@pytest.mark.ollama
+@pytest.mark.e2e
 async def test_async_functions_return_computed_thunks():
     """Test that async session functions return ComputedModelOutputThunk when await_result=True."""
     with start_session() as session:

--- a/test/core/test_streaming_sync_functions.py
+++ b/test/core/test_streaming_sync_functions.py
@@ -1,10 +1,10 @@
 """Tests for streaming support using async functions with await_result parameter."""
 
-# pytest: ollama, llm
-
 import asyncio
 
 import pytest
+
+pytestmark = [pytest.mark.ollama, pytest.mark.e2e]
 
 from mellea.core import ComputedModelOutputThunk, ModelOutputThunk
 from mellea.stdlib.session import start_session


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
## Type of PR

- [x] Bug Fix

## Description

- Fixes #798

### Problem

When running the full test suite (`uv run pytest`), Ollama's default 5-minute
keep-alive means models from earlier tests stay resident in memory long after
their subprocess or test function exits. Heavyweight models accumulate and
starve later tests of headroom — the SOFAI graph-colouring example crashed
with a 500 because an 11 GB guardian model from an earlier example was still
resident.

`test/conftest.py` already managed this for the regular test suite via
`--group-by-backend` warm-up/eviction, but that flag is not on by default and
`docs/examples/` had no equivalent at all.

### Ollama models across the test suite

The examples use a wide variety of models that cannot be hardcoded:

| Model | ~Size | Where |
|-------|-------|-------|
| `granite4:micro` | 2 GB | test (conftest warmup, payloads, intrinsics) |
| `granite4:micro-h` | 2 GB | test (telemetry, components, genslot), examples (m_serve) |
| `granite3.2-vision` | 3 GB | test (conftest warmup, vision), examples (vision) |
| `llama3.2:1b` | 1.3 GB | test (SOFAI sampling, graph colouring) |
| `granite4:latest` | 5 GB | examples (melp ×5) |
| `granite3.3:8b` | 5 GB | examples (decompose) |
| `deepseek-r1:8b` | 5 GB | examples (guardian, guardian_hf) |
| `qwen2.5vl:7b` | 6 GB | examples (vision_openai) |
| `pielee/qwen3-4b-thinking-2507_q8` | 4 GB | examples (SOFAI graph colouring) |
| `phi:2.7b` | 2 GB | examples (SOFAI graph colouring) |
| `granite3-guardian:2b` | 1.5 GB | examples (mini_researcher) |
| `llama3.2:3b` | 2 GB | examples (tutorial, mify, notebook) |

Running even a handful of these consecutively without eviction can exhaust
available memory.

### Solution

Add **per-module Ollama model eviction** to `test/conftest.py` via a
`pytest_runtest_teardown` hook. When pytest crosses a file boundary between
Ollama-marked tests, the hook queries `/api/ps` for all loaded models and
evicts each with `keep_alive=0`.

- Always active — no flags required
- Covers both `test/` and `docs/examples/`
- Discovers models dynamically rather than hardcoding a list

### Compromise

Eviction happens at **module boundaries**, not per-test. Tests within a single
file share the loaded model with no overhead. When crossing files, any loaded
model is evicted — even if the next file uses the same one. This means a
redundant unload/reload (~5–15 s) when consecutive files share a model.

This is a deliberate trade-off: predictable memory behaviour matters more than
saving a reload, particularly on constrained CI runners where an OOM crash
costs far more than a few seconds of model loading.

Eviction also targets *all* loaded Ollama models, not just those loaded by the
test. If you are using Ollama interactively whilst the suite runs, your model
will be evicted between test modules.

### Missing `ollama` markers

Two test files under `test/core/` called `start_session()` (real Ollama
backend) but lacked `pytest.mark.ollama`. They had the inert
`# pytest: ollama, llm` comment syntax, which is only parsed for
`docs/examples/` items — regular test files require a proper `pytestmark`
or decorator. Without the marker, the eviction hook never fired for them,
leaving models resident through subsequent non-Ollama tests.

- `test/core/test_streaming_sync_functions.py` — added module-level
  `pytestmark = [pytest.mark.ollama, pytest.mark.e2e]`
- `test/core/test_computed_model_output_thunk.py` — added per-function
  `@pytest.mark.ollama` and `@pytest.mark.e2e` on the 3 tests that use
  a real Ollama session (8 pure unit tests left unmarked)

### Other changes

- Removed the now-redundant `OLLAMA_KEEP_ALIVE=1m` tip from `test/README.md`
  (active eviction supersedes a manual idle-timeout workaround)
- Added an "Ollama Model Eviction" section to `test/README.md` documenting
  both eviction mechanisms

### Testing

The eviction logic is best-effort infrastructure — it queries a live Ollama
server, so unit testing without mocking the HTTP calls is not meaningful.
Verified locally by running the full suite with `-s` and confirming models
are evicted between files via `ollama-evict` log output.