### PR TITLE
feat(stdlib): streaming event types, events() iterator, and OTEL bridge (#902)

### DIFF
--- a/docs/docs/concepts/requirements-system.md
+++ b/docs/docs/concepts/requirements-system.md
@@ -300,3 +300,30 @@ requirements = [
 All requirements are validated after each generation attempt. The repair request lists
 every requirement that failed, not just the first one, so the model can address all
 issues in a single repair pass.
+
+## Streaming validation
+
+`stream_validate()` is the streaming counterpart to `validate()`. It is called
+once per semantic chunk as tokens arrive from the model, before the full output
+is available. Requirements that need to detect problems early — too many
+sentences, a prohibited keyword in the first paragraph, unexpected JSON
+structure mid-output — override `stream_validate()` to express that logic.
+
+`stream_validate()` returns a `PartialValidationResult` with a tri-state `success`
+field:
+
+- `"unknown"` — no conclusion yet; the chunk is passed to the consumer and
+  `validate()` will be called at stream end.
+- `"pass"` — the chunk looks valid so far; it is passed to the consumer and
+  `validate()` is still called at stream end (a streaming pass is informational,
+  not final).
+- `"fail"` — the stream is cancelled immediately; no further chunks reach the
+  consumer; `validate()` is skipped for this requirement.
+
+State isolation is per-clone: `stream_with_chunking()` copies each requirement
+with `copy()` before starting the orchestrator, so the original objects are never
+mutated. Requirements that accumulate state across chunks (e.g. a running word
+count) should reassign mutable containers rather than mutate in place, since
+clones share the original's `__dict__` values at copy time.
+
+> **See also:** [Streaming with per-chunk validation](../how-to/use-async-and-streaming#streaming-with-per-chunk-validation)

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -32,6 +32,7 @@ to run.
 | `context/` | Context inspection, sampling with context trees, parallel context branches |
 | `sessions/` | Custom session types and backend selection |
 | `async/` | How to utilize basic async capabilities |
+| `streaming/` | `stream_with_chunking()` with per-chunk validation, typed event vocabulary, early-exit on fail |
 
 ### Data and documents
 

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -182,6 +182,9 @@ paragraphs), calls `stream_validate()` on each chunk in parallel, and can
 exit early if any requirement returns `"fail"` — preventing the consumer from
 seeing invalid content mid-stream.
 
+The primary way to observe a `stream_with_chunking()` run is via typed
+`StreamEvent` objects from `result.events()`:
+
 ```python
 # Requires: mellea
 # Returns: None
@@ -191,7 +194,14 @@ from mellea.core.backend import Backend
 from mellea.core.base import Context
 from mellea.core.requirement import PartialValidationResult, Requirement, ValidationResult
 from mellea.stdlib.components import Instruction
-from mellea.stdlib.streaming import stream_with_chunking
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
 
 
 class MaxSentencesReq(Requirement):
@@ -229,14 +239,45 @@ async def main() -> None:
     result = await stream_with_chunking(
         action, m.backend, m.ctx, quick_check_requirements=[req], chunking="sentence"
     )
-    async for chunk in result.astream():
-        print(chunk)
+
+    async for event in result.events():
+        match event:
+            case ChunkEvent():
+                print(f"  chunk[{event.chunk_index}]: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(f"  FAIL at chunk {event.chunk_index}: {event.results}")
+            case StreamingDoneEvent():
+                print(f"  stream done — {len(event.full_text)} chars")
+            case FullValidationEvent():
+                print(f"  final: {'pass' if event.passed else 'fail'}")
+            case CompletedEvent():
+                print(f"  completed — success={event.success}")
+            case _:
+                pass  # ErrorEvent and other future types
+
     await result.acomplete()
     print(f"completed={result.completed}, failures={len(result.streaming_failures)}")
 
 
 asyncio.run(main())
 ```
+
+If you only need the raw validated text without event metadata, use
+`result.astream()` instead:
+
+```python
+result = await stream_with_chunking(
+    action, m.backend, m.ctx, quick_check_requirements=[req], chunking="sentence"
+)
+async for chunk in result.astream():
+    print(chunk)
+await result.acomplete()
+```
+
+Both `astream()` (raw chunks) and `events()` are available on the same result
+object. They use independent queues, so you can run them concurrently with
+`asyncio.gather`. Both are **single-consumer** — a second iteration on either
+will block indefinitely.
 
 ### The `stream_validate` tri-state
 
@@ -252,44 +293,6 @@ three values:
 After a natural stream end, `validate()` is called on every non-`"fail"`
 requirement (both `"pass"` and `"unknown"`). This means `"pass"` from
 `stream_validate` does **not** replace the final `validate()` call.
-
-### Observing events
-
-The orchestrator emits typed events throughout execution. Use `result.events()`
-in place of, or alongside, `result.astream()`:
-
-```python
-from mellea.stdlib.streaming import (
-    ChunkEvent,
-    CompletedEvent,
-    FullValidationEvent,
-    QuickCheckEvent,
-    StreamingDoneEvent,
-    stream_with_chunking,
-)
-
-result = await stream_with_chunking(action, backend, ctx, quick_check_requirements=[req])
-
-async for event in result.events():
-    match event:
-        case ChunkEvent():
-            print(f"chunk {event.chunk_index}: {event.text!r}")
-        case QuickCheckEvent(passed=False):
-            print(f"validation failed at chunk {event.chunk_index}")
-        case StreamingDoneEvent():
-            print(f"stream done — {len(event.full_text)} chars")
-        case FullValidationEvent():
-            print(f"final validation: {'pass' if event.passed else 'fail'}")
-        case CompletedEvent():
-            print(f"completed — success={event.success}")
-
-await result.acomplete()
-```
-
-Both `astream()` (raw chunks) and `events()` are available on the same result
-object. They use independent queues, so you can run them concurrently with
-`asyncio.gather`. Both are **single-consumer** — a second iteration on either
-will block indefinitely.
 
 > **See also:** [The Requirements System — Streaming validation](../concepts/requirements-system#streaming-validation)
 

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -174,6 +174,125 @@ asyncio.run(sequential_chat())
 
 For parallel generation, use `SimpleContext`.
 
+## Streaming with per-chunk validation
+
+`stream_with_chunking()` adds per-chunk validation to a streaming generation.
+It splits the accumulated text into semantic units (sentences, words, or
+paragraphs), calls `stream_validate()` on each chunk in parallel, and can
+exit early if any requirement returns `"fail"` — preventing the consumer from
+seeing invalid content mid-stream.
+
+```python
+# Requires: mellea
+# Returns: None
+import asyncio
+
+from mellea.core.backend import Backend
+from mellea.core.base import Context
+from mellea.core.requirement import PartialValidationResult, Requirement, ValidationResult
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.streaming import stream_with_chunking
+
+
+class MaxSentencesReq(Requirement):
+    """Fails if the model generates more than *limit* sentences."""
+
+    def __init__(self, limit: int) -> None:
+        super().__init__()
+        self._limit = limit
+        self._count = 0
+
+    def format_for_llm(self) -> str:
+        return f"The response must be at most {self._limit} sentences."
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        self._count += 1
+        if self._count > self._limit:
+            return PartialValidationResult("fail", reason="Too many sentences")
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self, backend: Backend, ctx: Context, *, format=None, model_options=None
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+async def main() -> None:
+    from mellea.stdlib.session import start_session
+
+    m = start_session()
+    action = Instruction("Write a two-sentence summary of the water cycle.")
+    req = MaxSentencesReq(limit=3)
+
+    result = await stream_with_chunking(
+        action, m.backend, m.ctx, quick_check_requirements=[req], chunking="sentence"
+    )
+    async for chunk in result.astream():
+        print(chunk)
+    await result.acomplete()
+    print(f"completed={result.completed}, failures={len(result.streaming_failures)}")
+
+
+asyncio.run(main())
+```
+
+### The `stream_validate` tri-state
+
+Each call to `stream_validate` returns a `PartialValidationResult` with one of
+three values:
+
+| Value | Meaning |
+| ----- | ------- |
+| `"unknown"` | No conclusion yet — wait for the full output before judging. |
+| `"pass"` | This chunk is valid so far (informational; does not skip final `validate()`). |
+| `"fail"` | Invalid — cancel the stream immediately and record a streaming failure. |
+
+After a natural stream end, `validate()` is called on every non-`"fail"`
+requirement (both `"pass"` and `"unknown"`). This means `"pass"` from
+`stream_validate` does **not** replace the final `validate()` call.
+
+### Observing events
+
+The orchestrator emits typed events throughout execution. Use `result.events()`
+in place of, or alongside, `result.astream()`:
+
+```python
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
+
+result = await stream_with_chunking(action, backend, ctx, quick_check_requirements=[req])
+
+async for event in result.events():
+    match event:
+        case ChunkEvent():
+            print(f"chunk {event.chunk_index}: {event.text!r}")
+        case QuickCheckEvent(passed=False):
+            print(f"validation failed at chunk {event.chunk_index}")
+        case StreamingDoneEvent():
+            print(f"stream done — {len(event.full_text)} chars")
+        case FullValidationEvent():
+            print(f"final validation: {'pass' if event.passed else 'fail'}")
+        case CompletedEvent():
+            print(f"completed — success={event.success}")
+
+await result.acomplete()
+```
+
+Both `astream()` (raw chunks) and `events()` are available on the same result
+object. They use independent queues, so you can run them concurrently with
+`asyncio.gather`. Both are **single-consumer** — a second iteration on either
+will block indefinitely.
+
+> **See also:** [The Requirements System — Streaming validation](../concepts/requirements-system#streaming-validation)
+
 ---
 
 **See also:** [Tutorial 02: Streaming and Async](../tutorials/02-streaming-and-async) | [act() and aact()](../how-to/act-and-aact)

--- a/docs/examples/streaming/custom_chunking.py
+++ b/docs/examples/streaming/custom_chunking.py
@@ -1,0 +1,183 @@
+# pytest: ollama, e2e
+
+"""Streaming generation with a custom ChunkingStrategy subclass.
+
+Demonstrates:
+- Subclassing :class:`~mellea.stdlib.chunking.ChunkingStrategy` to define a
+  new splitting boundary
+- Implementing ``split()`` (stateless, idempotent) and ``flush()`` (end-of-stream
+  release of any withheld trailing fragment)
+- Using the custom chunker with ``stream_with_chunking()`` in place of a string alias
+- Validating line-by-line output from a numbered-list prompt
+
+``LineChunker`` splits on single newlines (``\\n``), emitting one line per
+``stream_validate`` call.  It sits between :class:`~mellea.stdlib.chunking.WordChunker`
+(one word) and :class:`~mellea.stdlib.chunking.SentenceChunker` (one sentence) in
+granularity, and is a natural fit for list-formatted model output.
+
+Extension pattern:
+  1. Subclass ``ChunkingStrategy``.
+  2. Implement ``split(accumulated_text)`` — return all complete chunks found in
+     the accumulated text so far; withhold any trailing fragment.  The method is
+     called on every new token delta, so it must be stateless and idempotent.
+  3. Override ``flush(accumulated_text)`` to release the withheld trailing fragment
+     when the stream ends naturally.  The default base implementation returns ``[]``
+     (fragment discarded); override it when the trailing fragment is semantically
+     significant.
+"""
+
+import asyncio
+import re
+
+from mellea.core.backend import Backend
+from mellea.core.base import Context
+from mellea.core.requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+)
+from mellea.stdlib.chunking import ChunkingStrategy
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
+
+# Matches a leading list marker: "1.", "1)", "1 .", or a bare number followed
+# by a space — covers common model output formats.
+_NUMBERED_LINE = re.compile(r"^\s*\d+[\.\)]\s")
+
+
+class LineChunker(ChunkingStrategy):
+    """Splits accumulated text on single newlines, emitting one line per chunk.
+
+    The line after the last ``\\n`` is withheld as a trailing fragment until
+    the stream ends and :meth:`flush` is called.  Blank lines are skipped —
+    they carry no content for a line-level validator.
+
+    This chunker is a good fit for numbered-list output, code listings, and
+    any structured response where the model uses line breaks as separators
+    rather than sentence-ending punctuation or double newlines.
+    """
+
+    def split(self, accumulated_text: str) -> list[str]:
+        """Return all complete lines (up to the last newline).
+
+        Args:
+            accumulated_text: The full text accumulated so far.
+
+        Returns:
+            Non-empty lines found before the last newline character.
+            The text after the last newline is withheld as a trailing fragment.
+        """
+        if "\n" not in accumulated_text:
+            return []
+        last_nl = accumulated_text.rfind("\n")
+        complete_section = accumulated_text[:last_nl]
+        return [line for line in complete_section.split("\n") if line.strip()]
+
+    def flush(self, accumulated_text: str) -> list[str]:
+        """Release the trailing line fragment at end of stream.
+
+        Args:
+            accumulated_text: The full accumulated text at stream end.
+
+        Returns:
+            The text after the last newline as a single-element list (stripped),
+            or an empty list if the text ends with a newline or is empty.
+        """
+        if not accumulated_text:
+            return []
+        last_nl = accumulated_text.rfind("\n")
+        trailing = (
+            accumulated_text if last_nl == -1 else accumulated_text[last_nl + 1 :]
+        ).strip()
+        return [trailing] if trailing else []
+
+
+class NumberedLineReq(Requirement):
+    """Fails the stream if any line does not start with a list number.
+
+    Each ``stream_validate`` call receives one complete line (from
+    :class:`LineChunker`).  This requirement enforces that every line follows
+    the ``N. item`` format, catching unstructured paragraphs or stray headers
+    that sneak into what should be a clean numbered list.
+    """
+
+    def format_for_llm(self) -> str:
+        return "Every line must begin with a number followed by a period (e.g. '1. ')."
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        if not _NUMBERED_LINE.match(chunk):
+            return PartialValidationResult(
+                "fail", reason=f"Line does not start with a number: {chunk.strip()!r}"
+            )
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self,
+        backend: Backend,
+        ctx: Context,
+        *,
+        format: type | None = None,
+        model_options: dict | None = None,
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+async def main() -> None:
+    from mellea.stdlib.session import start_session
+
+    m = start_session()
+    backend = m.backend
+    ctx = m.ctx
+
+    action = Instruction(
+        "List five world capitals, one per line, numbered 1 through 5. "
+        "Use the format: '1. City'. Output only the numbered list, nothing else."
+    )
+    chunker = LineChunker()
+    req = NumberedLineReq()
+
+    result = await stream_with_chunking(
+        action, backend, ctx, quick_check_requirements=[req], chunking=chunker
+    )
+
+    print("Streaming events as they arrive (one ChunkEvent per line):")
+    async for event in result.events():
+        match event:
+            case ChunkEvent():
+                print(f"  LINE[{event.chunk_index}]: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(
+                    f"  QUICK_CHECK[line {event.chunk_index}]: FAIL — "
+                    f"{event.results[0].reason if event.results else 'unknown'}"
+                )
+            case QuickCheckEvent():
+                print(f"  QUICK_CHECK[line {event.chunk_index}]: pass")
+            case StreamingDoneEvent():
+                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+            case FullValidationEvent():
+                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+            case CompletedEvent():
+                print(f"  COMPLETED: success={event.success}")
+            case _:
+                pass
+
+    await result.acomplete()
+
+    print(f"\nCompleted normally: {result.completed}")
+    if result.streaming_failures:
+        for _req, pvr in result.streaming_failures:
+            print(f"Streaming failure: {pvr.reason}")
+    else:
+        print(f"Full text:\n{result.full_text}")
+
+
+asyncio.run(main())

--- a/docs/examples/streaming/paragraph_chunking.py
+++ b/docs/examples/streaming/paragraph_chunking.py
@@ -1,0 +1,142 @@
+# pytest: ollama, e2e
+
+"""Streaming generation with per-paragraph validation using ParagraphChunker.
+
+Demonstrates:
+- Using the ``"paragraph"`` chunking alias for coarse-grained, structure-aware
+  validation
+- A paragraph-length gate that cancels generation if any paragraph is too long
+- How ParagraphChunker withholds text until a blank line (``\\n\\n``) is seen,
+  then emits the entire paragraph as a single chunk
+- The latency trade-off vs. SentenceChunker: fewer, larger chunks mean lower
+  validation overhead but later detection
+
+ParagraphChunker splits on two or more consecutive newlines.  Unlike
+SentenceChunker, it waits for the model to produce a blank line before
+emitting anything — so if the model writes everything as one long paragraph
+the stream completes before any chunk is emitted.  Use ParagraphChunker when
+the validation logic requires full paragraph context: topic coherence,
+heading structure, citation presence, or overall paragraph quality.
+"""
+
+import asyncio
+
+from mellea.core.backend import Backend
+from mellea.core.base import Context
+from mellea.core.requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+)
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
+
+_MAX_PARAGRAPH_WORDS = 60
+
+
+class ParagraphLengthReq(Requirement):
+    """Fails the stream if any paragraph exceeds a word-count limit.
+
+    Each ``stream_validate`` call receives one complete paragraph (from
+    :class:`~mellea.stdlib.chunking.ParagraphChunker`).  The validator counts
+    words and immediately fails the stream if the paragraph is too long.  This
+    lets you enforce a maximum paragraph length at generation time rather than
+    post-processing.
+    """
+
+    def __init__(self, max_words: int) -> None:
+        super().__init__()
+        self._max_words = max_words
+        self._para_index = 0
+
+    def format_for_llm(self) -> str:
+        return f"Each paragraph must contain at most {self._max_words} words."
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        self._para_index += 1
+        word_count = len(chunk.split())
+        if word_count > self._max_words:
+            return PartialValidationResult(
+                "fail",
+                reason=(
+                    f"Paragraph {self._para_index} has {word_count} words "
+                    f"(limit: {self._max_words})"
+                ),
+            )
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self,
+        backend: Backend,
+        ctx: Context,
+        *,
+        format: type | None = None,
+        model_options: dict | None = None,
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+async def main() -> None:
+    from mellea.stdlib.session import start_session
+
+    m = start_session()
+    backend = m.backend
+    ctx = m.ctx
+
+    action = Instruction(
+        "Write a two-paragraph explanation of how the internet works. "
+        "Separate the two paragraphs with a blank line. "
+        f"Keep each paragraph to at most {_MAX_PARAGRAPH_WORDS} words."
+    )
+    req = ParagraphLengthReq(max_words=_MAX_PARAGRAPH_WORDS)
+
+    result = await stream_with_chunking(
+        action, backend, ctx, quick_check_requirements=[req], chunking="paragraph"
+    )
+
+    print("Streaming events as they arrive (one ChunkEvent per paragraph):")
+    async for event in result.events():
+        match event:
+            case ChunkEvent():
+                word_count = len(event.text.split())
+                preview = event.text[:80].replace("\n", "↵")
+                print(
+                    f"  PARAGRAPH[{event.chunk_index}]: {word_count} words — "
+                    f"{preview!r}..."
+                )
+            case QuickCheckEvent(passed=False):
+                print(
+                    f"  QUICK_CHECK[para {event.chunk_index}]: FAIL — "
+                    f"{event.results[0].reason if event.results else 'unknown'}"
+                )
+            case QuickCheckEvent():
+                print(f"  QUICK_CHECK[para {event.chunk_index}]: pass")
+            case StreamingDoneEvent():
+                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+            case FullValidationEvent():
+                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+            case CompletedEvent():
+                print(f"  COMPLETED: success={event.success}")
+            case _:
+                pass
+
+    await result.acomplete()
+
+    print(f"\nCompleted normally: {result.completed}")
+    if result.streaming_failures:
+        for _req, pvr in result.streaming_failures:
+            print(f"Streaming failure: {pvr.reason}")
+    else:
+        print(f"Full text:\n{result.full_text}")
+
+
+asyncio.run(main())

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -102,6 +102,8 @@ async def main() -> None:
                 print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
             case CompletedEvent():
                 print(f"  COMPLETED: success={event.success}")
+            case _:
+                pass  # RetryEvent and any future event types
 
     await result.acomplete()
 

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -23,7 +23,13 @@ from mellea.stdlib.streaming import stream_with_chunking
 
 
 class MaxSentencesReq(Requirement):
-    """Fails if the model generates more than *limit* sentences mid-stream."""
+    """Fails if the model generates more than *limit* sentences mid-stream.
+
+    Each ``stream_validate`` call receives one complete sentence from the
+    :class:`~mellea.stdlib.chunking.SentenceChunker`.  The running count is
+    maintained on ``self`` — this is the standard pattern for requirements
+    that need context beyond a single chunk.
+    """
 
     def __init__(self, limit: int) -> None:
         self._limit = limit
@@ -35,8 +41,8 @@ class MaxSentencesReq(Requirement):
     async def stream_validate(
         self, chunk: str, *, backend: Backend, ctx: Context
     ) -> PartialValidationResult:
-        sentence_count = chunk.count(".") + chunk.count("!") + chunk.count("?")
-        if sentence_count > self._limit:
+        self._count += 1
+        if self._count > self._limit:
             return PartialValidationResult(
                 "fail",
                 reason=f"Response exceeded {self._limit} sentence limit mid-stream",

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -1,4 +1,4 @@
-# pytest: ollama, integration
+# pytest: ollama, e2e
 
 """Streaming generation with per-chunk validation using stream_with_chunking().
 
@@ -32,6 +32,7 @@ class MaxSentencesReq(Requirement):
     """
 
     def __init__(self, limit: int) -> None:
+        super().__init__()
         self._limit = limit
         self._count = 0
 

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -1,0 +1,91 @@
+# pytest: ollama, integration
+
+"""Streaming generation with per-chunk validation using stream_with_chunking().
+
+Demonstrates:
+- Subclassing Requirement to override stream_validate() for early-exit checks
+- Calling stream_with_chunking() with sentence-level chunking
+- Consuming validated chunks via astream() as they arrive
+- Awaiting full completion with acomplete() to access final_validations and full_text
+"""
+
+import asyncio
+
+from mellea.core.backend import Backend
+from mellea.core.base import Context
+from mellea.core.requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+)
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.streaming import stream_with_chunking
+
+
+class MaxSentencesReq(Requirement):
+    """Fails if the model generates more than *limit* sentences mid-stream."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._count = 0
+
+    def format_for_llm(self) -> str:
+        return f"The response must be at most {self._limit} sentences long."
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        sentence_count = chunk.count(".") + chunk.count("!") + chunk.count("?")
+        if sentence_count > self._limit:
+            return PartialValidationResult(
+                "fail",
+                reason=f"Response exceeded {self._limit} sentence limit mid-stream",
+            )
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self,
+        backend: Backend,
+        ctx: Context,
+        *,
+        format: type | None = None,
+        model_options: dict | None = None,
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+async def main() -> None:
+    from mellea.stdlib.session import start_session
+
+    m = start_session()
+    backend = m.backend
+    ctx = m.ctx
+
+    action = Instruction(
+        "Write a short paragraph about the water cycle in exactly two sentences."
+    )
+    req = MaxSentencesReq(limit=3)
+
+    result = await stream_with_chunking(
+        action, backend, ctx, quick_check_requirements=[req], chunking="sentence"
+    )
+
+    print("Streaming chunks as they arrive:")
+    async for chunk in result.astream():
+        print(f"  CHUNK: {chunk!r}")
+
+    await result.acomplete()
+
+    print(f"\nCompleted normally: {result.completed}")
+    print(f"Full text: {result.full_text!r}")
+
+    if result.streaming_failures:
+        for _req, pvr in result.streaming_failures:
+            print(f"Streaming failure: {pvr.reason}")
+
+    if result.final_validations:
+        for vr in result.final_validations:
+            print(f"Final validation: {'PASS' if vr.as_bool() else 'FAIL'}")
+
+
+asyncio.run(main())

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -5,7 +5,7 @@
 Demonstrates:
 - Subclassing Requirement to override stream_validate() for early-exit checks
 - Calling stream_with_chunking() with sentence-level chunking
-- Consuming validated chunks via astream() as they arrive
+- Observing the full event vocabulary via events() as they arrive
 - Awaiting full completion with acomplete() to access final_validations and full_text
 """
 
@@ -19,7 +19,14 @@ from mellea.core.requirement import (
     ValidationResult,
 )
 from mellea.stdlib.components import Instruction
-from mellea.stdlib.streaming import stream_with_chunking
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
 
 
 class MaxSentencesReq(Requirement):
@@ -77,9 +84,24 @@ async def main() -> None:
         action, backend, ctx, quick_check_requirements=[req], chunking="sentence"
     )
 
-    print("Streaming chunks as they arrive:")
-    async for chunk in result.astream():
-        print(f"  CHUNK: {chunk!r}")
+    print("Streaming events as they arrive:")
+    async for event in result.events():
+        match event:
+            case ChunkEvent():
+                print(f"  CHUNK[{event.chunk_index}]: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(
+                    f"  QUICK_CHECK[{event.chunk_index}]: FAIL — "
+                    f"{event.results[0].reason if event.results else 'unknown reason'}"
+                )
+            case QuickCheckEvent():
+                print(f"  QUICK_CHECK[{event.chunk_index}]: pass")
+            case StreamingDoneEvent():
+                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+            case FullValidationEvent():
+                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+            case CompletedEvent():
+                print(f"  COMPLETED: success={event.success}")
 
     await result.acomplete()
 

--- a/docs/examples/streaming/word_chunking.py
+++ b/docs/examples/streaming/word_chunking.py
@@ -52,10 +52,11 @@ class ForbiddenWordReq(Requirement):
 
     def __init__(self, forbidden: set[str]) -> None:
         super().__init__()
+        self._forbidden_display = sorted(forbidden)
         self._forbidden = {w.lower() for w in forbidden}
 
     def format_for_llm(self) -> str:
-        return f"Do not use any of the following words: {', '.join(sorted(self._forbidden))}."
+        return f"Do not use any of the following words: {', '.join(self._forbidden_display)}."
 
     async def stream_validate(
         self, chunk: str, *, backend: Backend, ctx: Context

--- a/docs/examples/streaming/word_chunking.py
+++ b/docs/examples/streaming/word_chunking.py
@@ -1,0 +1,134 @@
+# pytest: ollama, e2e
+
+"""Streaming generation with per-word validation using WordChunker.
+
+Demonstrates:
+- Using the ``"word"`` chunking alias for the finest-grained validation
+- Detecting a forbidden word the moment it appears in the stream
+- Early-exit cancelling generation before the consumer sees the bad word
+- How WordChunker compares to SentenceChunker in reaction time
+
+WordChunker splits on whitespace, so each ``stream_validate`` call receives
+exactly one word.  This is the highest-sensitivity strategy: validation fires
+before the model has finished even the current clause, letting you catch
+prohibited content with minimal output produced.
+
+The trade-off vs. SentenceChunker: validators that need sentence-level context
+(grammar, coherence) cannot operate correctly at word granularity because each
+chunk carries only a single token.  Use WordChunker when the check is
+token-local — forbidden words, length budgets, numeric thresholds.
+"""
+
+import asyncio
+
+from mellea.core.backend import Backend
+from mellea.core.base import Context
+from mellea.core.requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+)
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
+
+# Words that must not appear in the model's response.
+_FORBIDDEN = {"competitor", "CompetitorX", "legacy", "inferior", "obsolete"}
+
+
+class ForbiddenWordReq(Requirement):
+    """Fails the stream immediately if a forbidden word appears.
+
+    Each ``stream_validate`` call receives a single word (from
+    :class:`~mellea.stdlib.chunking.WordChunker`).  The check is O(1)
+    per word — set membership test — so it adds negligible latency.
+    """
+
+    def __init__(self, forbidden: set[str]) -> None:
+        super().__init__()
+        self._forbidden = {w.lower() for w in forbidden}
+
+    def format_for_llm(self) -> str:
+        return f"Do not use any of the following words: {', '.join(sorted(self._forbidden))}."
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Backend, ctx: Context
+    ) -> PartialValidationResult:
+        word = chunk.strip().lower().strip(".,!?;:\"'")
+        if word in self._forbidden:
+            return PartialValidationResult(
+                "fail", reason=f"Forbidden word detected: {chunk.strip()!r}"
+            )
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self,
+        backend: Backend,
+        ctx: Context,
+        *,
+        format: type | None = None,
+        model_options: dict | None = None,
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+async def main() -> None:
+    from mellea.stdlib.session import start_session
+
+    m = start_session()
+    backend = m.backend
+    ctx = m.ctx
+
+    action = Instruction(
+        "Describe three key advantages of cloud-native software development "
+        "in two or three sentences."
+    )
+    req = ForbiddenWordReq(forbidden=_FORBIDDEN)
+
+    result = await stream_with_chunking(
+        action, backend, ctx, quick_check_requirements=[req], chunking="word"
+    )
+
+    print("Streaming events as they arrive (one per word):")
+    word_count = 0
+    async for event in result.events():
+        match event:
+            case ChunkEvent():
+                word_count += 1
+                # Only print every 5th word to keep output readable
+                if word_count % 5 == 1:
+                    print(f"  ...word {word_count}: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(
+                    f"  QUICK_CHECK[word {event.chunk_index}]: FAIL — "
+                    f"{event.results[0].reason if event.results else 'unknown'}"
+                )
+            case StreamingDoneEvent():
+                print(
+                    f"  STREAMING_DONE: {word_count} words, {len(event.full_text)} chars"
+                )
+            case FullValidationEvent():
+                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+            case CompletedEvent():
+                print(f"  COMPLETED: success={event.success}")
+            case _:
+                pass
+
+    await result.acomplete()
+
+    print(f"\nCompleted normally: {result.completed}")
+    if result.streaming_failures:
+        for _req, pvr in result.streaming_failures:
+            print(f"Streaming failure: {pvr.reason}")
+        print(f"Text at cancellation: {result.full_text!r}")
+    else:
+        print(f"Full text: {result.full_text!r}")
+
+
+asyncio.run(main())

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -364,6 +364,64 @@ class ModelOutputThunk(CBlock, Generic[S]):
             ).total_seconds() * 1000
             self._first_chunk_received = True
 
