### PR TITLE
fix(streaming): replace sleep gate with _started event for cancel tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ Use the tool's common name (e.g., GitHub Copilot, Cursor, etc.).
 | `uv.lock` out of sync | Run `uv sync` |
 | Ollama refused | Run `ollama serve` |
 | Telemetry import errors | Run `uv sync` to install OpenTelemetry deps |
+| DCO failure after empty-commit CI kick | Use `git commit -s --allow-empty` — never hardcode `Signed-off-by`; email must match git config |
+| `git push` / signed commit fails with "agent refused" | 1Password SSH agent is locked — unlock 1Password before retrying |
 
 ## 10. Self-Review (before notifying user)
 1. `uv run pytest test/ -m "not qualitative"` passes?

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -244,6 +244,9 @@ class StreamChunkingResult:
         self._event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
         self._orchestration_task: asyncio.Task[None] | None = None
         self._done = asyncio.Event()
+        # Set by _orchestrate_streaming before its first suspension point so
+        # tests can wait for the task to be live before cancelling externally.
+        self._started = asyncio.Event()
         # Stashed so acomplete() surfaces orchestrator failures even when the
         # consumer never iterates astream(). Cleared once consumed by
         # whichever of the two reads it first.
@@ -448,6 +451,11 @@ async def _orchestrate_streaming(
     chunking: ChunkingStrategy,
     val_backend: Backend,
 ) -> None:
+    # Signal that the coroutine body is executing before the first suspension.
+    # Tests that cancel the task externally wait on this to avoid a race where
+    # cancel() fires after the task has already completed (no-op on a done task).
+    result._started.set()
+
     accumulated = ""
     emitted_end = 0  # byte offset in accumulated after the last emitted chunk
     prev_chunk_count = 0

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -244,9 +244,11 @@ class StreamChunkingResult:
         self._event_queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
         self._orchestration_task: asyncio.Task[None] | None = None
         self._done = asyncio.Event()
-        # Set by _orchestrate_streaming before its first suspension point so
-        # tests can wait for the task to be live before cancelling externally.
-        self._started = asyncio.Event()
+        # Set synchronously at the very top of _orchestrate_streaming, before
+        # any await, so external coordinators (e.g. cancellation tests) can wait
+        # until the task is live and suspended at its first I/O point.
+        # Single-use: not reset between runs; this object is not re-entrant.
+        self._orchestration_started = asyncio.Event()
         # Stashed so acomplete() surfaces orchestrator failures even when the
         # consumer never iterates astream(). Cleared once consumed by
         # whichever of the two reads it first.
@@ -452,9 +454,10 @@ async def _orchestrate_streaming(
     val_backend: Backend,
 ) -> None:
     # Signal that the coroutine body is executing before the first suspension.
-    # Tests that cancel the task externally wait on this to avoid a race where
-    # cancel() fires after the task has already completed (no-op on a done task).
-    result._started.set()
+    # External coordinators waiting on _orchestration_started are guaranteed to
+    # resume only after this task has yielded at its first real await, so a
+    # subsequent cancel() always lands on a live, non-done task.
+    result._orchestration_started.set()
 
     accumulated = ""
     emitted_end = 0  # byte offset in accumulated after the last emitted chunk

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -937,10 +937,13 @@ async def test_external_task_cancellation_releases_consumers() -> None:
 
     assert result._orchestration_task is not None
     # Wait until the orchestration coroutine has started and hit its first
-    # suspension point.  Using _started rather than a wall-clock sleep avoids
-    # the race where a fast runner drains the whole stream within the sleep
-    # window, making cancel() a no-op on an already-done task.
-    await asyncio.wait_for(result._started.wait(), timeout=2.0)
+    # suspension point.  Using _orchestration_started rather than a wall-clock
+    # sleep avoids the race where a fast runner drains the whole stream within
+    # the sleep window, making cancel() a no-op on an already-done task.
+    # _orchestration_started.wait() must precede cancel() — cancelling before
+    # the first scheduling means the event is never set.
+    await asyncio.wait_for(result._orchestration_started.wait(), timeout=2.0)
+    assert not result._orchestration_task.done()  # guard: task must still be live
 
     # Same mechanism asyncio.wait_for uses on timeout.
     result._orchestration_task.cancel()
