### PR TITLE
fix: add vllm pytest marker back

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,6 +343,7 @@ markers = [
     "huggingface: Tests requiring HuggingFace backend (local, heavy)",
     "litellm: Tests requiring LiteLLM backend",
     "bedrock: Tests requiring AWS Bedrock backend (requires credentials)",
+    "vllm: Tests requiring vLLM backend (local, GPU required)",
 
     # Capability markers
     "qualitative: Non-deterministic quality tests",


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number --> N/A

We removed the vllm flag when we removed the vllm backend. However, we still have some tests that require a vllm backend. Adding this back.

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used