### PR TITLE
docs: fixing docs contributor guide

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -252,7 +252,7 @@ jobs:
 
           CONTRIB_URL = (
               "https://github.com/generative-computing/mellea/blob/main"
-              "/docs/docs/guide/CONTRIBUTING.md"
+              "/docs/CONTRIBUTING_DOCS.md"
           )
           REPO = os.environ.get("GITHUB_REPOSITORY", "")
           RUN_ID = os.environ.get("GITHUB_RUN_ID", "")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 - Use `...` in `@generative` function bodies
 - Prefer primitives over classes
 - **Friendly Dependency Errors**: Wraps optional backend imports in `try/except ImportError` with a helpful message (e.g., "Please pip install mellea[hf]"). See `mellea/stdlib/session.py` for examples.
-- **CLI command docstrings**: Typer command functions in `cli/` follow an enriched convention with `Prerequisites:` and `See Also:` sections — these feed the auto-generated CLI reference page. See [`docs/docs/guide/CONTRIBUTING.md`](docs/docs/guide/CONTRIBUTING.md) for the full pattern. Regenerate after changes: `uv run poe clidocs`. Test the generator: `uv run pytest tooling/docs-autogen/test_cli_reference.py -v`. Full pipeline docs: [`tooling/docs-autogen/README.md`](tooling/docs-autogen/README.md).
+- **CLI command docstrings**: Typer command functions in `cli/` follow an enriched convention with `Prerequisites:` and `See Also:` sections — these feed the auto-generated CLI reference page. See [`docs/CONTRIBUTING_DOCS.md`](docs/CONTRIBUTING_DOCS.md) for the full pattern. Regenerate after changes: `uv run poe clidocs`. Test the generator: `uv run pytest tooling/docs-autogen/test_cli_reference.py -v`. Full pipeline docs: [`tooling/docs-autogen/README.md`](tooling/docs-autogen/README.md).
 - **Backend telemetry fields**: All backends must populate `mot.generation.usage` (dict with `prompt_tokens`, `completion_tokens`, `total_tokens`), `mot.generation.model` (str), and `mot.generation.provider` (str) in their `post_processing()` method. These fields live on `mot.generation`, a `GenerationMetadata` dataclass. `mot.generation.streaming` (bool) and `mot.generation.ttfb_ms` (float | None) are set automatically in `astream()` — backends do not need to set them. Metrics are automatically recorded by `TokenMetricsPlugin`, `LatencyMetricsPlugin`, and `ErrorMetricsPlugin` — don't add manual `record_token_usage_metrics()`, `record_request_duration()`, or `record_error()` calls.
 
 ## 6. Commits & Hooks
@@ -144,7 +144,7 @@ Use the tool's common name (e.g., GitHub Copilot, Cursor, etc.).
 ## 12. Writing Docs
 
 If you are modifying or creating pages under `docs/docs/`, follow the writing
-conventions in [`docs/docs/guide/CONTRIBUTING.md`](docs/docs/guide/CONTRIBUTING.md).
+conventions in [`docs/CONTRIBUTING_DOCS.md`](docs/CONTRIBUTING_DOCS.md).
 Key rules that differ from typical Markdown habits:
 
 - **No H1 in the body** — Mintlify renders the frontmatter `title` automatically;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -469,7 +469,7 @@ print(m.last_prompt())
 
 ### Documentation
 