+    async def cancel_generation(self) -> None:
+        """Cancel an in-progress streaming generation, drain the queue, and close any open telemetry span.
+
+        Safe to call at any point during streaming. After this method returns,
+        ``is_computed()`` is ``True`` and ``value`` contains whatever text was
+        accumulated before cancellation.  Calling on an already-computed MOT
+        is a no-op.
+
+        Draining the internal queue after cancellation is necessary to release
+        any ``asyncio.Queue.put()`` call that the generation task was blocked on
+        (queue maxsize=20).
+        """
+        if self._computed:
+            return
+
+        def _drain() -> None:
+            while not self._async_queue.empty():
+                try:
+                    self._async_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+
+        if self._generate is not None and not self._generate.done():
+            self._generate.cancel()
+
+        if self._generate_extra is not None and not self._generate_extra.done():
+            self._generate_extra.cancel()
+
+        # Drain before awaiting — unblocks any put() the task is stuck on.
+        _drain()
+
+        if self._generate is not None:
+            try:
+                await self._generate
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        if self._generate_extra is not None:
+            try:
+                await self._generate_extra
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        # Drain again for any final item the task put before terminating.
+        _drain()
+
+        span = self._meta.get("_telemetry_span")
+        if span is not None:
+            from ..telemetry import end_backend_span, set_span_error
+
+            set_span_error(span, RuntimeError("Generation cancelled"))
+            end_backend_span(span)
+            del self._meta["_telemetry_span"]
+
+        if self._underlying_value is None:
+            self._underlying_value = ""
+        self._computed = True
+
     def _copy_from(self, other: ModelOutputThunk) -> None:
         """Copy computed-output fields from *other* into *self*.
 

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -364,7 +364,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
             ).total_seconds() * 1000
             self._first_chunk_received = True
 
-    async def cancel_generation(self) -> None:
+    async def cancel_generation(self, error: Exception | None = None) -> None:
         """Cancel an in-progress streaming generation, drain the queue, and close any open telemetry span.
 
         Safe to call at any point during streaming. After this method returns,
@@ -375,6 +375,14 @@ class ModelOutputThunk(CBlock, Generic[S]):
         Draining the internal queue after cancellation is necessary to release
         any ``asyncio.Queue.put()`` call that the generation task was blocked on
         (queue maxsize=20).
+
+        Args:
+            error: Optional cause attributed to the open telemetry span.  When
+                provided, this exception is recorded via ``set_span_error`` so
+                the span reflects the actual reason for cancellation (e.g. the
+                requirement failure or an unhandled exception from a streaming
+                validator).  When ``None``, a generic
+                ``RuntimeError("Generation cancelled")`` is recorded.
         """
         if self._computed:
             return
@@ -414,7 +422,10 @@ class ModelOutputThunk(CBlock, Generic[S]):
         if span is not None:
             from ..telemetry import end_backend_span, set_span_error
 
-            set_span_error(span, RuntimeError("Generation cancelled"))
+            recorded: Exception = (
+                error if error is not None else RuntimeError("Generation cancelled")
+            )
+            set_span_error(span, recorded)
             end_backend_span(span)
             del self._meta["_telemetry_span"]
 

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -418,7 +418,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Drain again for any final item the task put before terminating.
         _drain()
 
-        span = self._meta.get("_telemetry_span")
+        span = self._meta.pop("_telemetry_span", None)
         if span is not None:
             from ..telemetry import end_backend_span, set_span_error
 
@@ -427,7 +427,6 @@ class ModelOutputThunk(CBlock, Generic[S]):
             )
             set_span_error(span, recorded)
             end_backend_span(span)
-            del self._meta["_telemetry_span"]
 
         if self._underlying_value is None:
             self._underlying_value = ""

--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -13,17 +13,37 @@ Streaming chunking strategies (for use with streaming validation) are available 
 ``mellea.stdlib.chunking`` and re-exported here for convenience.  The core streaming
 orchestration primitive :func:`~mellea.stdlib.streaming.stream_with_chunking` and
 its result type :class:`~mellea.stdlib.streaming.StreamChunkingResult` are also
-re-exported here.
+re-exported here, alongside the full :class:`~mellea.stdlib.streaming.StreamEvent`
+vocabulary for typed event observation.
 """
 
 from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
-from .streaming import StreamChunkingResult, stream_with_chunking
+from .streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    ErrorEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    RetryEvent,
+    StreamChunkingResult,
+    StreamEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
 
 __all__ = [
+    "ChunkEvent",
     "ChunkingStrategy",
+    "CompletedEvent",
+    "ErrorEvent",
+    "FullValidationEvent",
     "ParagraphChunker",
+    "QuickCheckEvent",
+    "RetryEvent",
     "SentenceChunker",
     "StreamChunkingResult",
+    "StreamEvent",
+    "StreamingDoneEvent",
     "WordChunker",
     "stream_with_chunking",
 ]

