### PR TITLE
feat: add stopping sequence to model options

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -675,7 +675,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # overwriting any values set by the util function or io.yaml defaults.
         # We don't update other_input since those inputs are specific to `generate_with_transformers`
         # and not covered by model options.
-        user_params = self._make_backend_specific_and_remove(model_options)
+        user_params = self._generate_kwargs(model_options)
         generate_input.update(user_params)
 
         chat_response = asyncio.to_thread(
@@ -970,7 +970,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 attention_mask=attention_mask.to(self._device),
                 return_dict_in_generate=True,
                 output_scores=True,
-                **self._make_backend_specific_and_remove(generate_options),
+                **self._generate_kwargs(generate_options),
                 **streaming_kwargs,  # type: ignore
                 **format_kwargs,  # type: ignore
             )
@@ -1132,7 +1132,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 input_ids,
                 return_dict_in_generate=True,
                 use_cache=self._use_caches,  # Only create KV cache if caching is enabled
-                **self._make_backend_specific_and_remove(generate_options),
+                **self._generate_kwargs(generate_options),
                 **streaming_kwargs,  # type: ignore
                 **format_kwargs,  # type: ignore
             )
@@ -1473,7 +1473,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 attention_mask=inputs["attention_mask"],
                 return_dict_in_generate=True,
                 output_scores=True,
-                **self._make_backend_specific_and_remove(model_opts),
+                **self._generate_kwargs(model_opts),
                 **format_kwargs,
             )
 
@@ -1593,11 +1593,18 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         backend_specific = ModelOption.replace_keys(
             model_options, self.from_mellea_model_opts_map
         )
-        cleaned = ModelOption.remove_special_keys(backend_specific)
-        # transformers' generate() requires `tokenizer=` whenever stop_strings is set.
-        if "stop_strings" in cleaned and "tokenizer" not in cleaned:
-            cleaned["tokenizer"] = self._tokenizer
-        return cleaned
+        return ModelOption.remove_special_keys(backend_specific)
+
+    def _generate_kwargs(self, model_options: dict[str, Any]) -> dict[str, Any]:
+        """Backend-specific options ready to splat into ``model.generate(...)``.
+
+        Wraps :meth:`_make_backend_specific_and_remove` and injects ``tokenizer=`` when
+        ``stop_strings`` is present, since transformers' ``generate()`` requires it.
+        """
+        kwargs = self._make_backend_specific_and_remove(model_options)
+        if "stop_strings" in kwargs and "tokenizer" not in kwargs:
+            kwargs["tokenizer"] = self._tokenizer
+        return kwargs
 
     def _filter_chat_template_only_options(
         self, model_options: dict[str, Any]

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -318,6 +318,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "seed": ModelOption.SEED,
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
+            "stop_strings": ModelOption.STOP_SEQUENCES,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -325,7 +326,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # Usually, values that are intentionally extracted while prepping for the backend generate call
         # will be omitted here so that they will be removed when model_options are processed
         # for the call to the model.
-        self.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+        self.from_mellea_model_opts_map = {
+            ModelOption.MAX_NEW_TOKENS: "max_new_tokens",
+            ModelOption.STOP_SEQUENCES: "stop_strings",
+        }
 
         self.default_to_constraint_checking_alora = default_to_constraint_checking_alora
 
@@ -1589,7 +1593,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         backend_specific = ModelOption.replace_keys(
             model_options, self.from_mellea_model_opts_map
         )
-        return ModelOption.remove_special_keys(backend_specific)
+        cleaned = ModelOption.remove_special_keys(backend_specific)
+        # transformers' generate() requires `tokenizer=` whenever stop_strings is set.
+        if "stop_strings" in cleaned and "tokenizer" not in cleaned:
+            cleaned["tokenizer"] = self._tokenizer
+        return cleaned
 
     def _filter_chat_template_only_options(
         self, model_options: dict[str, Any]

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1570,14 +1570,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         if model_options is None:
+            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
             model_options, self.to_mellea_model_opts_map
         )
-        return ModelOption.merge_model_options(
+        merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
+        ModelOption.validate_stop_sequences(merged)
+        return merged
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any]

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -675,7 +675,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # overwriting any values set by the util function or io.yaml defaults.
         # We don't update other_input since those inputs are specific to `generate_with_transformers`
         # and not covered by model options.
-        user_params = self._generate_kwargs(model_options)
+        user_params = self._make_backend_specific_and_remove(model_options)
+        if "stop_strings" in user_params and "tokenizer" not in user_params:
+            user_params["tokenizer"] = self._tokenizer
         generate_input.update(user_params)
 
         chat_response = asyncio.to_thread(
@@ -959,6 +961,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 )
             )
 
