### PR TITLE
fix: fixes invalid workflow file

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -377,7 +377,7 @@ jobs:
             docs: publish from ${{ github.sha }}
 
             Branch:  ${{ github.ref_name }}
-            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}
+            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR ##{0})', github.event.pull_request.number) }}
             Run:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Write deploy summary
@@ -408,4 +408,4 @@ jobs:
           STEPS_TARGET_OUTPUTS_BRANCH: ${{ steps.target.outputs.branch }}
           JOB_STATUS: ${{ job.status }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_SUFFIX: ${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}
+          PR_SUFFIX: ${{ github.event.pull_request.number && format(' (PR ##{0})', github.event.pull_request.number) }}

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -377,7 +377,7 @@ jobs:
             docs: publish from ${{ github.sha }}
 
             Branch:  ${{ github.ref_name }}
-            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR ##{0})', github.event.pull_request.number) }}
+            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}
             Run:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Write deploy summary
@@ -408,4 +408,4 @@ jobs:
           STEPS_TARGET_OUTPUTS_BRANCH: ${{ steps.target.outputs.branch }}
           JOB_STATUS: ${{ job.status }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_SUFFIX: ${{ github.event.pull_request.number && format(' (PR ##{0})', github.event.pull_request.number) }}
+          PR_SUFFIX: "${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}"

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -377,7 +377,7 @@ jobs:
             docs: publish from ${{ github.sha }}
 
             Branch:  ${{ github.ref_name }}
-            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) || '' }}
+            Trigger: ${{ github.event_name }}${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}
             Run:     https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Write deploy summary
@@ -408,4 +408,4 @@ jobs:
           STEPS_TARGET_OUTPUTS_BRANCH: ${{ steps.target.outputs.branch }}
           JOB_STATUS: ${{ job.status }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_SUFFIX: ${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) || '' }}
+          PR_SUFFIX: ${{ github.event.pull_request.number && format(' (PR #{0})', github.event.pull_request.number) }}


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #876

<!-- Brief description of the change being made along with an explanation. -->
Invalid workflow file: .github/workflows/docs-publish.yml#L1
(Line: 411, Col: 22): The expression is not closed. An unescaped ${{ sequence was found, but the closing }} sequence was not found.

The `||` or operator is not supported.
Just remove that. The `&&` already evaluates to empty string in that case.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used