-- **[Docs writing guide](docs/docs/guide/CONTRIBUTING.md)** - Conventions, PR checklist, and review process for documentation contributions
+- **[Docs writing guide](docs/CONTRIBUTING_DOCS.md)** - Conventions, PR checklist, and review process for documentation contributions
 - **[API Documentation](https://docs.mellea.ai)** - Published documentation site
 - **[Test Markers Guide](test/MARKERS_GUIDE.md)** - Detailed pytest marker documentation
 - **[AGENTS.md](AGENTS.md)** - Guidelines for AI assistants working on Mellea internals

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -1,12 +1,6 @@
----
-title: "Contributing to the Mellea docs"
-description: "Writing conventions, review process, and PR checklist for Mellea guide pages."
-# diataxis: reference
----
-
 # Contributing to the Mellea docs
 
-This file is the authoritative writing guide for `docs/docs/guide/`. It is linked from the root `CONTRIBUTING.md` and is also accessible on the published docs site.
+Writing conventions, review process, and PR checklist for pages under `docs/docs/`. This is a repo-level contributor guide for editing the Mintlify source — it is not a published docs page. The user-facing contributing guide is at [`docs/docs/community/contributing-guide.md`](docs/community/contributing-guide.md).
 
 ---
 
@@ -358,7 +352,7 @@ so when an `Attributes:` section is present it must exactly match the declared f
 The CI audit will fail on phantom fields (documented but not declared) and undocumented
 fields (declared but missing from `Attributes:`).
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full validation workflow.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full validation workflow.
 
 ### CI docstring checks reference
 
@@ -492,17 +486,17 @@ mintlify dev
 
 ## Linting
 
-All guide pages must pass `markdownlint` with zero warnings **per page before moving on**. Config: `docs/docs/guide/.markdownlint.json`.
+All pages under `docs/docs/` must pass `markdownlint` with zero warnings **per page before moving on**.
 
 ```bash
-markdownlint docs/docs/guide/your-page.md
+npx markdownlint-cli2 "docs/docs/**/*.md"
 ```
 
 ---
 
 ## Images
 
-- Store in `docs/docs/guide/images/`, relative paths, always include alt text.
+- Store in `docs/docs/images/` (or a section-local `images/` subdir), relative paths, always include alt text.
 - Prefer text or code over images where possible.
 
 ---

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -27,4 +27,4 @@ The site is available at <http://localhost:3000>.
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/generative-computing/mellea/blob/main/CONTRIBUTING.md) for the general contribution guide and
-[guide/CONTRIBUTING.md](guide/CONTRIBUTING.md) for documentation writing conventions.
+[CONTRIBUTING_DOCS.md](https://github.com/generative-computing/mellea/blob/main/docs/CONTRIBUTING_DOCS.md) for documentation writing conventions.

--- a/docs/docs/community/contributing-guide.md
+++ b/docs/docs/community/contributing-guide.md
@@ -337,7 +337,7 @@ print(m.last_prompt())
 ## Contributing to the docs
 
 Documentation lives in `docs/docs/`. The writing guide at
-[`docs/docs/guide/CONTRIBUTING`](https://github.com/generative-computing/mellea/blob/main/docs/docs/guide/CONTRIBUTING.md) covers conventions, the PR
+[`docs/CONTRIBUTING_DOCS.md`](https://github.com/generative-computing/mellea/blob/main/docs/CONTRIBUTING_DOCS.md) covers conventions, the PR
 checklist, and the review process for documentation contributions. Key points:
 
 - Start body content with H2 — Mintlify renders the frontmatter `title` as the page heading.

--- a/docs/docs/docs.json
+++ b/docs/docs/docs.json
@@ -466,7 +466,7 @@
     },
     {
       "source": "/core-concept/contribution-guide",
-      "destination": "/guide/CONTRIBUTING"
+      "destination": "/community/contributing-guide"
     },
     {
       "source": "/core-concept/prompt-engineering",

--- a/docs/docs/guide/.markdownlint.json
+++ b/docs/docs/guide/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD033": false,
-  "MD041": false,
-  "MD025": { "front_matter_title": "" }
-}

--- a/docs/docs/troubleshooting/faq.md
+++ b/docs/docs/troubleshooting/faq.md
@@ -309,7 +309,7 @@ asyncio.run(main())
 Read the contributing guide first:
 
 ```bash
-cat docs/docs/guide/CONTRIBUTING.md
+cat docs/CONTRIBUTING_DOCS.md
 ```
 
 The short version:

--- a/tooling/docs-autogen/audit_coverage.py
+++ b/tooling/docs-autogen/audit_coverage.py
@@ -688,8 +688,7 @@ _IN_GHA = os.environ.get("GITHUB_ACTIONS") == "true"
 # These point to upstream main; anchors for the CI checks reference section
 # will resolve once the PR introducing them is merged.
 _CONTRIB_DOCS_URL = (
-    "https://github.com/generative-computing/mellea/blob/main"
-    "/docs/CONTRIBUTING_DOCS.md"
+    "https://github.com/generative-computing/mellea/blob/main/docs/CONTRIBUTING_DOCS.md"
 )
 _COVERAGE_DOCS_URL = (
     "https://github.com/generative-computing/mellea/blob/main"

--- a/tooling/docs-autogen/audit_coverage.py
+++ b/tooling/docs-autogen/audit_coverage.py
@@ -689,7 +689,7 @@ _IN_GHA = os.environ.get("GITHUB_ACTIONS") == "true"
 # will resolve once the PR introducing them is merged.
 _CONTRIB_DOCS_URL = (
     "https://github.com/generative-computing/mellea/blob/main"
-    "/docs/docs/guide/CONTRIBUTING.md"
+    "/docs/CONTRIBUTING_DOCS.md"
 )
 _COVERAGE_DOCS_URL = (
     "https://github.com/generative-computing/mellea/blob/main"

--- a/tooling/docs-autogen/validate.py
+++ b/tooling/docs-autogen/validate.py
@@ -23,7 +23,7 @@ _ROOT_CONTRIB = (
 )
 _GUIDE_CONTRIB = (
     "https://github.com/generative-computing/mellea/blob/main"
-    "/docs/docs/guide/CONTRIBUTING.md"
+    "/docs/CONTRIBUTING_DOCS.md"
 )
 
 # Per-check fix hints: label (as passed to _print_check_errors) -> (fix text, ref URL)

--- a/tooling/docs-autogen/validate.py
+++ b/tooling/docs-autogen/validate.py
@@ -22,8 +22,7 @@ _ROOT_CONTRIB = (
     "https://github.com/generative-computing/mellea/blob/main/CONTRIBUTING.md"
 )
 _GUIDE_CONTRIB = (
-    "https://github.com/generative-computing/mellea/blob/main"
-    "/docs/CONTRIBUTING_DOCS.md"
+    "https://github.com/generative-computing/mellea/blob/main/docs/CONTRIBUTING_DOCS.md"
 )
 
 # Per-check fix hints: label (as passed to _print_check_errors) -> (fix text, ref URL)


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #965 

## Description
Moves `docs/docs/guide/CONTRIBUTING.md` to `docs/CONTRIBUTING_DOCS.md` (alongside `docs/AGENTS_TEMPLATE.md` and `docs/PUBLISHING.md`), strips the Mintlify frontmatter, and removes the now-empty `docs/docs/guide/` directory — clarifying that this is a repo-level docs-writing guide, not a published site page. Updates the 8 references across `CONTRIBUTING.md`, `AGENTS.md`, the docs-autogen tooling, the docs-publish workflow, and three doc pages to point at the new path. Fixes a broken redirect in `docs.json` (`/core-concept/contribution-guide` → `/community/contributing-guide`,  which is the actual user-facing contributing page in nav).

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
