### PR TITLE
docs(openai): document empty response from thinking-mode models

### DIFF
--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -254,6 +254,48 @@ The model string must exactly match the name your server recognises. For OpenAI,
 refer to the [OpenAI models page](https://platform.openai.com/docs/models). For
 local servers, list available models from the server's API or UI.
 
+### Empty `value` from a thinking-mode model
+
+A response with `result.value == ""` despite non-zero `completion_tokens` is the
+signature of a thinking-mode model that emitted only reasoning tokens and no
+final answer. The OpenAI backend reports the response faithfully — the model
+genuinely returned `content=None` — but the reasoning content is preserved
+separately on the underlying `ModelOutputThunk`.
+
+Diagnose with:
+
+```python
+result = m.instruct("What is 2 + 2?")
+print(repr(result.value))                    # ''
+print(result.generation.usage)               # {'completion_tokens': 9, ...}
+print(result._thinking)                      # populated reasoning content, if any
+```
+
+This affects models that default to thinking mode, most commonly Qwen3 served
+via vLLM with `--reasoning-parser qwen3`. To disable thinking and get a normal
+text response, pass the runtime-specific switch through `model_options`. For
+vLLM:
+
+```python
+from mellea import MelleaSession
+from mellea.backends.openai import OpenAIBackend
+
+m = MelleaSession(
+    OpenAIBackend(
+        model_id="Qwen/Qwen3-Coder-Next-FP8",
+        base_url="http://localhost:8000/v1",
+        api_key="unused",
+        model_options={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        },
+    )
+)
+```
+
+Other inference servers expose the same control under different names — check
+your runtime's documentation. If you intend to use thinking mode, read the
+reasoning trace from `result._thinking` rather than `result.value`.
+
 ---
 
 **See also:** [Backends and Configuration](../guide/backends-and-configuration) |


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [x] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #1060

Document the empty-`value` symptom that thinking-mode models exhibit on the OpenAI backend, rather than enforcing it with a `RuntimeError` in `post_processing()`.

A model returning `content=None` with `finish_reason=stop` and non-zero `completion_tokens` is the literal response from the API — the reasoning content is preserved on `ModelOutputThunk._thinking`. Raising would break legitimate thinking-mode flows and bypass Mellea's sampling and validator machinery, so the right fix is discoverability, not enforcement.

Adds an *Empty `value` from a thinking-mode model* subsection to `docs/docs/integrations/openai.md` covering:

- How to diagnose: `result.value`, `result.generation.usage`, `result._thinking`
- The vLLM/Qwen3 case as the most common concrete trigger
- The `chat_template_kwargs.enable_thinking=False` workaround for callers who did not intend thinking mode
- A pointer to `result._thinking` for callers who did

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Docs-only change — pre-commit (including `markdownlint`) passes locally.

### Attribution
- [x] AI coding assistants used

Assisted-by: Claude Code