+            generate_kwargs = self._make_backend_specific_and_remove(generate_options)
+            if "stop_strings" in generate_kwargs and "tokenizer" not in generate_kwargs:
+                # transformers' generate() requires a tokenizer to decode stop_strings.
+                generate_kwargs["tokenizer"] = self._tokenizer
+
             chat_response = asyncio.to_thread(
                 self._generate_with_adapter_lock,
                 "",  # Empty for no adapters.
@@ -970,7 +977,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 attention_mask=attention_mask.to(self._device),
                 return_dict_in_generate=True,
                 output_scores=True,
-                **self._generate_kwargs(generate_options),
+                **generate_kwargs,
                 **streaming_kwargs,  # type: ignore
                 **format_kwargs,  # type: ignore
             )
@@ -1124,6 +1131,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     generate_options, streaming_kwargs
                 )
 
+            generate_kwargs = self._make_backend_specific_and_remove(generate_options)
+            if "stop_strings" in generate_kwargs and "tokenizer" not in generate_kwargs:
+                # transformers' generate() requires a tokenizer to decode stop_strings.
+                generate_kwargs["tokenizer"] = self._tokenizer
+
             chat_response = asyncio.to_thread(
                 self._generate_with_adapter_lock,
                 "",  # Empty for no adapters.
@@ -1132,7 +1144,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 input_ids,
                 return_dict_in_generate=True,
                 use_cache=self._use_caches,  # Only create KV cache if caching is enabled
-                **self._generate_kwargs(generate_options),
+                **generate_kwargs,
                 **streaming_kwargs,  # type: ignore
                 **format_kwargs,  # type: ignore
             )
@@ -1464,6 +1476,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     [logits_processor]
                 )
 
+            generate_kwargs = self._make_backend_specific_and_remove(model_opts)
+            if "stop_strings" in generate_kwargs and "tokenizer" not in generate_kwargs:
+                # transformers' generate() requires a tokenizer to decode stop_strings.
+                generate_kwargs["tokenizer"] = self._tokenizer
+
             outputs = await asyncio.to_thread(
                 self._generate_with_adapter_lock,
                 "",  # Empty for no adapter.
@@ -1473,7 +1490,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 attention_mask=inputs["attention_mask"],
                 return_dict_in_generate=True,
                 output_scores=True,
-                **self._generate_kwargs(model_opts),
+                **generate_kwargs,
                 **format_kwargs,
             )
 
@@ -1570,7 +1587,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         if model_options is None:
-            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
@@ -1579,7 +1595,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
-        ModelOption.validate_stop_sequences(merged)
         return merged
 
     def _make_backend_specific_and_remove(
@@ -1597,17 +1612,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             model_options, self.from_mellea_model_opts_map
         )
         return ModelOption.remove_special_keys(backend_specific)
-
-    def _generate_kwargs(self, model_options: dict[str, Any]) -> dict[str, Any]:
-        """Backend-specific options ready to splat into ``model.generate(...)``.
-
-        Wraps :meth:`_make_backend_specific_and_remove` and injects ``tokenizer=`` when
-        ``stop_strings`` is present, since transformers' ``generate()`` requires it.
-        """
-        kwargs = self._make_backend_specific_and_remove(model_options)
-        if "stop_strings" in kwargs and "tokenizer" not in kwargs:
-            kwargs["tokenizer"] = self._tokenizer
-        return kwargs
 
     def _filter_chat_template_only_options(
         self, model_options: dict[str, Any]

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -208,14 +208,17 @@ class LiteLLMBackend(FormatterBackend):
         )
 
         if model_options is None:
+            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
             model_options, self.to_mellea_model_opts_map
         )
-        return ModelOption.merge_model_options(
+        merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
+        ModelOption.validate_stop_sequences(merged)
+        return merged
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any]

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -116,6 +116,7 @@ class LiteLLMBackend(FormatterBackend):
             "tools": ModelOption.TOOLS,
             "functions": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
+            "stop": ModelOption.STOP_SEQUENCES,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -127,6 +128,7 @@ class LiteLLMBackend(FormatterBackend):
             ModelOption.SEED: "seed",
             ModelOption.MAX_NEW_TOKENS: "max_completion_tokens",
             ModelOption.STREAM: "stream",
+            ModelOption.STOP_SEQUENCES: "stop",
         }
 
         self._past_event_loops: set[int] = set()

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -208,7 +208,6 @@ class LiteLLMBackend(FormatterBackend):
         )
 
         if model_options is None:
-            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
@@ -217,7 +216,6 @@ class LiteLLMBackend(FormatterBackend):
         merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
