### PR TITLE
test: unit tests for backend pure logic (cache, catalog, bedrock)

### DIFF
--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -1,0 +1,59 @@
+"""Unit tests for the intrinsics catalog — metadata lookup, validation, and enumeration."""
+
+import pytest
+
+from mellea.backends.adapters.catalog import (
+    AdapterType,
+    fetch_intrinsic_metadata,
+    known_intrinsic_names,
+)
+
+# --- known_intrinsic_names ---
+
+
+def test_known_intrinsic_names_returns_non_empty_list():
+    names = known_intrinsic_names()
+    assert isinstance(names, list)
+    assert len(names) > 0
+
+
+def test_known_intrinsic_names_contains_expected_entries():
+    names = known_intrinsic_names()
+    for expected in ("answerability", "citations", "uncertainty"):
+        assert expected in names
+
+
+# --- fetch_intrinsic_metadata ---
+
+
+def test_fetch_returns_correct_entry():
+    entry = fetch_intrinsic_metadata("answerability")
+    assert entry.name == "answerability"
+    assert isinstance(entry.repo_id, str)
+    assert len(entry.repo_id) > 0
+
+
+def test_fetch_unknown_name_raises_value_error():
+    with pytest.raises(ValueError, match="Unknown intrinsic name 'bogus'"):
+        fetch_intrinsic_metadata("bogus")
+
+
+def test_fetch_returns_defensive_copy():
+    entry_a = fetch_intrinsic_metadata("answerability")
+    entry_b = fetch_intrinsic_metadata("answerability")
+    assert entry_a == entry_b
+    assert entry_a is not entry_b
+
+
+# --- adapter types ---
+
+
+def test_default_adapter_types():
+    entry = fetch_intrinsic_metadata("answerability")
+    assert AdapterType.LORA in entry.adapter_types
+    assert AdapterType.ALORA in entry.adapter_types
+
+
+def test_lora_only_entry():
+    entry = fetch_intrinsic_metadata("query_clarification")
+    assert entry.adapter_types == (AdapterType.LORA,)

--- a/test/backends/test_bedrock_unit.py
+++ b/test/backends/test_bedrock_unit.py
@@ -75,6 +75,7 @@ def test_create_backend_with_model_identifier(mock_list, monkeypatch):
 
     assert isinstance(backend, OpenAIBackend)
     assert backend.model_id == "granite-3.3-8b"
+    assert backend._base_url == "https://bedrock-mantle.eu-west-1.api.aws/v1"
     mock_list.assert_called_once_with("eu-west-1")
 
 
@@ -85,6 +86,7 @@ def test_create_backend_with_string_model_id(mock_list, monkeypatch):
 
     assert isinstance(backend, OpenAIBackend)
     assert backend.model_id == "llama-4-scout"
+    assert backend._base_url == "https://bedrock-mantle.us-east-1.api.aws/v1"
 
 
 @patch("mellea.backends.bedrock.list_mantle_models", return_value=_FAKE_MODELS)

