### PR TITLE
docs: add redirect callout from MCP server page to MCP tools

### DIFF
--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -10,6 +10,8 @@ for exposing tools to AI clients. Mellea integrates with MCP via
 [FastMCP](https://github.com/jlowin/fastmcp): wrap any Mellea function as an MCP tool
 and call it from Claude Desktop, Cursor, or any MCP-compatible client.
 
+> Looking to **call** tools from an MCP server? See [MCP tools](../how-to/tools-and-agents#mcp-tools) in Tools and Agents.
+
 **Prerequisites:** `pip install mellea`, `pip install "mcp[cli]"`, Ollama running locally.
 
 ## Creating an MCP server


### PR DESCRIPTION
## Issue
Fixes #1109. Originally discussed in [generative-computing/mellea-website#50](https://github.com/generative-computing/mellea-website/pull/50).

## Description
The `/integrations/mcp` page covers exposing Mellea functions as MCP tools (Mellea-as-server). Searching "MCP" in the docs surfaces it first, which is confusing for users looking for the inverse direction — calling tools from an existing MCP server, documented under Tools and Agents.

This adds a one-line blockquote on the MCP server page pointing to `Tools and Agents → MCP tools`. The callout sits below the intro paragraph so Mintlify's search snippet remains the existing page description rather than the redirect text.

**Rendered callout:**

<img width="705" height="531" alt="Screenshot 2026-05-20 at 8 39 47 PM" src="https://github.com/user-attachments/assets/65058b16-acb1-46ec-85c6-6388337c5da7" />

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
