### PR TITLE
fix: remove unused keys from Message template args

### DIFF
--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -86,12 +86,7 @@ class Message(Component["Message"]):
         """
         return TemplateRepresentation(
             obj=self,
-            args={
-                "role": self.role,
-                "content": self._content_cblock,
-                "images": self._images,
-                "documents": self._docs,
-            },
+            args={"content": self._content_cblock, "documents": self._docs},
             template_order=["*", "Message"],
         )
 
@@ -218,21 +213,6 @@ class ToolMessage(Message):
         self.arguments = args
         self._tool_output = tool_output
         self._tool = tool
-
-    def format_for_llm(self) -> TemplateRepresentation:
-        """Return the same representation as ``Message`` with a ``name`` field added to the args dict.
-
-        Returns:
-            TemplateRepresentation: Template representation including the tool
-            name alongside the standard message fields.
-        """
-        message_repr = super().format_for_llm()
-        args = message_repr.args
-        args["name"] = self.name
-
-        return TemplateRepresentation(
-            obj=self, args=args, template_order=["*", "Message"]
-        )
 
     def __repr__(self) -> str:
         """Pretty representation of messages, because they are a special case."""

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -82,9 +82,7 @@ def test_message_format_for_llm_structure():
     msg = Message("user", "hello")
     tr = msg.format_for_llm()
     assert isinstance(tr, TemplateRepresentation)
-    assert tr.args["role"] == "user"
     assert tr.args["content"] is msg._content_cblock
-    assert tr.args["images"] is None
     assert tr.args["documents"] is None
 
 
@@ -210,24 +208,6 @@ def test_tool_message_fields():
     assert tm.role == "tool"
     assert tm.name == "my_tool"
     assert tm.arguments == {"x": 1}
-
-
-def test_tool_message_format_for_llm_includes_name():
-    from mellea.core import ModelToolCall
-
-    fake_tool = type("T", (), {"as_json_tool": {}})()
-    mtc = ModelToolCall("my_tool", fake_tool, {})
-    tm = ToolMessage(
-        role="tool",
-        content="output",
-        tool_output="output",
-        name="my_tool",
-        args={},
-        tool=mtc,
-    )
-    tr = tm.format_for_llm()
-    assert isinstance(tr, TemplateRepresentation)
-    assert tr.args["name"] == "my_tool"
 
 
 def test_tool_message_repr():


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

# Misc PR

## Type of PR

- [x] Bug Fix

## Description
- [ ] Link to Issue: Fixes <!-- issue number -->

`role`, `images`, and `name` were included in `Message`/`ToolMessage.format_for_llm()` args but are never consumed by any template — all backends read these fields directly from the `Message` object (e.g. `m.role`, `m.images`). Their presence caused a false-positive warning from the unused-keys check added in #975.

Investigation via git history confirmed `role` was present from the start and `images` was added in #126 (VLM support) with the stated intent of making them available for custom templates. However, no such custom templates exist in the codebase, and the consumption path has always been direct object access. The warning from #975 correctly flagged them.

Since `name` was the only addition in `ToolMessage.format_for_llm()`, the override is now identical to the inherited `Message` implementation and has been removed along with its test.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used