-        ModelOption.validate_stop_sequences(merged)
         return merged
 
     def _make_backend_specific_and_remove(

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -56,6 +56,26 @@ class ModelOption:
     """
 
     @staticmethod
+    def validate_stop_sequences(model_options: dict[str, Any]) -> None:
+        """Reject non-list values for ``STOP_SEQUENCES``.
+
+        Mellea requires ``list[str]`` so behavior is uniform across backends — a bare
+        string would silently work on OpenAI/LiteLLM but break HuggingFace's
+        ``stop_strings``.
+
+        Raises:
+            TypeError: if ``STOP_SEQUENCES`` is set and is not a ``list`` of ``str``.
+        """
+        value = model_options.get(ModelOption.STOP_SEQUENCES)
+        if value is None:
+            return
+        if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
+            raise TypeError(
+                "ModelOption.STOP_SEQUENCES must be a list[str]; "
+                f"got {type(value).__name__}: {value!r}"
+            )
+
+    @staticmethod
     def replace_keys(options: dict, from_to: dict[str, str]) -> dict[str, Any]:
         """Return a new dict with selected keys in ``options`` renamed according to ``from_to``.
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -56,29 +56,6 @@ class ModelOption:
     """
 
     @staticmethod
-    def validate_stop_sequences(model_options: dict[str, Any]) -> None:
-        """Reject non-list values for ``STOP_SEQUENCES``.
-
-        Mellea requires ``list[str]`` so behavior is uniform across backends — a bare
-        string would silently work on OpenAI/LiteLLM but break HuggingFace's
-        ``stop_strings``.
-
-        Args:
-            model_options: Model options dict to validate; checked for the ``STOP_SEQUENCES`` key.
-
-        Raises:
-            TypeError: if ``STOP_SEQUENCES`` is set and is not a ``list`` of ``str``.
-        """
-        value = model_options.get(ModelOption.STOP_SEQUENCES)
-        if value is None:
-            return
-        if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
-            raise TypeError(
-                "ModelOption.STOP_SEQUENCES must be a list[str]; "
-                f"got {type(value).__name__}: {value!r}"
-            )
-
-    @staticmethod
     def replace_keys(options: dict, from_to: dict[str, str]) -> dict[str, Any]:
         """Return a new dict with selected keys in ``options`` renamed according to ``from_to``.
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -30,6 +30,8 @@ class ModelOption:
         THINKING (str): Sentinel key for enabling/configuring reasoning/thinking mode.
         SEED (str): Sentinel key for the random seed for reproducible generation.
         STREAM (str): Sentinel key for enabling streaming responses.
+        STOP_SEQUENCES (str): Sentinel key for a ``list[str]`` of strings that, when
+            encountered in the model output, cause generation to halt.
     """
 
     TOOLS = "@@@tools@@@"
@@ -45,6 +47,13 @@ class ModelOption:
     THINKING = "@@@thinking@@@"
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"
+    STOP_SEQUENCES = "@@@stop_sequences@@@"
+    """Must be a ``list[str]``. Generation halts when the model emits any of these strings.
+
+    Backends translate this to their native parameter (``stop`` for OpenAI/Ollama/LiteLLM
+    chat backends, ``stop_strings`` for HuggingFace, ``stop_sequences`` for the WatsonX
+    text-generation endpoint).
+    """
 
     @staticmethod
     def replace_keys(options: dict, from_to: dict[str, str]) -> dict[str, Any]:

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -63,6 +63,9 @@ class ModelOption:
         string would silently work on OpenAI/LiteLLM but break HuggingFace's
         ``stop_strings``.
 
+        Args:
+            model_options: Model options dict to validate; checked for the ``STOP_SEQUENCES`` key.
+
         Raises:
             TypeError: if ``STOP_SEQUENCES`` is set and is not a ``list`` of ``str``.
         """

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -246,14 +246,17 @@ class OllamaModelBackend(FormatterBackend):
         )
 
         if model_options is None:
+            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
             model_options, self.to_mellea_model_opts_map
         )
-        return ModelOption.merge_model_options(
+        merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
+        ModelOption.validate_stop_sequences(merged)
+        return merged
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any]

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -117,6 +117,7 @@ class OllamaModelBackend(FormatterBackend):
             "seed": ModelOption.SEED,
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
+            "stop": ModelOption.STOP_SEQUENCES,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -128,6 +129,7 @@ class OllamaModelBackend(FormatterBackend):
             ModelOption.CONTEXT_WINDOW: "num_ctx",
             ModelOption.MAX_NEW_TOKENS: "num_predict",
             ModelOption.SEED: "seed",
+            ModelOption.STOP_SEQUENCES: "stop",
         }
 
     def _get_ollama_model_id(self) -> str:

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -246,7 +246,6 @@ class OllamaModelBackend(FormatterBackend):
         )
 
         if model_options is None:
