### PR TITLE
feat(stdlib): add ChunkingStrategy ABC and built-in chunkers

### DIFF
--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -8,4 +8,11 @@ sampling, budget forcing), session management via ``MelleaSession``, and the
 ``@mify`` decorator for turning ordinary Python objects into components. Import from
 the sub-packages — ``mellea.stdlib.components``, ``mellea.stdlib.sampling``, and
 ``mellea.stdlib.session`` — for day-to-day use.
+
+Streaming chunking strategies (for use with streaming validation) are available at
+``mellea.stdlib.chunking`` and re-exported here for convenience.
 """
+
+from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
+
+__all__ = ["ChunkingStrategy", "ParagraphChunker", "SentenceChunker", "WordChunker"]

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -3,6 +3,8 @@
 import re
 from abc import ABC, abstractmethod
 
+__all__ = ["ChunkingStrategy", "ParagraphChunker", "SentenceChunker", "WordChunker"]
+
 
 class ChunkingStrategy(ABC):
     """Abstract base class for text chunking strategies used in streaming validation.
@@ -11,6 +13,12 @@ class ChunkingStrategy(ABC):
     list of complete chunks ready for downstream validation. Any trailing fragment
     that has not yet reached a chunk boundary is withheld — it is not included in
     the returned list. Each call is stateless and idempotent given the same input.
+
+    End-of-stream contract: ``split()`` always withholds the trailing fragment.
+    When the stream terminates, callers are responsible for processing any remainder:
+    take the full accumulated text, identify everything after the last returned
+    chunk boundary, and handle it appropriately (e.g. pass to a final validator
+    or discard).
     """
 
     @abstractmethod
@@ -28,20 +36,31 @@ class ChunkingStrategy(ABC):
         ...
 
 
-# Sentence boundary: sentence-ending punctuation optionally followed by closing
-# quotes/parens, then either whitespace or end-of-string.
-_SENTENCE_BOUNDARY = re.compile(r'[.!?]["\')]?\s')
+# Sentence boundary: sentence-ending punctuation, optionally followed by a closing
+# quote or paren, then whitespace.
+# Character class covers: straight double/single quotes, right double/single curly
+# quotes (U+201D / U+2019), and closing paren.
+# The \u escapes are processed by the re engine (not Python's string parser), so
+# this works correctly in a raw string.
+_SENTENCE_BOUNDARY = re.compile(r'[.!?]["\'”’)]?\s')
+
+# Whitespace run separator used by WordChunker.
+_WHITESPACE = re.compile(r"\s+")
+
+# Paragraph boundary patterns used by ParagraphChunker.
+_PARA_BOUNDARY = re.compile(r"\n{2,}")
+_PARA_BOUNDARY_END = re.compile(r"\n{2,}$")
 
 
 class SentenceChunker(ChunkingStrategy):
     """Splits accumulated text on sentence boundaries.
 
     Sentence boundaries are detected by ``.``, ``!``, or ``?``, optionally
-    followed by a closing quote or parenthesis, then whitespace. The final
-    sentence is only returned once it is followed by whitespace or another
-    sentence — a trailing fragment with no following whitespace is withheld.
-    Abbreviations are a known edge case: they will be split on (simple regex,
-    not NLP).
+    followed by a closing quote (straight or curly) or parenthesis, then
+    whitespace. The final sentence is only returned once it is followed by
+    whitespace or another sentence — a trailing fragment with no following
+    whitespace is withheld. Abbreviations are a known edge case: they will
+    be split on (simple regex, not NLP).
     """
 
     def split(self, accumulated_text: str) -> list[str]:
@@ -68,8 +87,10 @@ class SentenceChunker(ChunkingStrategy):
             # but not the trailing whitespace character.
             end = match.start() + len(match.group().rstrip())
             chunks.append(remaining[:end])
-            # Advance past the whitespace separator
-            remaining = remaining[match.end() :]
+            # Advance past the entire whitespace separator; lstrip() handles
+            # multi-character gaps (double-space, tab, etc.) so they don't
+            # leak into the next chunk as leading whitespace.
+            remaining = remaining[match.end() :].lstrip()
 
         return chunks
 
@@ -96,7 +117,7 @@ class WordChunker(ChunkingStrategy):
 
         # Split on runs of whitespace; the last token is a trailing fragment
         # unless accumulated_text ends with whitespace.
-        parts = re.split(r"\s+", accumulated_text)
+        parts = _WHITESPACE.split(accumulated_text)
 
         # re.split on leading whitespace produces an empty first element; strip it.
         if parts and parts[0] == "":
@@ -120,6 +141,9 @@ class ParagraphChunker(ChunkingStrategy):
     Two or more consecutive newline characters are treated as a paragraph
     separator. The trailing paragraph fragment (text not yet followed by ``\n\n``)
     is withheld.
+
+    Note: only Unix-style ``\n\n`` separators are recognised. CRLF
+    (``\r\n\r\n``) paragraph separators are not supported.
     """
 
     def split(self, accumulated_text: str) -> list[str]:
