### PR TITLE
fix: silence false-positive context warning in react framework

### DIFF
--- a/mellea/stdlib/frameworks/react.py
+++ b/mellea/stdlib/frameworks/react.py
@@ -90,6 +90,7 @@ async def react(
             model_options=model_options,
             tool_calls=True,
             await_result=True,
+            silence_context_type_warning=True,
         )
 
         # Have to assert this due to type hints.
@@ -119,6 +120,7 @@ async def react(
                     model_options=model_options,
                     format=format,
                     await_result=True,
+                    silence_context_type_warning=True,
                 )
                 assert isinstance(next_context, ChatContext)
                 context = next_context


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

# Misc PR

## Type of PR

- [x] Bug Fix

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

`react()` uses `ChatContext` for multi-turn history, which triggers the "not using SimpleContext with async requests" warning on every turn. The warning is a false positive here — `react()` serializes all `aact()` calls with sequential awaits, so there is no risk of stale context from concurrent access.

The `silence_context_type_warning` parameter exists precisely for this case; the sync `act()` wrapper already uses it for the same reason.

### Testing
- [ ] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used