### PR TITLE
chore: add backwards compatibility for intrinsics needing instruction creation

### DIFF
--- a/mellea/stdlib/components/intrinsic/_guardian_legacy.py
+++ b/mellea/stdlib/components/intrinsic/_guardian_legacy.py
@@ -1,0 +1,81 @@
+"""Frozen pre-#1037 envelope builders for the Guardian intrinsic helpers.
+
+These strings are the exact prompts the legacy Guardian adapters were trained
+against, extracted verbatim from commit ``4d372b0``. They must not be edited:
+old adapters loaded from pre-r1.0 HuggingFace repos (whose ``io.yaml`` has
+``instruction: ~``) only behave correctly when the helpers append one of these
+envelopes as the last user message themselves.
+
+Used only by the ``legacy_envelope=True`` path in
+``mellea.stdlib.components.intrinsic.guardian``.
+"""
+
+_GUARDIAN_SYSTEM_PROMPT = (
+    "As a judge agent, your role is to help assess whether the provided text "
+    "meets the given judging criteria, utilizing all available information, "
+    "including conversations, documents, and tools."
+)
+
+
+def _legacy_policy_guardrails_envelope(policy_text: str) -> str:
+    """Return the pre-#1037 ``<guardian>`` envelope for ``policy_guardrails``."""
+    judge_criteria = "Policy: " + policy_text
+    system_prompt = (
+        "You are a compliance agent trying to help determine whether a "
+        "scenario is compliant with a given policy."
+    )
+    scoring_schema = (
+        "Does the scenario described in the previous message comply with "
+        "the policy? Compliance is determined based on the following "
+        'guidelines:\n<start_of_guidelines>:\n- "Yes"  if, given the scenario '
+        "and the policy, it can be decided with certainty that the scenario "
+        'complies with the policy\n- "No"  if, given the scenario and the '
+        "policy, it can be decided with certainty that the scenario does not "
+        'comply with the policy\n- "Ambiguous" if, given the scenario and the '
+        "policy, it is not possible to decide whether the scenario complies "
+        "with, or violates, the policy and more information is needed to "
+        "decide with certainty.\n<end_of_guidelines>\n\nYour answer must be "
+        'either "Yes", "No", or "Ambiguous". You MUST return your answer as '
+        'a valid JSON object with the key "label". For example, if your '
+        'answer is "Yes", respond as "{"label":"Yes"}".'
+    )
+    return (
+        f"<guardian> {system_prompt}\n\n"
+        f"### Criteria: {judge_criteria}\n\n"
+        f"### Scoring Schema: {scoring_schema}"
+    )
+
+
+def _legacy_guardian_check_envelope(criteria_text: str, target_role: str) -> str:
+    """Return the pre-#1037 ``<guardian>`` envelope for ``guardian_check``."""
+    scoring = (
+        f"If the last {target_role}'s text meets the criteria, "
+        f"return 'yes'; otherwise, return 'no'."
+    )
+    return (
+        f"<guardian>{_GUARDIAN_SYSTEM_PROMPT}\n\n"
+        f"### Criteria: {criteria_text}\n\n"
+        f"### Scoring Schema: {scoring}"
+    )
+
+
+def _legacy_factuality_detection_envelope() -> str:
+    """Return the pre-#1037 ``<guardian>`` envelope for ``factuality_detection``."""
+    return """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return 'yes'; otherwise, return 'no'.
+"""
+
+
+def _legacy_factuality_correction_envelope() -> str:
+    """Return the pre-#1037 ``<guardian>`` envelope for ``factuality_correction``."""
+    return """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return a corrected version of the assistant's message based on the given context; otherwise, return 'none'.
+"""

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -7,14 +7,48 @@ That envelope is built from the ``instruction:`` field of each adapter's
 ``io.yaml`` via :class:`IntrinsicsRewriter`; the helpers below just resolve
 any convenience inputs (e.g. :data:`CRITERIA_BANK` lookups) and pass the
 resolved kwargs through.
