### PR TITLE
feat: Adds Granite 4.1 model ids

### DIFF
--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -95,6 +95,26 @@ IBM_GRANITE_4_MICRO_3B = ModelIdentifier(
     watsonx_name="ibm/granite-4-h-small",  # Keeping hybrid version here for backwards compatibility.
 )
 
+# Granite 4.1
+
+IBM_GRANITE_4_1_30B = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-4.1-30b",
+    ollama_name="granite4.1:30b",
+    mlx_name="ibm-granite/granite-4.1-30b-fp8",
+)
+
+IBM_GRANITE_4_1_8B = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-4.1-8b",
+    ollama_name="granite4.1:8b",
+    mlx_name="ibm-granite/granite-4.1-8b-fp8",
+)
+
+IBM_GRANITE_4_1_3B = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-4.1-3b",
+    ollama_name="granite4.1:3b",
+    mlx_name="ibm-granite/granite-4.1-3b-fp8",
+)
+
 # Granite 3.3 Vision Model (2B)
 IBM_GRANITE_3_3_VISION_2B = ModelIdentifier(
     hf_model_name="ibm-granite/granite-vision-3.3-2b",

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -89,10 +89,6 @@ IBM_GRANITE_3_3_8B = ModelIdentifier(
     watsonx_name="ibm/granite-3-3-8b-instruct",
 )
 
-# Deprecated: Use IBM_GRANITE_4_HYBRID_MICRO or IBM_GRANITE_4_HYBRID_SMALL instead
-# Kept for backward compatibility with per-backend model selection:
-# - Ollama/HF: Uses MICRO (fits in CI memory constraints)
-# - Watsonx: Uses SMALL (required for watsonx support)
 IBM_GRANITE_4_MICRO_3B = ModelIdentifier(
     hf_model_name="ibm-granite/granite-4.0-micro",
     ollama_name="granite4:micro",


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Adds Granite 4.1 model IDs

This PR adds model IDs for the Granite 4.1 models and makes the 4.1 3b model the default model when starting a session without a model id.

## Type of PR

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used