@@ -973,7 +976,8 @@ async def test_external_cancellation_acomplete_raise_once() -> None:
     )
 
     assert result._orchestration_task is not None
-    await asyncio.wait_for(result._started.wait(), timeout=2.0)
+    await asyncio.wait_for(result._orchestration_started.wait(), timeout=2.0)
+    assert not result._orchestration_task.done()  # guard: task must still be live
     result._orchestration_task.cancel()
     await asyncio.wait_for(result._done.wait(), timeout=2.0)
 

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -936,9 +936,11 @@ async def test_external_task_cancellation_releases_consumers() -> None:
     )
 
     assert result._orchestration_task is not None
-    # Yield once so the orchestration task enters its main loop before we
-    # cancel it.
-    await asyncio.sleep(0.01)
+    # Wait until the orchestration coroutine has started and hit its first
+    # suspension point.  Using _started rather than a wall-clock sleep avoids
+    # the race where a fast runner drains the whole stream within the sleep
+    # window, making cancel() a no-op on an already-done task.
+    await asyncio.wait_for(result._started.wait(), timeout=2.0)
 
     # Same mechanism asyncio.wait_for uses on timeout.
     result._orchestration_task.cancel()
@@ -971,7 +973,7 @@ async def test_external_cancellation_acomplete_raise_once() -> None:
     )
 
     assert result._orchestration_task is not None
-    await asyncio.sleep(0.01)
+    await asyncio.wait_for(result._started.wait(), timeout=2.0)
     result._orchestration_task.cancel()
     await asyncio.wait_for(result._done.wait(), timeout=2.0)
 

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -943,7 +943,9 @@ async def test_external_task_cancellation_releases_consumers() -> None:
     # _orchestration_started.wait() must precede cancel() — cancelling before
     # the first scheduling means the event is never set.
     await asyncio.wait_for(result._orchestration_started.wait(), timeout=2.0)
-    assert not result._orchestration_task.done()  # guard: task must still be live
+    assert not result._orchestration_task.done(), (
+        "orchestrator already done before cancel() — test would vacuously pass"
+    )
 
     # Same mechanism asyncio.wait_for uses on timeout.
     result._orchestration_task.cancel()
@@ -977,7 +979,9 @@ async def test_external_cancellation_acomplete_raise_once() -> None:
 
     assert result._orchestration_task is not None
     await asyncio.wait_for(result._orchestration_started.wait(), timeout=2.0)
-    assert not result._orchestration_task.done()  # guard: task must still be live
+    assert not result._orchestration_task.done(), (
+        "orchestrator already done before cancel() — test would vacuously pass"
+    )
     result._orchestration_task.cancel()
     await asyncio.wait_for(result._done.wait(), timeout=2.0)
 
@@ -1692,10 +1696,12 @@ async def test_cancelled_task_sets_completed_false() -> None:
     )
     assert result._orchestration_task is not None
 
-    # Yield once so the orchestration task starts and reaches its first real
-    # await (Queue.get inside astream).  Without this, the task is cancelled
-    # before coro.send(None) is ever called, and Python skips the coroutine
-    # body entirely — the finally block never runs.
+    # Deliberately uses sleep(0) rather than _orchestration_started.wait():
+    # BlockingBackend blocks indefinitely, so there is no race with the stream
+    # completing before cancel().  sleep(0) is sufficient to satisfy the
+    # coro.send(None) requirement: Python 3.12's C Task implementation skips
+    # the coroutine body entirely (including finally blocks) when cancelled
+    # before the first send.
     await asyncio.sleep(0)
 
     result._orchestration_task.cancel()


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Misc PR

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #1132

Two streaming cancellation tests gated on `await asyncio.sleep(0.01)` before calling `cancel()`. On a fast runner, `StreamingMockBackend` (only `sleep(0)` between tokens) can drain the whole 200-word stream inside that window — `cancel()` then no-ops on an already-done task and no `CancelledError` is raised.

Adds `_orchestration_started` (`asyncio.Event`) to `StreamChunkingResult`, set synchronously at the top of `_orchestrate_streaming` before any `await`. The two tests now wait on this event instead of sleeping: once it fires the task is suspended at its first real I/O point, so `cancel()` is guaranteed to land on a live task. An `assert not task.done()` guard follows the wait to catch any future regression to vacuous-pass behaviour.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code as added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used