### PR TITLE
fix: log unexpected errors server-side, return generic message to client (#991)

### DIFF
--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -3,7 +3,6 @@
 import asyncio
 import importlib.util
 import inspect
-import logging
 import os
 import sys
 import time
@@ -24,6 +23,7 @@ except ImportError as e:
     ) from e
 
 from mellea.backends.model_options import ModelOption
+from mellea.core import MelleaLogger
 from mellea.helpers.openai_compatible_helpers import (
     build_completion_usage,
     build_tool_calls,
@@ -43,7 +43,7 @@ from .schema_converter import json_schema_to_pydantic
 from .streaming import stream_chat_completion_chunks
 from .utils import extract_finish_reason
 
-logger = logging.getLogger(__name__)
+logger = MelleaLogger.get_logger()
 
 app = FastAPI(
     title="M serve OpenAI API Compatible Server",

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -269,11 +269,6 @@ def make_chat_endpoint(module):
                 error_type="invalid_request_error",
             )
         except Exception:
-            # Catch-all for any unexpected errors. Log the full traceback
-            # server-side (operators must be able to diagnose the 500), and
-            # return a generic message to the client, the raw `str(e)` can
-            # leak file paths / internal state across the API boundary
-            # (#991).
             logger.exception("Unhandled error in chat-completion handler")
             return create_openai_error_response(
                 status_code=500,

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib.util
 import inspect
+import logging
 import os
 import sys
 import time
@@ -41,6 +42,8 @@ from .models import (
 from .schema_converter import json_schema_to_pydantic
 from .streaming import stream_chat_completion_chunks
 from .utils import extract_finish_reason
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="M serve OpenAI API Compatible Server",
@@ -265,11 +268,16 @@ def make_chat_endpoint(module):
                 message=f"Invalid request: {e!s}",
                 error_type="invalid_request_error",
             )
-        except Exception as e:
-            # Catch-all for any unexpected errors (including AttributeError)
+        except Exception:
+            # Catch-all for any unexpected errors. Log the full traceback
+            # server-side (operators must be able to diagnose the 500), and
+            # return a generic message to the client — the raw `str(e)` can
+            # leak file paths / internal state across the API boundary
+            # (#991).
+            logger.exception("Unhandled error in chat-completion handler")
             return create_openai_error_response(
                 status_code=500,
-                message=f"Internal server error: {e!s}",
+                message="Internal server error",
                 error_type="server_error",
             )
 

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -271,7 +271,7 @@ def make_chat_endpoint(module):
         except Exception:
             # Catch-all for any unexpected errors. Log the full traceback
             # server-side (operators must be able to diagnose the 500), and
-            # return a generic message to the client — the raw `str(e)` can
+            # return a generic message to the client, the raw `str(e)` can
             # leak file paths / internal state across the API boundary
             # (#991).
             logger.exception("Unhandled error in chat-completion handler")

--- a/test/cli/test_serve_errors.py
+++ b/test/cli/test_serve_errors.py
@@ -128,7 +128,6 @@ def test_generic_error_handling(mock_module_generic_error, sample_request):
     assert "error" in data
     assert data["error"]["type"] == "server_error"
     assert "Internal server error" in data["error"]["message"]
-    # The raw exception message must not leak to the client.
     assert "Unexpected error" not in data["error"]["message"]
 
 

--- a/test/cli/test_serve_errors.py
+++ b/test/cli/test_serve_errors.py
@@ -128,7 +128,8 @@ def test_generic_error_handling(mock_module_generic_error, sample_request):
     assert "error" in data
     assert data["error"]["type"] == "server_error"
     assert "Internal server error" in data["error"]["message"]
-    assert "Unexpected error" in data["error"]["message"]
+    # The raw exception message must not leak to the client.
+    assert "Unexpected error" not in data["error"]["message"]
 
 
 @pytest.mark.unit

--- a/test/cli/test_serve_integration.py
+++ b/test/cli/test_serve_integration.py
@@ -569,6 +569,5 @@ class TestHTTPErrorHandling:
         data = response.json()
         assert "error" in data
         assert data["error"]["type"] == "server_error"
-        # The raw exception message must not leak to the client.
         assert "Internal error" not in data["error"]["message"]
         assert "Internal server error" in data["error"]["message"]

--- a/test/cli/test_serve_integration.py
+++ b/test/cli/test_serve_integration.py
@@ -569,4 +569,6 @@ class TestHTTPErrorHandling:
         data = response.json()
         assert "error" in data
         assert data["error"]["type"] == "server_error"
-        assert "Internal error" in data["error"]["message"]
+        # The raw exception message must not leak to the client.
+        assert "Internal error" not in data["error"]["message"]
+        assert "Internal server error" in data["error"]["message"]


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: fixes: #991

The catch-all `except Exception` in `cli/serve/app.py` had two problems:

1. **No server-side log trail.** Operators saw a 500 response with no stack trace in the application log, the exact case where a visible traceback matters.
2. **Exception message leaked verbatim to clients.** `f"Internal server error: {e!s}"` returned arbitrary `str(e)` content (file paths, internal module names, schema fragments) across the OpenAI-compatible API boundary.

Replaces the handler with `logger.exception("Unhandled error in chat-completion handler")` (full traceback, named logger) plus a generic client message. The explicit `except ValueError` 400-mapping above it stays untouched, that path is intentional validation feedback.


<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used