### PR TITLE
feat: add health check endpoint to CLI serve

### DIFF
--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -52,7 +52,7 @@ app = FastAPI(
 )
 
 
-@app.get("/health", status_code=200)
+@app.get("/health")
 async def health_check():
     """Basic liveness check endpoint.
 

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -53,7 +53,7 @@ app = FastAPI(
 
 
 @app.get("/health")
-async def health_check():
+async def health_check() -> dict[str, str]:
     """Basic liveness check endpoint.
 
     Returns a 200 OK status to signal that the Python process is alive and responding.

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -7,12 +7,12 @@ import os
 import sys
 import time
 import uuid
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 try:
     import typer
     import uvicorn
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI, HTTPException, Request
     from fastapi.exceptions import RequestValidationError
     from fastapi.responses import JSONResponse, StreamingResponse
     from pydantic import BaseModel
@@ -45,11 +45,48 @@ from .utils import extract_finish_reason
 
 logger = MelleaLogger.get_logger()
 
+# Track whether the server has been initialized with a module
+_server_ready = False
+
 app = FastAPI(
     title="M serve OpenAI API Compatible Server",
     description="M programs that run as a simple OpenAI API-compatible server",
     version="0.1.0",
 )
+
+
+@app.get("/health", status_code=200)
+async def health_check():
+    """Basic liveness check endpoint.
+
+    Returns a 200 OK status to signal that the Python process is alive and responding.
+
+    Returns:
+        dict: A dictionary with status "healthy".
+    """
+    return {"status": "healthy"}
+
+
+@app.get("/ready")
+async def readiness_check():
+    """Readiness check endpoint.
+
+    Returns 200 if the server has loaded a module and registered the chat
+    completions route. Returns 503 if the server is still starting up.
+
+    This endpoint is useful for Kubernetes readiness probes to ensure the
+    service doesn't receive traffic before it's ready to handle requests.
+
+    Returns:
+        dict: A dictionary with status "ready" when ready (HTTP 200).
+
+    Raises:
+        HTTPException: 503 status with error detail if server is not ready.
+    """
+    if _server_ready:
+        return {"status": "ready"}
+    else:
+        raise HTTPException(status_code=503, detail="Server not ready")
 
 
 @app.exception_handler(RequestValidationError)
@@ -286,6 +323,8 @@ def run_server(
     port: int = 8080,
 ):
     """Serve a FastAPI endpoint for a given script."""
+    global _server_ready
+
     module = load_module_from_path(script_path)
     route_path = "/v1/chat/completions"
 
@@ -295,5 +334,9 @@ def run_server(
         methods=["POST"],
         response_model=ChatCompletion | OpenAIErrorResponse,
     )
+
+    # Mark server as ready after route is successfully registered
+    _server_ready = True
+
     typer.echo(f"Serving {route_path} at http://{host}:{port}")
     uvicorn.run(app, host=host, port=port)

--- a/cli/serve/app.py
+++ b/cli/serve/app.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 try:
     import typer
     import uvicorn
-    from fastapi import FastAPI, HTTPException, Request
+    from fastapi import FastAPI, Request
     from fastapi.exceptions import RequestValidationError
     from fastapi.responses import JSONResponse, StreamingResponse
     from pydantic import BaseModel
@@ -45,9 +45,6 @@ from .utils import extract_finish_reason
 
 logger = MelleaLogger.get_logger()
 
