### PR TITLE
feat: add stream_validate() hook to Requirement (#900)

### DIFF
--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -283,6 +283,32 @@ class Requirement(Component[str]):
                 context=val_ctx,
             )
 
+    async def stream_validate(
+        self, chunk: str, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        """Hook for per-chunk streaming validation.
+
+        The default implementation returns ``PartialValidationResult("unknown")``
+        — meaning insufficient data to decide yet. Subclasses override this method
+        to inspect the accumulated chunk and return ``"pass"`` or ``"fail"`` early.
+
+        This method must not mutate ``self``. The orchestrator is responsible for
+        cloning the requirement before each attempt; any state needed across chunks
+        must be managed externally.
+
+        Args:
+            chunk: The accumulated model output so far (not just the latest token).
+            backend: The inference backend, available for backend-assisted checks.
+            ctx: The current generation context.
+
+        Returns:
+            PartialValidationResult: ``"unknown"`` by default. Subclasses may return
+            ``"pass"`` (constraint satisfied so far) or ``"fail"`` (constraint violated,
+            streaming should be aborted). In Phase 1, ``"pass"`` is informational and
+            does not short-circuit the final ``validate()`` call.
+        """
+        return PartialValidationResult("unknown")
+
     def parts(self) -> list[Component | CBlock]:
         """Returns all of the constituent parts of a Requirement.
 

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -290,7 +290,7 @@ class Requirement(Component[str]):
 
         The default implementation returns ``PartialValidationResult("unknown")``
         — meaning insufficient data to decide yet. Subclasses override this method
-        to inspect the accumulated chunk and return ``"pass"`` or ``"fail"`` early.
+        to inspect the current chunk and return ``"pass"`` or ``"fail"`` early.
 
         Implementations may accumulate state on ``self`` across calls within a
         single attempt. The orchestrator clones the requirement (``copy(req)``)
@@ -302,10 +302,23 @@ class Requirement(Component[str]):
         ``self._buffer.append(chunk)``), or override ``__copy__`` for proper
         isolation.
 
+        Implementations must not call ``mot.astream()`` or otherwise read the
+        underlying stream; the orchestrator is the single consumer of the MOT
+        stream (see ``ModelOutputThunk.astream``). Requirements that need access
+        to the text seen so far should accumulate it themselves from the
+        ``chunk`` values they receive.
+
         Args:
-            chunk: The accumulated model output so far (not just the latest token).
+            chunk: A single complete semantic chunk produced by the chunking
+                strategy (e.g. one sentence for ``SentenceChunker``). This is
+                the delta since the previous ``stream_validate`` call for this
+                attempt, not the accumulated output. Requirements that need
+                earlier context should retain it on ``self`` across calls.
             backend: The inference backend, available for backend-assisted checks.
-            ctx: The current generation context.
+            ctx: The current generation context. During streaming the MOT is
+                not yet computed, so ``ctx`` does not contain the generated
+                output; use ``chunk`` (and any state accumulated on ``self``)
+                instead.
 
         Returns:
             PartialValidationResult: ``"unknown"`` by default. Subclasses may return

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -304,8 +304,8 @@ class Requirement(Component[str]):
         Returns:
             PartialValidationResult: ``"unknown"`` by default. Subclasses may return
             ``"pass"`` (constraint satisfied so far) or ``"fail"`` (constraint violated,
-            streaming should be aborted). In Phase 1, ``"pass"`` is informational and
-            does not short-circuit the final ``validate()`` call.
+            streaming should be aborted). ``"pass"`` does not short-circuit the final
+            ``validate()`` call; the orchestrator decides whether to skip it.
         """
         return PartialValidationResult("unknown")
 

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -284,7 +284,7 @@ class Requirement(Component[str]):
             )
 
     async def stream_validate(
-        self, chunk: str, backend: Backend, ctx: Context
+        self, chunk: str, *, backend: Backend, ctx: Context
     ) -> PartialValidationResult:
         """Hook for per-chunk streaming validation.
 

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -292,9 +292,15 @@ class Requirement(Component[str]):
         — meaning insufficient data to decide yet. Subclasses override this method
         to inspect the accumulated chunk and return ``"pass"`` or ``"fail"`` early.
 
-        This method must not mutate ``self``. The orchestrator is responsible for
-        cloning the requirement before each attempt; any state needed across chunks
-        must be managed externally.
+        Implementations may accumulate state on ``self`` across calls within a
+        single attempt. The orchestrator clones the requirement (``copy(req)``)
+        before each attempt, so state does not bleed across retries.
+
+        Shallow-copy caveat: mutable container fields (e.g. ``self._buffer = []``)
+        are shared by reference under ``copy()``. Reassign rather than mutate in
+        place (``self._buffer = self._buffer + [chunk]``, not
+        ``self._buffer.append(chunk)``), or override ``__copy__`` for proper
+        isolation.
 
         Args:
             chunk: The accumulated model output so far (not just the latest token).

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -5,9 +5,7 @@ from copy import copy
 
 import pytest
 
-from mellea.core import PartialValidationResult, Requirement
-from mellea.core.backend import Backend
-from mellea.core.base import Context
+from mellea.core import Backend, Context, PartialValidationResult, Requirement
 
 
 @pytest.mark.asyncio
@@ -132,7 +130,12 @@ async def test_stateful_subclass_accumulates_state():
 
 @pytest.mark.asyncio
 async def test_stateful_subclass_clone_isolation():
-    """copy() of a stateful requirement gives an independent clone — orchestrator pattern."""
+    """Orchestrator clone pattern: copy() before each attempt gives a fresh independent clone.
+
+    The orchestrator holds the original requirement and never calls stream_validate on it
+    directly. Before each attempt it clones the original; each clone starts from the
+    original's (zero) state and advances independently.
+    """
 
     class CallCounter(Requirement):
         def __init__(self) -> None:
@@ -145,15 +148,19 @@ async def test_stateful_subclass_clone_isolation():
             self._calls += 1
             return PartialValidationResult("unknown")
 
-    req = CallCounter()
-    await req.stream_validate("a", backend=None, ctx=None)  # type: ignore[arg-type]
-    await req.stream_validate("b", backend=None, ctx=None)  # type: ignore[arg-type]
-    assert req._calls == 2
+    req = CallCounter()  # original — never used directly by the orchestrator
 
-    # Simulate orchestrator cloning before a new attempt
-    cloned = copy(req)
-    assert cloned._calls == 2  # clone inherits state at clone time
+    # Attempt 1
+    attempt1 = copy(req)
+    assert attempt1._calls == 0
+    await attempt1.stream_validate("a", backend=None, ctx=None)  # type: ignore[arg-type]
+    await attempt1.stream_validate("b", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert attempt1._calls == 2
 
-    await cloned.stream_validate("c", backend=None, ctx=None)  # type: ignore[arg-type]
-    assert cloned._calls == 3  # clone advances independently
-    assert req._calls == 2  # original is unchanged
+    # Attempt 2 (retry) — fresh clone from the same original
+    attempt2 = copy(req)
+    assert attempt2._calls == 0  # starts clean, not carrying attempt1's state
+    await attempt2.stream_validate("c", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert attempt2._calls == 1
+
+    assert req._calls == 0  # original never mutated

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -32,7 +32,7 @@ def test_stream_validate_is_coroutine():
 async def test_subclass_can_return_pass():
     class PassRequirement(Requirement):
         async def stream_validate(
-            self, chunk: str, backend: Backend, ctx: Context
+            self, chunk: str, *, backend: Backend, ctx: Context
         ) -> PartialValidationResult:
             return PartialValidationResult("pass")
 
@@ -45,7 +45,7 @@ async def test_subclass_can_return_pass():
 async def test_subclass_can_return_fail():
     class FailRequirement(Requirement):
         async def stream_validate(
-            self, chunk: str, backend: Backend, ctx: Context
+            self, chunk: str, *, backend: Backend, ctx: Context
         ) -> PartialValidationResult:
             if "bad" in chunk:
                 return PartialValidationResult("fail", reason="bad word detected")

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -1,0 +1,68 @@
+"""Unit tests for Requirement.stream_validate() hook."""
+
+import inspect
+
+import pytest
+
+from mellea.core import PartialValidationResult, Requirement
+
+
+@pytest.mark.asyncio
+async def test_default_returns_unknown():
+    req = Requirement(description="some requirement")
+    result = await req.stream_validate("some chunk", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert result.success == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_default_returns_partial_validation_result_instance():
+    req = Requirement()
+    result = await req.stream_validate("chunk", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert isinstance(result, PartialValidationResult)
+
+
+def test_stream_validate_is_coroutine():
+    req = Requirement()
+    assert inspect.iscoroutinefunction(req.stream_validate)
+
+
+@pytest.mark.asyncio
+async def test_subclass_can_return_pass():
+    class PassRequirement(Requirement):
+        async def stream_validate(self, chunk, backend, ctx) -> PartialValidationResult:
+            return PartialValidationResult("pass")
+
+    req = PassRequirement(description="always passes")
+    result = await req.stream_validate("any chunk", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert result.success == "pass"
+
+
+@pytest.mark.asyncio
+async def test_subclass_can_return_fail():
+    class FailRequirement(Requirement):
+        async def stream_validate(self, chunk, backend, ctx) -> PartialValidationResult:
+            if "bad" in chunk:
+                return PartialValidationResult("fail", reason="bad word detected")
+            return PartialValidationResult("unknown")
+
+    req = FailRequirement(description="no bad words")
+    result = await req.stream_validate("this is bad content", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert result.success == "fail"
+    assert result.reason == "bad word detected"
+
+    result_unknown = await req.stream_validate("good content", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert result_unknown.success == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_does_not_mutate_requirement():
+    req = Requirement(description="original description")
+    original_description = req.description
+    original_output = req._output
+    original_validation_fn = req.validation_fn
+
+    await req.stream_validate("some chunk", backend=None, ctx=None)  # type: ignore[arg-type]
+
+    assert req.description == original_description
+    assert req._output == original_output
+    assert req.validation_fn == original_validation_fn

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -5,6 +5,8 @@ import inspect
 import pytest
 
 from mellea.core import PartialValidationResult, Requirement
+from mellea.core.backend import Backend
+from mellea.core.base import Context
 
 
 @pytest.mark.asyncio
@@ -29,7 +31,9 @@ def test_stream_validate_is_coroutine():
 @pytest.mark.asyncio
 async def test_subclass_can_return_pass():
     class PassRequirement(Requirement):
-        async def stream_validate(self, chunk, backend, ctx) -> PartialValidationResult:
+        async def stream_validate(
+            self, chunk: str, backend: Backend, ctx: Context
+        ) -> PartialValidationResult:
             return PartialValidationResult("pass")
 
     req = PassRequirement(description="always passes")
@@ -40,7 +44,9 @@ async def test_subclass_can_return_pass():
 @pytest.mark.asyncio
 async def test_subclass_can_return_fail():
     class FailRequirement(Requirement):
-        async def stream_validate(self, chunk, backend, ctx) -> PartialValidationResult:
+        async def stream_validate(
+            self, chunk: str, backend: Backend, ctx: Context
+        ) -> PartialValidationResult:
             if "bad" in chunk:
                 return PartialValidationResult("fail", reason="bad word detected")
             return PartialValidationResult("unknown")
@@ -66,3 +72,13 @@ async def test_does_not_mutate_requirement():
     assert req.description == original_description
     assert req._output == original_output
     assert req.validation_fn == original_validation_fn
+
+
+@pytest.mark.asyncio
+async def test_stream_validate_idempotent():
+    req = Requirement(description="repeated calls")
+    result1 = await req.stream_validate("chunk one", backend=None, ctx=None)  # type: ignore[arg-type]
+    result2 = await req.stream_validate("chunk two", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert result1.success == "unknown"
+    assert result2.success == "unknown"
+    assert req._output is None

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -122,7 +122,7 @@ async def test_stateful_subclass_accumulates_state():
 
     result = await req.stream_validate(
         "intro text\n- one\n- two\n- three\n- four",
-        backend=None,
+        backend=None,  # type: ignore[arg-type]
         ctx=None,  # type: ignore[arg-type]
     )
     assert req._bullet_count == 4  # delta added 2 more

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -87,17 +87,24 @@ async def test_stream_validate_idempotent():
 
 @pytest.mark.asyncio
 async def test_stateful_subclass_accumulates_state():
-    """Stateful subclass correctly accumulates state across stream_validate calls."""
+    """Stateful subclass correctly accumulates state across stream_validate calls.
+
+    Uses delta extraction (via _seen_len) to count only new bullet points per call —
+    a pattern that genuinely requires state from prior calls.
+    """
 
     class BulletCounter(Requirement):
         def __init__(self) -> None:
             super().__init__(description="no more than 3 bullets")
+            self._seen_len = 0
             self._bullet_count = 0
 
         async def stream_validate(
             self, chunk: str, *, backend: Backend, ctx: Context
         ) -> PartialValidationResult:
-            self._bullet_count = chunk.count("\n-")
+            delta = chunk[self._seen_len :]
+            self._seen_len = len(chunk)
+            self._bullet_count += delta.count("\n-")
             if self._bullet_count > 3:
                 return PartialValidationResult(
                     "fail", reason=f"{self._bullet_count} bullets exceeds limit"
@@ -110,15 +117,15 @@ async def test_stateful_subclass_accumulates_state():
     await req.stream_validate("intro text", backend=None, ctx=None)  # type: ignore[arg-type]
     assert req._bullet_count == 0
 
-    await req.stream_validate("intro\n- one\n- two", backend=None, ctx=None)  # type: ignore[arg-type]
-    assert req._bullet_count == 2
+    await req.stream_validate("intro text\n- one\n- two", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert req._bullet_count == 2  # delta added 2 new bullets
 
     result = await req.stream_validate(
-        "intro\n- one\n- two\n- three\n- four",
+        "intro text\n- one\n- two\n- three\n- four",
         backend=None,
         ctx=None,  # type: ignore[arg-type]
     )
-    assert req._bullet_count == 4
+    assert req._bullet_count == 4  # delta added 2 more
     assert result.success == "fail"
     assert result.reason is not None and "4" in result.reason
 

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -87,22 +87,20 @@ async def test_stream_validate_idempotent():
 async def test_stateful_subclass_accumulates_state():
     """Stateful subclass correctly accumulates state across stream_validate calls.
 
