### PR TITLE
fix(test): widen hallucination detection tolerance (#809)

### DIFF
--- a/test/stdlib/components/intrinsic/test_rag.py
+++ b/test/stdlib/components/intrinsic/test_rag.py
@@ -158,12 +158,12 @@ def test_hallucination_detection(backend):
     result = rag.flag_hallucinated_content(assistant_response, docs, context, backend)
     # pytest.approx() chokes on lists of records, so we do this complicated dance.
     for r, e in zip(result, expected, strict=True):  # type: ignore
-        assert pytest.approx(r, abs=3e-2) == e
+        assert pytest.approx(r, abs=5e-2) == e
 
     # Second call hits a different code path from the first one
     result = rag.flag_hallucinated_content(assistant_response, docs, context, backend)
     for r, e in zip(result, expected, strict=True):  # type: ignore
-        assert pytest.approx(r, abs=3e-2) == e
+        assert pytest.approx(r, abs=5e-2) == e
 
 
 @pytest.mark.qualitative


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #809

Widen `pytest.approx` tolerance from `abs=3e-2` → `abs=5e-2` in `test_hallucination_detection`. Scores are logprob-derived weighted expected values — inference non-determinism causes drift of ~0.036, breaching the old threshold while the categorical signal remains stable.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [X] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

^ on tests this now seems more consistent with the looser tolerance