### PR TITLE
ci: more flexible pr template handling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component.md
@@ -1,3 +1,4 @@
+<!-- mellea-pr-checklist-marker -->
 # Component PR
 
 Use this template when adding or modifying components in `mellea/stdlib/components/`.

--- a/.github/PULL_REQUEST_TEMPLATE/misc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/misc.md
@@ -1,3 +1,4 @@
+<!-- mellea-pr-checklist-marker -->
 # Misc PR
 
 ## Type of PR

--- a/.github/PULL_REQUEST_TEMPLATE/requirement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/requirement.md
@@ -1,3 +1,4 @@
+<!-- mellea-pr-checklist-marker -->
 # Requirement PR
 
 Use this template when adding or modifying requirements in `mellea/stdlib/requirements/`.

--- a/.github/PULL_REQUEST_TEMPLATE/sampling.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sampling.md
@@ -1,3 +1,4 @@
+<!-- mellea-pr-checklist-marker -->
 # Sampling Strategy PR
 
 Use this template when adding or modifying sampling strategies in `mellea/stdlib/sampling/`.

--- a/.github/PULL_REQUEST_TEMPLATE/tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tool.md
@@ -1,3 +1,4 @@
+<!-- mellea-pr-checklist-marker -->
 # Tool PR
 
 Use this template when adding or modifying components in `mellea/stdlib/tools/`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
 # Pull Request
 
+> **Pick a template before filling this out.** Click one of the links below to
+> reload this page with the right checklist pre-filled, then write your details.
+> Your text is preserved — a bot will only append a checklist if you skip the
+> picker.
+
+- [Component](?expand=1&template=component.md) — adds or modifies code in `mellea/stdlib/components/`
+- [Requirement](?expand=1&template=requirement.md) — adds or modifies code in `mellea/stdlib/requirements/`
+- [Sampling Strategy](?expand=1&template=sampling.md) — adds or modifies code in `mellea/stdlib/sampling/`
+- [Tool](?expand=1&template=tool.md) — adds or modifies code in `mellea/stdlib/tools/`
+- [Misc](?expand=1&template=misc.md) — bug fix, new feature, documentation, or anything else
+
 NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
-
-Only modify this text by checking one of the boxes below. This comment will be overwritten with a specific pull request template based off your choice.
-
-Type of Pull Request:
-
-- [ ] Component
-- [ ] Requirement
-- [ ] Sampling Strategy
-- [ ] Tool
-- [ ] Misc: Bug Fix, New Feature, Documentation Update, Other

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -59,11 +59,7 @@ jobs:
           TEMPLATE_CONTENT=$(cat "$TEMPLATE_FILE")
 
           # Preserve the user's body verbatim; append the checklist below a divider.
-          NEW_BODY="${PR_BODY}
-
----
-
-${TEMPLATE_CONTENT}"
+          NEW_BODY=$(printf '%s\n\n---\n\n%s\n' "$PR_BODY" "$TEMPLATE_CONTENT")
 
           gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
           echo "Appended ${PR_TYPE} checklist to PR body"

--- a/.github/workflows/pr-update.yml
+++ b/.github/workflows/pr-update.yml
@@ -10,12 +10,12 @@ name: PR Bot
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
-  update-pr-body:
+  append-checklist:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.body, 'mellea-pr-edited-marker') }}
+    if: ${{ !contains(github.event.pull_request.body, 'mellea-pr-checklist-marker') }}
     permissions:
       pull-requests: write
       contents: read
@@ -30,30 +30,19 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_TYPE=""
+          # Default to misc — the picker is the primary path; this is the safety net.
+          PR_TYPE="misc"
 