-    Uses delta extraction (via _seen_len) to count only new bullet points per call —
-    a pattern that genuinely requires state from prior calls.
+    Each call receives a single chunk (the delta produced by the chunking
+    strategy). Requirements maintain their own running state across calls
+    rather than re-scanning accumulated text.
     """
 
     class BulletCounter(Requirement):
         def __init__(self) -> None:
             super().__init__(description="no more than 3 bullets")
-            self._seen_len = 0
             self._bullet_count = 0
 
         async def stream_validate(
             self, chunk: str, *, backend: Backend, ctx: Context
         ) -> PartialValidationResult:
-            delta = chunk[self._seen_len :]
-            self._seen_len = len(chunk)
-            self._bullet_count += delta.count("\n-")
+            self._bullet_count += chunk.count("\n-")
             if self._bullet_count > 3:
                 return PartialValidationResult(
                     "fail", reason=f"{self._bullet_count} bullets exceeds limit"
@@ -115,15 +113,15 @@ async def test_stateful_subclass_accumulates_state():
     await req.stream_validate("intro text", backend=None, ctx=None)  # type: ignore[arg-type]
     assert req._bullet_count == 0
 
-    await req.stream_validate("intro text\n- one\n- two", backend=None, ctx=None)  # type: ignore[arg-type]
-    assert req._bullet_count == 2  # delta added 2 new bullets
+    await req.stream_validate("\n- one\n- two", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert req._bullet_count == 2
 
     result = await req.stream_validate(
-        "intro text\n- one\n- two\n- three\n- four",
+        "\n- three\n- four",
         backend=None,  # type: ignore[arg-type]
         ctx=None,  # type: ignore[arg-type]
     )
-    assert req._bullet_count == 4  # delta added 2 more
+    assert req._bullet_count == 4
     assert result.success == "fail"
     assert result.reason is not None and "4" in result.reason
 

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -1,6 +1,7 @@
 """Unit tests for Requirement.stream_validate() hook."""
 
 import inspect
+from copy import copy
 
 import pytest
 
@@ -82,3 +83,70 @@ async def test_stream_validate_idempotent():
     assert result1.success == "unknown"
     assert result2.success == "unknown"
     assert req._output is None
+
+
+@pytest.mark.asyncio
+async def test_stateful_subclass_accumulates_state():
+    """Stateful subclass correctly accumulates state across stream_validate calls."""
+
+    class BulletCounter(Requirement):
+        def __init__(self) -> None:
+            super().__init__(description="no more than 3 bullets")
+            self._bullet_count = 0
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Backend, ctx: Context
+        ) -> PartialValidationResult:
+            self._bullet_count = chunk.count("\n-")
+            if self._bullet_count > 3:
+                return PartialValidationResult(
+                    "fail", reason=f"{self._bullet_count} bullets exceeds limit"
+                )
+            return PartialValidationResult("unknown")
+
+    req = BulletCounter()
+    assert req._bullet_count == 0
+
+    await req.stream_validate("intro text", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert req._bullet_count == 0
+
+    await req.stream_validate("intro\n- one\n- two", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert req._bullet_count == 2
+
+    result = await req.stream_validate(
+        "intro\n- one\n- two\n- three\n- four",
+        backend=None,
+        ctx=None,  # type: ignore[arg-type]
+    )
+    assert req._bullet_count == 4
+    assert result.success == "fail"
+    assert result.reason is not None and "4" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_stateful_subclass_clone_isolation():
+    """copy() of a stateful requirement gives an independent clone — orchestrator pattern."""
+
+    class CallCounter(Requirement):
+        def __init__(self) -> None:
+            super().__init__(description="call counter")
+            self._calls = 0
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Backend, ctx: Context
+        ) -> PartialValidationResult:
+            self._calls += 1
+            return PartialValidationResult("unknown")
+
+    req = CallCounter()
+    await req.stream_validate("a", backend=None, ctx=None)  # type: ignore[arg-type]
+    await req.stream_validate("b", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert req._calls == 2
+
+    # Simulate orchestrator cloning before a new attempt
+    cloned = copy(req)
+    assert cloned._calls == 2  # clone inherits state at clone time
+
+    await cloned.stream_validate("c", backend=None, ctx=None)  # type: ignore[arg-type]
+    assert cloned._calls == 3  # clone advances independently
+    assert req._calls == 2  # original is unchanged


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Requirement PR

## Description
- [x] Link to Issue: Closes #900

<!-- Brief description of the requirement being added/modified along with an explanation for why it should be in the standard library. -->

Adds `async stream_validate(chunk, *, backend, ctx) -> PartialValidationResult` to the base `Requirement` class as a per-chunk streaming validation hook. The default implementation returns `PartialValidationResult("unknown")`; subclasses override to inspect the **current chunk** (the semantic delta from the chunking strategy — one sentence, word, or paragraph per call) and signal `"pass"` or `"fail"` early. Stateful implementations maintain their own running state across calls (e.g. `self._count += chunk.count("•")`); the orchestrator (in the stacked PR #942) clones the requirement before each attempt so state does not bleed across retries.

Part of streaming epic #891. Builds on #924 (merged — `PartialValidationResult`) and #923 (merged — `ChunkingStrategy`).

### Design decisions

Per the agreed Phase 1 spec:

- **Method name**: `stream_validate` (not `avalidate`) — different operation, different semantics
- **Return type**: `PartialValidationResult` (tri-state `"pass"` / `"fail"` / `"unknown"`) — from #898 / #924
- **Chunk semantics**: `chunk` is a single complete chunk from the chunking strategy (the delta since the previous call), **not** the full accumulated output. This matches the #891 epic's "one chunk at a time" contract and the #900 spec.
- **`backend` and `ctx` are keyword-only**: prevents positional confusion and keeps future parameter additions non-breaking
- **`"pass"` is informational**: does not short-circuit the final `validate()` call in Phase 1
- **No `reset()` method**: state isolation is handled by orchestrator cloning (`copy(req)`) before each attempt

No LLM-as-a-Judge logic here — this is a pure hook for custom validation overrides.

### Review feedback addressed

@jakelorocco flagged on first pass that an earlier iteration of this branch passed the accumulated output to `stream_validate` rather than a single chunk, which deviated from the spec. Commit `82bdd3a5` restores the spec-compliant behaviour:

- `requirement.py` docstring rewritten to describe `chunk` as the delta from the chunking strategy, with notes on `ctx` being incomplete during streaming and the MOT single-consumer constraint.
- `test_stateful_subclass_accumulates_state` rewritten: `BulletCounter` now accumulates on `self._count` across delta calls, dropping the earlier `self._seen_len` workaround that only made sense under accumulated semantics.

The corresponding orchestrator change (pass single chunk, not accumulated) is in the stacked PR #942.

## Implementation Checklist

### Base Class
- [x] Extends appropriate base class:
  - `Requirement` - standard requirement

### Validation Logic
- [x] Hook method on base `Requirement`; no default `validation_fn` added (stream_validate is an override point, not a validation implementation)
- [x] Returns `PartialValidationResult` with tri-state `success` and optional `reason` / `score`

### Integration
- [x] No change to `mellea/stdlib/requirements/__init__.py` needed — this PR modifies the base class, not a new requirement

### Testing
- [x] Tests added to `test/core/test_stream_validate.py`:
  - `test_default_returns_unknown` — base class always returns `"unknown"`
  - `test_default_returns_partial_validation_result_instance` — correct return type
  - `test_stream_validate_is_coroutine` — method is async
  - `test_subclass_can_return_pass` / `test_subclass_can_return_fail` — subclass overrides work
  - `test_does_not_mutate_requirement` / `test_stream_validate_idempotent` — base class is stateless
  - `test_stateful_subclass_accumulates_state` — delta-semantics bullet counter correctly accumulates on `self`
  - `test_stateful_subclass_clone_isolation` — `copy()` produces independent clones for orchestrator use
- [x] New code has 100% coverage
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used
