### PR TITLE
fix: granite33 response_end span uses sentence length not full respon…

### DIFF
--- a/mellea/formatters/granite/granite3/granite33/output.py
+++ b/mellea/formatters/granite/granite3/granite33/output.py
@@ -224,7 +224,7 @@ def _add_citation_response_spans(
 
         citation["response_text"] = response_text
         citation["response_begin"] = index
-        citation["response_end"] = index + len(response_text_without_citations)
+        citation["response_end"] = index + len(response_text)
 
     return augmented_citation_info
 

--- a/test/formatters/granite/test_granite33_output.py
+++ b/test/formatters/granite/test_granite33_output.py
@@ -233,9 +233,7 @@ class TestAddCitationResponseSpans:
         response_without_citations = f"{sent1} {sent2}"
 
         result = _add_citation_response_spans(
-            [self._make_citation()],
-            response_with_citations,
-            response_without_citations,
+            [self._make_citation()], response_with_citations, response_without_citations
         )
 
         assert len(result) == 1

--- a/test/formatters/granite/test_granite33_output.py
+++ b/test/formatters/granite/test_granite33_output.py
@@ -244,11 +244,9 @@ class TestAddCitationResponseSpans:
         end = citation["response_end"]
         text = citation["response_text"]
 
-        # The span must exactly bracket the cited sentence in the clean response
+        assert begin == 0
+        assert end == len(sent1)  # sentence length, not full response length
         assert response_without_citations[begin:end] == text
-        # Span length must equal the sentence length, not the full response length
-        assert end - begin == len(text)
-        assert end <= len(response_without_citations)
 
     def test_multiple_citations_each_span_correct(self):
         """Each citation span must cover only its own sentence."""

--- a/test/formatters/granite/test_granite33_output.py
+++ b/test/formatters/granite/test_granite33_output.py
@@ -18,6 +18,7 @@ from mellea.formatters.granite.granite3.granite33.constants import (
 )
 from mellea.formatters.granite.granite3.granite33.output import (
     Granite33OutputProcessor,
+    _add_citation_response_spans,
     _get_docs_from_citations,
     _parse_citations_text,
     _remove_citations_from_response_text,
@@ -203,6 +204,94 @@ class TestGetDocsFromCitations33:
         # The special token line has no colon-separated numeric id
         found_real = [d for d in result if d["text"] == "Real doc."]
         assert len(found_real) == 1
+
+
+# ---------------------------------------------------------------------------
+# _add_citation_response_spans
+# ---------------------------------------------------------------------------
+
+
+class TestAddCitationResponseSpans:
+    """Tests for _add_citation_response_spans (issue #843 regression guard)."""
+
+    def _make_citation(self, doc_id: str = "1") -> dict:
+        return {"doc_id": doc_id, "context_text": "some context"}
+
+    def test_response_end_uses_sentence_length_not_full_response(self):
+        """Regression: response_end must be index + len(sentence), not index + len(full_response).
+
+        Before the fix, _add_citation_response_spans used len(response_text_without_citations)
+        — the full response length — instead of len(response_text) — the cited sentence length.
+        This caused response_end to overshoot for any sentence that is not the last one.
+        """
+        sent1 = "Short sentence."
+        sent2 = "This is the second sentence, which is longer."
+        cite_tag = f'{CITE_START}{{"document_id": "1"}}{CITE_END}'
+        response_with_citations = f"{sent1} {cite_tag} {sent2}"
+        response_without_citations = f"{sent1} {sent2}"
+
+        result = _add_citation_response_spans(
+            [self._make_citation("1")],
+            response_with_citations,
+            response_without_citations,
+        )
+
+        assert len(result) == 1
+        citation = result[0]
+        begin = citation["response_begin"]
+        end = citation["response_end"]
+        text = citation["response_text"]
+
+        # The span must exactly bracket the cited sentence in the clean response
+        assert response_without_citations[begin:end] == text
+        # Span length must equal the sentence length, not the full response length
+        assert end - begin == len(text)
+        assert end <= len(response_without_citations)
+
+    def test_multiple_citations_each_span_correct(self):
+        """Each citation span must cover only its own sentence."""
+        sent1 = "First sentence."
+        sent2 = "Second sentence."
+        cite1 = f'{CITE_START}{{"document_id": "1"}}{CITE_END}'
+        cite2 = f'{CITE_START}{{"document_id": "2"}}{CITE_END}'
+        response_with = f"{sent1} {cite1} {sent2} {cite2}"
+        response_without = f"{sent1} {sent2}"
+
+        result = _add_citation_response_spans(
+            [self._make_citation("1"), self._make_citation("2")],
+            response_with,
+            response_without,
+        )
+
+        assert len(result) == 2
+        for citation in result:
+            begin = citation["response_begin"]
+            end = citation["response_end"]
+            text = citation["response_text"]
+            assert response_without[begin:end] == text
+            assert end - begin == len(text)
+            assert end <= len(response_without)
+
+        # The two spans must not overlap
+        spans = sorted((c["response_begin"], c["response_end"]) for c in result)
+        assert spans[0][1] <= spans[1][0]
+
+    def test_single_sentence_response(self):
+        """Single-sentence response: span must cover the full clean response."""
+        sent = "The only sentence."
+        cite_tag = f'{CITE_START}{{"document_id": "1"}}{CITE_END}'
+        response_with = f"{sent} {cite_tag}"
+        response_without = sent
+
+        result = _add_citation_response_spans(
+            [self._make_citation("1")], response_with, response_without
+        )
+
+        assert len(result) == 1
+        citation = result[0]
+        begin = citation["response_begin"]
+        end = citation["response_end"]
+        assert response_without[begin:end] == citation["response_text"]
 
 
 # ---------------------------------------------------------------------------

--- a/test/formatters/granite/test_granite33_output.py
+++ b/test/formatters/granite/test_granite33_output.py
@@ -212,10 +212,12 @@ class TestGetDocsFromCitations33:
 
 
 class TestAddCitationResponseSpans:
-    """Tests for _add_citation_response_spans (issue #843 regression guard)."""
+    """Regression tests for citation response span computation."""
 
-    def _make_citation(self, doc_id: str = "1") -> dict:
-        return {"doc_id": doc_id, "context_text": "some context"}
+    def _make_citation(self) -> dict:
+        # Citations are matched positionally by _add_citation_response_spans,
+        # not by doc_id — the doc_id value here is irrelevant to the function.
+        return {"doc_id": "1", "context_text": "some context"}
 
     def test_response_end_uses_sentence_length_not_full_response(self):
         """Regression: response_end must be index + len(sentence), not index + len(full_response).
@@ -231,7 +233,7 @@ class TestAddCitationResponseSpans:
         response_without_citations = f"{sent1} {sent2}"
 
         result = _add_citation_response_spans(
-            [self._make_citation("1")],
+            [self._make_citation()],
             response_with_citations,
             response_without_citations,
         )
@@ -258,7 +260,7 @@ class TestAddCitationResponseSpans:
         response_without = f"{sent1} {sent2}"
 
         result = _add_citation_response_spans(
-            [self._make_citation("1"), self._make_citation("2")],
+            [self._make_citation(), self._make_citation()],
             response_with,
             response_without,
         )
@@ -284,7 +286,7 @@ class TestAddCitationResponseSpans:
         response_without = sent
 
         result = _add_citation_response_spans(
-            [self._make_citation("1")], response_with, response_without
+            [self._make_citation()], response_with, response_without
         )
 
         assert len(result) == 1


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #843

One-line fix: `response_end` in granite 3.3 citation spans was computed as `index + len(response_text_without_citations)` (the full response length) instead of `index + len(response_text)` (the cited sentence length). Every citation span therefore overshot its end index — potentially beyond the end of the string — meaning any consumer slicing `response[begin:end]` would get far more text than intended.

Granite 3.2 already does this correctly (see `granite32/output.py:291–293`).

Branch rebased on `main` (clean; #818 has merged).

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Three regression tests added in `TestAddCitationResponseSpans` (`test/formatters/granite/test_granite33_output.py`):

- `test_response_end_uses_sentence_length_not_full_response` — direct regression for #843: multi-sentence response where the cited sentence is shorter than the full response; pins `begin == 0` and `end == len(sent1)`. Fails against the old code.
- `test_multiple_citations_each_span_correct` — two citations across two sentences; asserts both spans are correct and non-overlapping.
- `test_single_sentence_response` — baseline: single sentence, span covers it exactly.

Coverage on `granite33/output.py`: 81.64% → 82.77% (+1.1pp). The remaining uncovered lines are error/warning paths (e.g. citation-not-found, sentence-splitting edge cases) that require malformed model output to trigger.

### Follow-up

#851 — `str.find()` first-occurrence issue: if the same sentence appears more than once in a response, citations after the first get the wrong span. Spotted during review of this PR; out of scope here.