### PR TITLE
feat(core): add PartialValidationResult with tri-state semantics

### DIFF
--- a/mellea/core/__init__.py
+++ b/mellea/core/__init__.py
@@ -28,7 +28,12 @@ from .base import (
     blockify,
 )
 from .formatter import Formatter
-from .requirement import Requirement, ValidationResult, default_output_to_bool
+from .requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+    default_output_to_bool,
+)
 from .sampling import SamplingResult, SamplingStrategy
 from .utils import FancyLogger
 
@@ -49,6 +54,7 @@ __all__ = [
     "ImageBlock",
     "ModelOutputThunk",
     "ModelToolCall",
+    "PartialValidationResult",
     "Requirement",
     "S",
     "SamplingResult",

--- a/mellea/core/__init__.py
+++ b/mellea/core/__init__.py
@@ -4,7 +4,7 @@ This package defines the fundamental interfaces and data structures on which eve
 other layer of mellea is built: the ``Backend``, ``Formatter``, and
 ``SamplingStrategy`` protocols; the ``Component``, ``CBlock``, ``Context``, and
 ``ModelOutputThunk`` data types that flow through the inference pipeline; and
-``Requirement`` / ``ValidationResult`` for constrained generation. Start here when
+``Requirement`` / ``ValidationResult`` / ``PartialValidationResult`` for constrained generation. Start here when
 building a new backend, formatter, or sampling strategy, or when you need the type
 definitions shared across the library.
 """

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -102,7 +102,7 @@ class PartialValidationResult:
         context: Context | None = None,
     ):
         """Initialize PartialValidationResult with a tri-state success value."""
-        self._success = success
+        self._success: Literal["pass", "fail", "unknown"] = success
         self._reason = reason
         self._score = score
         self._thunk = thunk

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -79,6 +79,10 @@ class ValidationResult:
         """Return a boolean value based on the result."""
         return self.as_bool()
 
+    def __repr__(self) -> str:
+        """Return a developer-readable representation of the validation result."""
+        return f"ValidationResult({self._result!r}, reason={self._reason!r}, score={self._score!r})"
+
 
 class PartialValidationResult:
     """Tri-state result from per-chunk streaming validation.

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -11,6 +11,7 @@ without boilerplate.
 import re
 from collections.abc import Callable
 from copy import copy
+from typing import Literal
 
 from .backend import Backend, BaseModelSubclass
 from .base import CBlock, Component, Context, ModelOutputThunk, TemplateRepresentation
@@ -74,6 +75,74 @@ class ValidationResult:
 
     def __bool__(self) -> bool:
         """Return a boolean value based on the result."""
+        return self.as_bool()
+
+
+class PartialValidationResult:
+    """Tri-state result from per-chunk streaming validation.
+
+    Args:
+        success: Validation state — ``"pass"`` (constraint satisfied so far),
+            ``"fail"`` (constraint violated, stop streaming), or
+            ``"unknown"`` (insufficient data yet, continue streaming).
+        reason: Optional human-readable explanation.
+        score: Optional numeric confidence score.
+        thunk: Optional ModelOutputThunk from the validation call.
+        context: Optional context associated with the validation call.
+
+    """
+
+    def __init__(
+        self,
+        success: Literal["pass", "fail", "unknown"],
+        *,
+        reason: str | None = None,
+        score: float | None = None,
+        thunk: ModelOutputThunk | None = None,
+        context: Context | None = None,
+    ):
+        """Initialize PartialValidationResult with a tri-state success value."""
+        self._success = success
+        self._reason = reason
+        self._score = score
+        self._thunk = thunk
+        self._context = context
+
+    @property
+    def success(self) -> Literal["pass", "fail", "unknown"]:
+        """The tri-state validation result."""
+        return self._success
+
+    @property
+    def reason(self) -> str | None:
+        """Reason for the validation result."""
+        return self._reason
+
+    @property
+    def score(self) -> float | None:
+        """An optional score for the validation result."""
+        return self._score
+
+    @property
+    def thunk(self) -> ModelOutputThunk | None:
+        """The ModelOutputThunk associated with the validation call, if any."""
+        return self._thunk
+
+    @property
+    def context(self) -> Context | None:
+        """The context associated with the validation call, if any."""
+        return self._context
+
+    def as_bool(self) -> bool:
+        """Return True for ``"pass"``, False for ``"fail"`` or ``"unknown"``.
+
+        Returns:
+            bool: ``True`` if the partial result is ``"pass"``, ``False`` otherwise.
+        """
+        return self._success == "pass"
+
+    def __bool__(self) -> bool:
+        """Return a boolean value based on the success state."""
         return self.as_bool()
 
 

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -4,6 +4,8 @@ A ``Requirement`` pairs a human-readable description with a validation function 
 inspects a ``Context`` (and optionally a backend) to determine whether a model output
 meets a constraint. ``ValidationResult`` carries the pass/fail verdict along with an
 optional reason, score, and the ``ModelOutputThunk`` produced during validation.
+``PartialValidationResult`` provides a tri-state variant (``"pass"``, ``"fail"``,
+``"unknown"``) for per-chunk streaming validation.
 Helper factories such as ``default_output_to_bool`` make it easy to build requirements
 without boilerplate.
 """
@@ -81,6 +83,12 @@ class ValidationResult:
 class PartialValidationResult:
     """Tri-state result from per-chunk streaming validation.
 
+    Unlike :class:`ValidationResult`, which stores its verdict as a private
+    ``_result: bool``, this class exposes ``success`` as a public property.
+    The asymmetry is intentional: the tri-state value cannot be recovered from
+    a ``bool``, so a public property is the only way to distinguish ``"fail"``
+    from ``"unknown"`` after construction.
+
     Args:
         success: Validation state — ``"pass"`` (constraint satisfied so far),
             ``"fail"`` (constraint violated, stop streaming), or
@@ -102,6 +110,10 @@ class PartialValidationResult:
         context: Context | None = None,
     ):
         """Initialize PartialValidationResult with a tri-state success value."""
