### PR TITLE
fix(test): loosen fragile equality assertions in astream incremental tests

### DIFF
--- a/test/core/test_astream_incremental.py
+++ b/test/core/test_astream_incremental.py
@@ -40,14 +40,7 @@ async def test_astream_returns_incremental_chunks():
         # If not computed, chunk2 should be new content only
         assert chunk2 is not None, "Second chunk should not be None if not computed"
 
-        # The key test: chunk2 should NOT start with chunk1
-        # (it should be incremental, not accumulated)
         if len(chunk2) > 0:
-            # chunk2 should be different from chunk1 (new content)
-            assert chunk2 != chunk1, (
-                "Second chunk should be different from first (incremental)"
-            )
-
             # Get final value
             final_val = await mot.avalue()
 
@@ -133,13 +126,14 @@ async def test_astream_beginning_length_tracking():
     # Second call: beginning_length should be captured at start of this call
     chunk2 = await mot.astream()
 
-    if chunk2 and len(chunk2) > 0:
-        # chunk2 should not include chunk1's content
-        # This verifies the slicing logic at lines 352-356
-        if chunk1:
-            assert not chunk2.startswith(chunk1), (
-                "Second chunk should not start with first chunk (should be incremental)"
-            )
+    if chunk2 and len(chunk2) > 0 and chunk1:
+        # Verify that chunks reassemble correctly (not that they differ textually —
+        # two consecutive identical tokens are valid).
+        final_val = await mot.avalue()
+        accumulated = chunk1 + chunk2
+        assert final_val.startswith(accumulated) or accumulated.startswith(final_val), (
+            "Assembled chunks should match final value progression"
+        )
 
 
 @pytest.mark.ollama


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #628

Two assertions in `test/core/test_astream_incremental.py` compared streaming chunk content for inequality, which caused intermittent test failures:

```python
assert chunk2 != chunk1                  # fragile
assert not chunk2.startswith(chunk1)     # fragile
```

Two consecutive streaming chunks can legitimately contain identical content — repeated tokens, whitespace, short common substrings — so these assertions fail spuriously under load or with slow models.

Both replaced with structural reassembly checks: verify that the accumulated chunks form a valid prefix of (or equal) the final streamed value. This is the invariant that actually matters, and is the same pattern already used correctly in `test_astream_multiple_calls_accumulate_correctly`.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used