### PR TITLE
test: add tests for new intrinsic field name

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -405,6 +405,66 @@ def test_read_yaml():
     IntrinsicsRewriter(config_file=local_path)
 
 
+def test_name_field_accepted_by_make_config_dict():
+    """make_config_dict accepts 'name' as an optional field without error."""
+    config_with_name = {
+        "model": None,
+        "response_format": None,
+        "transformations": None,
+        "name": "my_intrinsic_display_name",
+    }
+    result = intrinsics_util.make_config_dict(config_dict=config_with_name)
+    assert result is not None
+    assert result["name"] == "my_intrinsic_display_name"
+    # Other optional fields are filled with None
+    assert result["parameters"] is None
+    assert result["sentence_boundaries"] is None
+    assert result["instruction"] is None
+
+    # Without name, it defaults to None
+    config_without_name = {
+        "model": None,
+        "response_format": None,
+        "transformations": None,
+    }
+    result2 = intrinsics_util.make_config_dict(config_dict=config_without_name)
+    assert result2 is not None
+    assert result2["name"] is None
+
+
+def test_rewriter_transform_with_name_field():
+    """IntrinsicsRewriter.transform() produces identical output with or without 'name'."""
+    config_with_name = {
+        "model": None,
+        "response_format": None,
+        "transformations": None,
+        "name": "answerability_v2",
+        "parameters": {"max_completion_tokens": 64},
+        "sentence_boundaries": None,
+        "instruction": None,
+    }
+    config_without_name = {
+        "model": None,
+        "response_format": None,
+        "transformations": None,
+        "parameters": {"max_completion_tokens": 64},
+        "sentence_boundaries": None,
+        "instruction": None,
+    }
+
+    rewriter_with = IntrinsicsRewriter(config_dict=config_with_name)
+    rewriter_without = IntrinsicsRewriter(config_dict=config_without_name)
+
+    json_data = _read_file(_INPUT_JSON_DIR / "simple.json")
+    before = ChatCompletion.model_validate_json(json_data)
+
+    after_with = rewriter_with.transform(before)
+    after_without = rewriter_without.transform(before)
+
+    # Both should produce identical output (name is metadata-only)
+    assert after_with.model_dump_json() == after_without.model_dump_json()
+
+
 _CANNED_INPUT_EXPECTED_DIR = _TEST_DATA_DIR / "test_canned_input"
 
 


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes #983 <!-- issue number -->

Note: After reading the code the testing, I don't think we actually need these tests but adding in case others disagree. The name parameter doesn't get propagated and I believe would require explicitly changing the IntrinsicRewriter to do so.

These tests just check that the config dict gets created correctly and that Intrinsics rewritten with and without name are the exact same still.

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used