### PR TITLE
chore: add local DCO check via pre-commit commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
+default_install_hook_types: [pre-commit, commit-msg]
 exclude: ^(scratchpad/)
 
 repos:
+  - repo: local
+    hooks:
+      - id: dco-check
+        name: DCO sign-off check
+        entry: "bash -c 'grep -q \"^Signed-off-by: \" \"$1\" || { echo \"Missing Signed-off-by trailer. Use: git commit -s\"; exit 1; }' --"
+        language: system
+        stages: [commit-msg]
+
   - repo: local
     hooks:
       # Moving ruff hooks to the local version allows for different behavior locally and in ci/cd pipelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,6 +302,9 @@ Use your real name and a reachable email. PRs with unsigned commits will be bloc
 by the DCO check until every commit is signed off. To retroactively sign existing
 commits, use `git rebase --signoff <base>` and force-push.
 
+The repo's pre-commit config also runs a local DCO check at `commit-msg` time, so
+unsigned commits fail before they're pushed.
+
 <details>
 <summary>Developer Certificate of Origin v1.1 (full text)</summary>
 


### PR DESCRIPTION
## Issue
Fixes #

## Description

Adds a `commit-msg`-stage pre-commit hook that fails commits missing a `Signed-off-by` trailer, complementing the GitHub DCO bot enabled in #1129. Surfaces the same DCO check locally so contributors find out at commit time instead of after pushing.

`default_install_hook_types: [pre-commit, commit-msg]` ensures `pre-commit install` wires up both hook types automatically — no special install flags needed.

**Existing contributors**: re-run `pre-commit install` once after pulling this branch to pick up the new `commit-msg` hook.

**Long-time contributors**: if your `.git/hooks/` directory has leftover `pre-commit.legacy` or `pre-commit.old` files from previous migrations, `pre-commit install` will detect them, enter migration mode, and silently skip installing the new `commit-msg` hook. After running `pre-commit install`, check for `.git/hooks/commit-msg` — if it's missing, run the explicit form once:

```bash
pre-commit install --hook-type commit-msg
```

After that, future config changes are picked up automatically with no further action.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Manually verified on clean clones:
- Fresh clone + `pre-commit install` installs both `pre-commit` and `commit-msg` hooks
- Existing-contributor path (clone, install pre-commit on main, switch to this branch, re-run `pre-commit install`) also installs both hooks
- `git commit -m "..."` (no `-s`) fails with `Missing Signed-off-by trailer. Use: git commit -s`
- `git commit -s -m "..."` passes the DCO check

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
