### PR TITLE
fix: reload module for telemetry testing so all tests can run

### DIFF
--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -87,8 +87,10 @@ if _OTEL_AVAILABLE and (_TRACE_APPLICATION_ENABLED or _TRACE_BACKEND_ENABLED):
     _tracer_provider = _setup_tracer_provider()
     # Create separate tracers for application and backend
     _mellea_version = version("mellea")
-    _application_tracer = trace.get_tracer("mellea.application", _mellea_version)  # type: ignore
-    _backend_tracer = trace.get_tracer("mellea.backend", _mellea_version)  # type: ignore
+    _application_tracer = _tracer_provider.get_tracer(
+        "mellea.application", _mellea_version
+    )
+    _backend_tracer = _tracer_provider.get_tracer("mellea.backend", _mellea_version)
 
 
 def is_application_tracing_enabled() -> bool:

--- a/test/telemetry/test_metrics.py
+++ b/test/telemetry/test_metrics.py
@@ -52,8 +52,8 @@ def enable_metrics(monkeypatch):
     monkeypatch.delenv("MELLEA_METRICS_PROMETHEUS", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
-    monkeypatch.delenv("OTL_METRIC_EXPORT_INTERVAL", raising=False)
-    monkeypatch.delenv("OTL_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("OTEL_METRIC_EXPORT_INTERVAL", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
     # Force reload of metrics module to pick up env vars
     import importlib
 

--- a/test/telemetry/test_metrics.py
+++ b/test/telemetry/test_metrics.py
@@ -46,6 +46,14 @@ def clean_metrics_env(monkeypatch):
 def enable_metrics(monkeypatch):
     """Enable metrics for tests."""
     monkeypatch.setenv("MELLEA_METRICS_ENABLED", "true")
+    # Clear other env vars to prevent user-set values from leaking into reload
+    monkeypatch.delenv("MELLEA_METRICS_CONSOLE", raising=False)
+    monkeypatch.delenv("MELLEA_METRICS_OTLP", raising=False)
+    monkeypatch.delenv("MELLEA_METRICS_PROMETHEUS", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTL_METRIC_EXPORT_INTERVAL", raising=False)
+    monkeypatch.delenv("OTL_SERVICE_NAME", raising=False)
     # Force reload of metrics module to pick up env vars
     import importlib
 
@@ -454,6 +462,9 @@ def test_otlp_enabled_without_endpoint_warning(monkeypatch):
     """Test that enabling OTLP without endpoint produces helpful warning."""
     monkeypatch.setenv("MELLEA_METRICS_ENABLED", "true")
     monkeypatch.setenv("MELLEA_METRICS_OTLP", "true")
+    # Ensure no endpoint env vars are set (user env could have these)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
 
     import importlib
 

--- a/test/telemetry/test_tracing.py
+++ b/test/telemetry/test_tracing.py
@@ -43,7 +43,21 @@ def enable_backend_tracing(monkeypatch):
     importlib.reload(mellea.telemetry.tracing)
 
 
-def test_telemetry_disabled_by_default():
+@pytest.fixture
+def disable_tracing(monkeypatch):
+    """Disable all tracing for tests."""
+    monkeypatch.delenv("MELLEA_TRACE_APPLICATION", raising=False)
+    monkeypatch.delenv("MELLEA_TRACE_BACKEND", raising=False)
+    import importlib
+
+    import mellea.telemetry.tracing
+
+    importlib.reload(mellea.telemetry.tracing)
+    yield
+    importlib.reload(mellea.telemetry.tracing)
+
+
+def test_telemetry_disabled_by_default(disable_tracing):
     """Test that telemetry is disabled by default."""
     from mellea.telemetry import (
         is_application_tracing_enabled,

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -37,12 +37,18 @@ pytestmark = [
 @pytest.fixture(scope="module", autouse=True)
 def setup_telemetry():
     """Set up telemetry for all tests in this module."""
+    import importlib
+
+    import mellea.telemetry.tracing
+
     mp = pytest.MonkeyPatch()
     mp.setenv("MELLEA_TRACE_BACKEND", "true")
+    importlib.reload(mellea.telemetry.tracing)
 
     yield
 
-    mp.undo()
+    mp.setenv("MELLEA_TRACE_BACKEND", "false")
+    importlib.reload(mellea.telemetry.tracing)
 
 
 @pytest.fixture

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -124,8 +124,12 @@ async def test_context_propagation_parent_child(span_exporter, gh_run):
     ctx = SimpleContext()
     ctx = ctx.add(Message(role="user", content="Say 'test' and nothing else"))
 
-    # Create a parent span
-    tracer = trace.get_tracer(__name__)
+    # Create a parent span using the module's own tracer provider
+    # (not the global one, which may be pinned to a different provider
+    # due to OTel's set-once semantics for set_tracer_provider)
+    from mellea.telemetry import tracing
+
+    tracer = tracing._tracer_provider.get_tracer(__name__)
     with tracer.start_as_current_span("parent_operation"):
         mot, _ = await backend.generate_from_context(
             Message(role="assistant", content=""), ctx

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -75,8 +75,6 @@ def span_exporter():
 @pytest.mark.asyncio
 async def test_span_duration_captures_async_operation(span_exporter, gh_run):
     """Test that span duration includes the full async operation time."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
     ctx = SimpleContext()
@@ -121,8 +119,6 @@ async def test_span_duration_captures_async_operation(span_exporter, gh_run):
 @pytest.mark.asyncio
 async def test_context_propagation_parent_child(span_exporter, gh_run):
     """Test that parent-child span relationships are maintained."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
     ctx = SimpleContext()
@@ -166,8 +162,6 @@ async def test_context_propagation_parent_child(span_exporter, gh_run):
 @pytest.mark.asyncio
 async def test_token_usage_recorded_after_completion(span_exporter, gh_run):
     """Test that token usage metrics are recorded after async completion."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
     ctx = SimpleContext()
@@ -217,8 +211,6 @@ async def test_token_usage_recorded_after_completion(span_exporter, gh_run):
 @pytest.mark.asyncio
 async def test_span_not_closed_prematurely(span_exporter, gh_run):
     """Test that spans are not closed before async operations complete."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
     ctx = SimpleContext()
@@ -253,8 +245,6 @@ async def test_span_not_closed_prematurely(span_exporter, gh_run):
 @pytest.mark.asyncio
 async def test_multiple_generations_separate_spans(span_exporter, gh_run):
     """Test that multiple generations create separate spans."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
     ctx = SimpleContext()
@@ -287,8 +277,6 @@ async def test_multiple_generations_separate_spans(span_exporter, gh_run):
 @pytest.mark.asyncio
 async def test_streaming_span_duration(span_exporter, gh_run):
     """Test that streaming operations have accurate span durations."""
-    if gh_run:
-        pytest.skip("Skipping in CI - requires Ollama")
 
     from mellea.backends.model_options import ModelOption
 

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -73,7 +73,7 @@ def span_exporter():
 
 
 @pytest.mark.asyncio
-async def test_span_duration_captures_async_operation(span_exporter, gh_run):
+async def test_span_duration_captures_async_operation(span_exporter):
     """Test that span duration includes the full async operation time."""
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
@@ -117,7 +117,7 @@ async def test_span_duration_captures_async_operation(span_exporter, gh_run):
 
 
 @pytest.mark.asyncio
-async def test_context_propagation_parent_child(span_exporter, gh_run):
+async def test_context_propagation_parent_child(span_exporter):
     """Test that parent-child span relationships are maintained."""
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
@@ -164,7 +164,7 @@ async def test_context_propagation_parent_child(span_exporter, gh_run):
 
 
 @pytest.mark.asyncio
-async def test_token_usage_recorded_after_completion(span_exporter, gh_run):
+async def test_token_usage_recorded_after_completion(span_exporter):
     """Test that token usage metrics are recorded after async completion."""
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
@@ -213,7 +213,7 @@ async def test_token_usage_recorded_after_completion(span_exporter, gh_run):
 
 
 @pytest.mark.asyncio
-async def test_span_not_closed_prematurely(span_exporter, gh_run):
+async def test_span_not_closed_prematurely(span_exporter):
     """Test that spans are not closed before async operations complete."""
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
@@ -247,7 +247,7 @@ async def test_span_not_closed_prematurely(span_exporter, gh_run):
 
 
 @pytest.mark.asyncio
-async def test_multiple_generations_separate_spans(span_exporter, gh_run):
+async def test_multiple_generations_separate_spans(span_exporter):
     """Test that multiple generations create separate spans."""
 
     backend = OllamaModelBackend(model_id=IBM_GRANITE_4_HYBRID_MICRO.ollama_name)  # type: ignore
@@ -279,7 +279,7 @@ async def test_multiple_generations_separate_spans(span_exporter, gh_run):
 
 
 @pytest.mark.asyncio
-async def test_streaming_span_duration(span_exporter, gh_run):
+async def test_streaming_span_duration(span_exporter):
     """Test that streaming operations have accurate span durations."""
 
     from mellea.backends.model_options import ModelOption


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number --> N/A

Allows telemetry tests to always run. The other telemetry tests were already reloading the module. For some reason this one wasn't.

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)