### PR TITLE
fix: update hallucination_detection fixture for upstream NA enum addition

### DIFF
--- a/test/formatters/granite/testdata/test_canned_input/hallucination_detection.json
+++ b/test/formatters/granite/testdata/test_canned_input/hallucination_detection.json
@@ -40,7 +40,8 @@
                 "enum": [
                   "faithful",
                   "partial",
-                  "unfaithful"
+                  "unfaithful",
+                  "NA"
                 ]
               },
               "e": {


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #915

The upstream YAML in `ibm-granite/granitelib-rag-r1.0` added `"NA"` as a valid enum value for the faithfulness field in `HallucinationOutputEntry` (for sentences that do not contain factual claims requiring grounding, e.g. greetings or opinions). The `test_canned_input/hallucination_detection.json` fixture was not updated to match, causing `test_canned_input[hallucination_detection]` to fail in CI. Same fix pattern as #897.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used