### PR TITLE
fix: update model ids and documentation links for switch

### DIFF
--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -36,12 +36,12 @@ Or, with a Granite Switch model via the OpenAI backend:
 
 ```python
 from mellea.backends.openai import OpenAIBackend
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.formatters import TemplateFormatter
 
 backend = OpenAIBackend(
-    model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
-    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name),
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
+    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name),
     base_url="http://localhost:8000/v1",  # vLLM server
     api_key="EMPTY",
     load_embedded_adapters=True,

--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -278,12 +278,12 @@ Then create a backend with `load_embedded_adapters=True`:
 
 ```python
 from mellea.backends.openai import OpenAIBackend
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.formatters import TemplateFormatter
 
 backend = OpenAIBackend(
-    model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
-    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name),
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
+    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name),
     base_url="http://localhost:8000/v1",
     api_key="EMPTY",
     load_embedded_adapters=True,
@@ -305,12 +305,12 @@ For more control, load adapters manually with `load_embedded_adapters=False`:
 ```python
 from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
 from mellea.backends.openai import OpenAIBackend
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.formatters import TemplateFormatter
 
 backend = OpenAIBackend(
-    model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
-    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name),
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
+    formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name),
     base_url="http://localhost:8000/v1",
     api_key="EMPTY",
     load_embedded_adapters=False,
@@ -318,7 +318,7 @@ backend = OpenAIBackend(
 
 # Load a single adapter from the model's HuggingFace repo
 adapters = EmbeddedIntrinsicAdapter.from_hub(
-    IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
+    IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
     intrinsic_name="answerability",
 )
 for adapter in adapters:
@@ -347,4 +347,4 @@ local servers, list available models from the server's API or UI.
 
 **See also:** [Backends and Configuration](../how-to/backends-and-configuration) |
 [Enforce Structured Output](../how-to/enforce-structured-output) |
-[Official Granite Switch Documentation](GRANITE_SWITCH_DOCS)
+[Official Granite Switch Documentation](https://github.com/generative-computing/granite-switch)

--- a/docs/docs/reference/glossary.md
+++ b/docs/docs/reference/glossary.md
@@ -295,7 +295,7 @@ See: [Making Agents Reliable](../tutorials/04-making-agents-reliable)
 
 A Granite model variant with LoRA and aLoRA adapters pre-baked into the model weights. When served via vLLM and accessed through `OpenAIBackend` with `load_embedded_adapters=True`, these embedded adapters enable [Intrinsics](../advanced/intrinsics) (RAG quality checks, requirement validation, safety evaluation) without runtime adapter loading. Only intrinsics embedded in the model are available — check the model's `adapter_index.json`.
 
-See: [Official Granite Switch Documentation](GRANITE_SWITCH_DOCS) |
+See: [Official Granite Switch Documentation](https://github.com/generative-computing/granite-switch) |
 [Intrinsics](../advanced/intrinsics) |
 [OpenAI and OpenAI-Compatible APIs](../integrations/openai)
 

--- a/docs/examples/granite-switch/answerability_openai.py
+++ b/docs/examples/granite-switch/answerability_openai.py
@@ -26,14 +26,14 @@ except requests.ConnectionError:
     print(f"Skipped: vLLM server not reachable at {VLLM_BASE_URL}", file=sys.stderr)
     raise SystemExit(1)
 
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.backends.openai import OpenAIBackend
 from mellea.formatters import TemplateFormatter
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import rag
 from mellea.stdlib.context import ChatContext
 
-SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B.hf_model_name
+SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name
 assert SWITCH_MODEL_ID is not None
 
 backend = OpenAIBackend(

--- a/docs/examples/granite-switch/hallucination_detection_openai.py
+++ b/docs/examples/granite-switch/hallucination_detection_openai.py
@@ -26,14 +26,14 @@ except requests.ConnectionError:
     print(f"Skipped: vLLM server not reachable at {VLLM_BASE_URL}", file=sys.stderr)
     raise SystemExit(1)
 
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.backends.openai import OpenAIBackend
 from mellea.formatters import TemplateFormatter
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import rag
 from mellea.stdlib.context import ChatContext
 
-SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B.hf_model_name
+SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name
 assert SWITCH_MODEL_ID is not None
 
 backend = OpenAIBackend(

--- a/docs/examples/granite-switch/manual_adapter_loading.py
+++ b/docs/examples/granite-switch/manual_adapter_loading.py
@@ -36,14 +36,14 @@ except requests.ConnectionError:
     raise SystemExit(1)
 
 from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.backends.openai import OpenAIBackend
 from mellea.formatters import TemplateFormatter
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import rag
 from mellea.stdlib.context import ChatContext
 
-SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B.hf_model_name
+SWITCH_MODEL_ID = IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name
 assert SWITCH_MODEL_ID is not None
 
 # Create the backend WITHOUT auto-loading adapters.

--- a/docs/examples/intrinsics/README.md
+++ b/docs/examples/intrinsics/README.md
@@ -85,7 +85,7 @@ out, new_ctx = mfuncs.act(
 OpenAIBackends also support a type of embedded adapter for Granite Switch models:
 ```python
 backend = OpenAIBackend(
-        model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
+        model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
         load_embedded_adapters=True,  # Auto-loads adapters from huggingface repo.
         ...
 )

