### PR TITLE
fix: guard hf dep for m alora command

### DIFF
--- a/cli/alora/commands.py
+++ b/cli/alora/commands.py
@@ -204,7 +204,13 @@ def alora_add_readme(
         OSError: If no Hugging Face authentication token is found.
         SystemExit: If the user declines to upload the generated README.
     """
-    from huggingface_hub import HfFolder, create_repo, upload_file
+    try:
+        from huggingface_hub import HfFolder, create_repo, upload_file
+    except ImportError as e:
+        raise ImportError(
+            "The 'm alora' command requires extra dependencies. "
+            'Please install them with: pip install "mellea[hf]"'
+        ) from e
 
     from cli.alora.readme_generator import generate_readme
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #855 

## Description
Wraps the `huggingface_hub` import in `alora_add_readme` (`cli/alora/commands.py`) with a try/except `ImportError` guard, matching the friendly install hint pattern already used by `m alora train`, `m alora upload`, and `m serve`. Without this, running `m alora add-readme` in an environment installed via `pip install "mellea[cli]"` (no `[hf]` extra) crashed with a raw `ModuleNotFoundError`. 

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