--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -39,7 +39,7 @@ __all__ = [
     "FullValidationEvent",
     "ParagraphChunker",
     "QuickCheckEvent",
-    "RetryEvent",
+    "RetryEvent",  # defined but not emitted in v1 — reserved for future retry support
     "SentenceChunker",
     "StreamChunkingResult",
     "StreamEvent",

--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -39,7 +39,7 @@ __all__ = [
     "FullValidationEvent",
     "ParagraphChunker",
     "QuickCheckEvent",
-    "RetryEvent",  # defined but not emitted in v1 — reserved for future retry support
+    "RetryEvent",
     "SentenceChunker",
     "StreamChunkingResult",
     "StreamEvent",

--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -10,9 +10,20 @@ the sub-packages — ``mellea.stdlib.components``, ``mellea.stdlib.sampling``, a
 ``mellea.stdlib.session`` — for day-to-day use.
 
 Streaming chunking strategies (for use with streaming validation) are available at
-``mellea.stdlib.chunking`` and re-exported here for convenience.
+``mellea.stdlib.chunking`` and re-exported here for convenience.  The core streaming
+orchestration primitive :func:`~mellea.stdlib.streaming.stream_with_chunking` and
+its result type :class:`~mellea.stdlib.streaming.StreamChunkingResult` are also
+re-exported here.
 """
 
 from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
+from .streaming import StreamChunkingResult, stream_with_chunking
 
-__all__ = ["ChunkingStrategy", "ParagraphChunker", "SentenceChunker", "WordChunker"]
+__all__ = [
+    "ChunkingStrategy",
+    "ParagraphChunker",
+    "SentenceChunker",
+    "StreamChunkingResult",
+    "WordChunker",
+    "stream_with_chunking",
+]

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -14,6 +14,15 @@ class ChunkingStrategy(ABC):
     that has not yet reached a chunk boundary is withheld — it is not included in
     the returned list. Each call is stateless and idempotent given the same input.
 
+    **Performance:** ``split()`` is called on every streaming delta, re-scanning
+    the full accumulated text each time (O(n) in total accumulated length per
+    call).  The orchestrator tracks ``prev_chunk_count`` to extract only the new
+    chunks.  This keeps the chunker stateless and removes the need for ``reset()``
+    or deep-copy support, at the cost of re-scanning text already seen.  For
+    typical model outputs (a few KB) the cost is negligible; for very long
+    streams, a stateful chunker that only processes the new delta would be more
+    efficient.
+
     End-of-stream contract: ``split()`` always withholds the trailing fragment.
     When the stream terminates, callers are responsible for processing any remainder:
     take the full accumulated text, identify everything after the last returned
@@ -27,7 +36,12 @@ class ChunkingStrategy(ABC):
 
         Args:
             accumulated_text: The full text accumulated so far, including all
-                previously seen tokens and the latest delta.
+                previously seen tokens and the latest delta.  Implementations
+                that scan this string are O(n) in accumulated length per call.
+                Stateful implementations that only process the new delta are
+                possible but must never mutate state on ``self`` in place —
+                use reassignment (``self._buf = self._buf + [x]``) so that
+                ``copy()``-based cloning in the orchestrator works correctly.
 
         Returns:
             A list of complete chunks. If no chunk boundary has been reached yet,

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -124,6 +124,15 @@ class SentenceChunker(ChunkingStrategy):
         ``lstrip`` is needed here.  The result is the fragment's content
         only, consistent with how :meth:`split` returns sentences without
         trailing whitespace.
+
+        Args:
+            accumulated_text: The full accumulated text at stream end.
+
+        Returns:
+            A single-element list containing the trailing sentence fragment
+            with leading and trailing whitespace stripped, or an empty list
+            when there is no fragment (all content ended in a sentence
+            boundary or the input is empty/whitespace-only).
         """
         if not accumulated_text:
             return []
@@ -177,7 +186,21 @@ class WordChunker(ChunkingStrategy):
         return parts
 
     def flush(self, accumulated_text: str) -> list[str]:
-        """Return the trailing word fragment (if any) as a final chunk."""
+        """Return the trailing word fragment (if any) as a final chunk.
+
+        The trailing fragment is the text after the last whitespace run when
+        the accumulated text does not end with whitespace.  When it does end
+        with whitespace, every word is already complete and no fragment is
+        released.
+
+        Args:
+            accumulated_text: The full accumulated text at stream end.
+
+        Returns:
+            A single-element list containing the trailing word fragment, or
+            an empty list when the input ends with whitespace (every word
+            already complete) or is empty.
+        """
         if not accumulated_text:
             return []
         if accumulated_text[-1].isspace():
@@ -232,6 +255,14 @@ class ParagraphChunker(ChunkingStrategy):
         a paragraph (e.g. a list item or a deliberate line break), and a
         consumer validating paragraph content should see the fragment as
         it was withheld.
+
+        Args:
+            accumulated_text: The full accumulated text at stream end.
+
+        Returns:
+            A single-element list containing the trailing paragraph fragment
+            byte-for-byte, or an empty list when the input ends with a
+            paragraph boundary (``\n\n`` or more) or is empty.
         """
         if not accumulated_text:
             return []

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -116,7 +116,15 @@ class SentenceChunker(ChunkingStrategy):
         return chunks
 
     def flush(self, accumulated_text: str) -> list[str]:
-        """Return the trailing sentence fragment (if any) as a final chunk."""
+        """Return the trailing sentence fragment (if any) as a final chunk.
+
+        Trailing whitespace on the fragment is non-semantic for sentence
+        boundaries and is dropped via ``rstrip``.  Leading whitespace is
+        already removed by the loop's ``lstrip`` on each advance, so no
+        ``lstrip`` is needed here.  The result is the fragment's content
+        only, consistent with how :meth:`split` returns sentences without
+        trailing whitespace.
+        """
         if not accumulated_text:
             return []
         remaining = accumulated_text
@@ -125,7 +133,7 @@ class SentenceChunker(ChunkingStrategy):
             if match is None:
                 break
             remaining = remaining[match.end() :].lstrip()
-        trailing = remaining.strip()
+        trailing = remaining.rstrip()
         return [trailing] if trailing else []
 
 
@@ -216,7 +224,15 @@ class ParagraphChunker(ChunkingStrategy):
         return [p for p in parts if p]
 
     def flush(self, accumulated_text: str) -> list[str]:
-        """Return the trailing paragraph fragment (if any) as a final chunk."""
+        r"""Return the trailing paragraph fragment (if any) as a final chunk.
+
+        Unlike :class:`SentenceChunker.flush`, the fragment is returned
+        byte-for-byte without stripping.  Internal whitespace — including
+        a trailing single ``\n`` — can be semantically meaningful inside
+        a paragraph (e.g. a list item or a deliberate line break), and a
+        consumer validating paragraph content should see the fragment as
+        it was withheld.
+        """
         if not accumulated_text:
             return []
         if _PARA_BOUNDARY_END.search(accumulated_text):

--- a/mellea/stdlib/chunking.py
+++ b/mellea/stdlib/chunking.py
@@ -35,6 +35,27 @@ class ChunkingStrategy(ABC):
         """
         ...
 
+    def flush(self, accumulated_text: str) -> list[str]:
+        """Return any trailing fragment that ``split`` withheld.
+
+        Called once by the orchestrator after the stream has ended naturally
+        (not on early-exit cancellation).  Gives the chunker a chance to
+        release the final fragment that did not reach a terminator.
+
+        The default implementation returns an empty list — the trailing
+        fragment is discarded.  Built-in chunkers override this to return
+        the withheld fragment as a single-element list when non-empty.
+
+        Args:
+            accumulated_text: The full accumulated text at stream end.
+
+        Returns:
+            The trailing fragment as ``[fragment]`` if it should be treated
+            as a final chunk, or an empty list to discard it.
+        """
+        _ = accumulated_text
+        return []
+
 
 # Sentence boundary: sentence-ending punctuation, optionally followed by a closing
 # quote or paren, then whitespace.
@@ -94,6 +115,19 @@ class SentenceChunker(ChunkingStrategy):
 
         return chunks
 
+    def flush(self, accumulated_text: str) -> list[str]:
+        """Return the trailing sentence fragment (if any) as a final chunk."""
+        if not accumulated_text:
+            return []
+        remaining = accumulated_text
+        while True:
+            match = _SENTENCE_BOUNDARY.search(remaining)
+            if match is None:
+                break
+            remaining = remaining[match.end() :].lstrip()
+        trailing = remaining.strip()
+        return [trailing] if trailing else []
+
 
 class WordChunker(ChunkingStrategy):
     """Splits accumulated text on whitespace boundaries.
@@ -134,6 +168,18 @@ class WordChunker(ChunkingStrategy):
 
         return parts
 
+    def flush(self, accumulated_text: str) -> list[str]:
+        """Return the trailing word fragment (if any) as a final chunk."""
+        if not accumulated_text:
+            return []
+        if accumulated_text[-1].isspace():
+            return []
+        parts = _WHITESPACE.split(accumulated_text)
+        for part in reversed(parts):
+            if part:
+                return [part]
+        return []
+
 
 class ParagraphChunker(ChunkingStrategy):
     r"""Splits accumulated text on double-newline paragraph boundaries.
@@ -168,3 +214,13 @@ class ParagraphChunker(ChunkingStrategy):
 
         # _PARA_BOUNDARY.split on leading \n\n produces an empty first element.
         return [p for p in parts if p]
+
+    def flush(self, accumulated_text: str) -> list[str]:
+        """Return the trailing paragraph fragment (if any) as a final chunk."""
+        if not accumulated_text:
+            return []
+        if _PARA_BOUNDARY_END.search(accumulated_text):
+            return []
+        parts = _PARA_BOUNDARY.split(accumulated_text)
+        trailing = parts[-1] if parts else ""
+        return [trailing] if trailing else []

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -144,6 +144,35 @@ async def _orchestrate_streaming(
     failed_indices: set[int] = set()
     early_exit = False
 
+    async def _validate_and_emit(c: str) -> bool:
+        """Run stream_validate on chunk c across active requirements.
+
+        Returns True if a failure was recorded (caller should early-exit),
+        False otherwise (chunk was emitted to the consumer queue).
+        """
+        active = [
+            (i, req) for i, req in enumerate(cloned_reqs) if i not in failed_indices
+        ]
+        if active:
+            pvrs: list[PartialValidationResult] = list(
+                await asyncio.gather(
+                    *[
+                        req.stream_validate(c, backend=val_backend, ctx=ctx)
+                        for _, req in active
+                    ]
+                )
+            )
+            for (idx, req), pvr in zip(active, pvrs):
+                if pvr.success == "fail":
+                    failed_indices.add(idx)
+                    result.streaming_failures.append((req, pvr))
+
+        if failed_indices:
+            return True
+
+        await result._chunk_queue.put(c)
+        return False
+
     try:
         while not mot.is_computed():
             try:
@@ -157,35 +186,26 @@ async def _orchestrate_streaming(
             prev_chunk_count = len(chunks)
 
             for c in new_chunks:
-                active = [
-                    (i, req)
-                    for i, req in enumerate(cloned_reqs)
-                    if i not in failed_indices
-                ]
-                if active:
-                    pvrs: list[PartialValidationResult] = list(
-                        await asyncio.gather(
-                            *[
-                                req.stream_validate(c, backend=val_backend, ctx=ctx)
-                                for _, req in active
-                            ]
-                        )
-                    )
-                    for (idx, req), pvr in zip(active, pvrs):
-                        if pvr.success == "fail":
-                            failed_indices.add(idx)
-                            result.streaming_failures.append((req, pvr))
-
-                if failed_indices:
+                failed = await _validate_and_emit(c)
+                if failed:
                     early_exit = True
                     result.completed = False
                     await mot.cancel_generation()
                     break
 
-                await result._chunk_queue.put(c)
-
             if early_exit:
                 break
+
+        # Stream ended naturally: flush any withheld trailing fragment and
+        # run stream_validate on it. Skipped on early exit — the generation
+        # was cancelled, the trailing fragment is incomplete.
+        if not early_exit:
+            for c in chunking.flush(accumulated):
+                failed = await _validate_and_emit(c)
+                if failed:
+                    early_exit = True
+                    result.completed = False
+                    break
 
         result.full_text = accumulated
 
@@ -237,6 +257,12 @@ async def stream_with_chunking(
     :attr:`StreamChunkingResult.completed` is set to ``False``.  The
     failing chunk is not emitted to the consumer; use
     :attr:`StreamChunkingResult.streaming_failures` to inspect what failed.
+
+    When the stream ends naturally, any trailing fragment withheld by the
+    chunking strategy (see :meth:`~mellea.stdlib.chunking.ChunkingStrategy.flush`)
+    is released as a final chunk and run through ``stream_validate`` on the
+    same terms as the regular chunks.  On early exit, the trailing fragment
+    is discarded because the generation was cancelled mid-token.
 
     After the stream ends (naturally or via early exit), ``validate()`` is
     called on all requirements that did not return ``"fail"``.  Requirements

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -154,8 +154,9 @@ async def _orchestrate_streaming(
             accumulated += delta
             chunks = chunking.split(accumulated)
             new_chunks = chunks[prev_chunk_count:]
+            prev_chunk_count = len(chunks)
 
-            if new_chunks:
+            for c in new_chunks:
                 active = [
                     (i, req)
                     for i, req in enumerate(cloned_reqs)
@@ -165,9 +166,7 @@ async def _orchestrate_streaming(
                     pvrs: list[PartialValidationResult] = list(
                         await asyncio.gather(
                             *[
-                                req.stream_validate(
-                                    accumulated, backend=val_backend, ctx=ctx
-                                )
+                                req.stream_validate(c, backend=val_backend, ctx=ctx)
                                 for _, req in active
                             ]
                         )
@@ -181,13 +180,12 @@ async def _orchestrate_streaming(
                     early_exit = True
                     result.completed = False
                     await mot.cancel_generation()
-                    for c in new_chunks:
-                        await result._chunk_queue.put(c)
                     break
 
-                for c in new_chunks:
-                    await result._chunk_queue.put(c)
-                prev_chunk_count = len(chunks)
+                await result._chunk_queue.put(c)
+
+            if early_exit:
+                break
 
         result.full_text = accumulated
 
@@ -225,20 +223,29 @@ async def stream_with_chunking(
     :meth:`~mellea.core.requirement.Requirement.stream_validate` on each new
     chunk in parallel across all requirements.
 
-    If any requirement returns ``"fail"`` during streaming validation, the
-    generation is cancelled immediately (via
+    For each new complete chunk produced by the chunking strategy,
+    ``stream_validate`` is called once per active requirement (in parallel
+    via :func:`asyncio.gather`), receiving that single chunk.  Multiple
+    chunks produced from one ``astream()`` iteration are validated
+    sequentially in order, so early exit on a ``"fail"`` result prevents
+    later chunks in the same batch from being validated or emitted to the
+    consumer.
+
+    If any requirement returns ``"fail"``, the generation is cancelled
+    immediately (via
     :meth:`~mellea.core.base.ModelOutputThunk.cancel_generation`) and
-    :attr:`StreamChunkingResult.completed` is set to ``False``.
+    :attr:`StreamChunkingResult.completed` is set to ``False``.  The
+    failing chunk is not emitted to the consumer; use
+    :attr:`StreamChunkingResult.streaming_failures` to inspect what failed.
 
     After the stream ends (naturally or via early exit), ``validate()`` is
     called on all requirements that did not return ``"fail"``.  Requirements
     are cloned (``copy(req)``) before use so originals are never mutated.
 
-    ``stream_validate`` receives the *accumulated* model output so far, not
-    just the current chunk.  The chunking strategy determines *when* it is
-    called (at chunk boundaries).  Requirements that want delta-only
-    processing track ``self._seen_len`` and slice
-    ``accumulated[self._seen_len:]``.
+    Requirements that need context beyond the current chunk should
+    accumulate it themselves across ``stream_validate`` calls (e.g.
+    ``self._seen = self._seen + chunk``).  They must not read ``mot.astream()``
+    directly — this orchestrator is the single consumer of the MOT stream.
 
     Note:
         v1 retry is simple re-invocation of this function.  Plugin hooks

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -1,0 +1,282 @@
+"""Streaming generation with per-chunk validation.
+
+Provides :func:`stream_with_chunking`, the core orchestration primitive that
+consumes a streaming :class:`~mellea.core.base.ModelOutputThunk`, applies a
+:class:`~mellea.stdlib.chunking.ChunkingStrategy` to produce semantic chunks,
+and runs :meth:`~mellea.core.requirement.Requirement.stream_validate` on each
+chunk in parallel.  Higher-level streaming APIs build on this function.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Sequence
+from copy import copy
+from typing import Any
+
+from ..backends.model_options import ModelOption
+from ..core.backend import Backend
+from ..core.base import CBlock, Component, Context, ModelOutputThunk
+from ..core.requirement import PartialValidationResult, Requirement, ValidationResult
+from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
+
+_CHUNKING_ALIASES: dict[str, type[ChunkingStrategy]] = {
+    "sentence": SentenceChunker,
+    "word": WordChunker,
+    "paragraph": ParagraphChunker,
+}
+
+
+class StreamChunkingResult:
+    """Result of a :func:`stream_with_chunking` operation.
+
+    Provides async iteration over validated text chunks as they complete
+    (:meth:`astream`), a blocking :meth:`acomplete` for awaiting the full
+    result including final validation, and :attr:`as_thunk` for wrapping the
+    output as a :class:`~mellea.core.base.ModelOutputThunk`.
+
+    Instances are created by :func:`stream_with_chunking`; do not instantiate
+    directly.
+
+    Attributes:
+        completed: ``False`` if the stream exited early because a requirement
+            returned ``"fail"`` during streaming; ``True`` otherwise.
+        full_text: The complete generated text accumulated during streaming.
+            Available after :meth:`acomplete` returns.
+        final_validations: :class:`~mellea.core.requirement.ValidationResult`
+            objects from the final :meth:`~mellea.core.requirement.Requirement.validate`
+            calls on all non-failed requirements.  Available after
+            :meth:`acomplete` returns.
+        streaming_failures: ``(Requirement, PartialValidationResult)`` pairs
+            for every requirement that returned ``"fail"`` during streaming.
+    """
+
+    def __init__(self, mot: ModelOutputThunk, ctx: Context) -> None:
+        """Initialise with the MOT and context from the backend call."""
+        self._mot = mot
+        self._ctx = ctx
+        self._chunk_queue: asyncio.Queue[str | None | Exception] = asyncio.Queue()
+        self._orchestration_task: asyncio.Task[None] | None = None
+        self._done = asyncio.Event()
+
+        self.completed: bool = True
+        self.full_text: str = ""
+        self.final_validations: list[ValidationResult] = []
+        self.streaming_failures: list[tuple[Requirement, PartialValidationResult]] = []
+
+    async def astream(self) -> AsyncIterator[str]:
+        """Yield validated text chunks as they complete.
+
+        Each yielded string is a chunk that has passed per-chunk streaming
+        validation (or the stream had no requirements).  Iteration ends when
+        all chunks have been yielded, whether the stream completed normally or
+        was cancelled early on a ``"fail"`` result.
+
+        Yields:
+            str: A validated text chunk from the chunking strategy.
+
+        Raises:
+            Exception: Propagates any error from the background orchestration
+                task.
+        """
+        while True:
+            item = await self._chunk_queue.get()
+            if item is None:
+                return
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    async def acomplete(self) -> None:
+        """Await full completion, including final validation.
+
+        After this method returns, :attr:`full_text`, :attr:`completed`,
+        :attr:`final_validations`, and :attr:`streaming_failures` are all
+        populated.  If :meth:`astream` has already been consumed to
+        exhaustion, this call is effectively a no-op.
+
+        Raises:
+            Exception: Propagates any error from the orchestration task.
+        """
+        await self._done.wait()
+        if self._orchestration_task is not None and self._orchestration_task.done():
+            exc = self._orchestration_task.exception()
+            if exc is not None:
+                raise exc
+
+    @property
+    def as_thunk(self) -> ModelOutputThunk:
+        """Wrap the output as a computed :class:`~mellea.core.base.ModelOutputThunk`.
+
+        Returns a new thunk with ``value`` set to :attr:`full_text` and
+        generation metadata copied from the original MOT.  Safe to call on
+        early-exit results; ``value`` will reflect whatever was accumulated
+        before cancellation.
+
+        Returns:
+            ModelOutputThunk: A computed thunk containing the streamed output.
+
+        Raises:
+            RuntimeError: If called before :meth:`acomplete` has returned.
+        """
+        if not self._done.is_set():
+            raise RuntimeError(
+                "as_thunk accessed before acomplete() — await acomplete() first"
+            )
+        thunk = ModelOutputThunk(value=self.full_text)
+        thunk.generation = copy(self._mot.generation)
+        return thunk
+
+
+async def _orchestrate_streaming(
+    result: StreamChunkingResult,
+    mot: ModelOutputThunk,
+    ctx: Context,
+    cloned_reqs: list[Requirement],
+    chunking: ChunkingStrategy,
+    val_backend: Backend,
+) -> None:
+    accumulated = ""
+    prev_chunk_count = 0
+    failed_indices: set[int] = set()
+    early_exit = False
+
+    try:
+        while not mot.is_computed():
+            try:
+                delta = await mot.astream()
+            except RuntimeError:
+                break
+
+            accumulated += delta
+            chunks = chunking.split(accumulated)
+            new_chunks = chunks[prev_chunk_count:]
+
+            if new_chunks:
+                active = [
+                    (i, req)
+                    for i, req in enumerate(cloned_reqs)
+                    if i not in failed_indices
+                ]
+                if active:
+                    pvrs: list[PartialValidationResult] = list(
+                        await asyncio.gather(
+                            *[
+                                req.stream_validate(
+                                    accumulated, backend=val_backend, ctx=ctx
+                                )
+                                for _, req in active
+                            ]
+                        )
+                    )
+                    for (idx, req), pvr in zip(active, pvrs):
+                        if pvr.success == "fail":
+                            failed_indices.add(idx)
+                            result.streaming_failures.append((req, pvr))
+
+                if failed_indices:
+                    early_exit = True
+                    result.completed = False
+                    await mot.cancel_generation()
+                    for c in new_chunks:
+                        await result._chunk_queue.put(c)
+                    break
+
+                for c in new_chunks:
+                    await result._chunk_queue.put(c)
+                prev_chunk_count = len(chunks)
+
+        result.full_text = accumulated
+
+        non_failed = [
+            req for i, req in enumerate(cloned_reqs) if i not in failed_indices
+        ]
+        if non_failed and not early_exit:
+            result.final_validations = list(
+                await asyncio.gather(
+                    *[req.validate(val_backend, ctx) for req in non_failed]
+                )
+            )
+
+    except Exception as exc:
+        await result._chunk_queue.put(exc)
+    finally:
+        await result._chunk_queue.put(None)
+        result._done.set()
+
+
+async def stream_with_chunking(
+    action: Component[Any] | CBlock,
+    backend: Backend,
+    ctx: Context,
+    *,
+    quick_check_requirements: Sequence[Requirement] | None = None,
+    chunking: str | ChunkingStrategy = "sentence",
+    quick_check_backend: Backend | None = None,
+) -> StreamChunkingResult:
+    """Generate a streaming response with per-chunk validation.
+
+    Starts a backend generation with streaming enabled, consumes the
+    :class:`~mellea.core.base.ModelOutputThunk`'s async stream in a single
+    background task, splits the accumulated text using *chunking*, and runs
+    :meth:`~mellea.core.requirement.Requirement.stream_validate` on each new
+    chunk in parallel across all requirements.
+
+    If any requirement returns ``"fail"`` during streaming validation, the
+    generation is cancelled immediately (via
+    :meth:`~mellea.core.base.ModelOutputThunk.cancel_generation`) and
+    :attr:`StreamChunkingResult.completed` is set to ``False``.
+
+    After the stream ends (naturally or via early exit), ``validate()`` is
+    called on all requirements that did not return ``"fail"``.  Requirements
+    are cloned (``copy(req)``) before use so originals are never mutated.
+
+    ``stream_validate`` receives the *accumulated* model output so far, not
+    just the current chunk.  The chunking strategy determines *when* it is
+    called (at chunk boundaries).  Requirements that want delta-only
+    processing track ``self._seen_len`` and slice
+    ``accumulated[self._seen_len:]``.
+
+    Note:
+        v1 retry is simple re-invocation of this function.  Plugin hooks
+        (``SAMPLING_LOOP_START``, ``SAMPLING_REPAIR``, etc.) do not fire
+        on retries — use the ``#902`` event types for observability instead.
+
+    Args:
+        action: The component or content block to generate from.
+        backend: The backend used for generation and final validation.
+        ctx: The generation context.
+        quick_check_requirements: Sequence of requirements to validate against
+            each chunk during streaming.  ``None`` disables streaming validation
+            (chunks are still produced; ``validate()`` is not called at stream end).
+        chunking: Chunking strategy — either a :class:`~mellea.stdlib.chunking.ChunkingStrategy`
+            instance or one of the string aliases ``"sentence"`` (default),
+            ``"word"``, or ``"paragraph"``.
+        quick_check_backend: Optional alternate backend for both
+            ``stream_validate`` and final ``validate`` calls.  When ``None``,
+            *backend* is used for validation.
+
+    Returns:
+        StreamChunkingResult: A result object providing :meth:`~StreamChunkingResult.astream`
+            for incremental chunk consumption and
+            :meth:`~StreamChunkingResult.acomplete` for blocking until done.
+    """
+    if isinstance(chunking, str):
+        cls = _CHUNKING_ALIASES.get(chunking)
+        if cls is None:
+            raise ValueError(
+                f"Unknown chunking alias {chunking!r}. Choose from: {list(_CHUNKING_ALIASES)}"
+            )
+        chunking = cls()
+
+    opts: dict[str, Any] = {ModelOption.STREAM: True}
+    mot, gen_ctx = await backend.generate_from_context(action, ctx, model_options=opts)
+
+    result = StreamChunkingResult(mot, gen_ctx)
+
+    cloned_reqs = [copy(req) for req in (quick_check_requirements or [])]
+    val_backend = quick_check_backend if quick_check_backend is not None else backend
+
+    result._orchestration_task = asyncio.create_task(
+        _orchestrate_streaming(result, mot, gen_ctx, cloned_reqs, chunking, val_backend)
+    )
+
+    return result

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -264,6 +264,15 @@ async def _orchestrate_streaming(
         result.completed = False
         await result._chunk_queue.put(exc)
     finally:
+        # CancelledError (BaseException, not Exception) bypasses the except
+        # block above, so cancel_generation() may not have been called.
+        # Guard here ensures the backend producer is always stopped, even on
+        # external task cancellation (e.g. asyncio.wait_for timeout).
+        if not mot.is_computed():
+            try:
+                await mot.cancel_generation()
+            except BaseException:
+                pass
         await result._chunk_queue.put(None)
         result._done.set()
 

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -247,8 +247,10 @@ async def _orchestrate_streaming(
         # otherwise mot._async_queue (maxsize=20) fills and the feeder task
         # blocks indefinitely. The spec (#891, #901) calls this out for the
         # "fail" path; the same reasoning applies to any unplanned exit.
+        # Pass `exc` so the backend telemetry span records the real cause
+        # rather than a generic "Generation cancelled".
         try:
-            await mot.cancel_generation()
+            await mot.cancel_generation(error=exc)
         except Exception as cleanup_exc:
             # Never let cleanup mask the original exception: log loudly and
             # continue to surface `exc` to the consumer.
@@ -304,9 +306,12 @@ async def stream_with_chunking(
     same terms as the regular chunks.  On early exit, the trailing fragment
     is discarded because the generation was cancelled mid-token.
 
-    After the stream ends (naturally or via early exit), ``validate()`` is
-    called on all requirements that did not return ``"fail"``.  Requirements
-    are cloned (``copy(req)``) before use so originals are never mutated.
+    After the stream ends naturally, ``validate()`` is called on every
+    requirement that did not return ``"fail"`` — both ``"pass"`` and
+    ``"unknown"`` trigger final validation.  On early exit, no ``validate()``
+    call is made; :attr:`StreamChunkingResult.final_validations` remains
+    empty.  Requirements are cloned (``copy(req)``) before use so originals
+    are never mutated.
 
     Requirements that need context beyond the current chunk should
     accumulate it themselves across ``stream_validate`` calls (e.g.

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -582,7 +582,11 @@ async def _orchestrate_streaming(
             # block above, so cancel_generation() may not have been called.
             # Guard here ensures the backend producer is always stopped, even on
             # external task cancellation (e.g. asyncio.wait_for timeout).
+            # Also mark completion as failed for any BaseException path (e.g.
+            # CancelledError) that bypassed the except block — otherwise
+            # result.completed stays True and CompletedEvent / metrics lie.
             if not mot.is_computed():
+                result.completed = False
                 try:
                     await mot.cancel_generation()
                 except BaseException:

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -49,10 +49,10 @@ class StreamEvent:
     """Base class for all streaming events emitted by :func:`stream_with_chunking`.
 
     The ``timestamp`` field is auto-populated at instantiation time; callers
-    do not set it.  Subclasses that add fields **must** declare them before the
-    ``timestamp`` field would conflict, and any new ``init=False`` fields must
-    use ``field(... , init=False)`` so the dataclass does not expose them as
-    constructor arguments.
+    do not set it.  Because ``timestamp`` has ``init=False`` it is never part
+    of ``__init__``, so subclasses may declare additional fields in any order
+    without conflict.  Any new ``init=False`` fields on subclasses must also
+    use ``field(..., init=False)``.
 
     Attributes:
         timestamp: Unix timestamp (seconds) at the moment the event was created.
@@ -239,6 +239,7 @@ class StreamChunkingResult:
         self._event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
         self._orchestration_task: asyncio.Task[None] | None = None
         self._done = asyncio.Event()
+        self._events_consumed: bool = False
 
         self.completed: bool = True
         self.full_text: str = ""
@@ -295,7 +296,9 @@ class StreamChunkingResult:
 
         Typical event order (natural completion with requirements):
 
-        1. :class:`ChunkEvent` / :class:`QuickCheckEvent` pairs, one per chunk.
+        1. :class:`QuickCheckEvent` / :class:`ChunkEvent` pairs, one per chunk
+           (validation fires first; the chunk is released to the consumer only
+           after passing).
         2. :class:`StreamingDoneEvent` — raw token stream has ended.
         3. :class:`FullValidationEvent` — final ``validate()`` calls returned.
         4. :class:`CompletedEvent` — orchestrator is exiting.
@@ -307,18 +310,26 @@ class StreamChunkingResult:
         On exception: :class:`ErrorEvent` followed by :class:`CompletedEvent`.
 
         **Single-consumer.**  Events are delivered via a queue that this method
-        drains; a second call after the first iteration completes blocks
-        indefinitely.
+        drains; calling ``events()`` a second time raises :exc:`RuntimeError`.
 
         Yields:
             StreamEvent: A typed event from the orchestrator.
 
+        Raises:
+            RuntimeError: If called more than once on the same result.
+
         Note:
-            ``events()`` itself never raises.  If the orchestrator encounters
-            an unhandled exception, an :class:`ErrorEvent` is emitted and
-            iteration ends normally.  Exceptions surface to the caller via
-            :meth:`astream` (as a re-raised exception) or :meth:`acomplete`.
+            ``events()`` itself never raises from the event stream.  If the
+            orchestrator encounters an unhandled exception, an
+            :class:`ErrorEvent` is emitted and iteration ends normally.
+            Exceptions surface to the caller via :meth:`astream` (as a
+            re-raised exception) or :meth:`acomplete`.
         """
+        if self._events_consumed:
+            raise RuntimeError(
+                "events() is single-consumer; this iterator has already been drained"
+            )
+        self._events_consumed = True
         while True:
             item = await self._event_queue.get()
             if item is None:
@@ -341,7 +352,11 @@ class StreamChunkingResult:
                 :meth:`astream` consumers — they do **not** propagate here.
         """
         await self._done.wait()
-        if self._orchestration_task is not None and self._orchestration_task.done():
+        if (
+            self._orchestration_task is not None
+            and self._orchestration_task.done()
+            and not self._orchestration_task.cancelled()
+        ):
             exc = self._orchestration_task.exception()
             if exc is not None:
                 raise exc
@@ -488,9 +503,18 @@ async def _orchestrate_streaming(
                 if early_exit:
                     break
 
-            # Stream ended naturally: flush any withheld trailing fragment.
-            # Skipped on early exit — the generation was cancelled.
+            # Stream ended naturally: emit StreamingDoneEvent first (the raw
+            # token stream is finished regardless of what flush validation does),
+            # then flush any withheld trailing fragment.
+            # Skipped entirely on early exit — the generation was cancelled.
             if not early_exit:
+                streaming_done = StreamingDoneEvent(attempt=1, full_text=accumulated)
+                await result._event_queue.put(streaming_done)
+                if span is not None:
+                    span.add_event(
+                        "streaming_done", {"full_text_length": len(accumulated)}
+                    )
+
                 for c in chunking.flush(accumulated):
                     failed = await _process_chunk(c, chunk_index)
                     if failed:
@@ -507,13 +531,6 @@ async def _orchestrate_streaming(
             result.full_text = accumulated
 
             if not early_exit:
-                streaming_done = StreamingDoneEvent(attempt=1, full_text=accumulated)
-                await result._event_queue.put(streaming_done)
-                if span is not None:
-                    span.add_event(
-                        "streaming_done", {"full_text_length": len(accumulated)}
-                    )
-
                 non_failed = [
                     req for i, req in enumerate(cloned_reqs) if i not in failed_indices
                 ]
@@ -526,7 +543,7 @@ async def _orchestrate_streaming(
                     result.final_validations = vrs
                     all_passed = all(vr.as_bool() for vr in vrs)
                     full_val_ev = FullValidationEvent(
-                        attempt=1, passed=all_passed, results=vrs
+                        attempt=1, passed=all_passed, results=list(vrs)
                     )
                     await result._event_queue.put(full_val_ev)
                     if span is not None:
@@ -543,20 +560,26 @@ async def _orchestrate_streaming(
             # that CompletedEvent.success and result.completed are consistent
             # if the consumer observes them during ErrorEvent processing.
             result.completed = False
-            # Orchestrator is leaving — stop the backend producer.
             result.full_text = accumulated  # best-effort partial capture
-            try:
-                await mot.cancel_generation(error=exc)
+            # Only cancel generation if the stream hasn't already completed
+            # (e.g. an exception from the final validate() call arrives after
+            # the token stream ended naturally — cancelling an already-computed
+            # MOT is a no-op at best and misleading in telemetry).
+            if not mot.is_computed():
+                try:
+                    await mot.cancel_generation(error=exc)
+                    error_detail = str(exc)
+                except Exception as cleanup_exc:
+                    # Never let cleanup mask the original exception.
+                    error_detail = f"{exc!r} (cancel cleanup raised: {cleanup_exc!r})"
+                    MelleaLogger.get_logger().debug(
+                        "stream_with_chunking: cancel_generation() raised during "
+                        "exception cleanup (original: %r, cleanup: %r)",
+                        exc,
+                        cleanup_exc,
+                    )
+            else:
                 error_detail = str(exc)
-            except Exception as cleanup_exc:
-                # Never let cleanup mask the original exception.
-                error_detail = f"{exc!r} (cancel cleanup raised: {cleanup_exc!r})"
-                MelleaLogger.get_logger().debug(
-                    "stream_with_chunking: cancel_generation() raised during "
-                    "exception cleanup (original: %r, cleanup: %r)",
-                    exc,
-                    cleanup_exc,
-                )
             error_ev = ErrorEvent(
                 exception_type=type(exc).__name__, detail=error_detail
             )
@@ -595,7 +618,11 @@ async def _orchestrate_streaming(
             completed_ev = CompletedEvent(
                 success=result.completed, full_text=result.full_text, attempts_used=1
             )
-            await result._event_queue.put(completed_ev)
+            # Use put_nowait for the terminal bookkeeping: both queues are
+            # unbounded so this can never raise QueueFull, and it eliminates
+            # the await points that could be interrupted by a pending
+            # CancelledError before _done.set() runs.
+            result._event_queue.put_nowait(completed_ev)
             if span is not None:
                 span.add_event(
                     "completed",
@@ -606,8 +633,8 @@ async def _orchestrate_streaming(
                 )
             record_sampling_outcome("stream_with_chunking", success=result.completed)
 
-            await result._chunk_queue.put(None)
-            await result._event_queue.put(None)
+            result._chunk_queue.put_nowait(None)
+            result._event_queue.put_nowait(None)
             result._done.set()
 
 

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -248,6 +248,19 @@ async def stream_with_chunking(
     directly — this orchestrator is the single consumer of the MOT stream.
 
     Note:
+        Chunks are emitted to the consumer (via
+        :meth:`StreamChunkingResult.astream`) only after every requirement's
+        ``stream_validate`` has returned for that chunk.  A slow validator
+        (for example, one that invokes an LLM) therefore adds latency to
+        every chunk — the consumer sees a chunk at most as quickly as the
+        slowest active validator.  This trade is deliberate in v1: it
+        preserves the invariant that the consumer never sees content that
+        has not been validated, which matters for UIs displaying generated
+        text live.  A future fast-path mode that emits chunks to the
+        consumer concurrently with validation (at the cost of that
+        invariant) may be added if a concrete use case calls for it.
+
+    Note:
         v1 retry is simple re-invocation of this function.  Plugin hooks
         (``SAMPLING_LOOP_START``, ``SAMPLING_REPAIR``, etc.) do not fire
         on retries — use the ``#902`` event types for observability instead.

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -16,6 +16,7 @@ from ..backends.model_options import ModelOption
 from ..core.backend import Backend
 from ..core.base import CBlock, Component, Context, ModelOutputThunk
 from ..core.requirement import PartialValidationResult, Requirement, ValidationResult
+from ..core.utils import MelleaLogger
 from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
 
 _CHUNKING_ALIASES: dict[str, type[ChunkingStrategy]] = {
@@ -75,6 +76,14 @@ class StreamChunkingResult:
         all chunks have been yielded, whether the stream completed normally or
         was cancelled early on a ``"fail"`` result.
 
+        **Single-consumer.** Chunks are delivered via an
+        :class:`asyncio.Queue` that this method drains; calling
+        ``astream()`` a second time on the same result blocks indefinitely
+        because the queue is empty and the terminating ``None`` sentinel
+        has already been consumed.  If you need the chunks after
+        iteration, capture them into a list during the first pass or use
+        :attr:`full_text` after :meth:`acomplete`.
+
         Yields:
             str: A validated text chunk from the chunking strategy.
 
@@ -115,6 +124,15 @@ class StreamChunkingResult:
         generation metadata copied from the original MOT.  Safe to call on
         early-exit results; ``value`` will reflect whatever was accumulated
         before cancellation.
+
+        Note:
+            On early exit, ``cancel_generation()`` forces the MOT into a
+            computed state without running the backend's
+            ``post_processing()``.  Telemetry fields on the returned thunk
+            (``generation.usage``, ``generation.ttfb_ms``, etc.) may
+            therefore be ``None`` or reflect the partial state at
+            cancellation time.  ``value`` and ``streaming`` are reliable;
+            usage totals are not.
 
         Returns:
             ModelOutputThunk: A computed thunk containing the streamed output.
@@ -178,7 +196,12 @@ async def _orchestrate_streaming(
             try:
                 delta = await mot.astream()
             except RuntimeError:
-                break
+                # Expected race: mot.is_computed() was False at the top of the
+                # loop but the stream finished before we re-entered astream().
+                # Any other RuntimeError is a real bug and must propagate.
+                if mot.is_computed():
+                    break
+                raise
 
             accumulated += delta
             chunks = chunking.split(accumulated)
@@ -220,6 +243,23 @@ async def _orchestrate_streaming(
             )
 
     except Exception as exc:
+        # Orchestrator is leaving — we must stop the backend producer too,
+        # otherwise mot._async_queue (maxsize=20) fills and the feeder task
+        # blocks indefinitely. The spec (#891, #901) calls this out for the
+        # "fail" path; the same reasoning applies to any unplanned exit.
+        try:
+            await mot.cancel_generation()
+        except Exception as cleanup_exc:
+            # Never let cleanup mask the original exception: log loudly and
+            # continue to surface `exc` to the consumer.
+            # TODO(#902): replace this log with an ErrorEvent emission.
+            MelleaLogger.get_logger().warning(
+                "stream_with_chunking: cancel_generation() raised during "
+                "exception cleanup (original: %r, cleanup: %r)",
+                exc,
+                cleanup_exc,
+            )
+        result.completed = False
         await result._chunk_queue.put(exc)
     finally:
         await result._chunk_queue.put(None)

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -5,11 +5,17 @@ consumes a streaming :class:`~mellea.core.base.ModelOutputThunk`, applies a
 :class:`~mellea.stdlib.chunking.ChunkingStrategy` to produce semantic chunks,
 and runs :meth:`~mellea.core.requirement.Requirement.stream_validate` on each
 chunk in parallel.  Higher-level streaming APIs build on this function.
+
+The orchestrator emits typed :class:`StreamEvent` objects that consumers can
+observe via :meth:`StreamChunkingResult.events`.  Raw validated chunks remain
+available via :meth:`StreamChunkingResult.astream`.
 """
 
 import asyncio
+import time
 from collections.abc import AsyncIterator, Sequence
 from copy import copy
+from dataclasses import dataclass, field
 from typing import Any
 
 from ..backends.model_options import ModelOption
@@ -17,6 +23,14 @@ from ..core.backend import Backend
 from ..core.base import CBlock, Component, Context, ModelOutputThunk
 from ..core.requirement import PartialValidationResult, Requirement, ValidationResult
 from ..core.utils import MelleaLogger
+from ..telemetry.metrics import (
+    classify_error,
+    record_error,
+    record_requirement_check,
+    record_requirement_failure,
+    record_sampling_outcome,
+)
+from ..telemetry.tracing import set_span_error, trace_application
 from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
 
 _CHUNKING_ALIASES: dict[str, type[ChunkingStrategy]] = {
@@ -25,14 +39,170 @@ _CHUNKING_ALIASES: dict[str, type[ChunkingStrategy]] = {
     "paragraph": ParagraphChunker,
 }
 
+# ---------------------------------------------------------------------------
+# Streaming event types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StreamEvent:
+    """Base class for all streaming events emitted by :func:`stream_with_chunking`.
+
+    The ``timestamp`` field is auto-populated at instantiation time; callers
+    do not set it.
+
+    Attributes:
+        timestamp: Unix timestamp (seconds) at the moment the event was created.
+    """
+
+    timestamp: float = field(default_factory=time.time, init=False)
+
+
+@dataclass
+class ChunkEvent(StreamEvent):
+    """Emitted after each validated chunk is delivered to the consumer.
+
+    Fired after all active requirements' ``stream_validate`` calls return
+    non-``"fail"`` for this chunk and the chunk has been placed on the
+    consumer queue.
+
+    Attributes:
+        text: The chunk text that was validated and emitted.
+        chunk_index: Zero-based position of this chunk in the stream.
+        attempt: Sampling attempt number (always ``1`` in v1).
+    """
+
+    text: str
+    chunk_index: int
+    attempt: int
+
+
+@dataclass
+class QuickCheckEvent(StreamEvent):
+    """Emitted after each per-chunk streaming validation batch.
+
+    One event per chunk, covering all active requirements in parallel.
+    Not emitted when there are no ``quick_check_requirements``.
+
+    Attributes:
+        chunk_index: Zero-based position of the chunk that was validated.
+        attempt: Sampling attempt number (always ``1`` in v1).
+        passed: ``True`` if all active requirements returned non-``"fail"``
+            for this chunk.
+        results: :class:`~mellea.core.requirement.PartialValidationResult`
+            from each active requirement, in the same order as the active
+            slice of ``quick_check_requirements``.
+    """
+
+    chunk_index: int
+    attempt: int
+    passed: bool
+    results: list[PartialValidationResult]
+
+
+@dataclass
+class StreamingDoneEvent(StreamEvent):
+    """Emitted when the raw token stream ends, before final validation.
+
+    Only emitted on natural stream completion.  Not emitted on early exit
+    (generation was cancelled before the stream finished) or on exception.
+
+    Attributes:
+        attempt: Sampling attempt number (always ``1`` in v1).
+        full_text: Complete accumulated text at stream end.
+    """
+
+    attempt: int
+    full_text: str
+
+
+@dataclass
+class FullValidationEvent(StreamEvent):
+    """Emitted after the final :meth:`~mellea.core.requirement.Requirement.validate` calls complete.
+
+    Only emitted when at least one requirement did not fail during streaming
+    and the stream completed naturally.  Not emitted on early exit.
+
+    Attributes:
+        attempt: Sampling attempt number (always ``1`` in v1).
+        passed: ``True`` if all final
+            :class:`~mellea.core.requirement.ValidationResult` objects passed.
+        results: :class:`~mellea.core.requirement.ValidationResult` from each
+            non-failed requirement, in requirement order.
+    """
+
+    attempt: int
+    passed: bool
+    results: list[ValidationResult]
+
+
+@dataclass
+class RetryEvent(StreamEvent):
+    """Reserved for future use.
+
+    Defined for API completeness — ``RetryEvent`` is not emitted by the
+    v1 orchestrator because v1 retry is caller-driven re-invocation of
+    :func:`stream_with_chunking`.  When orchestrator-side retry is added,
+    this event will fire before each re-attempt.
+
+    Attributes:
+        attempt: Attempt number being started (1-based).
+        reason: Human-readable reason for the retry.
+    """
+
+    attempt: int
+    reason: str
+
+
+@dataclass
+class CompletedEvent(StreamEvent):
+    """Emitted when the orchestrator exits, including early-exit cases.
+
+    Always the last event before :meth:`StreamChunkingResult.events`
+    terminates.  ``success`` reflects :attr:`StreamChunkingResult.completed`.
+
+    Attributes:
+        success: ``True`` if the stream completed normally (no ``"fail"``
+            result and no unhandled exception); ``False`` otherwise.
+        full_text: Complete accumulated text.  On early exit or exception,
+            reflects whatever was accumulated before cancellation.
+        attempts_used: Number of orchestrator invocations (always ``1`` in v1).
+    """
+
+    success: bool
+    full_text: str
+    attempts_used: int
+
+
+@dataclass
+class ErrorEvent(StreamEvent):
+    """Emitted when an unhandled exception occurs in the orchestrator.
+
+    Attributes:
+        exception_type: Python class name of the exception
+            (e.g. ``"ValueError"``).
+        detail: String representation of the exception.  If
+            ``cancel_generation()`` also raised during cleanup, the cleanup
+            error is appended.
+    """
+
+    exception_type: str
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
 
 class StreamChunkingResult:
     """Result of a :func:`stream_with_chunking` operation.
 
     Provides async iteration over validated text chunks as they complete
-    (:meth:`astream`), a blocking :meth:`acomplete` for awaiting the full
-    result including final validation, and :attr:`as_thunk` for wrapping the
-    output as a :class:`~mellea.core.base.ModelOutputThunk`.
+    (:meth:`astream`), typed :class:`StreamEvent` objects via :meth:`events`,
+    a blocking :meth:`acomplete` for awaiting the full result including final
+    validation, and :attr:`as_thunk` for wrapping the output as a
+    :class:`~mellea.core.base.ModelOutputThunk`.
 
     Instances are created by :func:`stream_with_chunking`; do not instantiate
     directly.
@@ -60,6 +230,7 @@ class StreamChunkingResult:
         self._mot = mot
         self._ctx = ctx
         self._chunk_queue: asyncio.Queue[str | None | Exception] = asyncio.Queue()
+        self._event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
         self._orchestration_task: asyncio.Task[None] | None = None
         self._done = asyncio.Event()
 
@@ -97,6 +268,49 @@ class StreamChunkingResult:
                 return
             if isinstance(item, Exception):
                 raise item
+            yield item
+
+    async def events(self) -> AsyncIterator[StreamEvent]:
+        """Yield typed streaming events as they are emitted by the orchestrator.
+
+        Each yielded object is a :class:`StreamEvent` subclass describing a
+        point in the orchestration lifecycle.  Consumers can dispatch on type:
+
+        .. code-block:: python
+
+            async for event in result.events():
+                match event:
+                    case ChunkEvent():
+                        print(f"chunk {event.chunk_index}: {event.text!r}")
+                    case QuickCheckEvent(passed=False):
+                        print(f"chunk {event.chunk_index} failed validation")
+                    case CompletedEvent():
+                        print(f"done — success={event.success}")
+
+        Typical event order (natural completion with requirements):
+
+        1. :class:`ChunkEvent` / :class:`QuickCheckEvent` pairs, one per chunk.
+        2. :class:`StreamingDoneEvent` — raw token stream has ended.
+        3. :class:`FullValidationEvent` — final ``validate()`` calls returned.
+        4. :class:`CompletedEvent` — orchestrator is exiting.
+
+        On early exit: :class:`QuickCheckEvent` (``passed=False``) is the
+        last validation event, followed by :class:`CompletedEvent`.  No
+        :class:`StreamingDoneEvent` or :class:`FullValidationEvent` is emitted.
+
+        On exception: :class:`ErrorEvent` followed by :class:`CompletedEvent`.
+
+        **Single-consumer.**  Events are delivered via a queue that this method
+        drains; a second call after the first iteration completes blocks
+        indefinitely.
+
+        Yields:
+            StreamEvent: A typed event from the orchestrator.
+        """
+        while True:
+            item = await self._event_queue.get()
+            if item is None:
+                return
             yield item
 
     async def acomplete(self) -> None:
@@ -149,6 +363,11 @@ class StreamChunkingResult:
         return thunk
 
 
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
 async def _orchestrate_streaming(
     result: StreamChunkingResult,
     mot: ModelOutputThunk,
@@ -161,120 +380,223 @@ async def _orchestrate_streaming(
     prev_chunk_count = 0
     failed_indices: set[int] = set()
     early_exit = False
+    chunk_index = 0
 
-    async def _validate_and_emit(c: str) -> bool:
-        """Run stream_validate on chunk c across active requirements.
+    with trace_application("stream_with_chunking") as span:
 
-        Returns True if a failure was recorded (caller should early-exit),
-        False otherwise (chunk was emitted to the consumer queue).
-        """
-        active = [
-            (i, req) for i, req in enumerate(cloned_reqs) if i not in failed_indices
-        ]
-        if active:
-            pvrs: list[PartialValidationResult] = list(
-                await asyncio.gather(
-                    *[
-                        req.stream_validate(c, backend=val_backend, ctx=ctx)
-                        for _, req in active
-                    ]
+        async def _process_chunk(c: str, ci: int) -> bool:
+            """Validate *c*, emit events, push to consumer queue.
+
+            Returns ``True`` if a ``"fail"`` was recorded (caller should
+            trigger early exit), ``False`` if the chunk was validated and
+            emitted successfully.
+            """
+            active = [
+                (i, req) for i, req in enumerate(cloned_reqs) if i not in failed_indices
+            ]
+            pvrs: list[PartialValidationResult] = []
+            if active:
+                pvrs = list(
+                    await asyncio.gather(
+                        *[
+                            req.stream_validate(c, backend=val_backend, ctx=ctx)
+                            for _, req in active
+                        ]
+                    )
                 )
-            )
-            for (idx, req), pvr in zip(active, pvrs):
-                if pvr.success == "fail":
-                    failed_indices.add(idx)
-                    result.streaming_failures.append((req, pvr))
+                for (idx, req), pvr in zip(active, pvrs):
+                    if pvr.success == "fail":
+                        failed_indices.add(idx)
+                        result.streaming_failures.append((req, pvr))
 
-        if failed_indices:
-            return True
-
-        await result._chunk_queue.put(c)
-        return False
-
-    try:
-        while not mot.is_computed():
-            try:
-                delta = await mot.astream()
-            except RuntimeError:
-                # Expected race: mot.is_computed() was False at the top of the
-                # loop but the stream finished before we re-entered astream().
-                # Any other RuntimeError is a real bug and must propagate.
-                if mot.is_computed():
-                    break
-                raise
-
-            accumulated += delta
-            chunks = chunking.split(accumulated)
-            new_chunks = chunks[prev_chunk_count:]
-            prev_chunk_count = len(chunks)
-
-            for c in new_chunks:
-                failed = await _validate_and_emit(c)
-                if failed:
-                    early_exit = True
-                    result.completed = False
-                    await mot.cancel_generation()
-                    break
-
-            if early_exit:
-                break
-
-        # Stream ended naturally: flush any withheld trailing fragment and
-        # run stream_validate on it. Skipped on early exit — the generation
-        # was cancelled, the trailing fragment is incomplete.
-        if not early_exit:
-            for c in chunking.flush(accumulated):
-                failed = await _validate_and_emit(c)
-                if failed:
-                    early_exit = True
-                    result.completed = False
-                    break
-
-        result.full_text = accumulated
-
-        non_failed = [
-            req for i, req in enumerate(cloned_reqs) if i not in failed_indices
-        ]
-        if non_failed and not early_exit:
-            result.final_validations = list(
-                await asyncio.gather(
-                    *[req.validate(val_backend, ctx) for req in non_failed]
+                any_fail = bool(failed_indices)
+                qc_event = QuickCheckEvent(
+                    chunk_index=ci, attempt=1, passed=not any_fail, results=pvrs
                 )
-            )
+                await result._event_queue.put(qc_event)
+                if span is not None:
+                    span.add_event(
+                        "quick_check",
+                        {
+                            "chunk_index": ci,
+                            "passed": not any_fail,
+                            "requirement_count": len(active),
+                        },
+                    )
+                for (_, req), pvr in zip(active, pvrs):
+                    record_requirement_check(type(req).__name__)
+                    if pvr.success == "fail":
+                        record_requirement_failure(type(req).__name__, pvr.reason or "")
 
-    except Exception as exc:
-        # Orchestrator is leaving — we must stop the backend producer too,
-        # otherwise mot._async_queue (maxsize=20) fills and the feeder task
-        # blocks indefinitely. The spec (#891, #901) calls this out for the
-        # "fail" path; the same reasoning applies to any unplanned exit.
-        # Pass `exc` so the backend telemetry span records the real cause
-        # rather than a generic "Generation cancelled".
+                if failed_indices:
+                    return True
+
+            await result._chunk_queue.put(c)
+            chunk_ev = ChunkEvent(text=c, chunk_index=ci, attempt=1)
+            await result._event_queue.put(chunk_ev)
+            if span is not None:
+                span.add_event("chunk", {"chunk_index": ci, "text_length": len(c)})
+            return False
+
         try:
-            await mot.cancel_generation(error=exc)
-        except Exception as cleanup_exc:
-            # Never let cleanup mask the original exception: log loudly and
-            # continue to surface `exc` to the consumer.
-            # TODO(#902): replace this log with an ErrorEvent emission.
-            MelleaLogger.get_logger().warning(
-                "stream_with_chunking: cancel_generation() raised during "
-                "exception cleanup (original: %r, cleanup: %r)",
-                exc,
-                cleanup_exc,
-            )
-        result.completed = False
-        await result._chunk_queue.put(exc)
-    finally:
-        # CancelledError (BaseException, not Exception) bypasses the except
-        # block above, so cancel_generation() may not have been called.
-        # Guard here ensures the backend producer is always stopped, even on
-        # external task cancellation (e.g. asyncio.wait_for timeout).
-        if not mot.is_computed():
+            while not mot.is_computed():
+                try:
+                    delta = await mot.astream()
+                except RuntimeError:
+                    # Expected race: mot.is_computed() was False at the top of the
+                    # loop but the stream finished before we re-entered astream().
+                    # Any other RuntimeError is a real bug and must propagate.
+                    if mot.is_computed():
+                        break
+                    raise
+
+                accumulated += delta
+                chunks = chunking.split(accumulated)
+                new_chunks = chunks[prev_chunk_count:]
+                prev_chunk_count = len(chunks)
+
+                for c in new_chunks:
+                    failed = await _process_chunk(c, chunk_index)
+                    if failed:
+                        early_exit = True
+                        result.completed = False
+                        await mot.cancel_generation()
+                        if span is not None:
+                            set_span_error(
+                                span,
+                                RuntimeError(
+                                    "Streaming validation failed: "
+                                    + (result.streaming_failures[-1][1].reason or "")
+                                ),
+                            )
+                        break
+                    chunk_index += 1
+
+                if early_exit:
+                    break
+
+            # Stream ended naturally: flush any withheld trailing fragment.
+            # Skipped on early exit — the generation was cancelled.
+            if not early_exit:
+                for c in chunking.flush(accumulated):
+                    failed = await _process_chunk(c, chunk_index)
+                    if failed:
+                        early_exit = True
+                        result.completed = False
+                        if span is not None:
+                            set_span_error(
+                                span,
+                                RuntimeError(
+                                    "Streaming validation failed on flush: "
+                                    + (result.streaming_failures[-1][1].reason or "")
+                                ),
+                            )
+                        break
+                    chunk_index += 1
+
+            result.full_text = accumulated
+
+            if not early_exit:
+                streaming_done = StreamingDoneEvent(attempt=1, full_text=accumulated)
+                await result._event_queue.put(streaming_done)
+                if span is not None:
+                    span.add_event(
+                        "streaming_done", {"full_text_length": len(accumulated)}
+                    )
+
+                non_failed = [
+                    req for i, req in enumerate(cloned_reqs) if i not in failed_indices
+                ]
+                if non_failed:
+                    vrs: list[ValidationResult] = list(
+                        await asyncio.gather(
+                            *[req.validate(val_backend, ctx) for req in non_failed]
+                        )
+                    )
+                    result.final_validations = vrs
+                    all_passed = all(vr.as_bool() for vr in vrs)
+                    full_val_ev = FullValidationEvent(
+                        attempt=1, passed=all_passed, results=vrs
+                    )
+                    await result._event_queue.put(full_val_ev)
+                    if span is not None:
+                        span.add_event(
+                            "full_validation",
+                            {
+                                "passed": all_passed,
+                                "requirement_count": len(non_failed),
+                            },
+                        )
+
+        except Exception as exc:
+            # Orchestrator is leaving — stop the backend producer.
+            result.full_text = accumulated  # best-effort partial capture
             try:
-                await mot.cancel_generation()
-            except BaseException:
-                pass
-        await result._chunk_queue.put(None)
-        result._done.set()
+                await mot.cancel_generation(error=exc)
+                error_detail = str(exc)
+            except Exception as cleanup_exc:
+                # Never let cleanup mask the original exception.
+                error_detail = f"{exc!r} (cancel cleanup raised: {cleanup_exc!r})"
+                MelleaLogger.get_logger().debug(
+                    "stream_with_chunking: cancel_generation() raised during "
+                    "exception cleanup (original: %r, cleanup: %r)",
+                    exc,
+                    cleanup_exc,
+                )
+            error_ev = ErrorEvent(
+                exception_type=type(exc).__name__, detail=error_detail
+            )
+            await result._event_queue.put(error_ev)
+            if span is not None:
+                span.add_event(
+                    "error",
+                    {
+                        "exception_type": error_ev.exception_type,
+                        "detail": error_ev.detail,
+                    },
+                )
+                set_span_error(span, exc)
+            record_error(
+                error_type=classify_error(exc),
+                model=result._mot.generation.model or "unknown",
+                provider=result._mot.generation.provider or "unknown",
+                exception_class=type(exc).__name__,
+            )
+            result.completed = False
+            await result._chunk_queue.put(exc)
+        finally:
+            # CancelledError (BaseException, not Exception) bypasses the except
+            # block above, so cancel_generation() may not have been called.
+            # Guard here ensures the backend producer is always stopped, even on
+            # external task cancellation (e.g. asyncio.wait_for timeout).
+            if not mot.is_computed():
+                try:
+                    await mot.cancel_generation()
+                except BaseException:
+                    pass
+
+            completed_ev = CompletedEvent(
+                success=result.completed, full_text=result.full_text, attempts_used=1
+            )
+            await result._event_queue.put(completed_ev)
+            if span is not None:
+                span.add_event(
+                    "completed",
+                    {
+                        "success": result.completed,
+                        "full_text_length": len(result.full_text),
+                    },
+                )
+            record_sampling_outcome("stream_with_chunking", success=result.completed)
+
+            await result._chunk_queue.put(None)
+            await result._event_queue.put(None)
+            result._done.set()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 async def stream_with_chunking(
@@ -322,6 +644,10 @@ async def stream_with_chunking(
     empty.  Requirements are cloned (``copy(req)``) before use so originals
     are never mutated.
 
+    The orchestrator emits typed :class:`StreamEvent` objects throughout
+    execution.  Consume them via :meth:`StreamChunkingResult.events` in
+    parallel with or instead of :meth:`StreamChunkingResult.astream`.
+
     Requirements that need context beyond the current chunk should
     accumulate it themselves across ``stream_validate`` calls (e.g.
     ``self._seen = self._seen + chunk``).  They must not read ``mot.astream()``
@@ -343,7 +669,8 @@ async def stream_with_chunking(
     Note:
         v1 retry is simple re-invocation of this function.  Plugin hooks
         (``SAMPLING_LOOP_START``, ``SAMPLING_REPAIR``, etc.) do not fire
-        on retries — use the ``#902`` event types for observability instead.
+        during streaming — use :meth:`StreamChunkingResult.events` for
+        observability instead.
 
     Args:
         action: The component or content block to generate from.
@@ -361,7 +688,8 @@ async def stream_with_chunking(
 
     Returns:
         StreamChunkingResult: A result object providing :meth:`~StreamChunkingResult.astream`
-            for incremental chunk consumption and
+            for incremental chunk consumption, :meth:`~StreamChunkingResult.events` for
+            typed streaming events, and
             :meth:`~StreamChunkingResult.acomplete` for blocking until done.
 
     Raises:

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -263,6 +263,10 @@ async def stream_with_chunking(
         StreamChunkingResult: A result object providing :meth:`~StreamChunkingResult.astream`
             for incremental chunk consumption and
             :meth:`~StreamChunkingResult.acomplete` for blocking until done.
+
+    Raises:
+        ValueError: If *chunking* is a string that does not match any known
+            alias (``"sentence"``, ``"word"``, ``"paragraph"``).
     """
     if isinstance(chunking, str):
         cls = _CHUNKING_ALIASES.get(chunking)

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -66,7 +66,7 @@ class ChunkEvent(StreamEvent):
     non-``"fail"`` for this chunk and the chunk has been placed on the
     consumer queue.
 
-    Attributes:
+    Args:
         text: The chunk text that was validated and emitted.
         chunk_index: Zero-based position of this chunk in the stream.
         attempt: Sampling attempt number (always ``1`` in v1).
@@ -84,7 +84,7 @@ class QuickCheckEvent(StreamEvent):
     One event per chunk, covering all active requirements in parallel.
     Not emitted when there are no ``quick_check_requirements``.
 
-    Attributes:
+    Args:
         chunk_index: Zero-based position of the chunk that was validated.
         attempt: Sampling attempt number (always ``1`` in v1).
         passed: ``True`` if all active requirements returned non-``"fail"``
@@ -107,7 +107,7 @@ class StreamingDoneEvent(StreamEvent):
     Only emitted on natural stream completion.  Not emitted on early exit
     (generation was cancelled before the stream finished) or on exception.
 
-    Attributes:
+    Args:
         attempt: Sampling attempt number (always ``1`` in v1).
         full_text: Complete accumulated text at stream end.
     """
@@ -123,7 +123,7 @@ class FullValidationEvent(StreamEvent):
     Only emitted when at least one requirement did not fail during streaming
     and the stream completed naturally.  Not emitted on early exit.
 
-    Attributes:
+    Args:
         attempt: Sampling attempt number (always ``1`` in v1).
         passed: ``True`` if all final
             :class:`~mellea.core.requirement.ValidationResult` objects passed.
@@ -145,7 +145,7 @@ class RetryEvent(StreamEvent):
     :func:`stream_with_chunking`.  When orchestrator-side retry is added,
     this event will fire before each re-attempt.
 
-    Attributes:
+    Args:
         attempt: Attempt number being started (1-based).
         reason: Human-readable reason for the retry.
     """
@@ -161,7 +161,7 @@ class CompletedEvent(StreamEvent):
     Always the last event before :meth:`StreamChunkingResult.events`
     terminates.  ``success`` reflects :attr:`StreamChunkingResult.completed`.
 
-    Attributes:
+    Args:
         success: ``True`` if the stream completed normally (no ``"fail"``
             result and no unhandled exception); ``False`` otherwise.
         full_text: Complete accumulated text.  On early exit or exception,
@@ -178,7 +178,7 @@ class CompletedEvent(StreamEvent):
 class ErrorEvent(StreamEvent):
     """Emitted when an unhandled exception occurs in the orchestrator.
 
-    Attributes:
+    Args:
         exception_type: Python class name of the exception
             (e.g. ``"ValueError"``).
         detail: String representation of the exception.  If

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -36,6 +36,11 @@ class StreamChunkingResult:
     Instances are created by :func:`stream_with_chunking`; do not instantiate
     directly.
 
+    Args:
+        mot: The :class:`~mellea.core.base.ModelOutputThunk` from the backend
+            generation call.
+        ctx: The generation context returned alongside the MOT.
+
     Attributes:
         completed: ``False`` if the stream exited early because a requirement
             returned ``"fail"`` during streaming; ``True`` otherwise.

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -30,7 +30,7 @@ from ..telemetry.metrics import (
     record_requirement_failure,
     record_sampling_outcome,
 )
-from ..telemetry.tracing import set_span_error, trace_application
+from ..telemetry.tracing import set_span_error, set_span_status_error, trace_application
 from .chunking import ChunkingStrategy, ParagraphChunker, SentenceChunker, WordChunker
 
 _CHUNKING_ALIASES: dict[str, type[ChunkingStrategy]] = {
@@ -49,7 +49,10 @@ class StreamEvent:
     """Base class for all streaming events emitted by :func:`stream_with_chunking`.
 
     The ``timestamp`` field is auto-populated at instantiation time; callers
-    do not set it.
+    do not set it.  Subclasses that add fields **must** declare them before the
+    ``timestamp`` field would conflict, and any new ``init=False`` fields must
+    use ``field(... , init=False)`` so the dataclass does not expose them as
+    constructor arguments.
 
     Attributes:
         timestamp: Unix timestamp (seconds) at the moment the event was created.
@@ -230,6 +233,9 @@ class StreamChunkingResult:
         self._mot = mot
         self._ctx = ctx
         self._chunk_queue: asyncio.Queue[str | None | Exception] = asyncio.Queue()
+        # If no consumer calls events(), events accumulate in this queue until
+        # the result object is garbage-collected.  That is intentional — event
+        # production is unconditional; consumption is opt-in.
         self._event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
         self._orchestration_task: asyncio.Task[None] | None = None
         self._done = asyncio.Event()
@@ -306,6 +312,12 @@ class StreamChunkingResult:
 
         Yields:
             StreamEvent: A typed event from the orchestrator.
+
+        Note:
+            ``events()`` itself never raises.  If the orchestrator encounters
+            an unhandled exception, an :class:`ErrorEvent` is emitted and
+            iteration ends normally.  Exceptions surface to the caller via
+            :meth:`astream` (as a re-raised exception) or :meth:`acomplete`.
         """
         while True:
             item = await self._event_queue.get()
@@ -322,7 +334,11 @@ class StreamChunkingResult:
         exhaustion, this call is effectively a no-op.
 
         Raises:
-            Exception: Propagates any error from the orchestration task.
+            BaseException: Propagates any :class:`BaseException` that escaped
+                the orchestration task entirely (e.g. ``KeyboardInterrupt``).
+                Ordinary :class:`Exception` types are caught by the orchestrator,
+                surfaced as :class:`ErrorEvent` objects, and re-raised to
+                :meth:`astream` consumers — they do **not** propagate here.
         """
         await self._done.wait()
         if self._orchestration_task is not None and self._orchestration_task.done():
@@ -409,7 +425,7 @@ async def _orchestrate_streaming(
                         failed_indices.add(idx)
                         result.streaming_failures.append((req, pvr))
 
-                any_fail = bool(failed_indices)
+                any_fail = any(pvr.success == "fail" for pvr in pvrs)
                 qc_event = QuickCheckEvent(
                     chunk_index=ci, attempt=1, passed=not any_fail, results=pvrs
                 )
@@ -462,12 +478,9 @@ async def _orchestrate_streaming(
                         result.completed = False
                         await mot.cancel_generation()
                         if span is not None:
-                            set_span_error(
-                                span,
-                                RuntimeError(
-                                    "Streaming validation failed: "
-                                    + (result.streaming_failures[-1][1].reason or "")
-                                ),
+                            reason = result.streaming_failures[-1][1].reason or ""
+                            set_span_status_error(
+                                span, f"Streaming validation failed: {reason}"
                             )
                         break
                     chunk_index += 1
@@ -484,12 +497,9 @@ async def _orchestrate_streaming(
                         early_exit = True
                         result.completed = False
                         if span is not None:
-                            set_span_error(
-                                span,
-                                RuntimeError(
-                                    "Streaming validation failed on flush: "
-                                    + (result.streaming_failures[-1][1].reason or "")
-                                ),
+                            reason = result.streaming_failures[-1][1].reason or ""
+                            set_span_status_error(
+                                span, f"Streaming validation failed on flush: {reason}"
                             )
                         break
                     chunk_index += 1
@@ -529,6 +539,10 @@ async def _orchestrate_streaming(
                         )
 
         except Exception as exc:
+            # Mark as failed immediately — before any event is enqueued — so
+            # that CompletedEvent.success and result.completed are consistent
+            # if the consumer observes them during ErrorEvent processing.
+            result.completed = False
             # Orchestrator is leaving — stop the backend producer.
             result.full_text = accumulated  # best-effort partial capture
             try:
@@ -562,7 +576,6 @@ async def _orchestrate_streaming(
                 provider=result._mot.generation.provider or "unknown",
                 exception_class=type(exc).__name__,
             )
-            result.completed = False
             await result._chunk_queue.put(exc)
         finally:
             # CancelledError (BaseException, not Exception) bypasses the except

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -245,12 +245,29 @@ def set_span_error(span: Any, exception: Exception) -> None:
         span.set_status(trace.Status(trace.StatusCode.ERROR, str(exception)))  # type: ignore
 
 
+def set_span_status_error(span: Any, description: str) -> None:
+    """Mark a span as ERROR without recording a phantom exception event.
+
+    Use this for validation failures and other non-exception error conditions
+    where the span should be marked failed but no exception was actually raised.
+    Calling ``set_span_error`` in these cases would create a misleading recorded
+    exception event in OTEL traces.
+
+    Args:
+        span: The span object (may be None if tracing is disabled)
+        description: Human-readable reason for the failure.
+    """
+    if span is not None and _OTEL_AVAILABLE:
+        span.set_status(trace.Status(trace.StatusCode.ERROR, description))  # type: ignore
+
+
 __all__ = [
     "end_backend_span",
     "is_application_tracing_enabled",
     "is_backend_tracing_enabled",
     "set_span_attribute",
     "set_span_error",
+    "set_span_status_error",
     "start_backend_span",
     "trace_application",
     "trace_backend",

--- a/test/stdlib/test_chunking.py
+++ b/test/stdlib/test_chunking.py
@@ -242,3 +242,79 @@ def test_paragraph_chunker_incremental_simulation():
         "First paragraph.",
         "Second paragraph.",
     ]
+
+
+# ---------------------------------------------------------------------------
+# flush() — trailing-fragment release at end of stream
+# ---------------------------------------------------------------------------
+
+
+def test_default_flush_returns_empty_list():
+    """The ABC default discards the trailing fragment."""
+
+    class Minimal(ChunkingStrategy):
+        def split(self, accumulated_text: str) -> list[str]:
+            _ = accumulated_text
+            return []
+
+    assert Minimal().flush("anything at all") == []
+    assert Minimal().flush("") == []
+
+
+def test_sentence_chunker_flush_empty():
+    assert SentenceChunker().flush("") == []
+
+
+def test_sentence_chunker_flush_only_complete():
+    """All text ends in a complete sentence with trailing whitespace → no fragment."""
+    assert SentenceChunker().flush("One. Two. ") == []
+
+
+def test_sentence_chunker_flush_trailing_fragment():
+    """Final sentence without trailing whitespace is released by flush."""
+    assert SentenceChunker().flush("One. Two without period") == ["Two without period"]
+
+
+def test_sentence_chunker_flush_terminated_no_trailing_space():
+    """Final sentence with terminator but no trailing whitespace is a fragment
+    under split() semantics and gets released by flush()."""
+    assert SentenceChunker().flush("One. Two.") == ["Two."]
+
+
+def test_sentence_chunker_flush_single_sentence_no_terminator():
+    assert SentenceChunker().flush("Incomplete sentence") == ["Incomplete sentence"]
+
+
+def test_word_chunker_flush_empty():
+    assert WordChunker().flush("") == []
+
+
+def test_word_chunker_flush_trailing_whitespace():
+    """Trailing whitespace means all words are complete → no fragment."""
+    assert WordChunker().flush("one two three ") == []
+
+
+def test_word_chunker_flush_trailing_fragment():
+    assert WordChunker().flush("one two three") == ["three"]
+
+
+def test_word_chunker_flush_single_word():
+    assert WordChunker().flush("solo") == ["solo"]
+
+
+def test_paragraph_chunker_flush_empty():
+    assert ParagraphChunker().flush("") == []
+
+
+def test_paragraph_chunker_flush_only_complete():
+    assert ParagraphChunker().flush("Para one.\n\nPara two.\n\n") == []
+
+
+def test_paragraph_chunker_flush_trailing_fragment():
+    assert ParagraphChunker().flush("Para one.\n\nPara two (no sep)") == [
+        "Para two (no sep)"
+    ]
+
+
+def test_paragraph_chunker_flush_single_paragraph_no_separator():
+    assert ParagraphChunker().flush("Only paragraph") == ["Only paragraph"]

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -678,10 +678,12 @@ async def test_cancel_generation_invoked_on_fail() -> None:
     call_count = 0
     real_cancel = ModelOutputThunk.cancel_generation
 
-    async def spy_cancel(self: ModelOutputThunk) -> None:
+    async def spy_cancel(
+        self: ModelOutputThunk, error: Exception | None = None
+    ) -> None:
         nonlocal call_count
         call_count += 1
-        await real_cancel(self)
+        await real_cancel(self, error)
 
     ModelOutputThunk.cancel_generation = spy_cancel  # type: ignore[method-assign]
     try:
@@ -702,10 +704,16 @@ async def test_cancel_generation_invoked_on_fail() -> None:
 
 @pytest.mark.asyncio
 async def test_exception_in_stream_validate_cancels_generation() -> None:
-    """If stream_validate raises, the orchestrator must still call
-    cancel_generation() — otherwise the backend producer blocks on the
-    (maxsize=20) queue — and surface the exception to the consumer via
-    astream()/acomplete()."""
+    """Verifies the orchestrator's exception-path cleanup: if stream_validate
+    raises, cancel_generation() is called and the exception surfaces to the
+    consumer via astream()/acomplete() without hanging.
+
+    This covers the cancel-on-exception path and the no-hang guarantee.
+    It does not directly exercise the worst-case "producer already blocked on
+    full queue" scenario (here the fail happens on chunk 1 so the queue never
+    fills); the cancel_generation drain logic is covered by its own tests in
+    test/core/.
+    """
 
     from mellea.core.base import ModelOutputThunk
 
@@ -736,10 +744,12 @@ async def test_exception_in_stream_validate_cancels_generation() -> None:
     call_count = 0
     real_cancel = ModelOutputThunk.cancel_generation
 
-    async def spy_cancel(self: ModelOutputThunk) -> None:
+    async def spy_cancel(
+        self: ModelOutputThunk, error: Exception | None = None
+    ) -> None:
         nonlocal call_count
         call_count += 1
-        await real_cancel(self)
+        await real_cancel(self, error)
 
     ModelOutputThunk.cancel_generation = spy_cancel  # type: ignore[method-assign]
     try:

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -122,6 +122,7 @@ class FailAfterWordsReq(Requirement):
     """
 
     def __init__(self, threshold: int) -> None:
+        super().__init__()
         self._threshold = threshold
         self._word_count = 0
 
@@ -146,6 +147,7 @@ class BackendRecordingReq(Requirement):
     """Records which backend was passed to stream_validate and validate."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.seen_backends: list[Any] = []
 
     def __copy__(self) -> "BackendRecordingReq":
@@ -174,6 +176,7 @@ class MutationDetectorReq(Requirement):
     """Tracks how many times stream_validate was called on this instance."""
 
     def __init__(self) -> None:
+        super().__init__()
         self._call_count = 0
 
     def format_for_llm(self) -> str:
@@ -291,22 +294,37 @@ async def test_quick_check_backend_routing() -> None:
 
     req = BackendRecordingReq()
 
-    result = await stream_with_chunking(
-        _action(),
-        main_backend,
-        _ctx(),
-        quick_check_requirements=[req],
-        chunking="sentence",
-        quick_check_backend=val_backend,
-    )
-    await result.acomplete()
+    # Capture the cloned requirement so we can inspect which backends it saw.
+    captured: list[BackendRecordingReq] = []
+    original_copy = BackendRecordingReq.__copy__
 
-    # The clone's seen_backends should only contain val_backend
-    # (The original req was never called; clones were.)
-    # Verify via final_validations side-effect: at least one backend recorded
+    def _capturing_copy(self: BackendRecordingReq) -> BackendRecordingReq:
+        clone = original_copy(self)
+        captured.append(clone)
+        return clone
+
+    BackendRecordingReq.__copy__ = _capturing_copy  # type: ignore[method-assign]
+    try:
+        result = await stream_with_chunking(
+            _action(),
+            main_backend,
+            _ctx(),
+            quick_check_requirements=[req],
+            chunking="sentence",
+            quick_check_backend=val_backend,
+        )
+        await result.acomplete()
+    finally:
+        BackendRecordingReq.__copy__ = original_copy  # type: ignore[method-assign]
+
     assert result.completed is True
-    # The original req._seen_backends is untouched (clone isolation)
+    # The original was never called — only clones are used.
     assert req.seen_backends == []
+    # The clone must have seen val_backend for every call (stream_validate + validate),
+    # never main_backend. This is the actual routing assertion.
+    assert len(captured) == 1
+    assert len(captured[0].seen_backends) > 0
+    assert all(b is val_backend for b in captured[0].seen_backends)
 
 
 @pytest.mark.asyncio

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -1,0 +1,384 @@
+"""Tests for stream_with_chunking() and StreamChunkingResult.
+
+Uses StreamingMockBackend — a deterministic test double that feeds tokens from a
+fixed response string into a MOT queue without network or LLM calls.
+
+All tests are unit tests (no @pytest.mark.ollama needed).
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from mellea.core.backend import Backend
+from mellea.core.base import CBlock, Context, GenerateType, ModelOutputThunk
+from mellea.core.requirement import (
+    PartialValidationResult,
+    Requirement,
+    ValidationResult,
+)
+from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.streaming import stream_with_chunking
+
+# ---------------------------------------------------------------------------
+# StreamingMockBackend
+# ---------------------------------------------------------------------------
+
+
+async def _mock_process(mot: ModelOutputThunk, chunk: Any) -> None:
+    if mot._underlying_value is None:
+        mot._underlying_value = ""
+    if chunk is not None:
+        mot._underlying_value += chunk
+
+
+async def _mock_post_process(_mot: ModelOutputThunk) -> None:
+    pass
+
+
+def _make_mot() -> ModelOutputThunk:
+    mot = ModelOutputThunk(value=None)
+    mot._action = CBlock("mock_action")
+    mot._generate_type = GenerateType.ASYNC
+    mot._process = _mock_process
+    mot._post_process = _mock_post_process
+    mot._chunk_size = 0
+    return mot
+
+
+async def _feed_tokens(mot: ModelOutputThunk, response: str, token_size: int) -> None:
+    i = 0
+    while i < len(response):
+        token = response[i : i + token_size]
+        await mot._async_queue.put(token)
+        await asyncio.sleep(0)
+        i += token_size
+    await mot._async_queue.put(None)
+
+
+class StreamingMockBackend(Backend):
+    """Test double that streams a fixed response one token at a time.
+
+    ``token_size`` controls how many characters constitute one token.
+    Validation calls (via ``stream_validate`` / ``validate``) are delegated
+    to the requirements themselves — this backend does not perform any real
+    inference.
+    """
+
+    def __init__(self, response: str, token_size: int = 1) -> None:
+        self._response = response
+        self._token_size = token_size
+
+    async def _generate_from_context(
+        self,
+        action: Any,
+        ctx: Context,
+        *,
+        format: Any = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> tuple[ModelOutputThunk, Context]:
+        _ = format, model_options, tool_calls
+        mot = _make_mot()
+        task = asyncio.create_task(_feed_tokens(mot, self._response, self._token_size))
+        _ = task
+        new_ctx = ctx.add(action).add(mot)
+        return mot, new_ctx
+
+    async def generate_from_raw(
+        self, actions: Any, ctx: Any, **kwargs: Any
+    ) -> list[ModelOutputThunk]:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Requirement test doubles
+# ---------------------------------------------------------------------------
+
+
+class AlwaysUnknownReq(Requirement):
+    """stream_validate always returns 'unknown'; validate returns True."""
+
+    def format_for_llm(self) -> str:
+        return "always unknown"
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Any, ctx: Any
+    ) -> PartialValidationResult:
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self, backend: Any, ctx: Any, *, format: Any = None, model_options: Any = None
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+class FailAfterWordsReq(Requirement):
+    """Returns 'fail' once the accumulated text reaches *threshold* words."""
+
+    def __init__(self, threshold: int) -> None:
+        self._threshold = threshold
+
+    def format_for_llm(self) -> str:
+        return f"fail after {self._threshold} words"
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Any, ctx: Any
+    ) -> PartialValidationResult:
+        if len(chunk.split()) >= self._threshold:
+            return PartialValidationResult("fail", reason="too many words")
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self, backend: Any, ctx: Any, *, format: Any = None, model_options: Any = None
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+class BackendRecordingReq(Requirement):
+    """Records which backend was passed to stream_validate and validate."""
+
+    def __init__(self) -> None:
+        self.seen_backends: list[Any] = []
+
+    def __copy__(self) -> "BackendRecordingReq":
+        clone = BackendRecordingReq()
+        clone.seen_backends = []  # fresh list — do not share with original
+        return clone
+
+    def format_for_llm(self) -> str:
+        return "backend recorder"
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Any, ctx: Any
+    ) -> PartialValidationResult:
+        _ = chunk
+        self.seen_backends.append(backend)
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self, backend: Any, ctx: Any, *, format: Any = None, model_options: Any = None
+    ) -> ValidationResult:
+        self.seen_backends.append(backend)
+        return ValidationResult(result=True)
+
+
+class MutationDetectorReq(Requirement):
+    """Tracks how many times stream_validate was called on this instance."""
+
+    def __init__(self) -> None:
+        self._call_count = 0
+
+    def format_for_llm(self) -> str:
+        return "mutation detector"
+
+    async def stream_validate(
+        self, chunk: str, *, backend: Any, ctx: Any
+    ) -> PartialValidationResult:
+        _ = chunk, backend, ctx
+        self._call_count += 1
+        return PartialValidationResult("unknown")
+
+    async def validate(
+        self, backend: Any, ctx: Any, *, format: Any = None, model_options: Any = None
+    ) -> ValidationResult:
+        return ValidationResult(result=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> SimpleContext:
+    return SimpleContext()
+
+
+def _action() -> CBlock:
+    return CBlock("prompt")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_calls_validate_at_stream_end() -> None:
+    """All 'unknown' requirements → validate() called at stream end; completed=True."""
+    response = "Hello world. How are you. "
+    backend = StreamingMockBackend(response, token_size=3)
+    req = AlwaysUnknownReq()
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="sentence"
+    )
+    await result.acomplete()
+
+    assert result.completed is True
+    assert result.full_text == response
+    assert len(result.final_validations) == 1
+    assert result.final_validations[0].as_bool() is True
+    assert result.streaming_failures == []
+
+
+@pytest.mark.asyncio
+async def test_early_exit_on_fail() -> None:
+    """Requirement fails mid-stream → completed=False, streaming_failures populated."""
+    # 5 words to trigger failure
+    response = "one two three four five six seven eight. "
+    backend = StreamingMockBackend(response, token_size=2)
+    req = FailAfterWordsReq(threshold=4)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="word"
+    )
+    await result.acomplete()
+
+    assert result.completed is False
+    assert len(result.streaming_failures) == 1
+    _req, pvr = result.streaming_failures[0]
+    assert pvr.success == "fail"
+    assert pvr.reason == "too many words"
+    # final_validations should be empty — final validate() skipped on early exit
+    assert result.final_validations == []
+
+
+@pytest.mark.asyncio
+async def test_clone_isolation_across_retries() -> None:
+    """Originals must not be mutated; two invocations are independent."""
+    response = "Sentence one. Sentence two. "
+    req = MutationDetectorReq()
+    original_reqs = [req]
+
+    backend = StreamingMockBackend(response, token_size=4)
+
+    r1 = await stream_with_chunking(
+        _action(),
+        backend,
+        _ctx(),
+        quick_check_requirements=original_reqs,
+        chunking="sentence",
+    )
+    await r1.acomplete()
+
+    r2 = await stream_with_chunking(
+        _action(),
+        backend,
+        _ctx(),
+        quick_check_requirements=original_reqs,
+        chunking="sentence",
+    )
+    await r2.acomplete()
+
+    # Original requirement must never have been called — only clones are used
+    assert req._call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_quick_check_backend_routing() -> None:
+    """stream_validate and validate receive quick_check_backend, not the main backend."""
+    response = "One sentence. Two sentences. "
+    main_backend = StreamingMockBackend(response, token_size=3)
+    val_backend = StreamingMockBackend("unused", token_size=1)
+
+    req = BackendRecordingReq()
+
+    result = await stream_with_chunking(
+        _action(),
+        main_backend,
+        _ctx(),
+        quick_check_requirements=[req],
+        chunking="sentence",
+        quick_check_backend=val_backend,
+    )
+    await result.acomplete()
+
+    # The clone's seen_backends should only contain val_backend
+    # (The original req was never called; clones were.)
+    # Verify via final_validations side-effect: at least one backend recorded
+    assert result.completed is True
+    # The original req._seen_backends is untouched (clone isolation)
+    assert req.seen_backends == []
+
+
+@pytest.mark.asyncio
+async def test_early_exit_does_not_deadlock() -> None:
+    """Early failure with a high-throughput stream must not hang."""
+    long_response = "word " * 200
+    backend = StreamingMockBackend(long_response, token_size=5)
+    req = FailAfterWordsReq(threshold=3)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="word"
+    )
+    # 5-second timeout — should complete in milliseconds on success
+    await asyncio.wait_for(result.acomplete(), timeout=5.0)
+
+    assert result.completed is False
+
+
+@pytest.mark.asyncio
+async def test_as_thunk_correctness() -> None:
+    """as_thunk is computed, value matches full_text, generation metadata preserved."""
+    response = "This is a test sentence. "
+    backend = StreamingMockBackend(response, token_size=4)
+
+    result = await stream_with_chunking(_action(), backend, _ctx(), chunking="sentence")
+    await result.acomplete()
+
+    thunk = result.as_thunk
+    assert thunk.is_computed()
+    assert thunk.value == result.full_text == response
+
+
+@pytest.mark.asyncio
+async def test_as_thunk_raises_before_acomplete() -> None:
+    """as_thunk raises RuntimeError if accessed before acomplete()."""
+    response = "Some text. "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    result = await stream_with_chunking(_action(), backend, _ctx(), chunking="sentence")
+
+    with pytest.raises(RuntimeError, match="acomplete"):
+        _ = result.as_thunk
+
+
+@pytest.mark.asyncio
+async def test_astream_yields_individual_chunks() -> None:
+    """Consumer via astream() receives individual chunks, not accumulated text."""
+    response = "First sentence. Second sentence. Third sentence. "
+    backend = StreamingMockBackend(response, token_size=5)
+
+    result = await stream_with_chunking(_action(), backend, _ctx(), chunking="sentence")
+
+    chunks: list[str] = []
+    async for chunk in result.astream():
+        chunks.append(chunk)
+
+    await result.acomplete()
+
+    # Each chunk must be a complete sentence (not the accumulated text)
+    assert len(chunks) == 3
+    for chunk in chunks:
+        assert chunk.endswith(".")
+    # Chunks don't include inter-sentence spaces; joined with a space they appear in full_text
+    assert " ".join(chunks) in result.full_text
+
+
+@pytest.mark.asyncio
+async def test_no_requirements_streams_without_validation() -> None:
+    """quick_check_requirements=None → chunks produced, no validate() called."""
+    response = "Chunk one. Chunk two. Chunk three. "
+    backend = StreamingMockBackend(response, token_size=3)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=None, chunking="sentence"
+    )
+    await result.acomplete()
+
+    assert result.completed is True
+    assert result.full_text == response
+    assert result.final_validations == []
+    assert result.streaming_failures == []

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -444,6 +444,124 @@ async def test_stream_validate_receives_individual_chunks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_trailing_fragment_is_flushed_to_consumer() -> None:
+    """Response without trailing whitespace: final sentence reaches astream() and stream_validate."""
+
+    class ChunkRecordingReq(Requirement):
+        def __init__(self) -> None:
+            self.seen_chunks: list[str] = []
+
+        def __copy__(self) -> "ChunkRecordingReq":
+            clone = ChunkRecordingReq()
+            clone.seen_chunks = []
+            return clone
+
+        def format_for_llm(self) -> str:
+            return "chunk recorder"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            self.seen_chunks.append(chunk)
+            return PartialValidationResult("unknown")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            return ValidationResult(result=True)
+
+    # No trailing whitespace after the final sentence — SentenceChunker withholds it.
+    response = "First sentence. Second sentence."
+    backend = StreamingMockBackend(response, token_size=4)
+    req = ChunkRecordingReq()
+
+    captured: list[ChunkRecordingReq] = []
+    original_copy = ChunkRecordingReq.__copy__
+
+    def _capturing_copy(self: ChunkRecordingReq) -> ChunkRecordingReq:
+        clone = original_copy(self)
+        captured.append(clone)
+        return clone
+
+    ChunkRecordingReq.__copy__ = _capturing_copy  # type: ignore[method-assign]
+    try:
+        result = await stream_with_chunking(
+            _action(),
+            backend,
+            _ctx(),
+            quick_check_requirements=[req],
+            chunking="sentence",
+        )
+        yielded: list[str] = []
+        async for chunk in result.astream():
+            yielded.append(chunk)
+        await result.acomplete()
+    finally:
+        ChunkRecordingReq.__copy__ = original_copy  # type: ignore[method-assign]
+
+    # Both sentences reach the consumer, including the terminating one without trailing whitespace.
+    assert yielded == ["First sentence.", "Second sentence."]
+    # stream_validate was called on both — the flush path is not a shortcut.
+    assert captured[0].seen_chunks == ["First sentence.", "Second sentence."]
+    assert result.completed is True
+
+
+@pytest.mark.asyncio
+async def test_early_exit_on_trailing_fragment() -> None:
+    """A fail on the flushed fragment records a streaming failure and skips final validate()."""
+
+    class FailOnSecondSentence(Requirement):
+        def __init__(self) -> None:
+            self._count = 0
+
+        def format_for_llm(self) -> str:
+            return "fail on second sentence"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            _ = chunk, backend, ctx
+            self._count += 1
+            if self._count >= 2:
+                return PartialValidationResult("fail", reason="second sentence hit")
+            return PartialValidationResult("unknown")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            return ValidationResult(result=True)
+
+    response = "First sentence. Second sentence."
+    backend = StreamingMockBackend(response, token_size=4)
+    req = FailOnSecondSentence()
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="sentence"
+    )
+    yielded: list[str] = []
+    async for chunk in result.astream():
+        yielded.append(chunk)
+    await result.acomplete()
+
+    assert result.completed is False
+    assert len(result.streaming_failures) == 1
+    # First sentence was emitted; second (the flushed fragment) failed and wasn't emitted.
+    assert yielded == ["First sentence."]
+    # Early exit on fail skips final validate().
+    assert result.final_validations == []
+
+
+@pytest.mark.asyncio
 async def test_no_requirements_streams_without_validation() -> None:
     """quick_check_requirements=None → chunks produced, no validate() called."""
     response = "Chunk one. Chunk two. Chunk three. "

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -433,14 +433,12 @@ async def test_stream_validate_receives_individual_chunks() -> None:
 
     assert len(captured) == 1
     seen = captured[0].seen_chunks
-    # Three complete sentences → three separate stream_validate calls.
-    assert len(seen) == 3
-    # Each chunk is one sentence, not a prefix of accumulated text.
-    for chunk in seen:
-        assert chunk.endswith(".")
-    # Lengths must not be monotonically growing (which would indicate accumulated text).
-    # With per-chunk semantics, each chunk is roughly the same length as one sentence.
-    assert not all(len(seen[i]) < len(seen[i + 1]) for i in range(len(seen) - 1))
+    # Exact match: three separate calls, one per complete sentence,
+    # each call receiving that sentence and nothing more.  Under the old
+    # accumulated-text semantics, seen would have been
+    # ["First sentence.", "First sentence. Second sentence.", ...] —
+    # exact match against the per-chunk list is the direct regression guard.
+    assert seen == ["First sentence.", "Second sentence.", "Third sentence."]
 
 
 @pytest.mark.asyncio
@@ -576,3 +574,190 @@ async def test_no_requirements_streams_without_validation() -> None:
     assert result.full_text == response
     assert result.final_validations == []
     assert result.streaming_failures == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_chunks_in_one_batch_with_mid_batch_fail() -> None:
+    """When one astream() delta produces several complete chunks and one in
+    the middle fails, earlier chunks emit, failing chunk is recorded, later
+    chunks are neither validated nor emitted."""
+
+    captured: list[Any] = []
+
+    class FailOnNthChunk(Requirement):
+        def __init__(self, n: int) -> None:
+            self._n = n
+            self._calls = 0
+            self.seen: list[str] = []
+
+        def __copy__(self) -> "FailOnNthChunk":
+            clone = FailOnNthChunk(self._n)
+            captured.append(clone)
+            return clone
+
+        def format_for_llm(self) -> str:
+            return f"fail on chunk {self._n}"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            _ = backend, ctx
+            self._calls += 1
+            self.seen.append(chunk)
+            if self._calls == self._n:
+                return PartialValidationResult("fail", reason=f"n={self._n}")
+            return PartialValidationResult("unknown")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            _ = backend, ctx, format, model_options
+            return ValidationResult(result=True)
+
+    # token_size larger than the whole response → one astream() delta delivers
+    # the full text, so chunking.split produces 4 sentences in a single batch.
+    response = "One. Two. Three. Four. "
+    backend = StreamingMockBackend(response, token_size=100)
+    req = FailOnNthChunk(n=2)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="sentence"
+    )
+    yielded: list[str] = []
+    async for c in result.astream():
+        yielded.append(c)
+    await result.acomplete()
+
+    assert result.completed is False
+    assert len(result.streaming_failures) == 1
+    # Chunk 1 was validated and emitted; chunk 2 was validated and failed
+    # (NOT emitted); chunks 3 and 4 were NEITHER validated NOR emitted.
+    assert yielded == ["One."]
+    assert len(captured) == 1
+    assert captured[0].seen == ["One.", "Two."]
+    assert captured[0]._calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_generation_invoked_on_fail() -> None:
+    """Early exit on 'fail' must call mot.cancel_generation() — the spec reason
+    is that asyncio.Queue(maxsize=20) will block the producer if the consumer
+    stops without cancelling."""
+
+    from mellea.core.base import ModelOutputThunk
+
+    response = "word " * 50
+    backend = StreamingMockBackend(response, token_size=3)
+
+    class FailOnFirstChunk(Requirement):
+        def format_for_llm(self) -> str:
+            return "fail immediately"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            _ = chunk, backend, ctx
+            return PartialValidationResult("fail", reason="nope")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            _ = backend, ctx, format, model_options
+            return ValidationResult(result=True)
+
+    call_count = 0
+    real_cancel = ModelOutputThunk.cancel_generation
+
+    async def spy_cancel(self: ModelOutputThunk) -> None:
+        nonlocal call_count
+        call_count += 1
+        await real_cancel(self)
+
+    ModelOutputThunk.cancel_generation = spy_cancel  # type: ignore[method-assign]
+    try:
+        result = await stream_with_chunking(
+            _action(),
+            backend,
+            _ctx(),
+            quick_check_requirements=[FailOnFirstChunk()],
+            chunking="word",
+        )
+        await asyncio.wait_for(result.acomplete(), timeout=5.0)
+    finally:
+        ModelOutputThunk.cancel_generation = real_cancel  # type: ignore[method-assign]
+
+    assert result.completed is False
+    assert call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_exception_in_stream_validate_cancels_generation() -> None:
+    """If stream_validate raises, the orchestrator must still call
+    cancel_generation() — otherwise the backend producer blocks on the
+    (maxsize=20) queue — and surface the exception to the consumer via
+    astream()/acomplete()."""
+
+    from mellea.core.base import ModelOutputThunk
+
+    class RaisingReq(Requirement):
+        def format_for_llm(self) -> str:
+            return "raises"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            _ = chunk, backend, ctx
+            raise ValueError("boom")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            _ = backend, ctx, format, model_options
+            return ValidationResult(result=True)
+
+    response = "word " * 50  # enough to fill maxsize=20 queue without cleanup
+    backend = StreamingMockBackend(response, token_size=3)
+
+    call_count = 0
+    real_cancel = ModelOutputThunk.cancel_generation
+
+    async def spy_cancel(self: ModelOutputThunk) -> None:
+        nonlocal call_count
+        call_count += 1
+        await real_cancel(self)
+
+    ModelOutputThunk.cancel_generation = spy_cancel  # type: ignore[method-assign]
+    try:
+        result = await stream_with_chunking(
+            _action(),
+            backend,
+            _ctx(),
+            quick_check_requirements=[RaisingReq()],
+            chunking="word",
+        )
+        with pytest.raises(ValueError, match="boom"):
+            async for _chunk in result.astream():
+                pass
+        # acomplete must complete (not hang) even though the orchestration
+        # task raised, because cancel_generation was called in the except path.
+        await asyncio.wait_for(result.acomplete(), timeout=5.0)
+    finally:
+        ModelOutputThunk.cancel_generation = real_cancel  # type: ignore[method-assign]
+
+    assert result.completed is False
+    assert call_count >= 1

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -1089,3 +1089,64 @@ async def test_concurrent_astream_and_events() -> None:
 
     chunk_evts = [e for e in evts if isinstance(e, ChunkEvent)]
     assert [e.chunk_index for e in chunk_evts] == list(range(len(chunks)))
+
+
+# ---------------------------------------------------------------------------
+# CancelledError path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_sets_completed_false() -> None:
+    """External task cancellation must leave result.completed=False.
+
+    CancelledError is a BaseException and bypasses except Exception, so
+    the finally block is responsible for setting result.completed=False.
+    Regression: without the fix, result.completed stays True and
+    CompletedEvent / record_sampling_outcome lie to callers.
+
+    Uses a backend whose token feed blocks on an asyncio.Event that is
+    never set, guaranteeing the orchestrator is suspended at astream()
+    when the task is cancelled.
+
+    Requires ``await asyncio.sleep(0)`` before ``cancel()`` — see inline
+    comment.  Python 3.12's C Task implementation skips the coroutine body
+    entirely (including finally blocks) when cancelled before the first
+    ``coro.send(None)``.
+    """
+    gate = asyncio.Event()  # never set — feed task blocks indefinitely
+
+    async def _blocking_feed(mot: ModelOutputThunk) -> None:
+        await gate.wait()
+
+    class BlockingBackend(Backend):
+        async def _generate_from_context(
+            self, action: Any, ctx: Any, **kwargs: Any
+        ) -> tuple[ModelOutputThunk, Any]:
+            mot = _make_mot()
+            task = asyncio.create_task(_blocking_feed(mot))
+            _ = task
+            return mot, ctx.add(action).add(mot)
+
+        async def generate_from_raw(self, *args: Any, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+    result = await stream_with_chunking(
+        _action(), BlockingBackend(), _ctx(), chunking="word"
+    )
+    assert result._orchestration_task is not None
+
+    # Yield once so the orchestration task starts and reaches its first real
+    # await (Queue.get inside astream).  Without this, the task is cancelled
+    # before coro.send(None) is ever called, and Python skips the coroutine
+    # body entirely — the finally block never runs.
+    await asyncio.sleep(0)
+
+    result._orchestration_task.cancel()
+
+    try:
+        await result._orchestration_task
+    except BaseException:
+        pass
+
+    assert result.completed is False

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -115,10 +115,15 @@ class AlwaysUnknownReq(Requirement):
 
 
 class FailAfterWordsReq(Requirement):
-    """Returns 'fail' once the accumulated text reaches *threshold* words."""
+    """Returns 'fail' once the cumulative word count reaches *threshold*.
+
+    Each call to ``stream_validate`` receives a single chunk (delta) from the
+    chunking strategy; the running total is maintained on the instance.
+    """
 
     def __init__(self, threshold: int) -> None:
         self._threshold = threshold
+        self._word_count = 0
 
     def format_for_llm(self) -> str:
         return f"fail after {self._threshold} words"
@@ -126,7 +131,8 @@ class FailAfterWordsReq(Requirement):
     async def stream_validate(
         self, chunk: str, *, backend: Any, ctx: Any
     ) -> PartialValidationResult:
-        if len(chunk.split()) >= self._threshold:
+        self._word_count += len(chunk.split())
+        if self._word_count >= self._threshold:
             return PartialValidationResult("fail", reason="too many words")
         return PartialValidationResult("unknown")
 
@@ -365,6 +371,76 @@ async def test_astream_yields_individual_chunks() -> None:
         assert chunk.endswith(".")
     # Chunks don't include inter-sentence spaces; joined with a space they appear in full_text
     assert " ".join(chunks) in result.full_text
+
+
+@pytest.mark.asyncio
+async def test_stream_validate_receives_individual_chunks() -> None:
+    """stream_validate is called once per chunk with the chunk itself, not accumulated text."""
+
+    class ChunkRecordingReq(Requirement):
+        def __init__(self) -> None:
+            self.seen_chunks: list[str] = []
+
+        def __copy__(self) -> "ChunkRecordingReq":
+            clone = ChunkRecordingReq()
+            clone.seen_chunks = []
+            return clone
+
+        def format_for_llm(self) -> str:
+            return "chunk recorder"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            self.seen_chunks.append(chunk)
+            return PartialValidationResult("unknown")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            return ValidationResult(result=True)
+
+    response = "First sentence. Second sentence. Third sentence. "
+    backend = StreamingMockBackend(response, token_size=4)
+    req = ChunkRecordingReq()
+
+    # Capture the cloned requirement used by the orchestrator via a side channel.
+    captured: list[ChunkRecordingReq] = []
+    original_copy = ChunkRecordingReq.__copy__
+
+    def _capturing_copy(self: ChunkRecordingReq) -> ChunkRecordingReq:
+        clone = original_copy(self)
+        captured.append(clone)
+        return clone
+
+    ChunkRecordingReq.__copy__ = _capturing_copy  # type: ignore[method-assign]
+    try:
+        result = await stream_with_chunking(
+            _action(),
+            backend,
+            _ctx(),
+            quick_check_requirements=[req],
+            chunking="sentence",
+        )
+        await result.acomplete()
+    finally:
+        ChunkRecordingReq.__copy__ = original_copy  # type: ignore[method-assign]
+
+    assert len(captured) == 1
+    seen = captured[0].seen_chunks
+    # Three complete sentences → three separate stream_validate calls.
+    assert len(seen) == 3
+    # Each chunk is one sentence, not a prefix of accumulated text.
+    for chunk in seen:
+        assert chunk.endswith(".")
+    # Lengths must not be monotonically growing (which would indicate accumulated text).
+    # With per-chunk semantics, each chunk is roughly the same length as one sentence.
+    assert not all(len(seen[i]) < len(seen[i + 1]) for i in range(len(seen) - 1))
 
 
 @pytest.mark.asyncio

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -8,6 +8,7 @@ All tests are unit tests (no @pytest.mark.ollama needed).
 
 import asyncio
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -19,7 +20,17 @@ from mellea.core.requirement import (
     ValidationResult,
 )
 from mellea.stdlib.context import SimpleContext
-from mellea.stdlib.streaming import stream_with_chunking
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    ErrorEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    RetryEvent,
+    StreamEvent,
+    StreamingDoneEvent,
+    stream_with_chunking,
+)
 
 # ---------------------------------------------------------------------------
 # StreamingMockBackend
@@ -721,6 +732,13 @@ async def test_cancel_generation_invoked_on_fail() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unknown_chunking_alias_raises_value_error() -> None:
+    backend = StreamingMockBackend("hello world")
+    with pytest.raises(ValueError, match="unknown_alias"):
+        await stream_with_chunking(_action(), backend, _ctx(), chunking="unknown_alias")
+
+
+@pytest.mark.asyncio
 async def test_exception_in_stream_validate_cancels_generation() -> None:
     """Verifies the orchestrator's exception-path cleanup: if stream_validate
     raises, cancel_generation() is called and the exception surfaces to the
@@ -789,3 +807,285 @@ async def test_exception_in_stream_validate_cancels_generation() -> None:
 
     assert result.completed is False
     assert call_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Event type construction
+# ---------------------------------------------------------------------------
+
+
+def test_stream_event_types_have_auto_timestamp() -> None:
+    """All seven event types set timestamp automatically; callers do not pass it."""
+    import time
+
+    before = time.time()
+    all_events = [
+        ChunkEvent(text="hello", chunk_index=0, attempt=1),
+        QuickCheckEvent(
+            chunk_index=0,
+            attempt=1,
+            passed=True,
+            results=[PartialValidationResult("unknown")],
+        ),
+        StreamingDoneEvent(attempt=1, full_text="hello"),
+        FullValidationEvent(
+            attempt=1, passed=True, results=[ValidationResult(result=True)]
+        ),
+        RetryEvent(attempt=2, reason="too long"),
+        CompletedEvent(success=True, full_text="hello", attempts_used=1),
+        ErrorEvent(exception_type="ValueError", detail="boom"),
+    ]
+    after = time.time()
+
+    for ev in all_events:
+        assert isinstance(ev, StreamEvent)
+        assert before <= ev.timestamp <= after, (
+            f"{type(ev).__name__} timestamp out of range"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Event emission — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emission_order_happy_path() -> None:
+    """Happy path: ChunkEvent/QuickCheckEvent pairs, then StreamingDoneEvent,
+    FullValidationEvent, CompletedEvent(success=True)."""
+    response = "First sentence. Second sentence. "
+    backend = StreamingMockBackend(response, token_size=4)
+    req = AlwaysUnknownReq()
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="sentence"
+    )
+    await result.acomplete()
+
+    evts: list[StreamEvent] = [e async for e in result.events()]
+
+    assert isinstance(evts[-1], CompletedEvent)
+    assert evts[-1].success is True
+    assert evts[-1].attempts_used == 1
+
+    types = [type(e) for e in evts]
+    assert StreamingDoneEvent in types
+    assert types.index(StreamingDoneEvent) < types.index(CompletedEvent)
+    assert FullValidationEvent in types
+    assert types.index(FullValidationEvent) > types.index(StreamingDoneEvent)
+
+    chunk_events = [e for e in evts if isinstance(e, ChunkEvent)]
+    qc_events = [e for e in evts if isinstance(e, QuickCheckEvent)]
+    assert len(chunk_events) == 2
+    assert len(qc_events) == 2
+    assert [e.chunk_index for e in chunk_events] == [0, 1]
+    assert [e.chunk_index for e in qc_events] == [0, 1]
+    assert all(e.passed for e in qc_events)
+
+
+@pytest.mark.asyncio
+async def test_streaming_done_event_carries_full_text() -> None:
+    """StreamingDoneEvent.full_text matches full_text on the result."""
+    response = "One sentence. Two sentences. "
+    backend = StreamingMockBackend(response, token_size=5)
+
+    result = await stream_with_chunking(_action(), backend, _ctx(), chunking="sentence")
+    await result.acomplete()
+
+    evts = [e async for e in result.events()]
+    done_events = [e for e in evts if isinstance(e, StreamingDoneEvent)]
+    assert len(done_events) == 1
+    assert done_events[0].full_text == result.full_text
+
+
+# ---------------------------------------------------------------------------
+# Event emission — early exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_emission_on_early_exit() -> None:
+    """Early exit: QuickCheckEvent(passed=False) present; no StreamingDoneEvent
+    or FullValidationEvent; CompletedEvent(success=False)."""
+    response = "word " * 30
+    backend = StreamingMockBackend(response, token_size=3)
+    req = FailAfterWordsReq(threshold=2)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="word"
+    )
+    await result.acomplete()
+
+    evts = [e async for e in result.events()]
+
+    assert isinstance(evts[-1], CompletedEvent)
+    assert evts[-1].success is False
+
+    types = [type(e) for e in evts]
+    assert FullValidationEvent not in types
+    assert StreamingDoneEvent not in types
+
+    fail_qc = [e for e in evts if isinstance(e, QuickCheckEvent) and not e.passed]
+    assert len(fail_qc) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Event emission — exception path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_event_on_stream_validate_exception() -> None:
+    """When stream_validate raises, ErrorEvent is emitted and CompletedEvent follows."""
+
+    class RaisingReq2(Requirement):
+        def format_for_llm(self) -> str:
+            return "raises"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            raise RuntimeError("test-error")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            return ValidationResult(result=True)
+
+    backend = StreamingMockBackend("hello world", token_size=5)
+    result = await stream_with_chunking(
+        _action(),
+        backend,
+        _ctx(),
+        quick_check_requirements=[RaisingReq2()],
+        chunking="word",
+    )
+    with pytest.raises(RuntimeError, match="test-error"):
+        async for _c in result.astream():
+            pass
+    await asyncio.wait_for(result.acomplete(), timeout=5.0)
+
+    evts = [e async for e in result.events()]
+
+    error_events = [e for e in evts if isinstance(e, ErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].exception_type == "RuntimeError"
+    assert "test-error" in error_events[0].detail
+
+    assert isinstance(evts[-1], CompletedEvent)
+    assert evts[-1].success is False
+
+
+# ---------------------------------------------------------------------------
+# Metric helper calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_requirement_check_called_per_chunk() -> None:
+    """record_requirement_check is called once per chunk per active requirement."""
+    response = "One. Two. "
+    backend = StreamingMockBackend(response, token_size=3)
+    req = AlwaysUnknownReq()
+
+    with patch("mellea.stdlib.streaming.record_requirement_check") as mock_check:
+        result = await stream_with_chunking(
+            _action(),
+            backend,
+            _ctx(),
+            quick_check_requirements=[req],
+            chunking="sentence",
+        )
+        await result.acomplete()
+
+    assert mock_check.call_count == 2
+    for call in mock_check.call_args_list:
+        assert call.args[0] == "AlwaysUnknownReq"
+
+
+@pytest.mark.asyncio
+async def test_record_requirement_failure_called_on_fail() -> None:
+    """record_requirement_failure is called with class name and reason on fail."""
+    response = "word " * 10
+    backend = StreamingMockBackend(response, token_size=3)
+    req = FailAfterWordsReq(threshold=2)
+
+    with patch("mellea.stdlib.streaming.record_requirement_failure") as mock_fail:
+        result = await stream_with_chunking(
+            _action(), backend, _ctx(), quick_check_requirements=[req], chunking="word"
+        )
+        await result.acomplete()
+
+    assert mock_fail.call_count >= 1
+    first_call = mock_fail.call_args_list[0]
+    assert first_call.args[0] == "FailAfterWordsReq"
+    assert first_call.args[1] == "too many words"
+
+
+@pytest.mark.asyncio
+async def test_record_sampling_outcome_success() -> None:
+    """record_sampling_outcome called with success=True on normal completion."""
+    response = "One sentence. "
+    backend = StreamingMockBackend(response, token_size=4)
+
+    with patch("mellea.stdlib.streaming.record_sampling_outcome") as mock_outcome:
+        result = await stream_with_chunking(
+            _action(), backend, _ctx(), chunking="sentence"
+        )
+        await result.acomplete()
+
+    mock_outcome.assert_called_once_with("stream_with_chunking", success=True)
+
+
+@pytest.mark.asyncio
+async def test_record_sampling_outcome_failure_on_early_exit() -> None:
+    """record_sampling_outcome called with success=False on early exit."""
+    response = "word " * 20
+    backend = StreamingMockBackend(response, token_size=3)
+    req = FailAfterWordsReq(threshold=1)
+
+    with patch("mellea.stdlib.streaming.record_sampling_outcome") as mock_outcome:
+        result = await stream_with_chunking(
+            _action(), backend, _ctx(), quick_check_requirements=[req], chunking="word"
+        )
+        await result.acomplete()
+
+    mock_outcome.assert_called_once_with("stream_with_chunking", success=False)
+
+
+# ---------------------------------------------------------------------------
+# Concurrent astream() + events()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_astream_and_events() -> None:
+    """astream() and events() can be consumed concurrently without interference."""
+    response = "Alpha. Beta. Gamma. "
+    backend = StreamingMockBackend(response, token_size=4)
+    req = AlwaysUnknownReq()
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=[req], chunking="sentence"
+    )
+
+    async def drain_chunks() -> list[str]:
+        return [c async for c in result.astream()]
+
+    async def drain_events() -> list[StreamEvent]:
+        return [e async for e in result.events()]
+
+    chunks, evts = await asyncio.gather(drain_chunks(), drain_events())
+    await result.acomplete()
+
+    assert len(chunks) == 3
+    assert isinstance(evts[-1], CompletedEvent)
+    assert evts[-1].success is True
+
+    chunk_evts = [e for e in evts if isinstance(e, ChunkEvent)]
+    assert [e.chunk_index for e in chunk_evts] == list(range(len(chunks)))

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -607,6 +607,27 @@ async def test_no_requirements_streams_without_validation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_no_requirements_events_omits_full_validation_event() -> None:
+    """With no quick_check_requirements, events() emits StreamingDoneEvent but
+    NOT FullValidationEvent — there is nothing to validate at stream end."""
+    response = "Chunk one. Chunk two. "
+    backend = StreamingMockBackend(response, token_size=3)
+
+    result = await stream_with_chunking(
+        _action(), backend, _ctx(), quick_check_requirements=None, chunking="sentence"
+    )
+    await result.acomplete()
+
+    evts = [e async for e in result.events()]
+    types = [type(e) for e in evts]
+
+    assert StreamingDoneEvent in types
+    assert FullValidationEvent not in types
+    assert isinstance(evts[-1], CompletedEvent)
+    assert evts[-1].success is True
+
+
+@pytest.mark.asyncio
 async def test_multiple_chunks_in_one_batch_with_mid_batch_fail() -> None:
     """When one astream() delta produces several complete chunks and one in
     the middle fails, earlier chunks emit, failing chunk is recorded, later
@@ -851,7 +872,7 @@ def test_stream_event_types_have_auto_timestamp() -> None:
 
 @pytest.mark.asyncio
 async def test_event_emission_order_happy_path() -> None:
-    """Happy path: ChunkEvent/QuickCheckEvent pairs, then StreamingDoneEvent,
+    """Happy path: QuickCheckEvent/ChunkEvent pairs, then StreamingDoneEvent,
     FullValidationEvent, CompletedEvent(success=True)."""
     response = "First sentence. Second sentence. "
     backend = StreamingMockBackend(response, token_size=4)
@@ -881,6 +902,13 @@ async def test_event_emission_order_happy_path() -> None:
     assert [e.chunk_index for e in chunk_events] == [0, 1]
     assert [e.chunk_index for e in qc_events] == [0, 1]
     assert all(e.passed for e in qc_events)
+
+    # QuickCheckEvent fires before ChunkEvent within each pair: validation must
+    # complete before the chunk is released to the consumer queue.
+    for ci in range(2):
+        qc_pos = evts.index(qc_events[ci])
+        ch_pos = evts.index(chunk_events[ci])
+        assert qc_pos < ch_pos, f"chunk {ci}: QuickCheckEvent must precede ChunkEvent"
 
 
 @pytest.mark.asyncio
@@ -1115,6 +1143,7 @@ async def test_cancelled_task_sets_completed_false() -> None:
     ``coro.send(None)``.
     """
     gate = asyncio.Event()  # never set — feed task blocks indefinitely
+    feed_task: asyncio.Task[None] | None = None
 
     async def _blocking_feed(mot: ModelOutputThunk) -> None:
         await gate.wait()
@@ -1123,9 +1152,9 @@ async def test_cancelled_task_sets_completed_false() -> None:
         async def _generate_from_context(
             self, action: Any, ctx: Any, **kwargs: Any
         ) -> tuple[ModelOutputThunk, Any]:
+            nonlocal feed_task
             mot = _make_mot()
-            task = asyncio.create_task(_blocking_feed(mot))
-            _ = task
+            feed_task = asyncio.create_task(_blocking_feed(mot))
             return mot, ctx.add(action).add(mot)
 
         async def generate_from_raw(self, *args: Any, **kwargs: Any) -> Any:
@@ -1149,4 +1178,19 @@ async def test_cancelled_task_sets_completed_false() -> None:
     except BaseException:
         pass
 
+    # Primary assertion: completed must be False after external cancellation.
     assert result.completed is False
+
+    # The finally block must have run to completion: _done must be set and
+    # acomplete() must not hang.  This is the actual failure mode the fix
+    # guards against — if _done is never set, acomplete() blocks forever.
+    assert result._done.is_set()
+    await asyncio.wait_for(result.acomplete(), timeout=2.0)
+
+    # Clean up the blocking feed task to avoid "Task destroyed while pending".
+    if feed_task is not None:
+        feed_task.cancel()
+        try:
+            await feed_task
+        except BaseException:
+            pass

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -7,6 +7,7 @@ All tests are unit tests (no @pytest.mark.ollama needed).
 """
 
 import asyncio
+import time
 from typing import Any
 from unittest.mock import patch
 
@@ -733,6 +734,7 @@ async def test_cancel_generation_invoked_on_fail() -> None:
 
 @pytest.mark.asyncio
 async def test_unknown_chunking_alias_raises_value_error() -> None:
+    """An unrecognised chunking alias raises ValueError before any backend call."""
     backend = StreamingMockBackend("hello world")
     with pytest.raises(ValueError, match="unknown_alias"):
         await stream_with_chunking(_action(), backend, _ctx(), chunking="unknown_alias")
@@ -816,8 +818,6 @@ async def test_exception_in_stream_validate_cancels_generation() -> None:
 
 def test_stream_event_types_have_auto_timestamp() -> None:
     """All seven event types set timestamp automatically; callers do not pass it."""
-    import time
-
     before = time.time()
     all_events = [
         ChunkEvent(text="hello", chunk_index=0, attempt=1),


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [x] New Feature
- [x] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Closes #902

Part of epic #891 · **Wave 4 of 4** (final wave — nothing further is planned after this PR).

Adds the streaming event-type vocabulary, wires the OTEL bridge into the orchestrator, replaces the `MelleaLogger.warning` stopgap with `ErrorEvent`, and ships all narrative docs for the streaming validation epic.

### What changed

- **`mellea/stdlib/streaming.py`** — eight typed event dataclasses (`StreamEvent` base + `ChunkEvent`, `QuickCheckEvent`, `StreamingDoneEvent`, `FullValidationEvent`, `RetryEvent`, `CompletedEvent`, `ErrorEvent`) with auto-populated `timestamp`. `StreamChunkingResult.events()` single-consumer async iterator backed by an independent queue — can be consumed concurrently with `astream()`. Event emission wired into `_orchestrate_streaming` at every lifecycle point. Orchestrator wrapped in `trace_application("stream_with_chunking")` for an OTEL application span across the full orchestration lifetime. Metric helper calls at each emission point (`record_requirement_check`, `record_requirement_failure`, `record_sampling_outcome`, `record_error`). `ErrorEvent` replaces the `MelleaLogger.warning` stopgap in the `except Exception` branch. `QuickCheckEvent.passed` reflects per-chunk result (not cumulative state). Early-exit paths use `set_span_status_error` rather than a phantom `RuntimeError` to mark the OTEL span as failed. `result.completed = False` set before any event is enqueued in the exception path.

- **`mellea/telemetry/tracing.py`** — new `set_span_status_error()` helper: sets ERROR status on a span without recording a phantom exception event (use this for validation failures where no exception was actually raised).

- **`mellea/stdlib/__init__.py`** — exports all eight event types.

- **`docs/docs/how-to/use-async-and-streaming.md`** — new "Streaming with per-chunk validation" section: leads with `events()` as the primary API with a full `match` dispatch example including `case _: pass` fallback; `astream()` shown as a secondary alternative for raw-chunk access; `stream_validate` tri-state table.

- **`docs/docs/concepts/requirements-system.md`** — new "Streaming validation" section: `stream_validate()` semantics, tri-state `PartialValidationResult`, state isolation via per-clone copy, cross-link to how-to page.

- **`docs/examples/streaming/streaming_chunking.py`** — updated to use `events()` API with `match` dispatch on all six emitted event types; `case _: pass` fallback for `RetryEvent` and future types.

### Testing
- [x] Tests added to the respective file if code was changed
  - `test/stdlib/test_streaming.py` — 12 new tests (28 total, all pass): event timestamp construction, event emission order on happy path (including intra-pair QuickCheck-before-Chunk ordering), `StreamingDoneEvent.full_text` content, early-exit event sequence, `ErrorEvent` on `stream_validate` exception, `record_requirement_check` call count, `record_requirement_failure` args, `record_sampling_outcome` on success and on early-exit fail, concurrent `astream()` + `events()` consumption, no-requirements path omits `FullValidationEvent`, single-consumer guard raises on second drain.
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

## Stacked PR

**Prerequisite: #942** (Wave 3 — `stream_with_chunking()`, `StreamChunkingResult` skeleton, sentence chunker flush).

This PR stacks on `feat/901-stream-with-chunking`. The diff against `main` includes Wave 3 changes from that PR. When reviewing, focus on the eleven commits added here:

```
bd2a5aed fix(stdlib): address fourth-round review findings on streaming events (#902)
c6d896e6 fix(stdlib): address third-round review feedback (CancelledError finally guard, telemetry pop race fix, super().__init__() in test doubles, e2e marker, ValueError test)
b93474b2 docs: add word, paragraph, and custom chunking examples (#902)
0537272c docs: add case _ fallback to streaming_chunking example match block (#902)
ab8dc45f fix(stdlib): address code review feedback on streaming events (#902)
e4035e51 docs(stdlib): fix event dataclass docstrings to use Args not Attributes (#902)
240cd481 docs: add streaming/ to examples catalogue index (#902)
b8c11267 docs: update streaming_chunking example to events() API (#902)
9291d5e7 docs: add streaming validation sections to how-to and concepts (#902)
0f205778 test(stdlib): add event emission and OTEL bridge tests (#902)
a13d58b1 feat(stdlib): add streaming event types, events() iterator, and OTEL bridge (#902)
```

### What to ignore (Wave 3, covered by #942)

- `mellea/core/base.py` — `cancel_generation` addition
- `mellea/stdlib/chunking.py` — `flush()` implementation and flush override overloads
- Wave-3 commits in `mellea/stdlib/streaming.py` — `_orchestrate_streaming` orchestrator, `StreamChunkingResult` class skeleton, `stream_with_chunking()` entry point
- `test/stdlib/test_streaming.py` — the 16 orchestrator tests from Wave 3