### PR TITLE
fix: restore @pytest.mark.block_network on test_openai_compat

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -434,6 +434,7 @@ def test_canned_input(yaml_json_combo_no_alora):
     assert after_json == expected_json
 
 
+@pytest.mark.block_network
 def test_openai_compat(yaml_json_combo_no_alora):
     """
     Verify that the dataclasses for intrinsics chat completions can be directly passed


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# fix: restore @pytest.mark.block_network on test_openai_compat

## Type of PR

- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description

Restores `@pytest.mark.block_network` to `test_openai_compat` in `test/formatters/granite/test_intrinsics_formatters.py`.

The marker was removed inadvertently during the marker taxonomy audit in #742. Without it, `pytest-recording` no longer blocks socket access and the OpenAI client makes a real TCP connection to the deliberately unreachable URL used by the test (`http://example.com:98765/...`). The OS connect timeout fires at ~31 s per call; with 17 parameterised cases × 2 calls each, this adds approximately 18 minutes per matrix job, doubling CI time from ~17 min to ~35 min.

The test comment already states *"Note that network access is blocked for this test case"* — confirming the removal was not intentional.

See #903 for the full investigation.

### Testing

- [x] Existing tests and GitHub automation pass (a maintainer will kick off the GitHub automation when the rest of the PR is populated)