### PR TITLE
docs: clarify uv add requires an existing uv project

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,6 +17,11 @@ pip install mellea
 uv add mellea
 ```
 
+> **Note:** `uv add` adds Mellea to an existing uv project, so run it from a
+> directory created with `uv init` (or one that already has a `pyproject.toml`).
+> To install into a plain virtual environment without a uv project, use
+> `uv pip install mellea` instead.
+
 ## Optional extras
 
 Install extras for specific backends and features:


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #757

## Description
The installation docs show `uv add mellea`, but `uv add` only works inside an existing uv project (one created with `uv init` or already holding a `pyproject.toml`). Users who just want to try Mellea in a plain virtual environment hit an error. This adds a short note clarifying that requirement and pointing to `uv pip install mellea` as the no-project alternative, matching the maintainer suggestion in the issue thread.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
