### PR TITLE
fix: raise ValueError on duplicate subtask tags in reorder_subtasks

### DIFF
--- a/cli/decompose/decompose.py
+++ b/cli/decompose/decompose.py
@@ -62,8 +62,18 @@ def reorder_subtasks(
         come before dependents, with numbering prefixes updated.
 
     Raises:
+        ValueError: If duplicate subtask tags are detected (case-insensitive).
         ValueError: If a circular dependency is detected.
     """
+    seen: set[str] = set()
+    for subtask in subtasks:
+        tag = subtask["tag"].lower()
+        if tag in seen:
+            raise ValueError(
+                f'Duplicate subtask tag "{tag}". Tags must be unique (case-insensitive).'
+            )
+        seen.add(tag)
+
     subtask_map = {subtask["tag"].lower(): subtask for subtask in subtasks}
 
     graph = {}

--- a/test/cli/test_decompose_unit.py
+++ b/test/cli/test_decompose_unit.py
@@ -62,6 +62,18 @@ def test_reorder_circular_raises():
         reorder_subtasks(subtasks)
 
 
+def test_reorder_duplicate_tag_raises():
+    subtasks = [_subtask("a", "1. Task A"), _subtask("a", "2. Also A")]
+    with pytest.raises(ValueError, match="Duplicate subtask tag"):
+        reorder_subtasks(subtasks)
+
+
+def test_reorder_duplicate_tag_case_insensitive_raises():
+    subtasks = [_subtask("Step_A", "1. Task A"), _subtask("step_a", "2. Also A")]
+    with pytest.raises(ValueError, match="Duplicate subtask tag"):
+        reorder_subtasks(subtasks)
+
+
 def test_reorder_renumbers_subtasks():
     subtasks = [
         _subtask("b", "2. Task B", depends_on=["a"]),


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [X] Link to Issue: Fixes <!-- issue number -->

Fixes #864 

### Testing
- [X] Tests added to the respective file if code was changed
- [X] New code has 100% coverage if code as added
- [X] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [X] AI coding assistants used