### PR TITLE
feat: handle message docs correctly

### DIFF
--- a/docs/examples/sessions/creating_a_new_type_of_session.py
+++ b/docs/examples/sessions/creating_a_new_type_of_session.py
@@ -1,5 +1,6 @@
 # pytest: ollama, qualitative, e2e
 
+from collections.abc import Iterable
 from typing import Literal
 
 from PIL import Image as PILImage
@@ -14,7 +15,7 @@ from mellea.core import (
     ImageBlock,
     Requirement,
 )
-from mellea.stdlib.components import Message
+from mellea.stdlib.components import Document, Message
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import reqify
 from mellea.stdlib.requirements.safety.guardian import GuardianCheck, GuardianRisk
@@ -45,6 +46,7 @@ class ChatCheckingSession(MelleaSession):
         | Literal["tool"] = "user",
         *,
         images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        documents: Iterable[str | Document] | None = None,
         user_variables: dict[str, str] | None = None,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -66,6 +68,8 @@ class ChatCheckingSession(MelleaSession):
         chat_msg = super().chat(
             content,
             role,
+            images=images,
+            documents=documents,
             user_variables=user_variables,
             format=format,
             model_options=model_options,

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -320,7 +320,9 @@ class LiteLLMBackend(FormatterBackend):
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
-        conversation.extend([message_to_openai_message(m) for m in messages])
+        conversation.extend(
+            [message_to_openai_message(m, self.formatter) for m in messages]
+        )
 
         extra_params: dict[str, Any] = {}
         if _format is not None:

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -368,9 +368,11 @@ class OllamaModelBackend(FormatterBackend):
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
 
+        # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
+        # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
         conversation.extend(
             [
-                {"role": m.role, "content": m.content, "images": m.images}
+                {"role": m.role, "content": self.formatter.print(m), "images": m.images}
                 for m in messages
             ]
         )

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -811,7 +811,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
-        conversation.extend([message_to_openai_message(m) for m in messages])
+        conversation.extend(
+            [message_to_openai_message(m, self.formatter) for m in messages]
+        )
 
         extra_params: dict[str, Any] = {}
         if _format is not None:

--- a/mellea/backends/utils.py
+++ b/mellea/backends/utils.py
@@ -68,8 +68,10 @@ def to_chat(
     # add action
     ctx_as_message_list.extend(formatter.to_chat_messages([action]))
 
+    # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
+    # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
     ctx_as_conversation: list = [
-        {"role": m.role, "content": m.content} for m in ctx_as_message_list
+        {"role": m.role, "content": formatter.print(m)} for m in ctx_as_message_list
     ]
 
     # Check that we ddin't accidentally end up with CBlocks.

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -379,7 +379,12 @@ class WatsonxAIBackend(FormatterBackend):
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
-        conversation.extend([{"role": m.role, "content": m.content} for m in messages])
+
+        # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
+        # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
+        conversation.extend(
+            [{"role": m.role, "content": self.formatter.print(m)} for m in messages]
+        )
 
         if _format is not None:
             model_opts["response_format"] = {

--- a/mellea/formatters/template_formatter.py
+++ b/mellea/formatters/template_formatter.py
@@ -16,6 +16,7 @@ from dataclasses import fields
 from typing import Any
 
 import jinja2
+import jinja2.meta
 
 from ..backends.cache import SimpleLRUCache
 from ..backends.model_ids import ModelIdentifier
@@ -108,8 +109,8 @@ class TemplateFormatter(ChatFormatter):
                             f"template formatter encountered a TemplateRepresentation with no obj when stringifying {c.__class__}; setting obj to {c}"
                         )
                         representation.obj = c
-                    return self._load_template(representation).render(
-                        stringified_template_args
+                    return self._render_representation(
+                        representation, stringified_template_args
                     )
 
             case c if isinstance(c, Mapping):
@@ -131,6 +132,25 @@ class TemplateFormatter(ChatFormatter):
                     f"formatter encountered an unexpected type in _stringify; using str() on {c.__class__}"
                 )
                 return str(c)
+
+    def _render_representation(
+        self,
+        representation: TemplateRepresentation,
+        stringified_template_args: dict[str, Any],
+    ) -> str:
+        """Load a template for the representation, check for unused keys, and render."""
+        template = self._load_template(representation)
+
+        expected_vars = self._get_expected_variables(template, representation)
+        if expected_vars:
+            unused_keys = set(stringified_template_args.keys()) - expected_vars
+            if unused_keys:
+                MelleaLogger.get_logger().debug(
+                    f"TemplateRepresentation for {representation.obj.__class__.__name__} "
+                    f"provides keys not referenced by template '{template.name}': {sorted(unused_keys)}"
+                )
+
+        return template.render(stringified_template_args)
 
     def print(self, c: Component | CBlock) -> str:
         """Render a component or code block to a string using a Jinja2 template.
@@ -239,6 +259,24 @@ class TemplateFormatter(ChatFormatter):
         if self._use_template_cache and self._template_cache:
             self._template_cache.put(repr.obj.__class__.__name__, tmpl)
         return tmpl
+
+    def _get_expected_variables(
+        self, template: jinja2.Template, representation: TemplateRepresentation
+    ) -> set[str]:
+        """Return the set of externally-expected variable names for a template."""
+        try:
+            if representation.template:
+                source = representation.template
+            else:
+                loader = template.environment.loader
+                assert loader is not None
+                assert template.name is not None
+                source, _, _ = loader.get_source(template.environment, template.name)
+            ast = template.environment.parse(source)
+            return jinja2.meta.find_undeclared_variables(ast)
+        except Exception:
+            # Return an empty set if something goes wrong here.
+            return set()
 
     def _get_template(self, root_path: str, template_name: str) -> str:
         """Attempts to walk the provided directory structure to find the best matching template.

--- a/mellea/formatters/template_formatter.py
+++ b/mellea/formatters/template_formatter.py
@@ -145,7 +145,7 @@ class TemplateFormatter(ChatFormatter):
         if expected_vars:
             unused_keys = set(stringified_template_args.keys()) - expected_vars
             if unused_keys:
-                MelleaLogger.get_logger().debug(
+                MelleaLogger.get_logger().warn(
                     f"TemplateRepresentation for {representation.obj.__class__.__name__} "
                     f"provides keys not referenced by template '{template.name}': {sorted(unused_keys)}"
                 )

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from ..backends.tools import validate_tool_arguments
-from ..core import MelleaLogger, ModelToolCall
+from ..core import Formatter, MelleaLogger, ModelToolCall
 from ..core.base import AbstractMelleaTool, ModelOutputThunk
 from ..stdlib.components import Document, Message
 
@@ -154,17 +154,23 @@ def chat_completion_delta_merge(
     return merged
 
 
-def message_to_openai_message(msg: Message) -> dict:
+def message_to_openai_message(msg: Message, formatter: Formatter | None = None) -> dict:
     """Serialise a Mellea ``Message`` to the format required by OpenAI-compatible API providers.
 
     Args:
         msg: The ``Message`` object to serialise.
+        formatter: Optional formatter used to render the message content (including
+            documents) through the template system. When ``None``, uses the raw
+            ``msg.content`` string without document rendering.
 
     Returns:
         A dict with ``"role"`` and ``"content"`` fields. When the message carries
         images, ``"content"`` is a list of text and image-URL dicts; otherwise it
         is a plain string.
     """
+    # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
+    # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
+    content = formatter.print(msg) if formatter else msg.content
     if msg.images is not None:
         img_list = [
             {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img}"}}
@@ -173,10 +179,10 @@ def message_to_openai_message(msg: Message) -> dict:
 
         return {
             "role": msg.role,
-            "content": [{"type": "text", "text": msg.content}, *img_list],
+            "content": [{"type": "text", "text": content}, *img_list],
         }
     else:
-        return {"role": msg.role, "content": msg.content}
+        return {"role": msg.role, "content": content}
         # Target format:
         # {
         #     "role": "user",

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -8,7 +8,7 @@ the ``as_chat_history`` utility for converting a ``Context`` into a flat list of
 ``Message`` objects.
 """
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Iterable
 from typing import Any, Literal
 
 from ...core import (
@@ -20,14 +20,11 @@ from ...core import (
     ModelToolCall,
     TemplateRepresentation,
 )
-from .docs.document import Document
+from .docs.document import Document, _coerce_documents
 
 
 class Message(Component["Message"]):
     """A single Message in a Chat history.
-
-    TODO: we may want to deprecate this Component entirely.
-    The fact that some Component gets rendered as a chat message is `Formatter` miscellania.
 
     Args:
         role (str): The role that this message came from (e.g., ``"user"``,
@@ -51,14 +48,14 @@ class Message(Component["Message"]):
         content: str,
         *,
         images: None | list[ImageBlock] = None,
-        documents: None | list[Document] = None,
+        documents: None | Iterable[str | Document] = None,
     ):
         """Initialize a Message with a role, text content, and optional images and documents."""
         self.role = role
         self.content = content  # TODO this should be private.
         self._content_cblock = CBlock(self.content)
         self._images = images
-        self._docs = documents
+        self._docs = _coerce_documents(documents)
 
     @property
     def images(self) -> None | list[str]:

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -8,7 +8,7 @@ the ``as_chat_history`` utility for converting a ``Context`` into a flat list of
 ``Message`` objects.
 """
 
-from collections.abc import Mapping, Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any, Literal
 
 from ...core import (

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -20,7 +20,7 @@ from ...core import (
     ModelToolCall,
     TemplateRepresentation,
 )
-from .docs.document import Document, _coerce_documents
+from .docs.document import Document, _coerce_to_documents
 
 
 class Message(Component["Message"]):
@@ -55,7 +55,7 @@ class Message(Component["Message"]):
         self.content = content  # TODO this should be private.
         self._content_cblock = CBlock(self.content)
         self._images = images
-        self._docs = _coerce_documents(documents)
+        self._docs = _coerce_to_documents(documents)
 
     @property
     def images(self) -> None | list[str]:
@@ -103,7 +103,15 @@ class Message(Component["Message"]):
 
         docs = []
         if self._docs is not None:
-            docs = [f"{doc.format_for_llm()[:10]}..." for doc in self._docs]
+            # Do a quick format of each document.
+            docs = [
+                # Equivalent to: "[Document <ID>] <TITLE>: <TEXT>...".
+                f"[Document{' ' + str(doc.doc_id) if doc.doc_id else ''}] {str(doc.title) + ': ' if doc.title else ''}{doc.text}"[
+                    :20
+                ]
+                + "..."
+                for doc in self._docs
+            ]
         return f'mellea.Message(role="{self.role}", content="{self.content}", images="{images}", documents="{docs}")'
 
     def _parse(self, computed: ModelOutputThunk) -> "Message":

--- a/mellea/stdlib/components/docs/document.py
+++ b/mellea/stdlib/components/docs/document.py
@@ -9,7 +9,7 @@ retrieval-augmented generation (RAG) workflows.
 import collections.abc
 import warnings
 
-from ....core import CBlock, Component, ModelOutputThunk
+from ....core import CBlock, Component, ModelOutputThunk, TemplateRepresentation
 
 
 class Document(Component[str]):
@@ -41,20 +41,23 @@ class Document(Component[str]):
         """
         return []
 
-    def format_for_llm(self) -> str:
-        """Formats the `Document` into a string.
+    def format_for_llm(self) -> TemplateRepresentation:
+        """Formats the `Document` as a ``TemplateRepresentation``.
 
-        Returns: a string
+        Returns: a TemplateRepresentation with text, title, and doc_id args.
         """
-        # Format: "[Document <doc_id>]\n<title>: <text>".
-        return f"[Document{' ' + str(self.doc_id) if self.doc_id else ''}]\n{str(self.title) + ': ' if self.title else ''}{self.text}"
+        return TemplateRepresentation(
+            obj=self,
+            args={"text": self.text, "title": self.title, "doc_id": self.doc_id},
+            template_order=["*", "Document"],
+        )
 
     def _parse(self, computed: ModelOutputThunk) -> str:
         """Parse the model output. Returns string value for now."""
         return computed.value if computed.value is not None else ""
 
 
-def _coerce_documents(
+def _coerce_to_documents(
     documents: collections.abc.Iterable[str | Document] | None,
     *,
     auto_doc_id: bool = False,
@@ -90,7 +93,7 @@ def _coerce_documents(
     return result
 
 
-def _coerce_document(document: str | Document) -> Document:
+def _coerce_to_document(document: str | Document) -> Document:
     """Convert a single string or Document into a Document."""
     if isinstance(document, str):
         return Document(text=document)

--- a/mellea/stdlib/components/docs/document.py
+++ b/mellea/stdlib/components/docs/document.py
@@ -46,14 +46,8 @@ class Document(Component[str]):
 
         Returns: a string
         """
-        doc = ""
-        if self.doc_id is not None:
-            doc += f"document ID '{self.doc_id}': "
-        if self.title is not None:
-            doc += f"'{self.title}': "
-        doc += f"{self.text}"
-
-        return doc
+        # Format: "[Document <doc_id>]\n<title>: <text>".
+        return f"[Document{' ' + str(self.doc_id) if self.doc_id else ''}]\n{str(self.title) + ': ' if self.title else ''}{self.text}"
 
     def _parse(self, computed: ModelOutputThunk) -> str:
         """Parse the model output. Returns string value for now."""

--- a/mellea/stdlib/components/docs/document.py
+++ b/mellea/stdlib/components/docs/document.py
@@ -6,10 +6,12 @@ typically attached to a ``Message`` via its ``documents`` parameter, enabling
 retrieval-augmented generation (RAG) workflows.
 """
 
+import collections.abc
+import warnings
+
 from ....core import CBlock, Component, ModelOutputThunk
 
 
-# TODO: Add support for passing in docs as model options.
 class Document(Component[str]):
     """A text passage with optional metadata for grounding model inputs.
 
@@ -56,3 +58,46 @@ class Document(Component[str]):
     def _parse(self, computed: ModelOutputThunk) -> str:
         """Parse the model output. Returns string value for now."""
         return computed.value if computed.value is not None else ""
+
+
+def _coerce_documents(
+    documents: collections.abc.Iterable[str | Document] | None,
+    *,
+    auto_doc_id: bool = False,
+) -> list[Document] | None:
+    """Convert an iterable of strings or Documents into a list of Documents.
+
+    Args:
+        documents: Strings, Document objects, a mix, or None.
+        auto_doc_id: When True, assign sequential string doc_id values
+            ("0", "1", ...) to Documents created from strings and warn about
+            existing Document objects that have no ``doc_id`` set.
+
+    Returns:
+        A list of Document objects, or None if the input was None.
+    """
+    if documents is None:
+        return None
+    result: list[Document] = []
+    for i, d in enumerate(documents):
+        if isinstance(d, str):
+            doc_id = str(i) if auto_doc_id else None
+            result.append(Document(text=d, doc_id=doc_id))
+        else:
+            if auto_doc_id and d.doc_id is None:
+                warnings.warn(
+                    f"Document at index {i} has no doc_id; results may omit "
+                    "document identification. Set doc_id on the Document or "
+                    "pass a plain string to auto-generate one.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+            result.append(d)
+    return result
+
+
+def _coerce_document(document: str | Document) -> Document:
+    """Convert a single string or Document into a Document."""
+    if isinstance(document, str):
+        return Document(text=document)
+    return document

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -1,8 +1,6 @@
 """Shared utilities for intrinsic convenience wrappers."""
 
-import collections.abc
 import json
-import warnings
 
 from ....backends import ModelOption
 from ....backends.adapters import (
@@ -16,42 +14,6 @@ from ....stdlib import functional as mfuncs
 from ...components import Document
 from ...context import ChatContext
 from .intrinsic import Intrinsic
-
-
-def _coerce_documents(
-    documents: collections.abc.Iterable[str | Document], *, auto_doc_id: bool = False
-) -> list[Document]:
-    """Convert an iterable of strings or Documents into a list of Documents.
-
-    Args:
-        documents: Strings, Document objects, or a mix.
-        auto_doc_id: When True, assign sequential string doc_id values
-            ("0", "1", ...) to Documents created from strings and warn about
-            existing Document objects that have no ``doc_id`` set.
-    """
-    result: list[Document] = []
-    for i, d in enumerate(documents):
-        if isinstance(d, str):
-            doc_id = str(i) if auto_doc_id else None
-            result.append(Document(text=d, doc_id=doc_id))
-        else:
-            if auto_doc_id and d.doc_id is None:
-                warnings.warn(
-                    f"Document at index {i} has no doc_id; results may omit "
-                    "document identification. Set doc_id on the Document or "
-                    "pass a plain string to auto-generate one.",
-                    UserWarning,
-                    stacklevel=3,
-                )
-            result.append(d)
-    return result
-
-
-def _coerce_document(document: str | Document) -> Document:
-    """Convert a single string or Document into a Document."""
-    if isinstance(document, str):
-        return Document(text=document)
-    return document
 
 
 def _resolve_question(

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -5,7 +5,8 @@ import collections.abc
 from ....backends.adapters import AdapterMixin
 from ...components import Document, Message
 from ...context import ChatContext
-from ._util import _coerce_documents, _resolve_response, call_intrinsic
+from ..docs.document import _coerce_documents
+from ._util import _resolve_response, call_intrinsic
 
 
 def check_certainty(context: ChatContext, backend: AdapterMixin) -> float:

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -5,7 +5,7 @@ import collections.abc
 from ....backends.adapters import AdapterMixin
 from ...components import Document, Message
 from ...context import ChatContext
-from ..docs.document import _coerce_documents
+from ..docs.document import _coerce_to_documents
 from ._util import _resolve_response, call_intrinsic
 
 
@@ -101,7 +101,7 @@ def find_context_attributions(
             Message(
                 "assistant",
                 response,
-                documents=_coerce_documents(documents, auto_doc_id=False),
+                documents=_coerce_to_documents(documents, auto_doc_id=False),
             )
         ),
         backend,

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -7,11 +7,7 @@ from ...components import Document
 from ...context import ChatContext
 from ..chat import Message
 from ..docs.document import _coerce_document, _coerce_documents
-from ._util import (
-    _resolve_question,
-    _resolve_response,
-    call_intrinsic,
-)
+from ._util import _resolve_question, _resolve_response, call_intrinsic
 
 
 def check_answerability(

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -6,7 +6,7 @@ from ....backends.adapters import AdapterMixin
 from ...components import Document
 from ...context import ChatContext
 from ..chat import Message
-from ..docs.document import _coerce_document, _coerce_documents
+from ..docs.document import _coerce_to_document, _coerce_to_documents
 from ._util import _resolve_question, _resolve_response, call_intrinsic
 
 
@@ -38,7 +38,9 @@ def check_answerability(
     question, context = _resolve_question(question, context, backend)
     result_json = call_intrinsic(
         "answerability",
-        context.add(Message("user", question, documents=_coerce_documents(documents))),
+        context.add(
+            Message("user", question, documents=_coerce_to_documents(documents))
+        ),
         backend,
     )
     return result_json["answerability"]
@@ -98,7 +100,9 @@ def clarify_query(
     question, context = _resolve_question(question, context, backend)
     result_json = call_intrinsic(
         "query_clarification",
-        context.add(Message("user", question, documents=_coerce_documents(documents))),
+        context.add(
+            Message("user", question, documents=_coerce_to_documents(documents))
+        ),
         backend,
     )
     return result_json["clarification"]
@@ -142,7 +146,7 @@ def find_citations(
             Message(
                 "assistant",
                 response,
-                documents=_coerce_documents(documents, auto_doc_id=False),
+                documents=_coerce_to_documents(documents, auto_doc_id=False),
             )
         ),
         backend,
@@ -178,7 +182,7 @@ def check_context_relevance(
         - "partially relevant"
     """
     question, context = _resolve_question(question, context, backend)
-    document = _coerce_document(document)
+    document = _coerce_to_document(document)
     result_json = call_intrinsic(
         "context_relevance",
         context.add(Message("user", question)),
@@ -221,7 +225,7 @@ def flag_hallucinated_content(
     result_json = call_intrinsic(
         "hallucination_detection",
         context.add(
-            Message("assistant", response, documents=_coerce_documents(documents))
+            Message("assistant", response, documents=_coerce_to_documents(documents))
         ),
         backend,
     )

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -6,9 +6,8 @@ from ....backends.adapters import AdapterMixin
 from ...components import Document
 from ...context import ChatContext
 from ..chat import Message
+from ..docs.document import _coerce_document, _coerce_documents
 from ._util import (
-    _coerce_document,
-    _coerce_documents,
     _resolve_question,
     _resolve_response,
     call_intrinsic,

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Iterable
 from typing import Any, Literal, overload
 
 from PIL import Image as PILImage
@@ -33,7 +33,14 @@ from ..plugins.hooks.tool import ToolPostInvokePayload, ToolPreInvokePayload
 from ..plugins.manager import has_plugins, invoke_hook
 from ..plugins.types import HookType
 from ..telemetry import set_span_attribute, trace_application
-from .components import Instruction, Message, MObjectProtocol, ToolMessage, mify
+from .components import (
+    Document,
+    Instruction,
+    Message,
+    MObjectProtocol,
+    ToolMessage,
+    mify,
+)
 from .context import SimpleContext
 from .sampling import RejectionSamplingStrategy
 
@@ -245,6 +252,7 @@ def chat(
     *,
     role: Message.Role = "user",
     images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    documents: Iterable[str | Document] | None = None,
     user_variables: dict[str, str] | None = None,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -258,6 +266,8 @@ def chat(
         backend: The backend used to generate the response.
         role: The role for the outgoing message (default ``"user"``).
         images: Optional list of images to include in the message.
+        documents: Optional documents to attach to the message. Each element
+            may be a string or a ``Document`` object.
         user_variables: Optional Jinja variable substitutions applied to ``content``.
         format: Optional Pydantic model for constrained decoding of the response.
         model_options: Additional model options to merge with backend defaults.
@@ -273,7 +283,9 @@ def chat(
     else:
         content_resolved = content
     images = _parse_and_clean_image_args(images)
-    user_message = Message(role=role, content=content_resolved, images=images)
+    user_message = Message(
+        role=role, content=content_resolved, images=images, documents=documents
+    )
 
     result, new_ctx = act(
         user_message,
@@ -915,6 +927,7 @@ async def achat(
     *,
     role: Message.Role = "user",
     images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    documents: Iterable[str | Document] | None = None,
     user_variables: dict[str, str] | None = None,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -928,6 +941,8 @@ async def achat(
         backend: The backend used to generate the response.
         role: The role for the outgoing message (default ``"user"``).
         images: Optional list of images to include in the message.
+        documents: Optional documents to attach to the message. Each element
+            may be a string or a ``Document`` object.
         user_variables: Optional Jinja variable substitutions applied to ``content``.
         format: Optional Pydantic model for constrained decoding of the response.
         model_options: Additional model options to merge with backend defaults.
@@ -943,7 +958,9 @@ async def achat(
     else:
         content_resolved = content
     images = _parse_and_clean_image_args(images)
-    user_message = Message(role=role, content=content_resolved, images=images)
+    user_message = Message(
+        role=role, content=content_resolved, images=images, documents=documents
+    )
 
     result, new_ctx = await aact(
         user_message,

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -10,6 +10,7 @@ session.
 
 from __future__ import annotations
 
+import collections.abc
 import contextlib
 import contextvars
 import inspect
@@ -43,7 +44,7 @@ from ..plugins.types import HookType
 from ..stdlib import functional as mfuncs
 from ..telemetry import set_span_attribute, trace_application
 from ..telemetry.context import with_context
-from .components import Message
+from .components import Document, Message
 from .context import ChatContext, SimpleContext
 from .sampling import RejectionSamplingStrategy
 from .start_backend import (
@@ -546,6 +547,7 @@ class MelleaSession:
         role: Message.Role = "user",
         *,
         images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        documents: collections.abc.Iterable[str | Document] | None = None,
         user_variables: dict[str, str] | None = None,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -557,6 +559,8 @@ class MelleaSession:
             content: The message text to send.
             role: The role for the outgoing message (default ``"user"``).
             images: Optional list of images to include in the message.
+            documents: Optional documents to attach to the message. Each element
+                may be a string or a ``Document`` object.
             user_variables: Optional Jinja variable substitutions applied to ``content``.
             format: Optional Pydantic model for constrained decoding of the response.
             model_options: Additional model options to merge with backend defaults.
@@ -571,6 +575,7 @@ class MelleaSession:
             backend=self.backend,
             role=role,
             images=images,
+            documents=documents,
             user_variables=user_variables,
             format=format,
             model_options=model_options,
@@ -939,6 +944,7 @@ class MelleaSession:
         role: Message.Role = "user",
         *,
         images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        documents: collections.abc.Iterable[str | Document] | None = None,
         user_variables: dict[str, str] | None = None,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -950,6 +956,8 @@ class MelleaSession:
             content: The message text to send.
             role: The role for the outgoing message (default ``"user"``).
             images: Optional list of images to include in the message.
+            documents: Optional documents to attach to the message. Each element
+                may be a string or a ``Document`` object.
             user_variables: Optional Jinja variable substitutions applied to ``content``.
             format: Optional Pydantic model for constrained decoding of the response.
             model_options: Additional model options to merge with backend defaults.
@@ -964,6 +972,7 @@ class MelleaSession:
             backend=self.backend,
             role=role,
             images=images,
+            documents=documents,
             user_variables=user_variables,
             format=format,
             model_options=model_options,

--- a/mellea/templates/prompts/default/Document.jinja2
+++ b/mellea/templates/prompts/default/Document.jinja2
@@ -1,0 +1,2 @@
+[Document{{ ' ' + doc_id if doc_id else '' }}]
+{{ title + ': ' if title else '' }}{{ text }}

--- a/mellea/templates/prompts/default/Message.jinja2
+++ b/mellea/templates/prompts/default/Message.jinja2
@@ -1,0 +1,7 @@
+{{- content -}}
+{%- if documents %}
+
+{% for doc in documents %}
+{{ doc }}
+{%- endfor %}
+{%- endif %}

--- a/test/backends/test_document_rendering_unit.py
+++ b/test/backends/test_document_rendering_unit.py
@@ -1,0 +1,310 @@
+"""Unit tests verifying that documents on Messages render correctly through each backend.
+
+Each test mocks the backend's API call, sends a Message with documents through
+generate_from_context, and asserts the rendered conversation contains the expected
+document format.
+"""
+
+import warnings
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import litellm
+import ollama
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
+
+from mellea.backends.litellm import LiteLLMBackend
+from mellea.backends.ollama import OllamaModelBackend
+from mellea.backends.openai import OpenAIBackend
+from mellea.stdlib.components import Message
+from mellea.stdlib.components.docs.document import Document
+from mellea.stdlib.context import ChatContext
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+DOC = Document("The answer is 42.", title="Guide", doc_id="1")
+USER_MSG = Message("user", "What is the answer?", documents=[DOC])
+
+
+def _make_context() -> ChatContext:
+    return ChatContext().add(USER_MSG)
+
+
+def _openai_chat_completion() -> ChatCompletion:
+    return ChatCompletion(
+        id="test",
+        created=0,
+        model="test-model",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content="42"),
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=1, total_tokens=11),
+    )
+
+
+def _ollama_chat_response() -> ollama.ChatResponse:
+    return ollama.ChatResponse(
+        model="granite3.3:8b",
+        created_at="2024-01-01T00:00:00Z",
+        message=ollama.Message(role="assistant", content="42"),
+        done=True,
+        done_reason="stop",
+    )
+
+
+def _litellm_model_response() -> litellm.ModelResponse:
+    return litellm.ModelResponse(
+        id="test",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "42"},
+            }
+        ],
+        usage={"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11},
+        model="openai/gpt-4o",
+    )
+
+
+def _assert_document_in_messages(messages: list[dict]) -> None:
+    """Assert that at least one message contains the rendered document."""
+    all_content = " ".join(m.get("content", "") for m in messages)
+    assert "[Document 1]" in all_content, f"Document header not found in: {all_content}"
+    assert "Guide:" in all_content, f"Document title not found in: {all_content}"
+    assert "The answer is 42." in all_content, (
+        f"Document text not found in: {all_content}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_renders_documents_in_prompt():
+    """OpenAI backend includes rendered documents in the messages sent to the API."""
+    backend = OpenAIBackend(
+        model_id="gpt-4o", api_key="fake-key", base_url="http://localhost:9999/v1"
+    )
+
+    mock_create = AsyncMock(return_value=_openai_chat_completion())
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with patch.object(
+        OpenAIBackend,
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_client,
+    ):
+        ctx = _make_context()
+        mot, _ = await backend._generate_from_context(
+            Message("user", "Follow up question"), ctx
+        )
+        await mot.avalue()
+
+    mock_create.assert_called_once()
+    messages = mock_create.call_args.kwargs["messages"]
+    _assert_document_in_messages(messages)
+
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+def _make_ollama_backend() -> OllamaModelBackend:
+    """Return an OllamaModelBackend with all network calls patched."""
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client", return_value=MagicMock()),
+        patch("mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()),
+    ):
+        return OllamaModelBackend(model_id="granite3.3:8b")
+
+
+@pytest.mark.asyncio
+async def test_ollama_renders_documents_in_prompt():
+    """Ollama backend includes rendered documents in the messages sent to the API."""
+    backend = _make_ollama_backend()
+
+    mock_chat = AsyncMock(return_value=_ollama_chat_response())
+
+    with patch.object(
+        OllamaModelBackend, "_async_client", new_callable=PropertyMock
+    ) as mock_client_prop:
+        mock_async_client = MagicMock()
+        mock_async_client.chat = mock_chat
+        mock_client_prop.return_value = mock_async_client
+
+        ctx = _make_context()
+        mot, _ = await backend._generate_from_context(
+            Message("user", "Follow up question"), ctx
+        )
+        await mot.avalue()
+
+    mock_chat.assert_called_once()
+    messages = mock_chat.call_args.kwargs["messages"]
+    _assert_document_in_messages(messages)
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_litellm_renders_documents_in_prompt():
+    """LiteLLM backend includes rendered documents in the messages sent to the API."""
+    backend = LiteLLMBackend(
+        model_id="openai/gpt-4o", base_url="http://localhost:9999/v1"
+    )
+
+    with patch(
+        "mellea.backends.litellm.litellm.acompletion", new_callable=AsyncMock
+    ) as mock_acompletion:
+        mock_acompletion.return_value = _litellm_model_response()
+
+        ctx = _make_context()
+        mot, _ = await backend._generate_from_context(
+            Message("user", "Follow up question"), ctx
+        )
+        await mot.avalue()
+
+    mock_acompletion.assert_called_once()
+    messages = mock_acompletion.call_args.kwargs["messages"]
+    _assert_document_in_messages(messages)
+
+
+# ---------------------------------------------------------------------------
+# Watsonx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watsonx_renders_documents_in_prompt():
+    """Watsonx backend includes rendered documents in the messages sent to the API."""
+    from mellea.backends.watsonx import WatsonxAIBackend
+
+    mock_achat_response = {
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "42"},
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11},
+    }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with (
+            patch("mellea.backends.watsonx.Credentials"),
+            patch("mellea.backends.watsonx.ModelInference") as mock_model_cls,
+        ):
+            mock_model_instance = MagicMock()
+            mock_model_cls.return_value = mock_model_instance
+            # achat must return a non-AsyncIterator (dict is fine)
+            mock_model_instance.achat = AsyncMock(return_value=mock_achat_response)
+
+            with patch.object(
+                WatsonxAIBackend,
+                "_model",
+                new_callable=PropertyMock,
+                return_value=mock_model_instance,
+            ):
+                backend = WatsonxAIBackend(
+                    model_id="ibm/granite-3-8b-instruct",
+                    api_key="fake-key",
+                    base_url="https://fake.cloud.ibm.com",
+                    project_id="fake-project",
+                )
+
+                ctx = _make_context()
+                mot, _ = await backend._generate_from_context(
+                    Message("user", "Follow up question"), ctx
+                )
+                await mot.avalue()
+
+    mock_model_instance.achat.assert_called_once()
+    messages = mock_model_instance.achat.call_args.kwargs["messages"]
+    _assert_document_in_messages(messages)
+
+
+# ---------------------------------------------------------------------------
+# HuggingFace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_huggingface_renders_documents_in_prompt():
+    """HuggingFace backend includes rendered documents in the chat template input."""
+    import torch
+    from transformers.generation.utils import GenerateDecoderOnlyOutput
+
+    mock_tokenizer = MagicMock()
+    mock_model = MagicMock()
+    mock_device = torch.device("cpu")
+
+    # apply_chat_template returns input_ids tensor
+    fake_input_ids = torch.tensor([[1, 2, 3, 4, 5]])
+    mock_tokenizer.apply_chat_template = MagicMock(return_value=fake_input_ids)
+
+    # model.generate returns a real GenerateDecoderOnlyOutput (not a MagicMock)
+    # to avoid AsyncIterator detection in send_to_queue
+    real_output = GenerateDecoderOnlyOutput(
+        sequences=torch.tensor([[1, 2, 3, 4, 5, 6, 7]]),
+        scores=None,
+        logits=None,
+        attentions=None,
+        hidden_states=None,
+        past_key_values=None,
+    )
+    mock_model.generate = MagicMock(return_value=real_output)
+
+    # decode returns the "answer"
+    mock_tokenizer.decode = MagicMock(return_value="42")
+
+    with (
+        patch("mellea.backends.huggingface.llguidance") as mock_llg,
+        patch("mellea.backends.huggingface.set_seed"),
+    ):
+        mock_llg.hf.from_tokenizer.return_value = MagicMock(vocab_size=32000)
+        mock_tokenizer._tokenizer = MagicMock()
+        mock_tokenizer._tokenizer.get_vocab_size.return_value = 32000
+
+        from mellea.backends.huggingface import LocalHFBackend
+
+        backend = LocalHFBackend(
+            model_id="ibm-granite/granite-3.3-8b-instruct",
+            custom_config=(mock_tokenizer, mock_model, mock_device),
+        )
+
+        ctx = _make_context()
+        mot, _ = await backend._generate_from_context(
+            Message("user", "Follow up question"), ctx
+        )
+        await mot.avalue()
+
+    mock_tokenizer.apply_chat_template.assert_called_once()
+    chat_list = mock_tokenizer.apply_chat_template.call_args[0][0]
+    # chat_list is a list of {"role": ..., "content": ...} dicts
+    all_content = " ".join(entry.get("content", "") for entry in chat_list)
+    assert "[Document 1]" in all_content, f"Document header not found in: {all_content}"
+    assert "Guide:" in all_content, f"Document title not found in: {all_content}"
+    assert "The answer is 42." in all_content, (
+        f"Document text not found in: {all_content}"
+    )

--- a/test/formatters/test_template_formatter.py
+++ b/test/formatters/test_template_formatter.py
@@ -310,5 +310,52 @@ def test_to_chat_messages_not_parsed_repr(tf: TemplateFormatter):
     assert messages[0].content == "different content"
 
 
+def test_unused_template_args_inline_warns(tf: TemplateFormatter, caplog):
+    """Debug message emitted when inline template does not use all provided args."""
+    import logging
+
+    repr = TemplateRepresentation(
+        obj=Instruction("desc"),
+        args={"description": "hello", "extra_key": "unused"},
+        template="{{description}}",
+    )
+    with caplog.at_level(logging.DEBUG, logger="mellea"):
+        tf._render_representation(repr, {"description": "hello", "extra_key": "unused"})
+
+    assert any("not referenced by template" in r.message for r in caplog.records)
+    assert any("extra_key" in r.message for r in caplog.records)
+
+
+def test_no_unused_keys_warning_when_all_used(
+    tf: TemplateFormatter, instr: Instruction, caplog
+):
+    """No debug message when all args keys are consumed by the file-loaded template."""
+    import logging
+
+    repr = instr.format_for_llm()
+    args = {k: tf._stringify(v) for k, v in repr.args.items()}
+    with caplog.at_level(logging.DEBUG, logger="mellea"):
+        tf._render_representation(repr, args)
+
+    assert not any("not referenced by template" in r.message for r in caplog.records)
+
+
+def test_unused_template_args_file_loaded_warns(tf: TemplateFormatter, caplog):
+    """Debug message emitted when a file-loaded template ignores some provided args."""
+    import logging
+
+    repr = TemplateRepresentation(
+        obj=Instruction("content"),
+        args={"content": "hello", "unused_key": "unused_value"},
+        template_order=["MObject"],
+    )
+    with caplog.at_level(logging.DEBUG, logger="mellea"):
+        tf._render_representation(
+            repr, {"content": "hello", "unused_key": "unused_value"}
+        )
+
+    assert any("unused_key" in r.message for r in caplog.records)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/stdlib/components/docs/test_document.py
+++ b/test/stdlib/components/docs/test_document.py
@@ -1,4 +1,8 @@
-from mellea.stdlib.components.docs.document import Document
+"""Tests for Document and _coerce_documents/_coerce_document."""
+
+import warnings
+
+from mellea.stdlib.components.docs.document import Document, _coerce_document, _coerce_documents
 
 
 def test_document_parts_returns_empty_list():
@@ -17,3 +21,69 @@ def test_document_format_for_llm():
 def test_document_format_for_llm_no_title():
     doc = Document("just text")
     assert doc.format_for_llm() == "just text"
+
+
+class TestCoerceDocuments:
+    def test_all_strings(self):
+        result = _coerce_documents(["foo", "bar"])
+        assert len(result) == 2
+        assert result[0].text == "foo"
+        assert result[0].doc_id is None
+        assert result[1].text == "bar"
+        assert result[1].doc_id is None
+
+    def test_all_documents(self):
+        d1 = Document("a", doc_id="x")
+        d2 = Document("b", doc_id="y")
+        result = _coerce_documents([d1, d2])
+        assert result[0] is d1
+        assert result[1] is d2
+
+    def test_mixed(self):
+        doc = Document("existing", doc_id="x")
+        result = _coerce_documents(["new", doc])
+        assert result[0].text == "new"
+        assert result[0].doc_id is None
+        assert result[1] is doc
+
+    def test_auto_doc_id_strings(self):
+        result = _coerce_documents(["a", "b", "c"], auto_doc_id=True)
+        assert [d.doc_id for d in result] == ["0", "1", "2"]
+        assert [d.text for d in result] == ["a", "b", "c"]
+
+    def test_auto_doc_id_preserves_existing(self):
+        doc = Document("a", doc_id="mine")
+        result = _coerce_documents([doc, "b"], auto_doc_id=True)
+        assert result[0].doc_id == "mine"
+        assert result[1].doc_id == "1"
+
+    def test_auto_doc_id_warns_on_missing_doc_id(self):
+        doc = Document("no id")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = _coerce_documents([doc], auto_doc_id=True)
+            assert len(w) == 1
+            assert "no doc_id" in str(w[0].message)
+        assert result[0] is doc
+
+    def test_auto_doc_id_no_warn_when_doc_id_present(self):
+        doc = Document("has id", doc_id="0")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _coerce_documents([doc], auto_doc_id=True)
+            assert len(w) == 0
+
+    def test_empty(self):
+        assert _coerce_documents([]) == []
+
+
+class TestCoerceDocument:
+    def test_string(self):
+        result = _coerce_document("hello")
+        assert isinstance(result, Document)
+        assert result.text == "hello"
+        assert result.doc_id is None
+
+    def test_passthrough(self):
+        doc = Document("existing", doc_id="1")
+        assert _coerce_document(doc) is doc

--- a/test/stdlib/components/docs/test_document.py
+++ b/test/stdlib/components/docs/test_document.py
@@ -2,7 +2,11 @@
 
 import warnings
 
-from mellea.stdlib.components.docs.document import Document, _coerce_document, _coerce_documents
+from mellea.stdlib.components.docs.document import (
+    Document,
+    _coerce_document,
+    _coerce_documents,
+)
 
 
 def test_document_parts_returns_empty_list():
@@ -20,7 +24,7 @@ def test_document_format_for_llm():
 
 def test_document_format_for_llm_no_title():
     doc = Document("just text")
-    assert doc.format_for_llm() == "just text"
+    assert doc.format_for_llm() == "[Document]\njust text"
 
 
 class TestCoerceDocuments:

--- a/test/stdlib/components/docs/test_document.py
+++ b/test/stdlib/components/docs/test_document.py
@@ -2,10 +2,12 @@
 
 import warnings
 
+from mellea.core import TemplateRepresentation
+from mellea.formatters.template_formatter import TemplateFormatter
 from mellea.stdlib.components.docs.document import (
     Document,
-    _coerce_document,
-    _coerce_documents,
+    _coerce_to_document,
+    _coerce_to_documents,
 )
 
 
@@ -17,19 +19,39 @@ def test_document_parts_returns_empty_list():
 def test_document_format_for_llm():
     doc = Document("hello world", title="Greeting", doc_id="abc")
     result = doc.format_for_llm()
-    assert "abc" in result
-    assert "Greeting" in result
-    assert "hello world" in result
+    assert isinstance(result, TemplateRepresentation)
+    assert result.args["text"] == "hello world"
+    assert result.args["title"] == "Greeting"
+    assert result.args["doc_id"] == "abc"
 
 
 def test_document_format_for_llm_no_title():
     doc = Document("just text")
-    assert doc.format_for_llm() == "[Document]\njust text"
+    result = doc.format_for_llm()
+    assert isinstance(result, TemplateRepresentation)
+    assert result.args["text"] == "just text"
+    assert result.args["title"] is None
+    assert result.args["doc_id"] is None
+
+
+def test_document_renders_via_template():
+    formatter = TemplateFormatter(model_id="test-model")
+    doc = Document("hello world", title="Greeting", doc_id="abc")
+    rendered = formatter.print(doc)
+    assert "[Document abc]" in rendered
+    assert "Greeting: hello world" in rendered
+
+
+def test_document_renders_without_title_or_id():
+    formatter = TemplateFormatter(model_id="test-model")
+    doc = Document("just text")
+    rendered = formatter.print(doc)
+    assert rendered.strip() == "[Document]\njust text"
 
 
 class TestCoerceDocuments:
     def test_all_strings(self):
-        result = _coerce_documents(["foo", "bar"])
+        result = _coerce_to_documents(["foo", "bar"])
         assert len(result) == 2
         assert result[0].text == "foo"
         assert result[0].doc_id is None
@@ -39,25 +61,25 @@ class TestCoerceDocuments:
     def test_all_documents(self):
         d1 = Document("a", doc_id="x")
         d2 = Document("b", doc_id="y")
-        result = _coerce_documents([d1, d2])
+        result = _coerce_to_documents([d1, d2])
         assert result[0] is d1
         assert result[1] is d2
 
     def test_mixed(self):
         doc = Document("existing", doc_id="x")
-        result = _coerce_documents(["new", doc])
+        result = _coerce_to_documents(["new", doc])
         assert result[0].text == "new"
         assert result[0].doc_id is None
         assert result[1] is doc
 
     def test_auto_doc_id_strings(self):
-        result = _coerce_documents(["a", "b", "c"], auto_doc_id=True)
+        result = _coerce_to_documents(["a", "b", "c"], auto_doc_id=True)
         assert [d.doc_id for d in result] == ["0", "1", "2"]
         assert [d.text for d in result] == ["a", "b", "c"]
 
     def test_auto_doc_id_preserves_existing(self):
         doc = Document("a", doc_id="mine")
-        result = _coerce_documents([doc, "b"], auto_doc_id=True)
+        result = _coerce_to_documents([doc, "b"], auto_doc_id=True)
         assert result[0].doc_id == "mine"
         assert result[1].doc_id == "1"
 
@@ -65,7 +87,7 @@ class TestCoerceDocuments:
         doc = Document("no id")
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = _coerce_documents([doc], auto_doc_id=True)
+            result = _coerce_to_documents([doc], auto_doc_id=True)
             assert len(w) == 1
             assert "no doc_id" in str(w[0].message)
         assert result[0] is doc
@@ -74,20 +96,20 @@ class TestCoerceDocuments:
         doc = Document("has id", doc_id="0")
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            _coerce_documents([doc], auto_doc_id=True)
+            _coerce_to_documents([doc], auto_doc_id=True)
             assert len(w) == 0
 
     def test_empty(self):
-        assert _coerce_documents([]) == []
+        assert _coerce_to_documents([]) == []
 
 
 class TestCoerceDocument:
     def test_string(self):
-        result = _coerce_document("hello")
+        result = _coerce_to_document("hello")
         assert isinstance(result, Document)
         assert result.text == "hello"
         assert result.doc_id is None
 
     def test_passthrough(self):
         doc = Document("existing", doc_id="1")
-        assert _coerce_document(doc) is doc
+        assert _coerce_to_document(doc) is doc

--- a/test/stdlib/components/intrinsic/test_resolve_util.py
+++ b/test/stdlib/components/intrinsic/test_resolve_util.py
@@ -1,84 +1,14 @@
-"""Tests for _coerce_documents, _coerce_document, _resolve_question, and _resolve_response."""
-
-import warnings
+"""Tests for _resolve_question and _resolve_response."""
 
 import pytest
 
 from mellea.core import CBlock, ModelOutputThunk
 from mellea.stdlib.components import Document, Instruction, Message
 from mellea.stdlib.components.intrinsic._util import (
-    _coerce_document,
-    _coerce_documents,
     _resolve_question,
     _resolve_response,
 )
 from mellea.stdlib.context import ChatContext
-
-
-class TestCoerceDocuments:
-    def test_all_strings(self):
-        result = _coerce_documents(["foo", "bar"])
-        assert len(result) == 2
-        assert result[0].text == "foo"
-        assert result[0].doc_id is None
-        assert result[1].text == "bar"
-        assert result[1].doc_id is None
-
-    def test_all_documents(self):
-        d1 = Document("a", doc_id="x")
-        d2 = Document("b", doc_id="y")
-        result = _coerce_documents([d1, d2])
-        assert result[0] is d1
-        assert result[1] is d2
-
-    def test_mixed(self):
-        doc = Document("existing", doc_id="x")
-        result = _coerce_documents(["new", doc])
-        assert result[0].text == "new"
-        assert result[0].doc_id is None
-        assert result[1] is doc
-
-    def test_auto_doc_id_strings(self):
-        result = _coerce_documents(["a", "b", "c"], auto_doc_id=True)
-        assert [d.doc_id for d in result] == ["0", "1", "2"]
-        assert [d.text for d in result] == ["a", "b", "c"]
-
-    def test_auto_doc_id_preserves_existing(self):
-        doc = Document("a", doc_id="mine")
-        result = _coerce_documents([doc, "b"], auto_doc_id=True)
-        assert result[0].doc_id == "mine"
-        assert result[1].doc_id == "1"
-
-    def test_auto_doc_id_warns_on_missing_doc_id(self):
-        doc = Document("no id")
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = _coerce_documents([doc], auto_doc_id=True)
-            assert len(w) == 1
-            assert "no doc_id" in str(w[0].message)
-        assert result[0] is doc
-
-    def test_auto_doc_id_no_warn_when_doc_id_present(self):
-        doc = Document("has id", doc_id="0")
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            _coerce_documents([doc], auto_doc_id=True)
-            assert len(w) == 0
-
-    def test_empty(self):
-        assert _coerce_documents([]) == []
-
-
-class TestCoerceDocument:
-    def test_string(self):
-        result = _coerce_document("hello")
-        assert isinstance(result, Document)
-        assert result.text == "hello"
-        assert result.doc_id is None
-
-    def test_passthrough(self):
-        doc = Document("existing", doc_id="1")
-        assert _coerce_document(doc) is doc
 
 
 class TestResolveQuestion:

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -87,6 +87,24 @@ def test_message_format_for_llm_structure():
     assert tr.args["documents"] is None
 
 
+def test_message_documents_string_coercion():
+    msg = Message("user", "hello", documents=["doc one", "doc two"])
+    assert msg._docs is not None
+    assert len(msg._docs) == 2
+    assert all(isinstance(d, Document) for d in msg._docs)
+    assert msg._docs[0].text == "doc one"
+    assert msg._docs[1].text == "doc two"
+
+
+def test_message_documents_mixed_coercion():
+    doc = Document("existing", doc_id="x")
+    msg = Message("user", "hello", documents=["new text", doc])
+    assert msg._docs is not None
+    assert len(msg._docs) == 2
+    assert msg._docs[0].text == "new text"
+    assert msg._docs[1] is doc
+
+
 # --- Message._parse — no tool calls ---
 
 

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -20,7 +20,7 @@ def test_message_with_docs():
     assert docs[0]["text"] == doc.text
     assert docs[0]["title"] == doc.title
 
-    assert "[Document]..." in str(msg)
+    assert "[Document] Im a titl..." in str(msg)
 
     tr = msg.format_for_llm()
     assert tr.args["documents"]
@@ -346,6 +346,15 @@ class TestMessageDocumentRendering:
         assert result["role"] == "user"
         assert result["content"] == "main content"
         assert "supporting text" not in result["content"]
+
+    def test_print_message_with_docs_renders_document_format(self, formatter):
+        """Verify exact rendered format of documents within a Message."""
+        doc = Document("The capital of France is Paris.", title="Geography", doc_id="7")
+        msg = Message("user", "What is the capital of France?", documents=[doc])
+        result = formatter.print(msg)
+        assert "What is the capital of France?" in result
+        assert "[Document 7]" in result
+        assert "Geography: The capital of France is Paris." in result
 
 
 if __name__ == "__main__":

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -1,7 +1,8 @@
 import pytest
 
 from mellea.core import CBlock, ModelOutputThunk, TemplateRepresentation
-from mellea.helpers import messages_to_docs
+from mellea.formatters.template_formatter import TemplateFormatter
+from mellea.helpers import message_to_openai_message, messages_to_docs
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.chat import ToolMessage, as_chat_history
 from mellea.stdlib.context import ChatContext
@@ -19,7 +20,7 @@ def test_message_with_docs():
     assert docs[0]["text"] == doc.text
     assert docs[0]["title"] == doc.title
 
-    assert "Im a titl..." in str(msg)
+    assert "[Document]..." in str(msg)
 
     tr = msg.format_for_llm()
     assert tr.args["documents"]
@@ -267,6 +268,84 @@ def test_as_chat_history_with_parsed_mot():
     history = as_chat_history(ctx)
     assert len(history) == 2
     assert history[1].content == "reply"
+
+
+# --- Formatter rendering of Message documents ---
+
+
+class TestMessageDocumentRendering:
+    """Tests that documents on Messages are rendered through the formatter."""
+
+    @pytest.fixture
+    def formatter(self):
+        return TemplateFormatter(model_id="test-model")
+
+    def test_print_message_without_docs(self, formatter):
+        msg = Message("user", "hello")
+        result = formatter.print(msg)
+        assert result == "hello"
+
+    def test_print_message_with_docs(self, formatter):
+        doc = Document("The answer is 42.", title="Guide", doc_id="1")
+        msg = Message("user", "What is the answer?", documents=[doc])
+        result = formatter.print(msg)
+        assert "What is the answer?" in result
+        assert "[Document 1]" in result
+        assert "Guide:" in result
+        assert "The answer is 42." in result
+
+    def test_print_message_with_multiple_docs(self, formatter):
+        docs = [
+            Document("First doc content.", doc_id="0"),
+            Document("Second doc content.", doc_id="1"),
+        ]
+        msg = Message("user", "Summarize these.", documents=docs)
+        result = formatter.print(msg)
+        assert "Summarize these." in result
+        assert "First doc content." in result
+        assert "Second doc content." in result
+
+    def test_print_message_with_string_docs(self, formatter):
+        msg = Message("user", "question", documents=["raw doc text"])
+        result = formatter.print(msg)
+        assert "question" in result
+        assert "raw doc text" in result
+
+    def test_to_chat_messages_preserves_docs_for_print(self, formatter):
+        """Messages with docs survive to_chat_messages() and can be printed."""
+        doc = Document("grounding info", title="Ref")
+        msg = Message("user", "query", documents=[doc])
+
+        messages = formatter.to_chat_messages([msg])
+        assert len(messages) == 1
+
+        returned_msg = messages[0]
+        # Role is still accessible as a separate field
+        assert returned_msg.role == "user"
+        # Documents are preserved
+        assert returned_msg._docs is not None
+        assert len(returned_msg._docs) == 1
+        # Formatter print renders docs into content
+        rendered = formatter.print(returned_msg)
+        assert "query" in rendered
+        assert "grounding info" in rendered
+        assert "Ref:" in rendered
+
+    def test_message_to_openai_message_with_formatter(self, formatter):
+        doc = Document("supporting text", doc_id="d1")
+        msg = Message("user", "main content", documents=[doc])
+        result = message_to_openai_message(msg, formatter)
+        assert result["role"] == "user"
+        assert "main content" in result["content"]
+        assert "supporting text" in result["content"]
+
+    def test_message_to_openai_message_without_formatter_drops_docs(self):
+        doc = Document("supporting text", doc_id="d1")
+        msg = Message("user", "main content", documents=[doc])
+        result = message_to_openai_message(msg)
+        assert result["role"] == "user"
+        assert result["content"] == "main content"
+        assert "supporting text" not in result["content"]
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -1,16 +1,19 @@
 """Unit tests for functional.py pure helpers — no backend, no LLM required.
 
-Covers _parse_and_clean_image_args image preprocessing.
+Covers _parse_and_clean_image_args image preprocessing and chat() document forwarding.
 """
 
 import base64
 import io
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image as PILImage
 
 from mellea.core import ImageBlock
-from mellea.stdlib.functional import _parse_and_clean_image_args
+from mellea.stdlib.components import Document, Message
+from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.functional import _parse_and_clean_image_args, chat
 
 
 def _make_image_block() -> ImageBlock:
@@ -60,6 +63,49 @@ def test_pil_images_converted_to_image_blocks():
 def test_non_list_raises():
     with pytest.raises(AssertionError, match="Images should be a list"):
         _parse_and_clean_image_args("not_a_list")  # type: ignore
+
+
+# --- chat() document forwarding ---
+
+
+@patch("mellea.stdlib.functional.act")
+def test_chat_forwards_documents_to_message(mock_act):
+    """Verify that chat() passes documents through to the Message it constructs."""
+    # Set up mock to return a fake assistant message and context
+    assistant_msg = Message(role="assistant", content="reply")
+    mock_result = MagicMock()
+    mock_result.parsed_repr = assistant_msg
+    mock_ctx = SimpleContext()
+    mock_act.return_value = (mock_result, mock_ctx)
+
+    backend = MagicMock()
+    ctx = SimpleContext()
+
+    chat("hello", ctx, backend, documents=["grounding text", "more context"])
+
+    # Inspect the Message that was passed to act()
+    user_message = mock_act.call_args[0][0]
+    assert isinstance(user_message, Message)
+    assert user_message._docs is not None
+    assert len(user_message._docs) == 2
+    assert all(isinstance(d, Document) for d in user_message._docs)
+    assert user_message._docs[0].text == "grounding text"
+    assert user_message._docs[1].text == "more context"
+
+
+@patch("mellea.stdlib.functional.act")
+def test_chat_no_documents_by_default(mock_act):
+    """Verify that chat() passes None documents when not specified."""
+    assistant_msg = Message(role="assistant", content="reply")
+    mock_result = MagicMock()
+    mock_result.parsed_repr = assistant_msg
+    mock_act.return_value = (mock_result, SimpleContext())
+
+    chat("hello", SimpleContext(), MagicMock())
+
+    user_message = mock_act.call_args[0][0]
+    assert isinstance(user_message, Message)
+    assert user_message._docs is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [x] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes <!-- issue number --> https://github.com/generative-computing/mellea/issues/952 and https://github.com/generative-computing/mellea/issues/949 and https://github.com/generative-computing/mellea/issues/963

<!-- Brief description of the change being made along with an explanation. -->

Adds support for printing Messages with documents attached. Adds support for attaching documents to Messages and chat interfaces. Modifies document format_for_llm to print something more in line with how intrinsics print the document.

Will need to create new issues to clean up message serialization post this change.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used