+
+Pre-#1037 adapters (and any adapter checkout whose ``io.yaml`` has
+``instruction: ~``) cannot be driven by the new path: the rewriter sees no
+template and silently sends the bare context to the model. For those, pass
+``legacy_envelope=True`` (or set ``MELLEA_GUARDIAN_LEGACY_ENVELOPE=1``) to
+restore the pre-#1037 behavior of building the envelope locally and
+appending it as a user message before dispatch.
 """
 
+import os
 import warnings
 
 from ....backends.adapters import AdapterMixin
 from ....core.utils import MelleaLogger
 from ...context import ChatContext
+from ..chat import Message
+from ._guardian_legacy import (
+    _legacy_factuality_correction_envelope,
+    _legacy_factuality_detection_envelope,
+    _legacy_guardian_check_envelope,
+    _legacy_policy_guardrails_envelope,
+)
 from ._util import call_intrinsic
+
+_LEGACY_ENVELOPE_ENV = "MELLEA_GUARDIAN_LEGACY_ENVELOPE"
+
+
+def _should_use_legacy_envelope(flag: bool | None) -> bool:
+    """Return whether the legacy ``<guardian>`` envelope path should be used.
+
+    Resolves the explicit ``legacy_envelope`` kwarg first; falls back to the
+    ``MELLEA_GUARDIAN_LEGACY_ENVELOPE`` environment variable.
+    """
+    if flag is not None:
+        return flag
+    return os.environ.get(_LEGACY_ENVELOPE_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
 
 _UNSET: object = object()
 """Sentinel distinguishing 'caller omitted scoring_schema' from 'caller passed
