### PR TITLE
test: add tool_arg_validator edge case test, fix typo (#826)

### DIFF
--- a/mellea/stdlib/requirements/tool_reqs.py
+++ b/mellea/stdlib/requirements/tool_reqs.py
@@ -84,7 +84,7 @@ def tool_arg_validator(
         assert output is not None
 
         if output.tool_calls is None:
-            tool_label = tool_name or "a tool"
+            tool_label = tool_name if tool_name is not None else "a tool"
             return ValidationResult(
                 result=False,
                 reason=f"Expected {tool_label} to be called but no tools were called.",

--- a/mellea/stdlib/requirements/tool_reqs.py
+++ b/mellea/stdlib/requirements/tool_reqs.py
@@ -60,11 +60,11 @@ def tool_arg_validator(
 ) -> Requirement:
     """A requirement that passes only if `validation_fn` returns a True value for the *value* of the `arg_name` argument to `tool_name`.
 
-    If `tool_name` is not specified, then this requirement is enforced for *every* tool that
+    If `tool_name` is not specified, then this requirement is enforced for *every* tool that was called.
 
     Args:
         description: The Requirement description.
-        tool_name: The (optional) tool name for .
+        tool_name: The (optional) tool name to validate. When None, all tools are checked.
         arg_name: The argument to check.
         validation_fn: A validation function for validating the value of the `arg_name` argument.
         check_only: propagates the `check_only` flag to the requirement.
@@ -76,7 +76,7 @@ def tool_arg_validator(
     Returns:
         A ``Requirement`` that validates the specified tool argument.
     """
-    if tool_name:
+    if tool_name is not None:
         tool_name = _name2str(tool_name)
 
     def _validate(ctx: Context) -> ValidationResult:
@@ -84,12 +84,13 @@ def tool_arg_validator(
         assert output is not None
 
         if output.tool_calls is None:
+            tool_label = tool_name or "a tool"
             return ValidationResult(
                 result=False,
-                reason=f"Expected {tool_name} to be called but no tools were called.",
+                reason=f"Expected {tool_label} to be called but no tools were called.",
             )
 
-        if tool_name:
+        if tool_name is not None:
             if tool_name not in output.tool_calls:
                 return ValidationResult(
                     result=False, reason=f"Tool {tool_name} was not called."

--- a/mellea/stdlib/requirements/tool_reqs.py
+++ b/mellea/stdlib/requirements/tool_reqs.py
@@ -116,7 +116,7 @@ def tool_arg_validator(
                     if not validate_result:
                         return ValidationResult(
                             result=False,
-                            reason=f"Validation did not pass for {tool_name}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
+                            reason=f"Validation did not pass for {tool}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
                         )
             return ValidationResult(result=True)
 

--- a/mellea/stdlib/requirements/tool_reqs.py
+++ b/mellea/stdlib/requirements/tool_reqs.py
@@ -106,7 +106,7 @@ def tool_arg_validator(
             else:
                 return ValidationResult(
                     result=False,
-                    reason=f"Valiudation did not pass for {tool_name}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
+                    reason=f"Validation did not pass for {tool_name}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
                 )
         else:
             for tool in output.tool_calls.keys():
@@ -116,7 +116,7 @@ def tool_arg_validator(
                     if not validate_result:
                         return ValidationResult(
                             result=False,
-                            reason=f"Valiudation did not pass for {tool_name}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
+                            reason=f"Validation did not pass for {tool_name}.{arg_name}. Arg value: {arg_value}. Argument validation result: {validate_result}",
                         )
             return ValidationResult(result=True)
 

--- a/test/stdlib/requirements/test_reqlib_tools.py
+++ b/test/stdlib/requirements/test_reqlib_tools.py
@@ -185,11 +185,13 @@ def test_tool_arg_validator_no_tool_name_one_fails():
     )
     result = req.validation_fn(ctx)
     assert result.as_bool() is False
+    assert "tool_b" in result.reason
+    assert "None" not in result.reason
 
 
 def test_tool_arg_validator_no_tool_name_arg_missing_everywhere():
-    """Documents current behavior: when tool_name=None and no tool call contains
-    the target arg_name, validation silently passes (the for-loop completes
+    """Documents current behavior (see #826): when tool_name=None and no tool call
+    contains the target arg_name, validation silently passes (the for-loop completes
     without failing). This is arguably a latent bug — the validator never runs."""
     ctx = _ctx_with_tool_calls({"tool_a": _make_tool_call("tool_a", {"y": 5})})
     req = tool_arg_validator(

--- a/test/stdlib/requirements/test_reqlib_tools.py
+++ b/test/stdlib/requirements/test_reqlib_tools.py
@@ -185,3 +185,18 @@ def test_tool_arg_validator_no_tool_name_one_fails():
     )
     result = req.validation_fn(ctx)
     assert result.as_bool() is False
+
+
+def test_tool_arg_validator_no_tool_name_arg_missing_everywhere():
+    """Documents current behavior: when tool_name=None and no tool call contains
+    the target arg_name, validation silently passes (the for-loop completes
+    without failing). This is arguably a latent bug — the validator never runs."""
+    ctx = _ctx_with_tool_calls({"tool_a": _make_tool_call("tool_a", {"y": 5})})
+    req = tool_arg_validator(
+        description="x must be positive",
+        tool_name=None,
+        arg_name="x",
+        validation_fn=lambda v: v > 0,
+    )
+    result = req.validation_fn(ctx)
+    assert result.as_bool() is True


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [x] Link to Issue: Fixes #826

Addresses items from @psschwei's review on #820, plus related tidy-ups in `tool_arg_validator`:

1. **Edge-case test**: adds `test_tool_arg_validator_no_tool_name_arg_missing_everywhere` documenting that `tool_arg_validator` with `tool_name=None` silently returns `True` when no tool call contains the target `arg_name`. Docstring flags this as a potential latent bug.
2. **Typo fix**: corrects `"Valiudation"` → `"Validation"` in both error reason strings.
3. **Bug fix**: error message in the `tool_name=None` branch interpolated `tool_name` (rendering as `None.arg_name`). Now uses the loop variable `tool` so the actual tool name appears.
4. **Bug fix**: error message when no tools are called and `tool_name=None` produced `"Expected None to be called"`. Now reads `"Expected a tool to be called"`.
5. **Guard fix**: `if tool_name:` truthiness check replaced with `if tool_name is not None:` so empty-string tool names don't silently fall into the wrong branch.
6. **Docstring fix**: completed the truncated `tool_name` parameter description and the function summary sentence.

### Coverage change (unit tests only)

| File | Stmts | Before (#820) | After |
|------|-------|---------------|-------|
| `tool_reqs.py` | 44 | 99% | 100% |

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)