### PR TITLE
chore: Add Ollama model name mappings for Granite 4.1 to intrinsics adapter resolution

### DIFF
--- a/mellea/formatters/granite/intrinsics/constants.py
+++ b/mellea/formatters/granite/intrinsics/constants.py
@@ -37,6 +37,9 @@ BASE_MODEL_TO_CANONICAL_NAME = {
     "ibm-granite/granite-4.1-8b": "granite-4.1-8b",
     "ibm-granite/granite-4.1-30b": "granite-4.1-30b",
     "granite4:micro": "granite4_micro",
+    "granite4.1:3b": "granite4.1_3b",
+    "granite4.1:8b": "granite4.1_8b",
+    "granite4.1:30b": "granite4.1_30b",
 }
 """Base model names that we accept for LoRA/aLoRA adapters in intrinsics libraries.
 Each model name maps to the name of the directory that contains (a)LoRA adapters for


### PR DESCRIPTION
cc: @frreiss 

---

<!-- mellea-pr-checklist-marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #1084 

- Add `granite4.1:3b`, `granite4.1:8b`, and `granite4.1:30b` to `BASE_MODEL_TO_CANONICAL_NAME` in `mellea/formatters/granite/intrinsics/constants.py`
- These map Ollama model identifiers to their corresponding GGUF adapter directory names (e.g. `granite4.1:3b` → `granite4.1_3b`)
- Follows the existing pattern for `granite4:micro` → `granite4_micro`

### Context

`download_intrinsic_adapter()` uses `BASE_MODEL_TO_CANONICAL_NAME` to normalize base model names before resolving LoRA/aLoRA adapter paths in the [Granite Intrinsics Library](https://huggingface.co/ibm-granite/granitelib-rag-r1.0).

When serving intrinsics adapters via Ollama, the base model name is the Ollama identifier (e.g. `granite4.1:3b`), not the HF model ID (`ibm-granite/granite-4.1-3b`). Without the mapping, the resolver searches for the literal path `answerability/granite4.1:3b/lora/io.yaml` instead of `answerability/granite4.1_3b/lora/io.yaml`, resulting in:

```
ValueError: Intrinsic 'answerability' as LoRA adapter on base model 'granite4.1:3b' not found...
Searched for path answerability/granite4.1:3b/lora/io.yaml
```


### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code as added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used