--- a/test/backends/test_bedrock_unit.py
+++ b/test/backends/test_bedrock_unit.py
@@ -1,0 +1,94 @@
+"""Unit tests for bedrock helpers — URI construction, ModelIdentifier matching, env var validation.
+
+These tests cover the pure-logic helpers and error paths in bedrock.py without
+requiring AWS credentials or network access. Happy-path tests mock only the
+network boundary (list_mantle_models) and verify the rest of the pipeline.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from mellea.backends.bedrock import (
+    _make_mantle_uri,
+    _make_region_for_uri,
+    create_bedrock_mantle_backend,
+)
+from mellea.backends.model_ids import ModelIdentifier
+from mellea.backends.openai import OpenAIBackend
+
+
+@dataclass
+class _FakeModel:
+    """Minimal stand-in for the model objects returned by list_mantle_models."""
+
+    id: str
+
+
+_FAKE_MODELS = [_FakeModel("granite-3.3-8b"), _FakeModel("llama-4-scout")]
+
+# --- _make_region_for_uri ---
+
+
+def test_region_default_when_none():
+    assert _make_region_for_uri(None) == "us-east-1"
+
+
+# --- _make_mantle_uri ---
+
+
+def test_mantle_uri_default_region():
+    uri = _make_mantle_uri()
+    assert uri == "https://bedrock-mantle.us-east-1.api.aws/v1"
+
+
+def test_mantle_uri_custom_region():
+    uri = _make_mantle_uri("ap-northeast-1")
+    assert uri == "https://bedrock-mantle.ap-northeast-1.api.aws/v1"
+
+
+# --- create_bedrock_mantle_backend error paths ---
+
+
+def test_model_identifier_without_bedrock_name_raises():
+    mid = ModelIdentifier(hf_model_name="some/model")
+    with pytest.raises(Exception, match="do not have a known bedrock model identifier"):
+        create_bedrock_mantle_backend(mid)
+
+
+def test_missing_env_var_raises(monkeypatch):
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    mid = ModelIdentifier(bedrock_name="some.model-id")
+    with pytest.raises(AssertionError, match="AWS_BEARER_TOKEN_BEDROCK"):
+        create_bedrock_mantle_backend(mid)
+
+
+# --- create_bedrock_mantle_backend happy paths (mock network boundary) ---
+
+
+@patch("mellea.backends.bedrock.list_mantle_models", return_value=_FAKE_MODELS)
+def test_create_backend_with_model_identifier(mock_list, monkeypatch):
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    mid = ModelIdentifier(bedrock_name="granite-3.3-8b")
+    backend = create_bedrock_mantle_backend(mid, region="eu-west-1")
+
+    assert isinstance(backend, OpenAIBackend)
+    assert backend.model_id == "granite-3.3-8b"
+    mock_list.assert_called_once_with("eu-west-1")
+
+
+@patch("mellea.backends.bedrock.list_mantle_models", return_value=_FAKE_MODELS)
+def test_create_backend_with_string_model_id(mock_list, monkeypatch):
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    backend = create_bedrock_mantle_backend("llama-4-scout")
+
+    assert isinstance(backend, OpenAIBackend)
+    assert backend.model_id == "llama-4-scout"
+
+
+@patch("mellea.backends.bedrock.list_mantle_models", return_value=_FAKE_MODELS)
+def test_model_not_in_region_raises(mock_list, monkeypatch):
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    with pytest.raises(Exception, match="not supported in region"):
+        create_bedrock_mantle_backend("nonexistent-model")

--- a/test/backends/test_cache.py
+++ b/test/backends/test_cache.py
@@ -36,7 +36,7 @@ def test_put_existing_key_updates_value():
 
 
 def test_put_existing_key_does_not_evict():
-    evicted: list = []
+    evicted: list[int] = []
     cache = SimpleLRUCache(capacity=1, on_evict=evicted.append)
     cache.put("a", 1)
     cache.put("a", 2)
@@ -57,7 +57,7 @@ def test_evicts_least_recently_used():
 
 
 def test_on_evict_callback_receives_evicted_value():
-    evicted: list = []
+    evicted: list[str] = []
     cache = SimpleLRUCache(capacity=2, on_evict=evicted.append)
     cache.put("a", "val_a")
     cache.put("b", "val_b")
@@ -66,7 +66,7 @@ def test_on_evict_callback_receives_evicted_value():
 
 
 def test_multiple_evictions_fire_callback_each_time():
-    evicted: list = []
+    evicted: list[int] = []
     cache = SimpleLRUCache(capacity=1, on_evict=evicted.append)
     cache.put("a", 1)
     cache.put("b", 2)  # evicts 1
@@ -91,7 +91,7 @@ def test_get_promotes_key_preventing_eviction():
 
 
 def test_zero_capacity_put_is_noop():
-    evicted: list = []
+    evicted: list[int] = []
     cache = SimpleLRUCache(capacity=0, on_evict=evicted.append)
     cache.put("a", 1)
     assert cache.current_size() == 0

--- a/test/backends/test_cache.py
+++ b/test/backends/test_cache.py
@@ -1,0 +1,108 @@
+"""Unit tests for SimpleLRUCache — LRU eviction, callbacks, and capacity edge cases."""
+
+from mellea.backends.cache import SimpleLRUCache
+
+# --- basic put / get ---
+
+
+def test_put_and_get():
+    cache = SimpleLRUCache(capacity=3)
+    cache.put("a", 1)
+    assert cache.get("a") == 1
+
+
+def test_get_missing_key_returns_none():
+    cache = SimpleLRUCache(capacity=3)
+    assert cache.get("missing") is None
+
+
+def test_current_size_tracks_entries():
+    cache = SimpleLRUCache(capacity=5)
+    assert cache.current_size() == 0
+    cache.put("a", 1)
+    cache.put("b", 2)
+    assert cache.current_size() == 2
+
+
+# --- update existing key ---
+
+
+def test_put_existing_key_updates_value():
+    cache = SimpleLRUCache(capacity=2)
+    cache.put("a", "old")
+    cache.put("a", "new")
+    assert cache.get("a") == "new"
+    assert cache.current_size() == 1
+
+
+def test_put_existing_key_does_not_evict():
+    evicted: list = []
+    cache = SimpleLRUCache(capacity=1, on_evict=evicted.append)
+    cache.put("a", 1)
+    cache.put("a", 2)
+    assert evicted == []
+
+
+# --- eviction ---
+
+
+def test_evicts_least_recently_used():
+    cache = SimpleLRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    cache.put("c", 3)  # should evict "a"
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.get("c") == 3
+
+
+def test_on_evict_callback_receives_evicted_value():
+    evicted: list = []
+    cache = SimpleLRUCache(capacity=2, on_evict=evicted.append)
+    cache.put("a", "val_a")
+    cache.put("b", "val_b")
+    cache.put("c", "val_c")  # evicts "a"
+    assert evicted == ["val_a"]
+
+
+def test_multiple_evictions_fire_callback_each_time():
+    evicted: list = []
+    cache = SimpleLRUCache(capacity=1, on_evict=evicted.append)
+    cache.put("a", 1)
+    cache.put("b", 2)  # evicts 1
+    cache.put("c", 3)  # evicts 2
+    assert evicted == [1, 2]
+
+
+# --- LRU ordering: get promotes to most-recent ---
+
+
+def test_get_promotes_key_preventing_eviction():
+    cache = SimpleLRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    cache.get("a")  # promote "a" — now "b" is LRU
+    cache.put("c", 3)  # should evict "b", not "a"
+    assert cache.get("a") == 1
+    assert cache.get("b") is None
+
+
+# --- capacity edge cases ---
+
+
+def test_zero_capacity_put_is_noop():
+    evicted: list = []
+    cache = SimpleLRUCache(capacity=0, on_evict=evicted.append)
+    cache.put("a", 1)
+    assert cache.current_size() == 0
+    assert cache.get("a") is None
+    assert evicted == []
+
+
+def test_capacity_one():
+    cache = SimpleLRUCache(capacity=1)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    assert cache.get("a") is None
+    assert cache.get("b") == 2
+    assert cache.current_size() == 1


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# test: unit tests for backend pure logic (cache, catalog, bedrock)

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [x] Link to Issue: Fixes #816

26 unit tests across 3 files for `backends/cache`, `backends/adapters/catalog`, and `backends/bedrock`. All pure logic — no model, no credentials, no network. Runs in ~7s.

### Why these tests exist

All three modules contain self-contained logic (LRU eviction, catalogue lookup, URI construction, pattern matching) that had little or no dedicated unit coverage. `cache.py` in particular is a production data structure used by the HF backend but was never directly tested. Part of the broader #726 testing epic.

### Coverage improvement

| File | Stmts | Before | After |
|------|-------|--------|-------|
| `cache.py` | 34 | 36% | **100%** |
| `adapters/catalog.py` | 22 | 88% | **100%** |
| `bedrock.py` | 42 | 19% | **87%** |

`bedrock.py` caps at 87% because the remaining lines are `list_mantle_models` and `stringify_mantle_model_ids` — thin wrappers around the OpenAI client hitting AWS. Those are correctly covered by the existing e2e test (`test_bedrock.py`, gated behind `require_api_key`).

### Test breakdown

| File | Tests | What's covered |
|------|-------|----------------|
| `test_cache.py` | 11 | put/get contract, LRU eviction order, `on_evict` callback (single and multiple), get-promotes-to-MRU, update-existing-key without eviction, zero capacity no-op, capacity-one boundary |
| `test_adapters/test_catalog.py` | 7 | `known_intrinsic_names()` enumeration, `fetch_intrinsic_metadata()` valid/invalid lookup, `ValueError` on unknown name, defensive copy verification, adapter type defaults vs LORA-only entries |
| `test_bedrock_unit.py` | 8 | `_make_region_for_uri` default, `_make_mantle_uri` construction (default + custom region), `ModelIdentifier` without `bedrock_name` raises, missing env var assertion, happy-path backend creation with `ModelIdentifier` and raw `str` (mocking only `list_mantle_models` at the network boundary), model-not-in-region error |

### Design decisions

- `cache.py`: No mocking needed — pure data structure tests with eviction callbacks tracked via a plain list
- `catalog.py`: Tests against the real catalogue data (not mocked entries) to catch accidental deletions or structural changes
- `bedrock.py`: Happy-path tests mock only `list_mantle_models` (the sole network call) with a lightweight `_FakeModel` dataclass, so the full pattern matching, env var validation, URI construction, and `OpenAIBackend` instantiation all run for real

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)