@@ -26,7 +60,11 @@ _TARGET_ROLE_TO_SCHEMA = {"user": "user_prompt", "assistant": "assistant_respons
 
 
 def policy_guardrails(
-    context: ChatContext, backend: AdapterMixin, policy_text: str
+    context: ChatContext,
+    backend: AdapterMixin,
+    policy_text: str,
+    *,
+    legacy_envelope: bool | None = None,
 ) -> str:
     """Checks whether text complied with specified policy.
 
@@ -36,11 +74,22 @@ def policy_guardrails(
     :param context: Chat context containing the conversation to evaluate.
     :param backend: Backend instance that supports LoRA adapters.
     :param policy_text: Policy against with compliance is to be checked
+    :param legacy_envelope: When ``True``, build the pre-#1037 ``<guardian>``
+        envelope locally and append it as a user message instead of relying on
+        the ``instruction:`` template in the adapter's ``io.yaml``. Use this
+        with adapters whose ``io.yaml`` has ``instruction: ~`` (i.e.
+        pre-r1.0 HuggingFace checkouts). Falls back to the
+        ``MELLEA_GUARDIAN_LEGACY_ENVELOPE`` env var when ``None``.
     :return: Compliance as a "Yes/No/Ambiguous" label (Yes = compliant).
     """
-    result_json = call_intrinsic(
-        "policy-guardrails", context, backend, kwargs={"policy_text": policy_text}
-    )
+    if _should_use_legacy_envelope(legacy_envelope):
+        envelope = _legacy_policy_guardrails_envelope(policy_text)
+        context = context.add(Message("user", envelope))
+        result_json = call_intrinsic("policy-guardrails", context, backend)
+    else:
+        result_json = call_intrinsic(
+            "policy-guardrails", context, backend, kwargs={"policy_text": policy_text}
+        )
 
     if "label" not in result_json.keys() and "score" not in result_json.keys():
         raise Exception(
@@ -166,6 +215,8 @@ def guardian_check(
     criteria: str,
     scoring_schema: str | object = _UNSET,
     target_role: str | None = None,
+    *,
+    legacy_envelope: bool | None = None,
 ) -> float:
     """Check whether text meets specified safety/quality criteria.
 
@@ -185,16 +236,46 @@ def guardian_check(
             custom string. Defaults to ``"assistant_response"``. Must
             still resolve to a yes/no verdict — the adapter's
             ``response_format`` constrains output to ``"yes"``/``"no"``.
+            Not supported with ``legacy_envelope=True``.
         target_role: Deprecated. Role whose last message is being
             evaluated (``"user"`` or ``"assistant"``). Prefer
             ``scoring_schema`` with a key from
             :data:`SCORING_SCHEMA_BANK`. Passing both
             ``scoring_schema`` and ``target_role`` raises
             :class:`TypeError`.
+        legacy_envelope: When ``True``, build the pre-#1037 ``<guardian>``
+            envelope locally and append it as a user message instead of
+            relying on the ``instruction:`` template in the adapter's
+            ``io.yaml``. The legacy envelope only supports
+            ``target_role`` semantics; passing ``scoring_schema`` together
+            with ``legacy_envelope=True`` raises :class:`TypeError`. Falls
+            back to the ``MELLEA_GUARDIAN_LEGACY_ENVELOPE`` env var when
+            ``None``.
 
     Returns:
         Risk score as a float between 0.0 (no risk) and 1.0 (risk detected).
     """
+    if _should_use_legacy_envelope(legacy_envelope):
+        if scoring_schema is not _UNSET:
+            raise TypeError(
+                "scoring_schema is not supported with legacy_envelope=True; "
+                "the legacy adapters were trained on a fixed scoring sentence "
+                "keyed off target_role."
+            )
+        if target_role is None:
+            resolved_target_role = "assistant"
+        elif target_role not in _TARGET_ROLE_TO_SCHEMA:
+            raise ValueError(
+                f"target_role must be 'user' or 'assistant', got {target_role!r}"
+            )
+        else:
+            resolved_target_role = target_role
+        criteria_text = CRITERIA_BANK.get(criteria, criteria)
+        envelope = _legacy_guardian_check_envelope(criteria_text, resolved_target_role)
+        context = context.add(Message("user", envelope))
+        result_json = call_intrinsic("guardian-core", context, backend)
+        return result_json["guardian"]["score"]
+
     if target_role is not None:
         warnings.warn(
             "`target_role` is deprecated; use `scoring_schema` instead "
@@ -240,7 +321,9 @@ def guardian_check(
     return result_json["guardian"]["score"]
 
 
-def factuality_detection(context: ChatContext, backend: AdapterMixin) -> str:
+def factuality_detection(
+    context: ChatContext, backend: AdapterMixin, *, legacy_envelope: bool | None = None
+) -> str:
     """Determine is the last response is factually incorrect.
 
     Intrinsic function that evaluates the factuality of the
@@ -249,14 +332,23 @@ def factuality_detection(context: ChatContext, backend: AdapterMixin) -> str:
 
     :param context: Chat context containing user question and assistant answer.
     :param backend: Backend instance that supports LoRA/aLoRA adapters.
+    :param legacy_envelope: When ``True``, build the pre-#1037 ``<guardian>``
+        envelope locally and append it as a user message instead of relying on
+        the ``instruction:`` template in the adapter's ``io.yaml``. Falls back
+        to the ``MELLEA_GUARDIAN_LEGACY_ENVELOPE`` env var when ``None``.
 
     :return: Factuality score as a "yes/no" label (yes = factually incorrect).
     """
+    if _should_use_legacy_envelope(legacy_envelope):
+        envelope = _legacy_factuality_detection_envelope()
+        context = context.add(Message("user", envelope))
     result_json = call_intrinsic("factuality-detection", context, backend)
     return result_json["score"]
 
 
-def factuality_correction(context: ChatContext, backend: AdapterMixin) -> str:
+def factuality_correction(
+    context: ChatContext, backend: AdapterMixin, *, legacy_envelope: bool | None = None
+) -> str:
     """Corrects the last response so that it is factually correct.
 
     Intrinsic function that corrects the assistant's response to a user's
@@ -264,8 +356,15 @@ def factuality_correction(context: ChatContext, backend: AdapterMixin) -> str:
 
     :param context: Chat context containing user question and assistant answer.
     :param backend: Backend instance that supports LoRA/aLoRA adapters.
+    :param legacy_envelope: When ``True``, build the pre-#1037 ``<guardian>``
+        envelope locally and append it as a user message instead of relying on
+        the ``instruction:`` template in the adapter's ``io.yaml``. Falls back
+        to the ``MELLEA_GUARDIAN_LEGACY_ENVELOPE`` env var when ``None``.
 
     :return: Correct assistant response.
     """
+    if _should_use_legacy_envelope(legacy_envelope):
+        envelope = _legacy_factuality_correction_envelope()
+        context = context.add(Message("user", envelope))
     result_json = call_intrinsic("factuality-correction", context, backend)
     return result_json["correction"]

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -31,6 +31,8 @@ from ._guardian_legacy import (
 )
 from ._util import call_intrinsic
 
+# Transitional; remove alongside ``_overlays/`` per #1017 once upstream ships
+# the r1.0 ``io.yaml`` templates and pre-r1.0 checkouts are clearly legacy.
 _LEGACY_ENVELOPE_ENV = "MELLEA_GUARDIAN_LEGACY_ENVELOPE"
 
 

--- a/test/stdlib/components/intrinsic/test_guardian_legacy.py
+++ b/test/stdlib/components/intrinsic/test_guardian_legacy.py
@@ -1,0 +1,287 @@
+"""Unit tests for the ``legacy_envelope`` backwards-compat path of guardian helpers.
+
+The pre-#1037 helpers built a ``<guardian>``-prefixed envelope locally and
+appended it as a user message before dispatch. The new helpers rely on the
+``instruction:`` template in the adapter's ``io.yaml``. For users pinned to
+older HuggingFace adapter checkouts (whose ``io.yaml`` has ``instruction: ~``),
+the new path silently dispatches with no envelope at all — the model gets
+garbage. ``legacy_envelope=True`` (or ``MELLEA_GUARDIAN_LEGACY_ENVELOPE=1``)
+restores the legacy behavior.
+
+These tests assert:
+
+* The frozen envelope strings match the pre-#1037 byte-for-byte expectation.
+* When ``legacy_envelope=True``, the helpers append the envelope as a user
+  message and dispatch with empty kwargs.
+* The env var fallback works.
+* ``scoring_schema`` is rejected when combined with ``legacy_envelope=True``.
+
+Tests are mock-based; no model is loaded.
+"""
+
+import pytest
+
+from mellea.stdlib.components.chat import Message
+from mellea.stdlib.components.intrinsic import guardian
+from mellea.stdlib.components.intrinsic._guardian_legacy import (
+    _legacy_factuality_correction_envelope,
+    _legacy_factuality_detection_envelope,
+    _legacy_guardian_check_envelope,
+    _legacy_policy_guardrails_envelope,
+)
+from mellea.stdlib.context import ChatContext
+
+# --- Frozen envelope strings (verbatim from pre-#1037 commit 4d372b0) ---
+
+_JUDGE_SYSTEM_PROMPT = (
+    "As a judge agent, your role is to help assess whether the provided text "
+    "meets the given judging criteria, utilizing all available information, "
+    "including conversations, documents, and tools."
+)
+
+_EXPECTED_GUARDIAN_CHECK = (
+    f"<guardian>{_JUDGE_SYSTEM_PROMPT}\n\n"
+    f"### Criteria: {guardian.CRITERIA_BANK['harm']}\n\n"
+    f"### Scoring Schema: If the last assistant's text meets the criteria, "
+    f"return 'yes'; otherwise, return 'no'."
+)
+
+_EXPECTED_GUARDIAN_CHECK_USER = (
+    f"<guardian>{_JUDGE_SYSTEM_PROMPT}\n\n"
+    f"### Criteria: {guardian.CRITERIA_BANK['harm']}\n\n"
+    f"### Scoring Schema: If the last user's text meets the criteria, "
+    f"return 'yes'; otherwise, return 'no'."
+)
+
+_EXPECTED_POLICY_GUARDRAILS = (
+    "<guardian> You are a compliance agent trying to help determine whether "
+    "a scenario is compliant with a given policy.\n\n"
+    "### Criteria: Policy: no PII\n\n"
+    "### Scoring Schema: Does the scenario described in the previous message "
+    "comply with the policy? Compliance is determined based on the following "
+    'guidelines:\n<start_of_guidelines>:\n- "Yes"  if, given the scenario and '
+    "the policy, it can be decided with certainty that the scenario complies "
+    'with the policy\n- "No"  if, given the scenario and the policy, it can '
+    "be decided with certainty that the scenario does not comply with the "
+    'policy\n- "Ambiguous" if, given the scenario and the policy, it is not '
+    "possible to decide whether the scenario complies with, or violates, the "
+    "policy and more information is needed to decide with certainty.\n"
+    '<end_of_guidelines>\n\nYour answer must be either "Yes", "No", or '
+    '"Ambiguous". You MUST return your answer as a valid JSON object with '
+    'the key "label". For example, if your answer is "Yes", respond as '
+    '"{"label":"Yes"}".'
+)
+
+_EXPECTED_FACTUALITY_DETECTION = """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return 'yes'; otherwise, return 'no'.
+"""
+
+_EXPECTED_FACTUALITY_CORRECTION = """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return a corrected version of the assistant's message based on the given context; otherwise, return 'none'.
+"""
+
+
+# --- Frozen-string contract guards ------------------------------------------
+
+
+def test_legacy_guardian_check_envelope_assistant_matches_pre_1037():
+    actual = _legacy_guardian_check_envelope(
+        guardian.CRITERIA_BANK["harm"], "assistant"
+    )
+    assert actual == _EXPECTED_GUARDIAN_CHECK
+
+
+def test_legacy_guardian_check_envelope_user_matches_pre_1037():
+    actual = _legacy_guardian_check_envelope(guardian.CRITERIA_BANK["harm"], "user")
+    assert actual == _EXPECTED_GUARDIAN_CHECK_USER
+
+
+def test_legacy_policy_guardrails_envelope_matches_pre_1037():
+    assert _legacy_policy_guardrails_envelope("no PII") == _EXPECTED_POLICY_GUARDRAILS
+
+
+def test_legacy_factuality_detection_envelope_matches_pre_1037():
+    assert _legacy_factuality_detection_envelope() == _EXPECTED_FACTUALITY_DETECTION
+
+
+def test_legacy_factuality_correction_envelope_matches_pre_1037():
+    assert _legacy_factuality_correction_envelope() == _EXPECTED_FACTUALITY_CORRECTION
+
+
+# --- Routing tests with mock backend ----------------------------------------
+
+
+@pytest.fixture
+def capture_call(monkeypatch):
+    """Spy ``call_intrinsic`` and capture (name, last context message, kwargs).
+
+    Returns stub responses shaped like the real Guardian outputs so the helpers'
+    return-value handling stays exercised.
+    """
+    captured: dict = {}
+
+    def fake_call_intrinsic(name, context, backend, /, kwargs=None, model_options=None):
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        # Pull the last message off the context, if any, so tests can assert
+        # what envelope (if any) the helper appended.
+        last_turn = context.last_turn()
+        if last_turn is not None and isinstance(last_turn.model_input, Message):
+            captured["last_message_content"] = last_turn.model_input.content
+        else:
+            captured["last_message_content"] = None
+        # Return a shape compatible with whichever helper called us. Unwrap
+        # to one of {label, score} for policy_guardrails (it forbids both),
+        # while still satisfying guardian_check ("guardian" record),
+        # factuality_detection ("score"), and factuality_correction
+        # ("correction").
+        if name == "policy-guardrails":
+            return {"label": "Yes"}
+        return {"guardian": {"score": 0.0}, "score": "no", "correction": "ok"}
+
+    monkeypatch.setattr(guardian, "call_intrinsic", fake_call_intrinsic)
+    return captured
+
+
+def test_guardian_check_legacy_envelope_appends_message_and_empties_kwargs(
+    capture_call,
+):
+    guardian.guardian_check(
+        ChatContext(), object(), criteria="harm", legacy_envelope=True
+    )
+    assert capture_call["name"] == "guardian-core"
+    assert capture_call["kwargs"] is None
+    assert capture_call["last_message_content"] == _EXPECTED_GUARDIAN_CHECK
+
+
+def test_guardian_check_legacy_envelope_with_user_target_role(capture_call):
+    guardian.guardian_check(
+        ChatContext(),
+        object(),
+        criteria="harm",
+        target_role="user",
+        legacy_envelope=True,
+    )
+    assert capture_call["last_message_content"] == _EXPECTED_GUARDIAN_CHECK_USER
+
+
+def test_guardian_check_legacy_rejects_scoring_schema(capture_call):
+    with pytest.raises(TypeError, match="scoring_schema is not supported"):
+        guardian.guardian_check(
+            ChatContext(),
+            object(),
+            criteria="harm",
+            scoring_schema="user_prompt",
+            legacy_envelope=True,
+        )
+
+
+def test_guardian_check_legacy_rejects_invalid_target_role(capture_call):
+    with pytest.raises(ValueError, match="target_role must be"):
+        guardian.guardian_check(
+            ChatContext(),
+            object(),
+            criteria="harm",
+            target_role="system",
+            legacy_envelope=True,
+        )
+
+
+def test_policy_guardrails_legacy_envelope_appends_message_and_empties_kwargs(
+    capture_call,
+):
+    guardian.policy_guardrails(
+        ChatContext(), object(), policy_text="no PII", legacy_envelope=True
+    )
+    assert capture_call["name"] == "policy-guardrails"
+    assert capture_call["kwargs"] is None
+    assert capture_call["last_message_content"] == _EXPECTED_POLICY_GUARDRAILS
+
+
+def test_factuality_detection_legacy_envelope_appends_message(capture_call):
+    guardian.factuality_detection(ChatContext(), object(), legacy_envelope=True)
+    assert capture_call["name"] == "factuality-detection"
+    assert capture_call["kwargs"] is None
+    assert capture_call["last_message_content"] == _EXPECTED_FACTUALITY_DETECTION
+
+
+def test_factuality_correction_legacy_envelope_appends_message(capture_call):
+    guardian.factuality_correction(ChatContext(), object(), legacy_envelope=True)
+    assert capture_call["name"] == "factuality-correction"
+    assert capture_call["kwargs"] is None
+    assert capture_call["last_message_content"] == _EXPECTED_FACTUALITY_CORRECTION
+
+
+# --- Default-path preservation ---------------------------------------------
+
+
+def test_default_path_unchanged_for_guardian_check(capture_call):
+    """Without legacy_envelope, helpers should still pass kwargs through."""
+    guardian.guardian_check(ChatContext(), object(), criteria="harm")
+    # New path passes criteria + scoring_schema as kwargs and does NOT add a
+    # user message itself.
+    assert capture_call["kwargs"] is not None
+    assert "criteria" in capture_call["kwargs"]
+    assert "scoring_schema" in capture_call["kwargs"]
+    assert capture_call["last_message_content"] is None
+
+
+def test_default_path_unchanged_for_policy_guardrails(capture_call):
+    guardian.policy_guardrails(ChatContext(), object(), policy_text="no PII")
+    assert capture_call["kwargs"] == {"policy_text": "no PII"}
+    assert capture_call["last_message_content"] is None
+
+
+def test_default_path_unchanged_for_factuality_detection(capture_call):
+    guardian.factuality_detection(ChatContext(), object())
+    assert capture_call["kwargs"] is None
+    assert capture_call["last_message_content"] is None
+
+
+# --- Env-var fallback -------------------------------------------------------
+
+
+def test_env_var_enables_legacy_envelope(monkeypatch, capture_call):
+    monkeypatch.setenv("MELLEA_GUARDIAN_LEGACY_ENVELOPE", "1")
+    guardian.guardian_check(ChatContext(), object(), criteria="harm")
+    assert capture_call["last_message_content"] == _EXPECTED_GUARDIAN_CHECK
+    assert capture_call["kwargs"] is None
+
+
+def test_env_var_unset_means_default_path(monkeypatch, capture_call):
+    monkeypatch.delenv("MELLEA_GUARDIAN_LEGACY_ENVELOPE", raising=False)
+    guardian.guardian_check(ChatContext(), object(), criteria="harm")
+    assert capture_call["kwargs"] is not None
+    assert capture_call["last_message_content"] is None
+
+
+def test_explicit_kwarg_overrides_env_var(monkeypatch, capture_call):
+    """legacy_envelope=False wins even when env var is set."""
+    monkeypatch.setenv("MELLEA_GUARDIAN_LEGACY_ENVELOPE", "1")
+    guardian.guardian_check(
+        ChatContext(), object(), criteria="harm", legacy_envelope=False
+    )
+    assert capture_call["kwargs"] is not None
+    assert capture_call["last_message_content"] is None
+
+
+@pytest.mark.parametrize("value", ["true", "yes", "on", "TRUE", "On"])
+def test_env_var_truthy_variants(monkeypatch, capture_call, value):
+    monkeypatch.setenv("MELLEA_GUARDIAN_LEGACY_ENVELOPE", value)
+    guardian.guardian_check(ChatContext(), object(), criteria="harm")
+    assert capture_call["last_message_content"] == _EXPECTED_GUARDIAN_CHECK
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_env_var_falsy_variants(monkeypatch, capture_call, value):
+    monkeypatch.setenv("MELLEA_GUARDIAN_LEGACY_ENVELOPE", value)
+    guardian.guardian_check(ChatContext(), object(), criteria="harm")
+    assert capture_call["last_message_content"] is None


### PR DESCRIPTION
# Pull Request

## Issue
Follow-on from #1017 

## Description
PR #1037 moved the `<guardian>` envelope construction out of the helper functions in `mellea/stdlib/components/intrinsic/guardian.py` and into the  `instruction:` field of each adapter's `io.yaml`, which broke users pinned to pre-r1.0 Guardian adapter checkouts whose `io.yaml` has `instruction: ~` that the new path silently dispatched with no envelope at all. 

This PR restores backwards compatibility by adding an opt-in `legacy_envelope` kwarg (with `MELLEA_GUARDIAN_LEGACY_ENVELOPE` env var fallback) to all four helpers; when enabled, they build the pre-#1037 envelope locally and append it as a user message before dispatch. The legacy envelope strings are frozen verbatim from commit `4d372b0` in a separate `_guardian_legacy.py` module and guarded by contract-string tests so they can't drift.

Example usage:

Set envvar to enable legacy functionality
```bash
export MELLEA_GUARDIAN_LEGACY_ENVELOPE=1
```

Write your code
```python
score = guardian_check(context, backend, criteria="harm")  # legacy path used
```

### Testing
- [X] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
