### PR TITLE
fix: key in json object returned by policy_guardrails intrinsic

### DIFF
--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -35,10 +35,19 @@ def policy_guardrails(
 
     context = context.add(Message("user", judge_protocol))
     result_json = call_intrinsic("policy-guardrails", context, backend)
-    if backend.model_id == model_ids.IBM_GRANITE_4_MICRO_3B:
+
+    if "label" not in result_json.keys() and "score" not in result_json.keys():
+        raise Exception(
+            "Expected Guardian result to have label xor score, but found neither."
+        )
+    elif "label" not in result_json.keys() and "score" in result_json.keys():
+        return result_json["score"]
+    elif "label" in result_json.keys() and "score" not in result_json.keys():
         return result_json["label"]
     else:
-        return result_json["score"]
+        raise Exception(
+            "Expected Guardian result to have label xor score, but found both."
+        )
 
 
 _SYSTEM_PROMPT = (

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -6,6 +6,7 @@ differs from other intrinsics, which rely on the ``instruction`` field in
 ``io.yaml``.
 """
 
+from ....backends import model_ids
 from ....backends.adapters import AdapterMixin
 from ...context import ChatContext
 from ..chat import Message
@@ -34,7 +35,10 @@ def policy_guardrails(
 
     context = context.add(Message("user", judge_protocol))
     result_json = call_intrinsic("policy-guardrails", context, backend)
-    return result_json["label"]
+    if backend.model_id == model_ids.IBM_GRANITE_4_MICRO_3B:
+        return result_json["label"]
+    else:
+        return result_json["score"]
 
 
 _SYSTEM_PROMPT = (


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Add version handling to Guardian Intrinsic

Guardian adapters for granite <= 4.0 return a `label`, but for granite == 4.1 return a `score`. This PR handles both cases, and throws an exception where we unexpectedly get neither or both keys in the response.

## Description
- [x] Link to Issue: Fixes https://github.com/generative-computing/mellea/issues/974

<!-- Brief description of the tool being added/modified along with an explanation for why it should be in the standard library. -->

### Testing
- [x] Tests added to `tests/stdlib/tools/` No new tests are necessary -- should be exercised by existing guardian tests.
- [x] New code has 100% coverage -- we still need to add 4.1 adapter tests, but we're trackign that separately.
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used