### PR TITLE
docs: add AI attribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -25,3 +25,6 @@ Use this template when adding or modifying components in `mellea/stdlib/componen
 - [ ] Tests added to `tests/components/`
 - [ ] New code has 100% coverage
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
+
+### Attribution
+- [ ] AI tools used (Assisted-by trailer added to commits)

--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -27,4 +27,4 @@ Use this template when adding or modifying components in `mellea/stdlib/componen
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
 
 ### Attribution
-- [ ] AI tools used (Assisted-by trailer added to commits)
+- [ ] AI coding assistants used

--- a/.github/PULL_REQUEST_TEMPLATE/misc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/misc.md
@@ -16,3 +16,6 @@
 - [ ] Tests added to the respective file if code was changed
 - [ ] New code has 100% coverage if code as added
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
+
+### Attribution
+- [ ] AI tools used (Assisted-by trailer added to commits)

--- a/.github/PULL_REQUEST_TEMPLATE/misc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/misc.md
@@ -18,4 +18,4 @@
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
 
 ### Attribution
-- [ ] AI tools used (Assisted-by trailer added to commits)
+- [ ] AI coding assistants used

--- a/.github/PULL_REQUEST_TEMPLATE/requirement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/requirement.md
@@ -30,4 +30,4 @@ Use this template when adding or modifying requirements in `mellea/stdlib/requir
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
 
 ### Attribution
-- [ ] AI tools used (Assisted-by trailer added to commits)
+- [ ] AI coding assistants used

--- a/.github/PULL_REQUEST_TEMPLATE/requirement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/requirement.md
@@ -28,3 +28,6 @@ Use this template when adding or modifying requirements in `mellea/stdlib/requir
 - [ ] Tests added to `tests/requirements/`
 - [ ] New code has 100% coverage
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
+
+### Attribution
+- [ ] AI tools used (Assisted-by trailer added to commits)

--- a/.github/PULL_REQUEST_TEMPLATE/sampling.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sampling.md
@@ -28,4 +28,4 @@ Use this template when adding or modifying sampling strategies in `mellea/stdlib
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
 
 ### Attribution
-- [ ] AI tools used (Assisted-by trailer added to commits)
+- [ ] AI coding assistants used

--- a/.github/PULL_REQUEST_TEMPLATE/sampling.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sampling.md
@@ -26,3 +26,6 @@ Use this template when adding or modifying sampling strategies in `mellea/stdlib
 - [ ] Tests added to `tests/sampling/`
 - [ ] New code has 100% coverage
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
+
+### Attribution
+- [ ] AI tools used (Assisted-by trailer added to commits)

--- a/.github/PULL_REQUEST_TEMPLATE/tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tool.md
@@ -22,4 +22,4 @@ Use this template when adding or modifying components in `mellea/stdlib/tools/`.
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
 
 ### Attribution
-- [ ] AI tools used (Assisted-by trailer added to commits)
+- [ ] AI coding assistants used

