### PR TITLE
fix: xfail uncertainty test instead of version pin

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -176,7 +176,6 @@ _YAML_JSON_COMBOS_LIST = [
         task="uncertainty",
         # Granite 4.0 adapters not currently available
         repo_id="ibm-granite/granitelib-core-r1.0",
-        revision="c9c189f5ad0b2890660397070613fda46d6ceb80",
     ),
     # aLoRA adapter for this intrinsic not currently available
     # YamlJsonCombo(
@@ -217,7 +216,6 @@ _YAML_JSON_COMBOS_LIST = [
         inputs_file=_INPUT_JSON_DIR / "context-attribution.json",
         task="context-attribution",
         repo_id="ibm-granite/granitelib-core-r1.0",
-        revision="c9c189f5ad0b2890660397070613fda46d6ceb80",
     ),
     # gpt-oss-20b intrinsics (canned output tests only, no inference)
     YamlJsonCombo(
@@ -408,12 +406,19 @@ def test_read_yaml():
 _CANNED_INPUT_EXPECTED_DIR = _TEST_DATA_DIR / "test_canned_input"
 
 
-def test_canned_input(yaml_json_combo_no_alora):
+def test_canned_input(yaml_json_combo_no_alora, request):
     """
     Verify that a given combination of chat completion and rewriting config produces
     the expected output
     """
     cfg = yaml_json_combo_no_alora
+    if cfg.short_name == "uncertainty":
+        request.applymarker(
+            pytest.mark.xfail(
+                reason="uncertainty downloads io.yaml from a live HF repo"
+                "snapshot may be stale if the upstream repo is updated"
+            )
+        )
     if cfg.arguments_file:
         with open(cfg.arguments_file, encoding="utf8") as f:
             transform_kwargs = json.load(f)


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #973 <!-- issue number -->

Instead of pinning the versioning for this, move to xfail which will let CI pass even if the HF intrinsics portion is updated while local snapshot is out of date.  

We didn't see failures on `context-attribution` before but while I was pinning I pinned both.  Sans pinning I think it makes sense to leave out context-attribution and add it to the xfail later if we run into issues.

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used