### PR TITLE
docs: clarify uv install paths

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -9,12 +9,35 @@ description: "Install Mellea and set up your Python environment."
 
 ## Install
 
+For an existing Python environment, install Mellea with pip:
+
 ```bash
 pip install mellea
 ```
 
+For an existing uv project, add Mellea as a project dependency:
+
 ```bash
 uv add mellea
+```
+
+If you are starting from scratch with uv, initialize the project first so uv can
+create `pyproject.toml`, select a supported Python version, and manage the
+virtual environment:
+
+```bash
+uv init my-mellea-app --python 3.11
+cd my-mellea-app
+uv add mellea
+```
+
+If you only want to try Mellea inside the current virtual environment without
+creating a uv project, use `uv pip install` instead:
+
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install mellea
 ```
 
 ## Optional extras


### PR DESCRIPTION
## Problem
The installation guide shows `uv add mellea`, but issue #757 notes that command assumes an initialized uv project. New users may need either a from-scratch uv project flow or a direct virtualenv install flow.

## Solution
Clarify the install section by distinguishing:

- existing pip environments (`pip install mellea`)
- existing uv projects (`uv add mellea`)
- new uv projects (`uv init ...` then `uv add mellea`)
- quick virtualenv trials (`uv venv` then `uv pip install mellea`)

Closes #757.

## Validation
- `git diff --check`

## Confidence
Score: 82/100
Category: docs