+        if success not in ("pass", "fail", "unknown"):
+            raise ValueError(
+                f"success must be 'pass', 'fail', or 'unknown', got {success!r}"
+            )
         self._success: Literal["pass", "fail", "unknown"] = success
         self._reason = reason
         self._score = score
@@ -136,6 +148,11 @@ class PartialValidationResult:
     def as_bool(self) -> bool:
         """Return True for ``"pass"``, False for ``"fail"`` or ``"unknown"``.
 
+        ``"unknown"`` maps to ``False`` intentionally. In streaming contexts,
+        check ``pvr.success == "unknown"`` before treating ``False`` as a definitive
+        failure — ``"unknown"`` means insufficient data so far, not a constraint
+        violation.
+
         Returns:
             bool: ``True`` if the partial result is ``"pass"``, ``False`` otherwise.
         """
@@ -144,6 +161,10 @@ class PartialValidationResult:
     def __bool__(self) -> bool:
         """Return a boolean value based on the success state."""
         return self.as_bool()
+
+    def __repr__(self) -> str:
+        """Return a developer-readable representation showing the tri-state value."""
+        return f"PartialValidationResult({self._success!r}, reason={self._reason!r}, score={self._score!r})"
 
 
 def default_output_to_bool(x: CBlock | str) -> bool:

--- a/test/core/test_partial_validation_result.py
+++ b/test/core/test_partial_validation_result.py
@@ -1,0 +1,48 @@
+"""Unit tests for PartialValidationResult tri-state semantics."""
+
+from mellea.core import PartialValidationResult
+
+
+def test_pass_state():
+    pvr = PartialValidationResult("pass")
+    assert pvr.success == "pass"
+    assert pvr.as_bool() is True
+    assert bool(pvr) is True
+
+
+def test_fail_state():
+    pvr = PartialValidationResult("fail")
+    assert pvr.success == "fail"
+    assert pvr.as_bool() is False
+    assert bool(pvr) is False
+
+
+def test_unknown_state():
+    pvr = PartialValidationResult("unknown")
+    assert pvr.success == "unknown"
+    assert pvr.as_bool() is False
+    assert bool(pvr) is False
+
+
+def test_default_optional_fields_are_none():
+    pvr = PartialValidationResult("unknown")
+    assert pvr.reason is None
+    assert pvr.score is None
+    assert pvr.thunk is None
+    assert pvr.context is None
+
+
+def test_reason_field():
+    pvr = PartialValidationResult("fail", reason="Too short")
+    assert pvr.reason == "Too short"
+
+
+def test_score_field():
+    pvr = PartialValidationResult("pass", score=0.95)
+    assert pvr.score == 0.95
+
+
+def test_as_bool_matches_bool():
+    for state in ("pass", "fail", "unknown"):
+        pvr = PartialValidationResult(state)  # type: ignore[arg-type]
+        assert pvr.as_bool() == bool(pvr)

--- a/test/core/test_partial_validation_result.py
+++ b/test/core/test_partial_validation_result.py
@@ -64,3 +64,15 @@ def test_repr_shows_state() -> None:
     assert "'fail'" in r
     assert "too short" in r
     assert "0.1" in r
+
+
+def test_thunk_field() -> None:
+    sentinel = object()
+    pvr = PartialValidationResult("pass", thunk=sentinel)  # type: ignore[arg-type]
+    assert pvr.thunk is sentinel
+
+
+def test_context_field() -> None:
+    sentinel = object()
+    pvr = PartialValidationResult("pass", context=sentinel)  # type: ignore[arg-type]
+    assert pvr.context is sentinel

--- a/test/core/test_partial_validation_result.py
+++ b/test/core/test_partial_validation_result.py
@@ -1,5 +1,7 @@
 """Unit tests for PartialValidationResult tri-state semantics."""
 
+import pytest
+
 from mellea.core import PartialValidationResult
 
 
@@ -42,7 +44,23 @@ def test_score_field():
     assert pvr.score == 0.95
 
 
-def test_as_bool_matches_bool():
-    for state in ("pass", "fail", "unknown"):
-        pvr = PartialValidationResult(state)  # type: ignore[arg-type]
-        assert pvr.as_bool() == bool(pvr)
+@pytest.mark.parametrize(
+    ("state", "expected"), [("pass", True), ("fail", False), ("unknown", False)]
+)
+def test_as_bool_correctness(state: str, expected: bool) -> None:
+    pvr = PartialValidationResult(state)  # type: ignore[arg-type]
+    assert pvr.as_bool() is expected
+    assert bool(pvr) is expected
+
+
+def test_invalid_success_raises() -> None:
+    with pytest.raises(ValueError, match="success must be"):
+        PartialValidationResult("maybe")  # type: ignore[arg-type]
+
+
+def test_repr_shows_state() -> None:
+    pvr = PartialValidationResult("fail", reason="too short", score=0.1)
+    r = repr(pvr)
+    assert "'fail'" in r
+    assert "too short" in r
+    assert "0.1" in r


### PR DESCRIPTION
Adds `PartialValidationResult` to `mellea/core/requirement.py` — a tri-state result type for per-chunk streaming validation.

## Changes

- `PartialValidationResult` class following the `ValidationResult` pattern (private fields, `@property` accessors, no dataclass)
- `success: Literal["pass", "fail", "unknown"]` — `"pass"` is informational; orchestrators call `validate()` at stream end for all non-`"fail"` results
- `__bool__` returns `True` for `"pass"`, `False` otherwise
- Exported from `mellea.core`
- Unit tests in `test/core/test_partial_validation_result.py`

## Test plan

- [ ] `uv run pytest test/core/test_partial_validation_result.py -v` passes
- [ ] `uv run ruff check` clean

Closes #898
Part of #891