### PR TITLE
feat: simplify plugin tests; fix plugin resetting

### DIFF
--- a/test/plugins/conftest.py
+++ b/test/plugins/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures for plugin tests."""
+
+import pytest
+
+from mellea.plugins.manager import has_plugins, shutdown_plugins
+
+
+@pytest.fixture(autouse=True, scope="package")
+async def _restore_plugins_after_package(request):
+    """Re-register acceptance sets once after all plugin tests finish.
+
+    Plugin tests freely shut down the manager for isolation.  This package-scoped
+    fixture captures whether plugins were active at the start and restores them in
+    teardown so that test modules collected *after* ``test/plugins/`` still see the
+    session-scoped acceptance sets registered by ``auto_register_acceptance_sets``.
+    """
+    plugins_disabled = request.config.getoption(
+        "--disable-default-mellea-plugins", default=False
+    )
+    was_enabled = has_plugins()
+    yield
+    if was_enabled and not plugins_disabled:
+        from mellea.plugins import register
+        from test.plugins._acceptance_sets import ALL_ACCEPTANCE_SETS
+
+        for ps in ALL_ACCEPTANCE_SETS:
+            register(ps)
+
+
+@pytest.fixture(autouse=True)
+async def reset_plugins():
+    """Shut down plugins before and after each test for isolation."""
+    await shutdown_plugins()
+    yield
+    await shutdown_plugins()

--- a/test/plugins/test_blocking.py
+++ b/test/plugins/test_blocking.py
@@ -18,7 +18,7 @@ from mellea.plugins import PluginMode, block, hook, modify, register
 from mellea.plugins.base import PluginViolationError
 from mellea.plugins.context import build_global_context
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import ensure_plugin_manager, invoke_hook, shutdown_plugins
+from mellea.plugins.manager import ensure_plugin_manager, invoke_hook
 from mellea.plugins.types import HookType
 
 # ---------------------------------------------------------------------------
@@ -50,18 +50,6 @@ async def _invoke_no_raise(payload: SessionPreInitPayload):
         violations_as_exceptions=False,
     )
     return result
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    """Shut down and reset the plugin manager after every test."""
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_execution_modes.py
+++ b/test/plugins/test_execution_modes.py
@@ -31,7 +31,7 @@ from mellea.plugins import PluginMode, PluginResult, block, hook, register
 from mellea.plugins.base import PluginViolationError
 from mellea.plugins.hooks.generation import GenerationPreCallPayload
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import invoke_hook, shutdown_plugins
+from mellea.plugins.manager import invoke_hook
 from mellea.plugins.types import HookType, PluginMode
 
 # ---------------------------------------------------------------------------
@@ -51,18 +51,6 @@ def _generation_payload(**kwargs) -> GenerationPreCallPayload:
     defaults: dict = dict(model_options={"temperature": 0.7})
     defaults.update(kwargs)
     return GenerationPreCallPayload(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def cleanup_plugins():
-    """Reset plugin manager state after every test."""
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -29,7 +29,6 @@ from mellea.core.base import (
     ModelOutputThunk,
 )
 from mellea.plugins import PluginResult, hook, register
-from mellea.plugins.manager import shutdown_plugins
 from mellea.stdlib.context import SimpleContext
 
 # ---------------------------------------------------------------------------
@@ -87,18 +86,6 @@ def _make_thunk():
     mot._chunk_size = 0
     mot._start = datetime.datetime.now()
     return mot
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    """Shut down and reset the plugin manager after every test."""
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_manager.py
+++ b/test/plugins/test_manager.py
@@ -3,47 +3,24 @@
 import pytest
 
 from mellea.plugins.base import MelleaBasePayload
-from mellea.plugins.manager import (
-    ensure_plugin_manager,
-    has_plugins,
-    invoke_hook,
-    shutdown_plugins,
-)
+from mellea.plugins.manager import ensure_plugin_manager, has_plugins, invoke_hook
 from mellea.plugins.types import HookType, PluginMode
 
 # These tests require the contextforge plugin framework
 pytest.importorskip("cpex.framework")
 
 
-@pytest.fixture(autouse=True)
-async def cleanup_plugins():
-    """Ensure plugin manager is shut down after each test."""
-    yield
-    await shutdown_plugins()
-
-
 class TestNoOpGuards:
     @pytest.mark.asyncio
-    async def test_invoke_hook_noop_when_no_plugins(self, request):
+    async def test_invoke_hook_noop_when_no_plugins(self):
         """When no plugins are registered, invoke_hook returns (None, original_payload)."""
-        plugins_disabled = request.config.getoption(
-            "--disable-default-mellea-plugins", default=False
-        )
-        if not plugins_disabled:
-            pytest.skip("must pass --disable-default-mellea-plugins for this test")
         payload = MelleaBasePayload(request_id="test-123")
         result, returned_payload = await invoke_hook(HookType.SESSION_PRE_INIT, payload)
         assert result is None
         assert returned_payload is payload
 
-    def test_has_plugins_false_by_default(self, request):
+    def test_has_plugins_false_by_default(self):
         """has_plugins() returns False when no plugins have been registered."""
-        plugins_disabled = request.config.getoption(
-            "--disable-default-mellea-plugins", default=False
-        )
-        if not plugins_disabled:
-            pytest.skip("must pass --disable-default-mellea-plugins for this test")
-        # After shutdown, plugins should not be enabled
         assert not has_plugins()
 
 

--- a/test/plugins/test_mellea_plugin.py
+++ b/test/plugins/test_mellea_plugin.py
@@ -11,14 +11,8 @@ pytest.importorskip("cpex.framework")
 
 from mellea.plugins import Plugin, hook, register
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import invoke_hook, shutdown_plugins
+from mellea.plugins.manager import invoke_hook
 from mellea.plugins.types import HookType
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    yield
-    await shutdown_plugins()
 
 
 def _make_payload() -> SessionPreInitPayload:

--- a/test/plugins/test_policy_enforcement.py
+++ b/test/plugins/test_policy_enforcement.py
@@ -17,7 +17,7 @@ from mellea.plugins.hooks.component import ComponentPostErrorPayload
 from mellea.plugins.hooks.generation import GenerationPreCallPayload
 from mellea.plugins.hooks.sampling import SamplingIterationPayload
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import invoke_hook, shutdown_plugins
+from mellea.plugins.manager import invoke_hook
 from mellea.plugins.types import HookType
 
 # ---------------------------------------------------------------------------
@@ -37,18 +37,6 @@ def _generation_payload(**kwargs) -> GenerationPreCallPayload:
     )
     defaults.update(kwargs)
     return GenerationPreCallPayload(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    """Shut down and reset the plugin manager after every test."""
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_priority_ordering.py
+++ b/test/plugins/test_priority_ordering.py
@@ -17,7 +17,7 @@ pytest.importorskip("cpex.framework")
 
 from mellea.plugins import Plugin, PluginSet, hook, register
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import invoke_hook, shutdown_plugins
+from mellea.plugins.manager import invoke_hook
 from mellea.plugins.types import HookType
 
 # ---------------------------------------------------------------------------
@@ -29,18 +29,6 @@ def _session_payload() -> SessionPreInitPayload:
     return SessionPreInitPayload(
         backend_name="test-backend", model_id="test-model", model_options=None
     )
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def cleanup_plugins():
-    """Reset plugin manager state after every test."""
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_scoping.py
+++ b/test/plugins/test_scoping.py
@@ -9,19 +9,8 @@ pytest.importorskip("cpex.framework")
 from mellea.plugins import Plugin, PluginSet, hook, plugin_scope, register
 from mellea.plugins.base import MelleaPlugin, PluginResult
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import (
-    deregister_session_plugins,
-    invoke_hook,
-    shutdown_plugins,
-)
+from mellea.plugins.manager import deregister_session_plugins, invoke_hook
 from mellea.plugins.types import HookType
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    """Reset the plugin manager to a clean state after every test."""
-    yield
-    await shutdown_plugins()
 
 
 def _payload() -> SessionPreInitPayload:

--- a/test/plugins/test_tool_hooks_redaction.py
+++ b/test/plugins/test_tool_hooks_redaction.py
@@ -19,7 +19,6 @@ pytest.importorskip("cpex.framework")
 
 from mellea.core.base import AbstractMelleaTool, ModelOutputThunk, ModelToolCall
 from mellea.plugins import PluginResult, hook, register
-from mellea.plugins.manager import shutdown_plugins
 from mellea.plugins.types import HookType
 from mellea.stdlib.functional import _acall_tools
 
@@ -50,17 +49,6 @@ def _make_result(tool_call: ModelToolCall) -> ModelOutputThunk:
     mot = MagicMock(spec=ModelOutputThunk)
     mot.tool_calls = {tool_call.name: tool_call}
     return mot
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    yield
-    await shutdown_plugins()
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_unregister.py
+++ b/test/plugins/test_unregister.py
@@ -8,14 +8,8 @@ pytest.importorskip("cpex.framework")
 
 from mellea.plugins import Plugin, PluginSet, hook, register, unregister
 from mellea.plugins.hooks.session import SessionPreInitPayload
-from mellea.plugins.manager import invoke_hook, shutdown_plugins
+from mellea.plugins.manager import invoke_hook
 from mellea.plugins.types import HookType
-
-
-@pytest.fixture(autouse=True)
-async def reset_plugins():
-    yield
-    await shutdown_plugins()
 
 
 def _payload() -> SessionPreInitPayload:


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number --> N/A

Changes
- Simplifies fixtures for plugin tests and removes code duplication
- Fixes bug where we were disabling the automatic plugin hooks for all tests after the plugin tests by accidentally leaving the plugins removed
- Allows for the tests that previously required `--disable-default-mellea-plugins` to run by default

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)