--- a/docs/examples/intrinsics/intrinsics.py
+++ b/docs/examples/intrinsics/intrinsics.py
@@ -14,12 +14,12 @@ backend = LocalHFBackend(model_id="ibm-granite/granite-3.3-8b-instruct")
 # Requires the adapter for this intrinsic to be embedded in the Granite Switch
 # model. See docs/examples/granite-switch/ for a full runnable example.
 # from mellea.backends.openai import OpenAIBackend
-# from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+# from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 # from mellea.formatters import TemplateFormatter
 #
 # backend = OpenAIBackend(
-#     model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name,
-#     formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B.hf_model_name),
+#     model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
+#     formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name),
 #     base_url="http://localhost:8000/v1",  # vLLM server URL
 #     api_key="EMPTY",
 #     load_embedded_adapters=True,

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -135,10 +135,20 @@ IBM_GRANITE_4_TINY_PREVIEW_BASE_7B = ModelIdentifier(
 )
 
 # Pre-Built Granite Switch Models
-IBM_GRANITE_SWITCH_4_1_3B = ModelIdentifier(
-    hf_model_name="GrizleeBer/gs-test-1"  # TODO: Placeholder. Change this value.
+IBM_GRANITE_SWITCH_4_1_3B_PREVIEW = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-switch-4.1-3b-preview"
 )
-"""Granite Switch."""  # Document what adapters are included by default here.
+"""Granite Switch Preview Model. Adapters: `citations`, `query_rewrite`, `query_clarification`, `hallucination_detection`, `answerability`, `policy-guardrails`, `guardian-core`, `uncertainty`, `requirement-check`, `context-attribution`, `factuality-detection`, `factuality-correction`."""  # Document what adapters are included by default here.
+
+IBM_GRANITE_SWITCH_4_1_8B_PREVIEW = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-switch-4.1-8b-preview"
+)
+"""Granite Switch Preview Model. Adapters: `citations`, `query_rewrite`, `query_clarification`, `hallucination_detection`, `answerability`, `policy-guardrails`, `guardian-core`, `uncertainty`, `requirement-check`, `context-attribution`, `factuality-detection`, `factuality-correction`."""  # Document what adapters are included by default here.
+
+IBM_GRANITE_SWITCH_4_1_30B_PREVIEW = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-switch-4.1-30b-preview"
+)
+"""Granite Switch Preview Model. Adapters: `citations`, `query_rewrite`, `query_clarification`, `hallucination_detection`, `answerability`, `policy-guardrails`, `guardian-core`, `uncertainty`, `requirement-check`, `context-attribution`, `factuality-detection`, `factuality-correction`."""  # Document what adapters are included by default here.
 
 #####################
 #### Meta models ####

--- a/test/backends/test_openai_intrinsics.py
+++ b/test/backends/test_openai_intrinsics.py
@@ -37,7 +37,7 @@ pytestmark = [
 # ---------------------------------------------------------------------------
 # Imports (after markers so collection-time skips fire first)
 # ---------------------------------------------------------------------------
-from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.backends.openai import OpenAIBackend
 from mellea.formatters import TemplateFormatter
 from mellea.stdlib import functional as mfuncs
@@ -54,7 +54,7 @@ from test.formatters.granite.test_intrinsics_formatters import (
 # Configuration
 # ---------------------------------------------------------------------------
 SWITCH_MODEL_ID = os.environ.get(
-    "GRANITE_SWITCH_MODEL_ID", IBM_GRANITE_SWITCH_4_1_3B.hf_model_name
+    "GRANITE_SWITCH_MODEL_ID", IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name
 )
 
 


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

## Description
- [ ] Link to Issue: Fixes https://github.com/generative-computing/mellea/issues/984 <!-- issue number -->


Updates documentation to have links to the eventual granite-switch location. Updates model ids to be the actual model ids of the granite switch models.
<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used