--- a/.github/PULL_REQUEST_TEMPLATE/tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tool.md
@@ -20,3 +20,6 @@ Use this template when adding or modifying components in `mellea/stdlib/tools/`.
 - [ ] Tests added to `tests/stdlib/tools/`
 - [ ] New code has 100% coverage
 - [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
+
+### Attribution
+- [ ] AI tools used (Assisted-by trailer added to commits)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 Pre-commit runs: ruff, mypy, uv-lock, codespell
 
-For AI attribution trailers, see [§7 AI Attribution](#7-ai-attribution).
+For AI attribution trailers, see [Section 7 (AI Attribution)](#7-ai-attribution).
 
 ## 7. AI Attribution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,10 +95,21 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 Pre-commit runs: ruff, mypy, uv-lock, codespell
 
-## 7. Timing
+## 7. AI Attribution
+
+AI tools are welcome for development work in this project.
+
+**For AI assistants:** The project requires sign-offs — use `-s` when committing. Do not add a separate `Signed-off-by` line in the AI's own name. Add an `Assisted-by:` trailer to the commit footer by default:
+
+```text
+Assisted-by: Claude Code
+Assisted-by: IBM Bob
+```
+
+## 8. Timing
 > **Don't cancel**: `pytest` (full) and `pre-commit --all-files` may take minutes. Canceling mid-run can corrupt state.
 
-## 8. Common Issues
+## 9. Common Issues
 | Problem | Fix |
 |---------|-----|
 | `ComponentParseError` | Add examples to docstring |
@@ -106,14 +117,14 @@ Pre-commit runs: ruff, mypy, uv-lock, codespell
 | Ollama refused | Run `ollama serve` |
 | Telemetry import errors | Run `uv sync` to install OpenTelemetry deps |
 
-## 9. Self-Review (before notifying user)
+## 10. Self-Review (before notifying user)
 1. `uv run pytest test/ -m "not qualitative"` passes?
 2. `ruff format` and `ruff check` clean?
 3. New functions typed with concise docstrings?
 4. Unit tests added for new functionality?
 5. Avoided over-engineering?
 
-## 10. Writing Tests
+## 11. Writing Tests
 
 - Place tests in `test/` mirroring source structure
 - Name files `test_*.py` (required for pydocstyle)
@@ -121,7 +132,7 @@ Pre-commit runs: ruff, mypy, uv-lock, codespell
 - Mark tests checking LLM output quality with `@pytest.mark.qualitative`
 - If a test fails, fix the **code**, not the test (unless the test was wrong)
 
-## 11. Writing Docs
+## 12. Writing Docs
 
 If you are modifying or creating pages under `docs/docs/`, follow the writing
 conventions in [`docs/docs/guide/CONTRIBUTING.md`](docs/docs/guide/CONTRIBUTING.md).
@@ -139,7 +150,7 @@ Key rules that differ from typical Markdown habits:
   mellea source; mark forward-looking content with `> **Coming soon:**`
 - **No visible TODOs** — if content is missing, open a GitHub issue instead
 
-## 12. Feedback Loop
+## 13. Feedback Loop
 
 Found a bug, workaround, or pattern? Update the docs:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,7 @@ Pre-commit runs: ruff, mypy, uv-lock, codespell
 
 ## 7. AI Attribution
 
-AI tools are welcome for development work in this project.
-
-**For AI assistants:** The project requires sign-offs — use `-s` when committing. Do not add a separate `Signed-off-by` line in the AI's own name. Add an `Assisted-by:` trailer to the commit footer by default:
+The project requires sign-offs — use `-s` when committing. Do not add a separate `Signed-off-by` line in the AI's own name. Add an `Assisted-by:` trailer to the commit footer by default:
 
 ```text
 Assisted-by: Claude Code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,14 +95,18 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 Pre-commit runs: ruff, mypy, uv-lock, codespell
 
+For AI attribution trailers, see [§7 AI Attribution](#7-ai-attribution).
+
 ## 7. AI Attribution
 
-The project requires sign-offs — use `-s` when committing. Do not add a separate `Signed-off-by` line in the AI's own name. Add an `Assisted-by:` trailer to the commit footer by default:
+Commits require a Signed-off-by trailer from the human author (added by running `git commit -s`). AI agents must not add a Signed-off-by in the tool's own name — instead, always add an `Assisted-by:` trailer to the commit footer:
 
 ```text
 Assisted-by: Claude Code
 Assisted-by: IBM Bob
 ```
+
+Use the tool's common name (e.g., GitHub Copilot, Cursor, etc.).
 
 ## 8. Timing
 > **Don't cancel**: `pytest` (full) and `pre-commit --all-files` may take minutes. Canceling mid-run can corrupt state.
@@ -152,6 +156,6 @@ Key rules that differ from typical Markdown habits:
 
 Found a bug, workaround, or pattern? Update the docs:
 
-- **Issue/workaround?** → Add to Section 7 (Common Issues) in this file
+- **Issue/workaround?** → Add to [Section 9 (Common Issues)](#9-common-issues) in this file
 - **Usage pattern?** → Add to [`docs/AGENTS_TEMPLATE.md`](docs/AGENTS_TEMPLATE.md)
 - **New pitfall?** → Add warning near relevant section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,16 +283,18 @@ Closes #123
 git commit -s -m "feat: your commit message"
 ```
 
-### AI Tools
+### AI Coding Assistants
 
 AI-assisted development is welcome. You are responsible for reviewing and understanding every change before submitting.
 
-AI tools following project guidelines add an `Assisted-by:` trailer to commit messages by default, identifying which tool was used:
+AI coding assistants following project guidelines add an `Assisted-by:` trailer to commit messages by default, identifying which tool was used:
 
 ```text
 Assisted-by: Claude Code
 Assisted-by: IBM Bob
 ```
+
+Add one line per tool used, using its common name (GitHub Copilot, Cursor, etc.).
 
 ### Pre-commit Hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,17 @@ Closes #123
 git commit -s -m "feat: your commit message"
 ```
 
+### AI Tools
+
+AI-assisted development is welcome. You are responsible for reviewing and understanding every change before submitting.
+
+AI tools following project guidelines add an `Assisted-by:` trailer to commit messages by default, identifying which tool was used:
+
+```text
+Assisted-by: Claude Code
+Assisted-by: IBM Bob
+```
+
 ### Pre-commit Hooks
 
 Pre-commit hooks run automatically before each commit and check:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -73,9 +73,9 @@ Keep PRs focused on one logical change. Smaller, well-scoped PRs are easier to r
 
 When a PR is accepted, the maintainers inherit both an asset and a liability: the new functionality is (hopefully) an asset, but the code and documentation required to support it are ongoing liabilities. Reviewers invest real time reading and understanding every PR.
 
-Contributors are responsible for every line they submit. Do not ask others to read and maintain code or documentation that you have not taken the time to read, understand, and refine yourself. This applies regardless of how the code was produced — whether written by hand or generated with AI tools.
+Contributors are responsible for every line they submit. Do not ask others to read and maintain code or documentation that you have not taken the time to read, understand, and refine yourself. This applies regardless of how the code was produced — whether written by hand or generated with AI coding assistants.
 
-**Use of AI tools:** We neither prohibit nor discourage the use of AI coding assistants. However, AI-generated code is not exempt from this standard. If you use AI tools to produce code or documentation, you are expected to review, understand, and take full ownership of the output before submitting it for review. The reviewer's time is not the place to discover what the AI wrote on your behalf. For attribution conventions, see [CONTRIBUTING.md](CONTRIBUTING.md).
+**Use of AI coding assistants:** We neither prohibit nor discourage the use of AI coding assistants. However, AI-generated code is not exempt from this standard. If you use AI coding assistants to produce code or documentation, you are expected to review, understand, and take full ownership of the output before submitting it for review. The reviewer's time is not the place to discover what the AI wrote on your behalf. For attribution conventions, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Merge queue
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -75,7 +75,7 @@ When a PR is accepted, the maintainers inherit both an asset and a liability: th
 
 Contributors are responsible for every line they submit. Do not ask others to read and maintain code or documentation that you have not taken the time to read, understand, and refine yourself. This applies regardless of how the code was produced — whether written by hand or generated with AI tools.
 
-**Use of AI tools:** We neither prohibit nor discourage the use of AI coding assistants. However, AI-generated code is not exempt from this standard. If you use AI tools to produce code or documentation, you are expected to review, understand, and take full ownership of the output before submitting it for review. The reviewer's time is not the place to discover what the AI wrote on your behalf.
+**Use of AI tools:** We neither prohibit nor discourage the use of AI coding assistants. However, AI-generated code is not exempt from this standard. If you use AI tools to produce code or documentation, you are expected to review, understand, and take full ownership of the output before submitting it for review. The reviewer's time is not the place to discover what the AI wrote on your behalf. For attribution conventions, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Merge queue
 

--- a/docs/docs/community/contributing-guide.md
+++ b/docs/docs/community/contributing-guide.md
@@ -171,6 +171,10 @@ git commit -s -m "feat: your commit message"
 
 **Branch naming:** `feat/topic`, `fix/issue-id`, `docs/topic`
 
+### AI tools
+
+AI-assisted development is welcome. You are responsible for reviewing and understanding every change before submitting. AI tools following project guidelines will add an `Assisted-by:` trailer to commit messages by default.
+
 ### Pre-commit hooks
 
 Pre-commit hooks run automatically before each commit and check:

--- a/docs/docs/community/contributing-guide.md
+++ b/docs/docs/community/contributing-guide.md
@@ -171,9 +171,14 @@ git commit -s -m "feat: your commit message"
 
 **Branch naming:** `feat/topic`, `fix/issue-id`, `docs/topic`
 
-### AI tools
+### AI coding assistants
 
-AI-assisted development is welcome. You are responsible for reviewing and understanding every change before submitting. AI tools following project guidelines will add an `Assisted-by:` trailer to commit messages by default.
+AI-assisted development is welcome. You are responsible for reviewing and understanding every change before submitting. AI coding assistants that follow project guidelines automatically add an `Assisted-by:` trailer to commit messages — one line per tool, using its common name (GitHub Copilot, Cursor, etc.):
+
+```text
+Assisted-by: Claude Code
+Assisted-by: IBM Bob
+```
 
 ### Pre-commit hooks
 


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

Adds an AI attribution policy for the project, partially adopting the
Linux kernel's `Assisted-by` trailer convention. AI tools add the trailer
by default, so no extra action is required from human contributors.

Changes across five locations:

- **`AGENTS.md`** — New Section 7 instructing AI assistants to add `Assisted-by:
  <tool>` by default and not to add a `Signed-off-by` in their own name
- **`CONTRIBUTING.md`** — New "AI Tools" subsection under Commit Messages
  documenting the policy for human contributors
- **`docs/docs/community/contributing-guide.md`** — Lighter version of the
  same for new contributors finding the website first
- **`.github/PULL_REQUEST_TEMPLATE/*.md`** — Optional Attribution checkbox
  added to all five PR templates

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI tools used (Assisted-by trailer added to commits)
