### PR TITLE
ci: add actionlint to validate workflow files on PRs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,17 @@ env:
   OLLAMA_HOST: "127.0.0.1:5000"
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Lint GitHub Actions workflows
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
   quality:
     runs-on: ubuntu-latest
     timeout-minutes: 180


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Closes #879

<!-- Brief description of the change being made along with an explanation. -->
Adds `actionlint` as a lightweight parallel job in `quality.yml` to validate GitHub Actions workflow syntax and `${{ }}` expression semantics on every PR.

Identified after #854 introduced a YAML quoting bug that was only caught and fixed by #877. Running `actionlint` against the pre-fix file produces the exact error at the right line — this gate would have caught it at PR time.

Action pinned to commit SHA per project convention established in #854.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used