### PR TITLE
ci: fix blocked dco check in merge queue

### DIFF
--- a/.github/workflows/dco-merge-queue.yml
+++ b/.github/workflows/dco-merge-queue.yml
@@ -1,0 +1,14 @@
+# Because of https://github.com/dcoapp/app/issues/199
+name: DCO
+on:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"


### PR DESCRIPTION
# Pull Request

## Issue


## Description
DCO Bot won't run in merge queues (https://github.com/dcoapp/app/issues/199), so adding a workaround so we can (a) keep DCO check required, and (b) merge PRs.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
