### PR TITLE
fix: disable OCR in RichDocument CI test to avoid modelscope.cn download

### DIFF
--- a/docs/examples/mify/rich_document_advanced.py
+++ b/docs/examples/mify/rich_document_advanced.py
@@ -79,9 +79,9 @@ class RichDocumentSections(RichDocument):
 
     @classmethod
     def from_document_file(
-        cls, source: str | Path | DocumentStream
+        cls, source: str | Path | DocumentStream, do_ocr: bool = True
     ) -> "RichDocumentSections":
-        rd = RichDocument.from_document_file(source)
+        rd = RichDocument.from_document_file(source, do_ocr=do_ocr)
         return RichDocumentSections(rd.docling())
 
 

--- a/mellea/stdlib/components/docs/richdocument.py
+++ b/mellea/stdlib/components/docs/richdocument.py
@@ -120,18 +120,22 @@ class RichDocument(Component[str]):
         return cls(doc_doc)
 
     @classmethod
-    def from_document_file(cls, source: str | Path | DocumentStream) -> RichDocument:
+    def from_document_file(
+        cls, source: str | Path | DocumentStream, do_ocr: bool = True
+    ) -> RichDocument:
         """Convert a document file to a ``RichDocument`` using Docling.
 
         Args:
             source (str | Path | DocumentStream): Path or stream for the
                 source document (e.g. a PDF or Markdown file).
+            do_ocr (bool): Whether to run OCR on the document. Disable for
+                text-based PDFs to avoid downloading OCR model weights.
 
         Returns:
             RichDocument: A new ``RichDocument`` wrapping the converted document.
         """
         pipeline_options = PdfPipelineOptions(
-            images_scale=2.0, generate_picture_images=True
+            images_scale=2.0, generate_picture_images=True, do_ocr=do_ocr
         )
 
         converter = DocumentConverter(

--- a/test/stdlib/components/docs/test_richdocument.py
+++ b/test/stdlib/components/docs/test_richdocument.py
@@ -20,7 +20,9 @@ pytestmark = pytest.mark.integration
 def rd() -> RichDocument:
     # Use a specific document so we can test some of the functionality
     # related to extracting and transforming text.
-    return RichDocument.from_document_file("https://arxiv.org/pdf/1906.04043")
+    return RichDocument.from_document_file(
+        "https://arxiv.org/pdf/1906.04043", do_ocr=False
+    )
 
 
 def test_richdocument_basics(rd: RichDocument):


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #634

Add a `do_ocr: bool = True` parameter to `RichDocument.from_document_file` and pass it through to `PdfPipelineOptions`. The test fixture for `test_richdocument` now passes `do_ocr=False` since the arxiv PDF (1906.04043) is text-based and doesn't need OCR.

This eliminates the intermittent CI failure where Docling's RapidOCR initialization tries to download model weights from `modelscope.cn` (a Chinese CDN that is unreliable from GitHub's US-based runners). The `RichDocumentSections` example subclass was also updated to match the new signature.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used
