### PR TITLE
test: add hook ordering regression coverage

### DIFF
--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -201,7 +201,7 @@ def start_session(
             )
         else:
             backend = backend_class(
-                model_id, model_options=model_options, **backend_kwargs
+                model_id_str, model_options=model_options, **backend_kwargs
             )
 
         logger.info(

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -28,7 +28,7 @@ from mellea.core.base import (
     GenerateType,
     ModelOutputThunk,
 )
-from mellea.plugins import PluginResult, hook, register
+from mellea.plugins import HookType, PluginResult, hook, register
 from mellea.stdlib.context import SimpleContext
 
 # ---------------------------------------------------------------------------
@@ -193,6 +193,47 @@ class TestGenerationHookCallSites:
         await mot.avalue()
 
         assert observed[0].latency_ms >= 0
+
+    async def test_generation_pre_call_mutation_is_applied_before_generation(
+        self,
+    ) -> None:
+        """GENERATION_PRE_CALL mutations reach the backend generation call."""
+        order: list[str] = []
+        captured_kwargs: dict[str, Any] = {}
+
+        class RecordingBackend(_MockBackend):
+            async def _generate_from_context(self, action, ctx, **kwargs):
+                order.append("generate")
+                captured_kwargs.update(kwargs)
+                return await super()._generate_from_context(action, ctx, **kwargs)
+
+        async def fake_invoke_hook(hook_type, payload, **_kwargs):
+            assert hook_type is HookType.GENERATION_PRE_CALL
+            order.append("hook")
+            modified = payload.model_copy(
+                update={"model_options": {"temperature": 0.25}, "tool_calls": True}
+            )
+            return (
+                PluginResult(continue_processing=True, modified_payload=modified),
+                modified,
+            )
+
+        backend = RecordingBackend()
+
+        with (
+            patch("mellea.core.backend.has_plugins", return_value=True),
+            patch("mellea.core.backend.invoke_hook", side_effect=fake_invoke_hook),
+        ):
+            await backend.generate_from_context(
+                CBlock("hook order"),
+                MagicMock(spec=Context),
+                model_options={"temperature": 1.0},
+                tool_calls=False,
+            )
+
+        assert order == ["hook", "generate"]
+        assert captured_kwargs["model_options"] == {"temperature": 0.25}
+        assert captured_kwargs["tool_calls"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -747,6 +788,55 @@ class TestSessionHookCallSites:
             start_session("ollama", model_id="test-model")
 
         assert order == ["pre_init", "post_init"]
+
+    def test_session_pre_init_mutation_is_applied_before_backend_init(self) -> None:
+        """SESSION_PRE_INIT mutations reach the backend constructor."""
+        from mellea.stdlib.session import start_session
+
+        order: list[str] = []
+        captured_backend_args: dict[str, Any] = {}
+
+        class RecordingBackend(_MockBackend):
+            def __init__(self, model_id, model_options=None, **kwargs):
+                order.append("backend_init")
+                captured_backend_args["model_id"] = model_id
+                captured_backend_args["model_options"] = model_options
+                captured_backend_args["kwargs"] = kwargs
+
+        async def fake_invoke_hook(hook_type, payload, **_kwargs):
+            assert hook_type is HookType.SESSION_PRE_INIT
+            order.append("hook")
+            modified = payload.model_copy(
+                update={
+                    "model_id": "hook-model",
+                    "model_options": {"temperature": 0.25},
+                }
+            )
+            return (
+                PluginResult(continue_processing=True, modified_payload=modified),
+                modified,
+            )
+
+        def has_session_pre_init(hook_type=None):
+            return hook_type is HookType.SESSION_PRE_INIT
+
+        with (
+            patch(
+                "mellea.stdlib.session.has_plugins", side_effect=has_session_pre_init
+            ),
+            patch("mellea.stdlib.session.invoke_hook", side_effect=fake_invoke_hook),
+            patch(
+                "mellea.stdlib.session.backend_name_to_class",
+                return_value=RecordingBackend,
+            ),
+        ):
+            start_session(
+                "ollama", model_id="original-model", model_options={"temperature": 1.0}
+            )
+
+        assert order == ["hook", "backend_init"]
+        assert captured_backend_args["model_id"] == "hook-model"
+        assert captured_backend_args["model_options"] == {"temperature": 0.25}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1000

## Description
Add regression coverage for hook call-site ordering and payload mutation before downstream processing.

This PR also applies `session_pre_init` `model_id` mutations when constructing the backend, so the hook-mutated `model_id_str` is passed to the backend constructor.

## Summary
- Adds regression tests for hook call-site ordering and payload mutation handling.
- Tests that `generation_pre_call` mutations are applied before backend generation.
- Tests that `session_pre_init` mutations are applied before backend construction.
- Updates `start_session()` to pass the hook-mutated `model_id_str` to the backend constructor.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Manual checks:
- `git diff --check` passed.
- Targeted pytest was not run locally because `uv` is not available on PATH.

### Attribution
- [x] AI coding assistants used

Assisted-by: OpenAI Codex

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.