-            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(
@@ -255,7 +254,6 @@ class OllamaModelBackend(FormatterBackend):
         merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
-        ModelOption.validate_stop_sequences(merged)
         return merged
 
     def _make_backend_specific_and_remove(

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -144,6 +144,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             "tools": ModelOption.TOOLS,
             "functions": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
+            "stop": ModelOption.STOP_SEQUENCES,
         }
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
         # These options should almost always be a subset of those specified in the `to_mellea_model_opts_map`.
@@ -154,6 +155,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             ModelOption.SEED: "seed",
             ModelOption.MAX_NEW_TOKENS: "max_completion_tokens",
             ModelOption.STREAM: "stream",
+            ModelOption.STOP_SEQUENCES: "stop",
         }
 
         # See notes above.
@@ -161,12 +163,14 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             "seed": ModelOption.SEED,
             "max_tokens": ModelOption.MAX_NEW_TOKENS,
             "stream": ModelOption.STREAM,
+            "stop": ModelOption.STOP_SEQUENCES,
         }
         # See notes above.
         self.from_mellea_model_opts_map_completions = {
             ModelOption.SEED: "seed",
             ModelOption.MAX_NEW_TOKENS: "max_tokens",
             ModelOption.STREAM: "stream",
+            ModelOption.STOP_SEQUENCES: "stop",
         }
 
         self.default_to_constraint_checking_alora = default_to_constraint_checking_alora

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -403,12 +403,15 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         backend_model_opts = ModelOption.replace_keys(self.model_options, remap_dict)
 
         if model_options is None:
+            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(model_options, remap_dict)
-        return ModelOption.merge_model_options(
+        merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
+        ModelOption.validate_stop_sequences(merged)
+        return merged
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any], is_chat_context: bool

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -403,14 +403,12 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         backend_model_opts = ModelOption.replace_keys(self.model_options, remap_dict)
 
         if model_options is None:
-            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(model_options, remap_dict)
         merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
-        ModelOption.validate_stop_sequences(merged)
         return merged
 
     def _make_backend_specific_and_remove(

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -144,6 +144,7 @@ class WatsonxAIBackend(FormatterBackend):
             "max_completion_tokens": ModelOption.MAX_NEW_TOKENS,
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
+            "stop": ModelOption.STOP_SEQUENCES,
         }
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
         # These options should almost always be a subset of those specified in the `to_mellea_model_opts_map`.
@@ -151,7 +152,8 @@ class WatsonxAIBackend(FormatterBackend):
         # will be omitted here so that they will be removed when model_options are processed
         # for the call to the model.
         self.from_mellea_model_opts_map_chats = {
-            ModelOption.MAX_NEW_TOKENS: "max_completion_tokens"
+            ModelOption.MAX_NEW_TOKENS: "max_completion_tokens",
+            ModelOption.STOP_SEQUENCES: "stop",
         }
 
         # See notes above.
@@ -159,11 +161,13 @@ class WatsonxAIBackend(FormatterBackend):
             "random_seed": ModelOption.SEED,
             "max_new_tokens": ModelOption.MAX_NEW_TOKENS,
             "stream": ModelOption.STREAM,
+            "stop_sequences": ModelOption.STOP_SEQUENCES,
         }
         # See notes above.
         self.from_mellea_model_opts_map_completions = {
             ModelOption.SEED: "random_seed",
             ModelOption.MAX_NEW_TOKENS: "max_new_tokens",
+            ModelOption.STOP_SEQUENCES: "stop_sequences",
         }
 
     @property

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -242,14 +242,12 @@ class WatsonxAIBackend(FormatterBackend):
         backend_model_opts = ModelOption.replace_keys(self.model_options, remap_dict)
 
         if model_options is None:
-            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(model_options, remap_dict)
         merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
