### PR TITLE
ci: migrate hold and pr-label actions to common org versions

### DIFF
--- a/.github/workflows/hold.yml
+++ b/.github/workflows/hold.yml
@@ -1,9 +1,11 @@
 # Blocks merge when the "do-not-merge/hold" label is applied to a PR.
 #
+# Thin wrapper around the org-wide reusable workflow at
+# generative-computing/.github. The trigger lives here (so PR/merge_group
+# events are observed in this repo) but all logic is centralized upstream.
+#
 # Uses pull_request_target so the label event from forks also triggers this
-# check. This workflow does NOT check out or execute PR code — do not add
-# actions/checkout of the PR head ref or run steps that reference
-# PR-controlled files.
+# check. The reusable workflow does NOT check out or execute PR code.
 
 name: "Hold"
 
@@ -12,29 +14,9 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   hold:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - name: Check for hold label
-        if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const HOLD_LABEL = 'do-not-merge/hold';
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (labels.includes(HOLD_LABEL)) {
-              core.setFailed(
-                `PR is labeled "${HOLD_LABEL}". ` +
-                `Remove the label to allow this check to pass.`
-              );
-            } else {
-              core.info(`No "${HOLD_LABEL}" label present.`);
-            }
-      - name: Skip in merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Hold status already validated before entering the merge queue"
+    uses: generative-computing/.github/.github/workflows/hold.yml@31ecef85b868eb2a9d7ea3a0efd5c12cb4746fc1 # main

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,6 +1,12 @@
-# This workflow uses pull_request_target, which grants write access to
-# the repo even for PRs from forks. This is safe ONLY because it never checks
-# out or executes code from the PR branch. Do NOT add:
+# Labels PRs based on conventional commit prefix in the title.
+#
+# Thin wrapper around the org-wide reusable workflow at
+# generative-computing/.github. The trigger lives here but all logic is
+# centralized upstream.
+#
+# This caller uses pull_request_target, which grants write access to the repo
+# even for PRs from forks. This is safe ONLY because the reusable workflow
+# never checks out or executes code from the PR branch. Do NOT add:
 #   - actions/checkout (of the PR head ref)
 #   - run: steps that reference PR-controlled files
 #   - any step that executes code from the pull request
@@ -13,50 +19,10 @@ on:
     types: [opened, edited, synchronize]
   merge_group:
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   label:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Apply label based on PR title prefix
-        if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            const title = context.payload.pull_request.title;
-            const labelMap = {
-              'feat':     'enhancement',
-              'fix':      'bug',
-              'docs':     'documentation',
-              'test':     'testing',
-              'perf':     'enhancement',
-              'refactor': 'enhancement',
-              'ci':       'integrations',
-              'chore':    null,
-              'build':    null,
-              'style':    null,
-              'revert':   null,
-              'release':  null,
-            };
-
-            const match = title.match(/^(\w+)[\(!\:]/);
-            if (!match) { core.setFailed(`PR title "${title}" does not match conventional commit format.`); return; }
-
-            const prefix = match[1];
-            const label = labelMap[prefix];
-            if (label === undefined) { core.setFailed(`PR title prefix "${prefix}" is not a recognized conventional commit type.`); return; }
-            if (!label) return;
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [label],
-            });
-      - name: Skip label in merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "PR title already validated at PR open/edit time"
-
-
+    uses: generative-computing/.github/.github/workflows/pr-label.yml@31ecef85b868eb2a9d7ea3a0efd5c12cb4746fc1 # main


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [X] Other

## Description
- [X] Link to Issue: Continuation of #1033 

<!-- Brief description of the change being made along with an explanation. -->

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used