### PR TITLE
fix: prevent double-wrapping of image data URIs in OpenAI message conversion

### DIFF
--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -188,10 +188,17 @@ def message_to_openai_message(msg: Message, formatter: Formatter | None = None) 
     # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
     content = formatter.print(msg) if formatter else msg.content
     if msg.images is not None:
-        img_list = [
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img}"}}
-            for img in msg.images
-        ]
+        img_list = []
+        for img in msg.images:
+            # Strip data URI prefix if present to avoid double-wrapping
+            if "data:" in img and "base64," in img:
+                img = img.split("base64,")[1]
+            img_list.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{img}"},
+                }
+            )
 
         return {
             "role": msg.role,

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -190,15 +190,8 @@ def message_to_openai_message(msg: Message, formatter: Formatter | None = None) 
     if msg.images is not None:
         img_list = []
         for img in msg.images:
-            # Strip data URI prefix if present to avoid double-wrapping
-            if "data:" in img and "base64," in img:
-                img = img.split("base64,")[1]
-            img_list.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{img}"},
-                }
-            )
+            url = img if img.startswith("data:") else f"data:image/png;base64,{img}"
+            img_list.append({"type": "image_url", "image_url": {"url": url}})
 
         return {
             "role": msg.role,

--- a/test/helpers/test_openai_compatible_helpers.py
+++ b/test/helpers/test_openai_compatible_helpers.py
@@ -322,6 +322,34 @@ class TestMessageToOpenaiMessage:
         assert len(result["content"]) == 1
         assert result["content"][0] == {"type": "text", "text": "hello"}
 
+    def test_image_with_data_uri_prefix_not_double_wrapped(self):
+        """ImageBlock with data URI prefix should not be double-wrapped."""
+        # Create an ImageBlock with the data URI prefix already included
+        img_with_prefix = ImageBlock(f"data:image/png;base64,{_B64_PNG}")
+        msg = Message(role="user", content="describe", images=[img_with_prefix])
+        result = message_to_openai_message(msg)
+
+        # The URL should have exactly one data:image/png;base64, prefix
+        url = result["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        # Count occurrences of the prefix - should be exactly 1
+        assert url.count("data:image/png;base64,") == 1
+        # Verify the base64 data follows immediately after the prefix
+        assert url == f"data:image/png;base64,{_B64_PNG}"
+
+    def test_image_without_data_uri_prefix_gets_wrapped(self):
+        """ImageBlock without data URI prefix should get wrapped once."""
+        # Create an ImageBlock with just the base64 data (no prefix)
+        img_without_prefix = ImageBlock(_B64_PNG)
+        msg = Message(role="user", content="describe", images=[img_without_prefix])
+        result = message_to_openai_message(msg)
+
+        # The URL should have exactly one data:image/png;base64, prefix
+        url = result["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        assert url.count("data:image/png;base64,") == 1
+        assert url == f"data:image/png;base64,{_B64_PNG}"
+
 
 # --- messages_to_docs ---
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1090 

## Description
<!-- What does this PR do and why? -->
ImageBlock values may contain a data URI prefix (data:image/png;base64,). The message_to_openai_message() function was unconditionally wrapping all images with this prefix, causing double-wrapping when the prefix was already present.

Now strips any existing data URI prefix before wrapping to ensure the output always has exactly one prefix, regardless of input format.

Fixes image rendering in OpenAI-compatible backends when ImageBlock is created with a full data URI.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
