### PR TITLE
fix: handle stale .vllm-venv in test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,6 +381,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.*-venv
 env/
 venv/
 ENV/

--- a/test/scripts/run_tests_with_ollama_and_vllm.sh
+++ b/test/scripts/run_tests_with_ollama_and_vllm.sh
@@ -219,7 +219,7 @@ if [[ "$WITH_VLLM" == "1" ]]; then
             log "Reusing existing vLLM venv at $VLLM_VENV (KEEP_VLLM_VENV=1)"
         else
             log "Creating isolated vLLM venv at $VLLM_VENV ..."
-            uv venv "$VLLM_VENV" --python 3.11
+            uv venv "$VLLM_VENV" --python 3.11 --clear
             log "Installing vllm into $VLLM_VENV ..."
             uv pip install --python "$VLLM_VENV/bin/python" vllm \
                 > "$LOGDIR/vllm_install.log" 2>&1 \


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# fix: handle stale .vllm-venv in test runner

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- Link to Issue: Fixes #828

The test runner's `trap cleanup EXIT` removes `.vllm-venv` on normal exit, but hard kills (SIGKILL, OOM, LSF timeout) bypass the trap, leaving a stale directory that causes `uv venv` to fail on the next run.

**Changes:**
- Add `--clear` to the `uv venv` call so stale directories are replaced
- Add `.*-venv` to `.gitignore` — when `CACHE_DIR` is unset the venv lands in the repo root

<!-- Note: --clear will replace a valid venv on concurrent runs, but those are already broken (port/PID conflicts). -->

### Testing
- [x] Verified `uv venv --clear` replaces an existing directory
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)