-# Track whether the server has been initialized with a module
-_server_ready = False
-
 app = FastAPI(
     title="M serve OpenAI API Compatible Server",
     description="M programs that run as a simple OpenAI API-compatible server",
@@ -62,31 +59,9 @@ async def health_check():
     Returns a 200 OK status to signal that the Python process is alive and responding.
 
     Returns:
-        dict: A dictionary with status "healthy".
+        dict: A dictionary with status "pass".
     """
-    return {"status": "healthy"}
-
-
-@app.get("/ready")
-async def readiness_check():
-    """Readiness check endpoint.
-
-    Returns 200 if the server has loaded a module and registered the chat
-    completions route. Returns 503 if the server is still starting up.
-
-    This endpoint is useful for Kubernetes readiness probes to ensure the
-    service doesn't receive traffic before it's ready to handle requests.
-
-    Returns:
-        dict: A dictionary with status "ready" when ready (HTTP 200).
-
-    Raises:
-        HTTPException: 503 status with error detail if server is not ready.
-    """
-    if _server_ready:
-        return {"status": "ready"}
-    else:
-        raise HTTPException(status_code=503, detail="Server not ready")
+    return {"status": "pass"}
 
 
 @app.exception_handler(RequestValidationError)
@@ -323,8 +298,6 @@ def run_server(
     port: int = 8080,
 ):
     """Serve a FastAPI endpoint for a given script."""
-    global _server_ready
-
     module = load_module_from_path(script_path)
     route_path = "/v1/chat/completions"
 
@@ -334,9 +307,5 @@ def run_server(
         methods=["POST"],
         response_model=ChatCompletion | OpenAIErrorResponse,
     )
-
-    # Mark server as ready after route is successfully registered
-    _server_ready = True
-
     typer.echo(f"Serving {route_path} at http://{host}:{port}")
     uvicorn.run(app, host=host, port=port)

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -49,12 +49,17 @@ class TestHealthCheckEndpoint:
     """Tests for the health check endpoint."""
 
     def test_health_check(self):
-        """Test that /health endpoint returns 200 with correct JSON response."""
+        """Test that /health GET endpoint returns 200 with correct JSON response."""
         client = TestClient(app)
         response = client.get("/health")
 
         assert response.status_code == 200
         assert response.json() == {"status": "pass"}
+
+    def test_health_check_rejects_post(self):
+        """Test that /health POST endpoint returns 405"""
+        client = TestClient(app)
+        assert client.post("/health").status_code == 405
 
 
 class TestChatEndpoint:

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -10,13 +10,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
 
-import cli.serve.app as app_module
-from cli.serve.app import (
-    _server_ready,
-    app,
-    make_chat_endpoint,
-    validation_exception_handler,
-)
+from cli.serve.app import app, make_chat_endpoint, validation_exception_handler
 from cli.serve.models import (
     ChatCompletion,
     ChatCompletionRequest,
@@ -60,41 +54,7 @@ class TestHealthCheckEndpoint:
         response = client.get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "healthy"}
-
-
-class TestReadinessCheckEndpoint:
-    """Tests for the readiness check endpoint."""
-
-    @pytest.fixture(autouse=True)
-    def reset_server_ready(self):
-        """Reset _server_ready state before and after each test."""
-        # Save original state
-        original_state = app_module._server_ready
-        # Reset to False for clean test start
-        app_module._server_ready = False
-        yield
-        # Restore original state after test
-        app_module._server_ready = original_state
-
-    def test_ready_returns_503_before_module_loaded(self):
-        """Test that /ready returns 503 when server hasn't loaded a module yet."""
-        client = TestClient(app)
-        response = client.get("/ready")
-
-        assert response.status_code == 503
-        assert response.json()["detail"] == "Server not ready"
-
-    def test_ready_returns_200_after_module_loaded(self):
-        """Test that /ready returns 200 after run_server() marks it ready."""
-        # Simulate what run_server() does
-        app_module._server_ready = True
-
-        client = TestClient(app)
-        response = client.get("/ready")
-
-        assert response.status_code == 200
-        assert response.json() == {"status": "ready"}
+        assert response.json() == {"status": "pass"}
 
 
 class TestChatEndpoint:

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -10,7 +10,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
 
-from cli.serve.app import make_chat_endpoint, validation_exception_handler
+import cli.serve.app as app_module
+from cli.serve.app import (
+    _server_ready,
+    app,
+    make_chat_endpoint,
+    validation_exception_handler,
+)
 from cli.serve.models import (
     ChatCompletion,
     ChatCompletionRequest,
@@ -43,6 +49,52 @@ def sample_request():
         temperature=0.7,
         max_tokens=100,
     )
+
+
+class TestHealthCheckEndpoint:
+    """Tests for the health check endpoint."""
+
+    def test_health_check(self):
+        """Test that /health endpoint returns 200 with correct JSON response."""
+        client = TestClient(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy"}
+
+
+class TestReadinessCheckEndpoint:
+    """Tests for the readiness check endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def reset_server_ready(self):
+        """Reset _server_ready state before and after each test."""
+        # Save original state
+        original_state = app_module._server_ready
+        # Reset to False for clean test start
+        app_module._server_ready = False
+        yield
+        # Restore original state after test
+        app_module._server_ready = original_state
+
+    def test_ready_returns_503_before_module_loaded(self):
+        """Test that /ready returns 503 when server hasn't loaded a module yet."""
+        client = TestClient(app)
+        response = client.get("/ready")
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Server not ready"
+
+    def test_ready_returns_200_after_module_loaded(self):
+        """Test that /ready returns 200 after run_server() marks it ready."""
+        # Simulate what run_server() does
+        app_module._server_ready = True
+
+        client = TestClient(app)
+        response = client.get("/ready")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ready"}
 
 
 class TestChatEndpoint:
@@ -722,8 +774,6 @@ class TestResponseFormat:
     @pytest.mark.asyncio
     async def test_json_schema_missing_schema_field(self, mock_module):
         """Test that json_schema without schema field raises ValidationError."""
-        from pydantic import ValidationError
-
         # Should raise ValidationError when creating ResponseFormat
         with pytest.raises(ValidationError) as exc_info:
             ResponseFormat(

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -48,17 +48,22 @@ def sample_request():
 class TestHealthCheckEndpoint:
     """Tests for the health check endpoint."""
 
-    def test_health_check(self):
+    @pytest.fixture(scope="class")
+    def client(self, request) -> TestClient:
+        """Set up the test client."""
+
+        # /health is registered at module-load time — TestClient(app) is correct here
+        return TestClient(app)
+
+    def test_health_check(self, client: TestClient):
         """Test that /health GET endpoint returns 200 with correct JSON response."""
-        client = TestClient(app)
         response = client.get("/health")
 
         assert response.status_code == 200
         assert response.json() == {"status": "pass"}
 
-    def test_health_check_rejects_post(self):
+    def test_health_check_rejects_post(self, client: TestClient):
         """Test that /health POST endpoint returns 405"""
-        client = TestClient(app)
         assert client.post("/health").status_code == 405
 
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1066

## Description
<!-- What does this PR do and why? -->
Adds /health endpoint to the FastAPI server for Kubernetes liveness probes.

- /health: always returns 200 (liveness check)

Future readiness check (i.e., /ready) deferred to be done in a separate PR.

Assisted-by: IBM Bob

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