-          # Check for checked boxes (supports [x] and [X])
-          if echo "$PR_BODY" | grep -qi '\[x\] Component'; then
-            PR_TYPE="component"
-          elif echo "$PR_BODY" | grep -qi '\[x\] Requirement'; then
-            PR_TYPE="requirement"
-          elif echo "$PR_BODY" | grep -qi '\[x\] Sampling Strategy'; then
-            PR_TYPE="sampling"
-          elif echo "$PR_BODY" | grep -qi '\[x\] Tool'; then
-            PR_TYPE="tool"
-          elif echo "$PR_BODY" | grep -qi '\[x\] Misc'; then
-            PR_TYPE="misc"
-          fi
-
-          if [ -z "$PR_TYPE" ]; then
-            echo "::error::No PR type selected. Please check one of of the boxes from the original pr template."
-            exit 1
+          if   echo "$PR_BODY" | grep -qi '\[x\] Component';         then PR_TYPE="component"
+          elif echo "$PR_BODY" | grep -qi '\[x\] Requirement';       then PR_TYPE="requirement"
+          elif echo "$PR_BODY" | grep -qi '\[x\] Sampling Strategy'; then PR_TYPE="sampling"
+          elif echo "$PR_BODY" | grep -qi '\[x\] Tool';              then PR_TYPE="tool"
           fi
 
           echo "pr_type=$PR_TYPE" >> "$GITHUB_OUTPUT"
           echo "Detected PR type: $PR_TYPE"
 
-      - name: Update PR body with checklist
+      - name: Append checklist to PR body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -62,23 +51,27 @@ jobs:
         run: |
           TEMPLATE_FILE=".github/PULL_REQUEST_TEMPLATE/${PR_TYPE}.md"
 
-          if [ -f "$TEMPLATE_FILE" ]; then
-            MARKER="<!-- mellea-pr-edited-marker: do not remove this marker -->"
-            TEMPLATE_CONTENT=$(cat "$TEMPLATE_FILE")
-
-            NEW_BODY="${MARKER}
-            ${TEMPLATE_CONTENT}"
-
-            gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
-            echo "Updated PR body with ${PR_TYPE} checklist"
-          else
+          if [ ! -f "$TEMPLATE_FILE" ]; then
             echo "::error::Template file not found: $TEMPLATE_FILE"
-            echo "Something as gone wrong. Contact a maintainer."
             exit 1
           fi
+
+          TEMPLATE_CONTENT=$(cat "$TEMPLATE_FILE")
+
+          # Preserve the user's body verbatim; append the checklist below a divider.
+          NEW_BODY="${PR_BODY}
+
+---
+
+${TEMPLATE_CONTENT}"
+
+          gh pr edit "$PR_NUMBER" --body "$NEW_BODY"
+          echo "Appended ${PR_TYPE} checklist to PR body"
 
       - name: Comment on PR
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc
         with:
           message: |
-            The PR description has been updated. Please fill out the template for your PR to be reviewed. 
+            A PR checklist has been appended to your description. Please complete it — your original text above the `---` divider has been preserved.
+
+            Next time, you can pick a template directly from the PR description box to skip this step.


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
  # Misc PR

## Type of PR

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Other

## Description
- [ ] Link to Issue: Fixes #951 

The PR Bot workflow currently overwrites the entire PR body when it fires, which means contributors who write a meaningful description upfront lose their text, and contributors who skip the checkbox dance break CI. This change shifts the primary path from "edit body, wait for bot, then write details" to "pick a template at PR creation time, write details once."

What changed

- Template picker in pull_request_template.md: replaced the checkbox list with direct links to each per-type template. Clicking a link reloads the new-PR page with the right checklist pre-filled, so users only fill out one form.
- Per-type templates carry a marker: each template in .github/PULL_REQUEST_TEMPLATE/ now starts with a hidden marker comment that signals "checklist already present."
- Workflow is now additive, not destructive: the bot only runs when the marker is absent, appends the checklist below a --- divider instead of overwriting, and preserves the user's original text verbatim above it.
- No more CI failures from missing checkboxes: if no type is detected, the bot falls back to the misc template instead of erroring.
- Trigger narrowed to opened: the workflow no longer re-fires when users edit their body, eliminating a class of redundant runs.

Net effect on contributors

- Users who pick a template at creation time: write their description once, never see the bot.
- Users who skip the picker: their text is preserved; the bot quietly appends a checklist below.
- Users who used to break CI by editing too quickly: no longer break CI.



### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used