-        ModelOption.validate_stop_sequences(merged)
         return merged
 
     def _make_backend_specific_and_remove(

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -242,12 +242,15 @@ class WatsonxAIBackend(FormatterBackend):
         backend_model_opts = ModelOption.replace_keys(self.model_options, remap_dict)
 
         if model_options is None:
+            ModelOption.validate_stop_sequences(backend_model_opts)
             return backend_model_opts
 
         generate_call_model_opts = ModelOption.replace_keys(model_options, remap_dict)
-        return ModelOption.merge_model_options(
+        merged = ModelOption.merge_model_options(
             backend_model_opts, generate_call_model_opts
         )
+        ModelOption.validate_stop_sequences(merged)
+        return merged
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any], is_chat_context: bool

--- a/test/backends/test_model_options.py
+++ b/test/backends/test_model_options.py
@@ -94,6 +94,16 @@ def test_model_option_replace_with_conflicts():
     assert ModelOption.TOOLS in processed_model_opts
 
 
+def test_model_option_sentinels_are_unique():
+    """All ``@@@``-prefixed sentinel values on ModelOption must be distinct."""
+    sentinel_values = [
+        v
+        for v in vars(ModelOption).values()
+        if isinstance(v, str) and v.startswith("@@@")
+    ]
+    assert len(sentinel_values) == len(set(sentinel_values))
+
+
 def test_model_option_merge():
     default_model_opts = {
         ModelOption.CONTEXT_WINDOW: 3,

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -249,5 +249,23 @@ def test_client_cache(session) -> None:
     assert len(backend._client_cache.cache.values()) == 2
 
 
+@pytest.mark.qualitative
+def test_stop_sequences(session) -> None:
+    """Generation should halt before any of the configured stop strings appears."""
+    stop = "STOP_HERE_MARKER"
+    result = session.instruct(
+        "Count from 1 to 20, separated by spaces. After 20, write 'STOP_HERE_MARKER' "
+        "and then keep counting to 30.",
+        model_options={
+            ModelOption.STOP_SEQUENCES: [stop],
+            ModelOption.MAX_NEW_TOKENS: 200,
+        },
+    )
+    # Ollama strips the stop string from the returned text, so it should not appear.
+    assert stop not in result.value, (
+        f"stop sequence leaked into output: {result.value!r}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -58,9 +58,11 @@ def test_simplify_and_merge_none_returns_empty_dict(backend):
 def test_simplify_and_merge_all_to_mellea_entries(backend):
     """Every to_mellea entry remaps to its ModelOption via _simplify_and_merge."""
     for backend_key, mellea_key in backend.to_mellea_model_opts_map.items():
-        result = backend._simplify_and_merge({backend_key: 42})
+        # STOP_SEQUENCES is validated as list[str]; other sentinels accept anything.
+        value = ["STOP"] if mellea_key == ModelOption.STOP_SEQUENCES else 42
+        result = backend._simplify_and_merge({backend_key: value})
         assert mellea_key in result, f"{backend_key!r} did not produce {mellea_key!r}"
-        assert result[mellea_key] == 42
+        assert result[mellea_key] == value
 
 
 def test_simplify_and_merge_remaps_num_predict(backend):

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -104,9 +104,13 @@ def test_simplify_and_merge_all_to_mellea_entries(backend, context):
     is_chat = context == "chats"
     to_map = getattr(backend, f"to_mellea_model_opts_map_{context}")
     for backend_key, mellea_key in to_map.items():
-        result = backend._simplify_and_merge({backend_key: 42}, is_chat_context=is_chat)
+        # STOP_SEQUENCES is validated as list[str]; other sentinels accept anything.
+        value = ["STOP"] if mellea_key == ModelOption.STOP_SEQUENCES else 42
+        result = backend._simplify_and_merge(
+            {backend_key: value}, is_chat_context=is_chat
+        )
         assert mellea_key in result, f"{backend_key!r} did not produce {mellea_key!r}"
-        assert result[mellea_key] == 42
+        assert result[mellea_key] == value
 
 
 def test_simplify_and_merge_remaps_max_completion_tokens(backend):

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -12,24 +12,6 @@ from mellea.backends import ModelOption
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
 
-
-def test_sentinel_value_is_unique():
-    """STOP_SEQUENCES sentinel must not collide with other ModelOption values."""
-    sentinels = {
-        v
-        for k, v in vars(ModelOption).items()
-        if isinstance(v, str) and v.startswith("@@@")
-    }
-    assert ModelOption.STOP_SEQUENCES in sentinels
-    # No duplicates among sentinel values.
-    sentinel_values = [
-        v
-        for k, v in vars(ModelOption).items()
-        if isinstance(v, str) and v.startswith("@@@")
-    ]
-    assert len(sentinel_values) == len(set(sentinel_values))
-
-
 # --- OpenAI ---
 
 
@@ -102,28 +84,3 @@ def test_litellm_stop_sequences_round_trip():
         {ModelOption.STOP_SEQUENCES: stops}
     )
     assert backend_specific["stop"] == stops
-
-
-# --- HuggingFace and Watsonx map shape (source-level, no optional deps) ---
-
-
-def _read(path: str) -> str:
-    from pathlib import Path
-
-    return Path(path).read_text()
-
-
-def test_huggingface_map_entries_present():
-    """Verify HF backend source registers STOP_SEQUENCES <-> stop_strings."""
-    src = _read("mellea/backends/huggingface.py")
-    assert '"stop_strings": ModelOption.STOP_SEQUENCES' in src
-    assert 'ModelOption.STOP_SEQUENCES: "stop_strings"' in src
-
-
-def test_watsonx_map_entries_present():
-    """Verify Watsonx backend source registers STOP_SEQUENCES for both endpoints."""
-    src = _read("mellea/backends/watsonx.py")
-    assert '"stop": ModelOption.STOP_SEQUENCES' in src
-    assert '"stop_sequences": ModelOption.STOP_SEQUENCES' in src
-    assert 'ModelOption.STOP_SEQUENCES: "stop"' in src
-    assert 'ModelOption.STOP_SEQUENCES: "stop_sequences"' in src

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -1,0 +1,129 @@
+"""Unit tests for ModelOption.STOP_SEQUENCES routing across backends.
+
+Verifies that the sentinel is mapped to the correct native parameter for each
+backend that exposes a stop-sequence concept. No live model or server is used.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mellea.backends import ModelOption
+from mellea.backends.ollama import OllamaModelBackend
+from mellea.backends.openai import OpenAIBackend
+
+
+def test_sentinel_value_is_unique():
+    """STOP_SEQUENCES sentinel must not collide with other ModelOption values."""
+    sentinels = {
+        v
+        for k, v in vars(ModelOption).items()
+        if isinstance(v, str) and v.startswith("@@@")
+    }
+    assert ModelOption.STOP_SEQUENCES in sentinels
+    # No duplicates among sentinel values.
+    sentinel_values = [
+        v
+        for k, v in vars(ModelOption).items()
+        if isinstance(v, str) and v.startswith("@@@")
+    ]
+    assert len(sentinel_values) == len(set(sentinel_values))
+
+
+# --- OpenAI ---
+
+
+def _make_openai_backend() -> OpenAIBackend:
+    return OpenAIBackend(
+        model_id="gpt-4o", api_key="fake-key", base_url="http://localhost:9999/v1"
+    )
+
+
+@pytest.mark.parametrize("context", ["chats", "completions"])
+def test_openai_stop_sequences_round_trip(context):
+    """Native ``stop`` -> sentinel -> ``stop`` for both chat and completions."""
+    backend = _make_openai_backend()
+    is_chat = context == "chats"
+    stops = ["END", "</s>"]
+
+    # to_mellea: native -> sentinel
+    simplified = backend._simplify_and_merge({"stop": stops}, is_chat_context=is_chat)
+    assert simplified[ModelOption.STOP_SEQUENCES] == stops
+
+    # from_mellea: sentinel -> native
+    backend_specific = backend._make_backend_specific_and_remove(
+        {ModelOption.STOP_SEQUENCES: stops}, is_chat_context=is_chat
+    )
+    assert backend_specific["stop"] == stops
+    assert ModelOption.STOP_SEQUENCES not in backend_specific
+
+
+# --- Ollama ---
+
+
+def _make_ollama_backend() -> OllamaModelBackend:
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client", return_value=MagicMock()),
+        patch("mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()),
+    ):
+        return OllamaModelBackend(model_id="granite3.3:8b")
+
+
+def test_ollama_stop_sequences_round_trip():
+    backend = _make_ollama_backend()
+    stops = ["END", "\n\nUser:"]
+
+    simplified = backend._simplify_and_merge({"stop": stops})
+    assert simplified[ModelOption.STOP_SEQUENCES] == stops
+
+    backend_specific = backend._make_backend_specific_and_remove(
+        {ModelOption.STOP_SEQUENCES: stops}
+    )
+    assert backend_specific["stop"] == stops
+    assert ModelOption.STOP_SEQUENCES not in backend_specific
+
+
+# --- LiteLLM ---
+
+
+def test_litellm_stop_sequences_round_trip():
+    pytest.importorskip("litellm")
+    from mellea.backends.litellm import LiteLLMBackend
+
+    backend = LiteLLMBackend(model_id="ollama_chat/granite3.3:8b")
+    stops = ["END"]
+
+    simplified = backend._simplify_and_merge({"stop": stops})
+    assert simplified[ModelOption.STOP_SEQUENCES] == stops
+
+    backend_specific = backend._make_backend_specific_and_remove(
+        {ModelOption.STOP_SEQUENCES: stops}
+    )
+    assert backend_specific["stop"] == stops
+
+
+# --- HuggingFace and Watsonx map shape (source-level, no optional deps) ---
+
+
+def _read(path: str) -> str:
+    from pathlib import Path
+
+    return Path(path).read_text()
+
+
+def test_huggingface_map_entries_present():
+    """Verify HF backend source registers STOP_SEQUENCES <-> stop_strings."""
+    src = _read("mellea/backends/huggingface.py")
+    assert '"stop_strings": ModelOption.STOP_SEQUENCES' in src
+    assert 'ModelOption.STOP_SEQUENCES: "stop_strings"' in src
+
+
+def test_watsonx_map_entries_present():
+    """Verify Watsonx backend source registers STOP_SEQUENCES for both endpoints."""
+    src = _read("mellea/backends/watsonx.py")
+    assert '"stop": ModelOption.STOP_SEQUENCES' in src
+    assert '"stop_sequences": ModelOption.STOP_SEQUENCES' in src
+    assert 'ModelOption.STOP_SEQUENCES: "stop"' in src
+    assert 'ModelOption.STOP_SEQUENCES: "stop_sequences"' in src

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -12,6 +12,27 @@ from mellea.backends import ModelOption
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
 
+# --- Input validation ---
+
+
+def test_stop_sequences_rejects_bare_string():
+    """A bare ``str`` is rejected — only ``list[str]`` is allowed."""
+    backend = _make_openai_backend()
+    with pytest.raises(TypeError, match="STOP_SEQUENCES must be a list"):
+        backend._simplify_and_merge(
+            {ModelOption.STOP_SEQUENCES: "END"}, is_chat_context=True
+        )
+
+
+def test_stop_sequences_rejects_non_string_elements():
+    """Lists containing non-str elements are rejected."""
+    backend = _make_openai_backend()
+    with pytest.raises(TypeError, match="STOP_SEQUENCES must be a list"):
+        backend._simplify_and_merge(
+            {ModelOption.STOP_SEQUENCES: ["END", 42]}, is_chat_context=True
+        )
+
+
 # --- OpenAI ---
 
 
@@ -84,3 +105,88 @@ def test_litellm_stop_sequences_round_trip():
         {ModelOption.STOP_SEQUENCES: stops}
     )
     assert backend_specific["stop"] == stops
+
+
+# --- Watsonx ---
+
+
+def _make_watsonx_backend():
+    """Construct a WatsonxAIBackend without touching the network."""
+    pytest.importorskip("ibm_watsonx_ai")
+    from mellea.backends.watsonx import WatsonxAIBackend
+
+    with (
+        patch("mellea.backends.watsonx.Credentials", return_value=MagicMock()),
+        patch("mellea.backends.watsonx.APIClient", return_value=MagicMock()),
+        patch("mellea.backends.watsonx.ModelInference", return_value=MagicMock()),
+    ):
+        return WatsonxAIBackend(
+            model_id="ibm/granite-3-8b-instruct",
+            api_key="fake-key",
+            base_url="https://example.invalid",
+            project_id="fake-project",
+        )
+
+
+@pytest.mark.parametrize(
+    "is_chat,native_key", [(True, "stop"), (False, "stop_sequences")]
+)
+def test_watsonx_stop_sequences_round_trip(is_chat, native_key):
+    """Native -> sentinel -> native for both chat (``stop``) and completions (``stop_sequences``)."""
+    backend = _make_watsonx_backend()
+    stops = ["END", "</s>"]
+
+    simplified = backend._simplify_and_merge(
+        {native_key: stops}, is_chat_context=is_chat
+    )
+    assert simplified[ModelOption.STOP_SEQUENCES] == stops
+
+    backend_specific = backend._make_backend_specific_and_remove(
+        {ModelOption.STOP_SEQUENCES: stops}, is_chat_context=is_chat
+    )
+    assert backend_specific[native_key] == stops
+    assert ModelOption.STOP_SEQUENCES not in backend_specific
+
+
+# --- HuggingFace _generate_kwargs branch ---
+
+
+def _make_hf_backend_stub():
+    """Construct a LocalHFBackend without loading a model.
+
+    Bypasses ``__init__`` because the real constructor downloads weights. We only
+    need the attributes ``_generate_kwargs`` reads: ``_tokenizer`` and
+    ``from_mellea_model_opts_map``.
+    """
+    pytest.importorskip("transformers")
+    from mellea.backends.huggingface import LocalHFBackend
+
+    backend = LocalHFBackend.__new__(LocalHFBackend)
+    backend._tokenizer = MagicMock(name="tokenizer")  # type: ignore[attr-defined]
+    backend.from_mellea_model_opts_map = {  # type: ignore[attr-defined]
+        ModelOption.STOP_SEQUENCES: "stop_strings"
+    }
+    return backend
+
+
+def test_hf_generate_kwargs_injects_tokenizer_when_stop_strings_present():
+    backend = _make_hf_backend_stub()
+    kwargs = backend._generate_kwargs({ModelOption.STOP_SEQUENCES: ["END"]})
+    assert kwargs["stop_strings"] == ["END"]
+    assert kwargs["tokenizer"] is backend._tokenizer
+
+
+def test_hf_generate_kwargs_omits_tokenizer_when_no_stop_strings():
+    backend = _make_hf_backend_stub()
+    kwargs = backend._generate_kwargs({"max_new_tokens": 16})
+    assert "tokenizer" not in kwargs
+    assert "stop_strings" not in kwargs
+
+
+def test_hf_generate_kwargs_preserves_user_supplied_tokenizer():
+    backend = _make_hf_backend_stub()
+    user_tokenizer = MagicMock(name="user-tokenizer")
+    kwargs = backend._generate_kwargs(
+        {ModelOption.STOP_SEQUENCES: ["END"], "tokenizer": user_tokenizer}
+    )
+    assert kwargs["tokenizer"] is user_tokenizer

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -12,27 +12,6 @@ from mellea.backends import ModelOption
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
 
-# --- Input validation ---
-
-
-def test_stop_sequences_rejects_bare_string():
-    """A bare ``str`` is rejected — only ``list[str]`` is allowed."""
-    backend = _make_openai_backend()
-    with pytest.raises(TypeError, match="STOP_SEQUENCES must be a list"):
-        backend._simplify_and_merge(
-            {ModelOption.STOP_SEQUENCES: "END"}, is_chat_context=True
-        )
-
-
-def test_stop_sequences_rejects_non_string_elements():
-    """Lists containing non-str elements are rejected."""
-    backend = _make_openai_backend()
-    with pytest.raises(TypeError, match="STOP_SEQUENCES must be a list"):
-        backend._simplify_and_merge(
-            {ModelOption.STOP_SEQUENCES: ["END", 42]}, is_chat_context=True
-        )
-
-
 # --- OpenAI ---
 
 
@@ -148,45 +127,29 @@ def test_watsonx_stop_sequences_round_trip(is_chat, native_key):
     assert ModelOption.STOP_SEQUENCES not in backend_specific
 
 
-# --- HuggingFace _generate_kwargs branch ---
+# --- HuggingFace ---
 
 
 def _make_hf_backend_stub():
     """Construct a LocalHFBackend without loading a model.
 
     Bypasses ``__init__`` because the real constructor downloads weights. We only
-    need the attributes ``_generate_kwargs`` reads: ``_tokenizer`` and
-    ``from_mellea_model_opts_map``.
+    need ``from_mellea_model_opts_map`` for the round-trip mapping check.
     """
     pytest.importorskip("transformers")
     from mellea.backends.huggingface import LocalHFBackend
 
     backend = LocalHFBackend.__new__(LocalHFBackend)
-    backend._tokenizer = MagicMock(name="tokenizer")  # type: ignore[attr-defined]
     backend.from_mellea_model_opts_map = {  # type: ignore[attr-defined]
         ModelOption.STOP_SEQUENCES: "stop_strings"
     }
     return backend
 
 
-def test_hf_generate_kwargs_injects_tokenizer_when_stop_strings_present():
+def test_hf_stop_sequences_maps_to_stop_strings():
     backend = _make_hf_backend_stub()
-    kwargs = backend._generate_kwargs({ModelOption.STOP_SEQUENCES: ["END"]})
-    assert kwargs["stop_strings"] == ["END"]
-    assert kwargs["tokenizer"] is backend._tokenizer
-
-
-def test_hf_generate_kwargs_omits_tokenizer_when_no_stop_strings():
-    backend = _make_hf_backend_stub()
-    kwargs = backend._generate_kwargs({"max_new_tokens": 16})
-    assert "tokenizer" not in kwargs
-    assert "stop_strings" not in kwargs
-
-
-def test_hf_generate_kwargs_preserves_user_supplied_tokenizer():
-    backend = _make_hf_backend_stub()
-    user_tokenizer = MagicMock(name="user-tokenizer")
-    kwargs = backend._generate_kwargs(
-        {ModelOption.STOP_SEQUENCES: ["END"], "tokenizer": user_tokenizer}
+    kwargs = backend._make_backend_specific_and_remove(
+        {ModelOption.STOP_SEQUENCES: ["END"]}
     )
-    assert kwargs["tokenizer"] is user_tokenizer
+    assert kwargs["stop_strings"] == ["END"]
+    assert ModelOption.STOP_SEQUENCES not in kwargs


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #28 

## Description
Adds a backend-agnostic `ModelOption.STOP_SEQUENCES` (a `list[str]`) so users can specify stopping strings without knowing each provider's native parameter name. Each backend translates the sentinel to its own key: `stop` for OpenAI/Ollama/LiteLLM/Watsonx-chat, `stop_sequences` for Watsonx text-gen, and `stop_strings` for HuggingFace (with `tokenizer=` auto-injected as transformers requires).



### Testing
- [X] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [X] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