@@ -136,10 +160,11 @@ class ParagraphChunker(ChunkingStrategy):
         if not accumulated_text:
             return []
 
-        parts = re.split(r"\n{2,}", accumulated_text)
+        parts = _PARA_BOUNDARY.split(accumulated_text)
 
         # If the text does not end with \n\n, the last part is a trailing fragment.
-        if not re.search(r"\n{2,}$", accumulated_text):
+        if not _PARA_BOUNDARY_END.search(accumulated_text):
             parts = parts[:-1]
 
+        # _PARA_BOUNDARY.split on leading \n\n produces an empty first element.
         return [p for p in parts if p]

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -39,10 +39,8 @@ class ChunkingStrategy(ABC):
 # Sentence boundary: sentence-ending punctuation, optionally followed by a closing
 # quote or paren, then whitespace.
 # Character class covers: straight double/single quotes, right double/single curly
-# quotes (U+201D / U+2019), and closing paren.
-# The \u escapes are processed by the re engine (not Python's string parser), so
-# this works correctly in a raw string.
-_SENTENCE_BOUNDARY = re.compile(r'[.!?]["\'”’)]?\s')
+# quotes (U+201D, U+2019), and closing paren.
+_SENTENCE_BOUNDARY = re.compile("[.!?][\"'" + chr(0x201D) + chr(0x2019) + ")]?\\s")
 
 # Whitespace run separator used by WordChunker.
 _WHITESPACE = re.compile(r"\s+")

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -40,7 +40,7 @@ class ChunkingStrategy(ABC):
 # quote or paren, then whitespace.
 # Character class covers: straight double/single quotes, right double/single curly
 # quotes (U+201D, U+2019), and closing paren.
-_SENTENCE_BOUNDARY = re.compile("[.!?][\"'" + chr(0x201D) + chr(0x2019) + ")]?\\s")
+_SENTENCE_BOUNDARY = re.compile("[.!?][\"'\u201d\u2019)]?\\s")
 
 # Whitespace run separator used by WordChunker.
 _WHITESPACE = re.compile(r"\s+")
@@ -58,7 +58,9 @@ class SentenceChunker(ChunkingStrategy):
     whitespace. The final sentence is only returned once it is followed by
     whitespace or another sentence — a trailing fragment with no following
     whitespace is withheld. Abbreviations are a known edge case: they will
-    be split on (simple regex, not NLP).
+    be split on (simple regex, not NLP). Inter-sentence whitespace (including
+    double-space or tab) is discarded and does not appear as leading whitespace
+    in subsequent chunks.
     """
 
     def split(self, accumulated_text: str) -> list[str]:

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -1,0 +1,145 @@
+"""ChunkingStrategy ABC and built-in implementations for streaming validation."""
+
+import re
+from abc import ABC, abstractmethod
+
+
+class ChunkingStrategy(ABC):
+    """Abstract base class for text chunking strategies used in streaming validation.
+
+    A chunking strategy receives the full accumulated text so far and returns a
+    list of complete chunks ready for downstream validation. Any trailing fragment
+    that has not yet reached a chunk boundary is withheld — it is not included in
+    the returned list. Each call is stateless and idempotent given the same input.
+    """
+
+    @abstractmethod
+    def split(self, accumulated_text: str) -> list[str]:
+        """Return complete chunks from accumulated_text, excluding any trailing fragment.
+
+        Args:
+            accumulated_text: The full text accumulated so far, including all
+                previously seen tokens and the latest delta.
+
+        Returns:
+            A list of complete chunks. If no chunk boundary has been reached yet,
+            returns an empty list. Never includes the trailing incomplete fragment.
+        """
+        ...
+
+
+# Sentence boundary: sentence-ending punctuation optionally followed by closing
+# quotes/parens, then either whitespace or end-of-string.
+_SENTENCE_BOUNDARY = re.compile(r'[.!?]["\')]?\s')
+
+
+class SentenceChunker(ChunkingStrategy):
+    """Splits accumulated text on sentence boundaries.
+
+    Sentence boundaries are detected by ``.``, ``!``, or ``?``, optionally
+    followed by a closing quote or parenthesis, then whitespace. The final
+    sentence is only returned once it is followed by whitespace or another
+    sentence — a trailing fragment with no following whitespace is withheld.
+    Abbreviations are a known edge case: they will be split on (simple regex,
+    not NLP).
+    """
+
+    def split(self, accumulated_text: str) -> list[str]:
+        """Return complete sentences from accumulated_text.
+
+        Args:
+            accumulated_text: The full text accumulated so far.
+
+        Returns:
+            Complete sentences detected so far. The trailing fragment (if any)
+            is withheld.
+        """
+        if not accumulated_text:
+            return []
+
+        chunks: list[str] = []
+        remaining = accumulated_text
+
+        while True:
+            match = _SENTENCE_BOUNDARY.search(remaining)
+            if match is None:
+                break
+            # Include up to and including the punctuation (and optional quote/paren),
+            # but not the trailing whitespace character.
+            end = match.start() + len(match.group().rstrip())
+            chunks.append(remaining[:end])
+            # Advance past the whitespace separator
+            remaining = remaining[match.end() :]
+
+        return chunks
+
+
+class WordChunker(ChunkingStrategy):
+    """Splits accumulated text on whitespace boundaries.
+
+    Each word is a chunk. Trailing text not yet followed by whitespace is
+    withheld.
+    """
+
+    def split(self, accumulated_text: str) -> list[str]:
+        """Return complete words from accumulated_text.
+
+        Args:
+            accumulated_text: The full text accumulated so far.
+
+        Returns:
+            All whitespace-delimited words except the trailing fragment (if any).
+            An empty list is returned when no whitespace boundary has been seen.
+        """
+        if not accumulated_text:
+            return []
+
+        # Split on runs of whitespace; the last token is a trailing fragment
+        # unless accumulated_text ends with whitespace.
+        parts = re.split(r"\s+", accumulated_text)
+
+        # re.split on leading whitespace produces an empty first element; strip it.
+        if parts and parts[0] == "":
+            parts = parts[1:]
+        if parts and parts[-1] == "":
+            parts = parts[:-1]
+
+        if not parts:
+            return []
+
+        # If the text does not end with whitespace, the last part is a fragment.
+        if not accumulated_text[-1].isspace():
+            return parts[:-1]
+
+        return parts
+
+
+class ParagraphChunker(ChunkingStrategy):
+    r"""Splits accumulated text on double-newline paragraph boundaries.
+
+    Two or more consecutive newline characters are treated as a paragraph
+    separator. The trailing paragraph fragment (text not yet followed by ``\n\n``)
+    is withheld.
+    """
+
+    def split(self, accumulated_text: str) -> list[str]:
+        """Return complete paragraphs from accumulated_text.
+
+        Args:
+            accumulated_text: The full text accumulated so far.
+
+        Returns:
+            Complete paragraphs (separated by two or more newlines). The
+            trailing incomplete paragraph is withheld. Returns an empty list
+            if no paragraph boundary has been reached.
+        """
+        if not accumulated_text:
+            return []
+
+        parts = re.split(r"\n{2,}", accumulated_text)
+
+        # If the text does not end with \n\n, the last part is a trailing fragment.
+        if not re.search(r"\n{2,}$", accumulated_text):
+            parts = parts[:-1]
+
+        return [p for p in parts if p]

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -1,7 +1,5 @@
 """Tests for ChunkingStrategy ABC and built-in chunker implementations."""
 
-import pytest
-
 from mellea.stdlib.chunking import ParagraphChunker, SentenceChunker, WordChunker
 
 # ---------------------------------------------------------------------------

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -1,6 +1,19 @@
 """Tests for ChunkingStrategy ABC and built-in chunker implementations."""
 
-from mellea.stdlib.chunking import ParagraphChunker, SentenceChunker, WordChunker
+import pytest
+
+from mellea.stdlib.chunking import (
+    ChunkingStrategy,
+    ParagraphChunker,
+    SentenceChunker,
+    WordChunker,
+)
+
+
+def test_chunking_strategy_is_abstract():
+    with pytest.raises(TypeError):
+        ChunkingStrategy()  # type: ignore[abstract]
+
 
 # ---------------------------------------------------------------------------
 # SentenceChunker

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -59,6 +59,14 @@ def test_sentence_chunker_closing_quote():
     assert result == ['He said "hello."', "She left."]
 
 
+def test_sentence_chunker_curly_quotes():
+    # Verifies U+201D (right double curly quote) and U+2019 (right single curly quote)
+    # are recognised as closing marks after sentence-ending punctuation.
+    c = SentenceChunker()
+    result = c.split("She said \u201cdone.\u201d Next sentence. ")
+    assert result == ["She said \u201cdone.\u201d", "Next sentence."]
+
+
 def test_sentence_chunker_unicode():
     c = SentenceChunker()
     result = c.split("Ça va bien. C'est délicieux. ")

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -1,0 +1,191 @@
+"""Tests for ChunkingStrategy ABC and built-in chunker implementations."""
+
+import pytest
+
+from mellea.stdlib.chunking import ParagraphChunker, SentenceChunker, WordChunker
+
+# ---------------------------------------------------------------------------
+# SentenceChunker
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_chunker_empty():
+    c = SentenceChunker()
+    assert c.split("") == []
+
+
+def test_sentence_chunker_no_boundary():
+    c = SentenceChunker()
+    assert c.split("The quick brown") == []
+
+
+def test_sentence_chunker_one_sentence_no_trailing():
+    # A sentence with no following whitespace is a trailing fragment — withheld.
+    c = SentenceChunker()
+    assert c.split("The quick brown fox.") == []
+
+
+def test_sentence_chunker_one_sentence_with_space():
+    # Sentence followed by a space signals completion.
+    c = SentenceChunker()
+    assert c.split("The quick brown fox. ") == ["The quick brown fox."]
+
+
+def test_sentence_chunker_with_trailing():
+    c = SentenceChunker()
+    result = c.split("The quick brown fox. He")
+    assert result == ["The quick brown fox."]
+
+
+def test_sentence_chunker_multiple():
+    c = SentenceChunker()
+    result = c.split("Hello world. Goodbye world. ")
+    assert result == ["Hello world.", "Goodbye world."]
+
+
+def test_sentence_chunker_exclamation():
+    c = SentenceChunker()
+    result = c.split("Stop! Go. ")
+    assert result == ["Stop!", "Go."]
+
+
+def test_sentence_chunker_question():
+    c = SentenceChunker()
+    result = c.split("Are you sure? Yes. ")
+    assert result == ["Are you sure?", "Yes."]
+
+
+def test_sentence_chunker_closing_quote():
+    c = SentenceChunker()
+    result = c.split('He said "hello." She left. ')
+    assert result == ['He said "hello."', "She left."]
+
+
+def test_sentence_chunker_unicode():
+    c = SentenceChunker()
+    result = c.split("Ça va bien. C'est délicieux. ")
+    assert result == ["Ça va bien.", "C'est délicieux."]
+
+
+def test_sentence_chunker_incremental_simulation():
+    # Simulate accumulating text token by token.
+    c = SentenceChunker()
+    assert c.split("The") == []
+    assert c.split("The quick") == []
+    assert c.split("The quick brown fox.") == []
+    assert c.split("The quick brown fox. He") == ["The quick brown fox."]
+    assert c.split("The quick brown fox. He ran.") == ["The quick brown fox."]
+    assert c.split("The quick brown fox. He ran. ") == [
+        "The quick brown fox.",
+        "He ran.",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# WordChunker
+# ---------------------------------------------------------------------------
+
+
+def test_word_chunker_empty():
+    c = WordChunker()
+    assert c.split("") == []
+
+
+def test_word_chunker_no_boundary():
+    c = WordChunker()
+    assert c.split("hello") == []
+
+
+def test_word_chunker_one_word_with_space():
+    c = WordChunker()
+    assert c.split("hello ") == ["hello"]
+
+
+def test_word_chunker_trailing_fragment():
+    c = WordChunker()
+    result = c.split("hello world")
+    assert result == ["hello"]
+
+
+def test_word_chunker_multiple_words():
+    c = WordChunker()
+    result = c.split("one two three ")
+    assert result == ["one", "two", "three"]
+
+
+def test_word_chunker_multiple_spaces():
+    c = WordChunker()
+    result = c.split("one  two  three ")
+    assert result == ["one", "two", "three"]
+
+
+def test_word_chunker_unicode():
+    c = WordChunker()
+    result = c.split("naïve résumé ")
+    assert result == ["naïve", "résumé"]
+
+
+def test_word_chunker_incremental_simulation():
+    c = WordChunker()
+    assert c.split("foo") == []
+    assert c.split("foobar") == []
+    assert c.split("foobar ") == ["foobar"]
+    assert c.split("foobar ba") == ["foobar"]
+    assert c.split("foobar baz ") == ["foobar", "baz"]
+
+
+# ---------------------------------------------------------------------------
+# ParagraphChunker
+# ---------------------------------------------------------------------------
+
+
+def test_paragraph_chunker_empty():
+    c = ParagraphChunker()
+    assert c.split("") == []
+
+
+def test_paragraph_chunker_no_boundary():
+    c = ParagraphChunker()
+    assert c.split("Just one paragraph with no double newline") == []
+
+
+def test_paragraph_chunker_one_complete_paragraph():
+    c = ParagraphChunker()
+    result = c.split("First paragraph.\n\n")
+    assert result == ["First paragraph."]
+
+
+def test_paragraph_chunker_with_trailing():
+    c = ParagraphChunker()
+    result = c.split("First paragraph.\n\nSecond paragraph in progress")
+    assert result == ["First paragraph."]
+
+
+def test_paragraph_chunker_multiple():
+    c = ParagraphChunker()
+    result = c.split("Para one.\n\nPara two.\n\n")
+    assert result == ["Para one.", "Para two."]
+
+
+def test_paragraph_chunker_triple_newline():
+    c = ParagraphChunker()
+    result = c.split("Para one.\n\n\nPara two.\n\n")
+    assert result == ["Para one.", "Para two."]
+
+
+def test_paragraph_chunker_unicode():
+    c = ParagraphChunker()
+    result = c.split("Première partie.\n\nDeuxième partie.\n\n")
+    assert result == ["Première partie.", "Deuxième partie."]
+
+
+def test_paragraph_chunker_incremental_simulation():
+    c = ParagraphChunker()
+    assert c.split("First") == []
+    assert c.split("First paragraph.") == []
+    assert c.split("First paragraph.\n\n") == ["First paragraph."]
+    assert c.split("First paragraph.\n\nSecond") == ["First paragraph."]
+    assert c.split("First paragraph.\n\nSecond paragraph.\n\n") == [
+        "First paragraph.",
+        "Second paragraph.",
+    ]

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -65,6 +65,32 @@ def test_sentence_chunker_unicode():
     assert result == ["Ça va bien.", "C'est délicieux."]
 
 
+def test_sentence_chunker_closing_paren():
+    c = SentenceChunker()
+    result = c.split("(See note.) Continue here. ")
+    assert result == ["(See note.)", "Continue here."]
+
+
+def test_sentence_chunker_double_space_separator():
+    # Regression: double-space between sentences must not leak into next chunk.
+    c = SentenceChunker()
+    result = c.split("First.  Second. ")
+    assert result == ["First.", "Second."]
+
+
+def test_sentence_chunker_tab_separator():
+    c = SentenceChunker()
+    result = c.split("First.\tSecond. ")
+    assert result == ["First.", "Second."]
+
+
+def test_sentence_chunker_abbreviation_known_bad():
+    # Known edge case: abbreviations cause a spurious split (simple regex, not NLP).
+    c = SentenceChunker()
+    result = c.split("Dr. Smith went home. He was tired. ")
+    assert result == ["Dr.", "Smith went home.", "He was tired."]
+
+
 def test_sentence_chunker_incremental_simulation():
     # Simulate accumulating text token by token.
     c = SentenceChunker()
@@ -130,6 +156,14 @@ def test_word_chunker_incremental_simulation():
     assert c.split("foobar ") == ["foobar"]
     assert c.split("foobar ba") == ["foobar"]
     assert c.split("foobar baz ") == ["foobar", "baz"]
+
+
+def test_word_chunker_leading_whitespace():
+    # re.split on " hello world" produces ['', 'hello', 'world'] — empty first
+    # element must be stripped.
+    c = WordChunker()
+    result = c.split(" hello world ")
+    assert result == ["hello", "world"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds `mellea/stdlib/chunking.py` with chunking infrastructure for streaming validation.

## Changes

- `ChunkingStrategy` ABC with `split(accumulated_text: str) -> list[str]`
- `SentenceChunker` — splits on `.`, `!`, `?` boundaries
- `WordChunker` — splits on whitespace
- `ParagraphChunker` — splits on `\n\n`
- Unit tests in `test/stdlib/test_chunking.py` (27 tests, all passing)

## Test plan

- [x] `uv run pytest test/stdlib/test_chunking.py -v` passes (27/27)
- [x] `uv run ruff check` clean
- [x] `uv run mypy mellea/stdlib/chunking.py` clean
- [x] Pre-commit hooks pass (ruff, mypy, codespell)

Closes #899
Part of #891