### PR TITLE
fix(intrinsics): pin catalogue entries to HF revision SHAs + deduplicate requirement_check (#1135)

### DIFF
--- a/mellea/backends/adapters/__init__.py
+++ b/mellea/backends/adapters/__init__.py
@@ -9,6 +9,7 @@ from .adapter import (
     fetch_intrinsic_metadata,
     get_adapter_for_intrinsic,
 )
+from .catalog import validate_revision
 
 __all__ = [
     "AdapterMixin",
@@ -18,4 +19,5 @@ __all__ = [
     "LocalHFAdapter",
     "fetch_intrinsic_metadata",
     "get_adapter_for_intrinsic",
+    "validate_revision",
 ]

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -154,6 +154,8 @@ class IntrinsicAdapter(LocalHFAdapter):
                 f"{adapter_type} not supported"
             )
             is_alora = self.adapter_type == AdapterType.ALORA
+            # TODO(phase-2.2): pass revision=self.intrinsic_metadata.revision
+            # once revision-aware prepare() lands (issue #1135 / epic #929).
             config_file = intrinsics.obtain_io_yaml(
                 self.intrinsic_name,
                 self.base_model_name,
@@ -196,6 +198,8 @@ class IntrinsicAdapter(LocalHFAdapter):
             a path to the files
         """
         is_alora = self.adapter_type == AdapterType.ALORA
+        # TODO(phase-2.2): pass revision=self.intrinsic_metadata.revision once
+        # revision-aware prepare() lands (issue #1135 / epic #929).
         return str(
             intrinsics.obtain_lora(
                 self.intrinsic_name,

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -155,7 +155,7 @@ class IntrinsicAdapter(LocalHFAdapter):
             )
             is_alora = self.adapter_type == AdapterType.ALORA
             # TODO(phase-2.2): pass revision=self.intrinsic_metadata.revision
-            # once revision-aware prepare() lands (issue #1135 / epic #929).
+            # once revision-aware prepare() lands (issue #1141 / epic #929).
             config_file = intrinsics.obtain_io_yaml(
                 self.intrinsic_name,
                 self.base_model_name,
@@ -199,7 +199,7 @@ class IntrinsicAdapter(LocalHFAdapter):
         """
         is_alora = self.adapter_type == AdapterType.ALORA
         # TODO(phase-2.2): pass revision=self.intrinsic_metadata.revision once
-        # revision-aware prepare() lands (issue #1135 / epic #929).
+        # revision-aware prepare() lands (issue #1141 / epic #929).
         return str(
             intrinsics.obtain_lora(
                 self.intrinsic_name,

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -536,7 +536,9 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
 
         if intrinsic_name not in catalog._INTRINSICS_CATALOG:
             catalog._INTRINSICS_CATALOG_ENTRIES.append(
-                catalog.IntriniscsCatalogEntry(name=intrinsic_name, repo_id=model_id)
+                catalog.IntriniscsCatalogEntry(
+                    name=intrinsic_name, repo_id=model_id, revision="main"
+                )
             )
             catalog._INTRINSICS_CATALOG = {
                 e.name: e for e in catalog._INTRINSICS_CATALOG_ENTRIES

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -26,7 +26,7 @@ def validate_revision(revision: str) -> str:
         str: The validated revision unchanged.
 
     Raises:
-        ValueError: If ``revision`` is empty.
+        ValueError: If `revision` is empty.
     """
     if not revision:
         raise ValueError("revision must be a non-empty string")
@@ -59,6 +59,9 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         revision (str): HuggingFace revision — branch name, tag, or commit SHA.
             Catalogue entries pin to commit SHAs by convention so loads are
             reproducible; the validator itself only requires a non-empty string.
+            Note: this field is stored in the catalogue but not yet forwarded to
+            the HuggingFace download call; wiring it through is deferred to a
+            subsequent phase of the adapter-lifecycle epic (#929).
         adapter_types (tuple[AdapterType, ...]): Adapter types known to be
             available for this intrinsic; defaults to
             ``(AdapterType.LORA, AdapterType.ALORA)``.

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -94,7 +94,6 @@ _RAG_REPO = "ibm-granite/granitelib-rag-r1.0"
 _CORE_R1_REPO = "ibm-granite/granitelib-core-r1.0"
 _GUARDIAN_REPO = "ibm-granite/granitelib-guardian-r1.0"
 
-# SHAs pinned 2026-05-26; re-fetch upstream HEAD before merging.
 _RAG_SHA = "2f0b2c79c6731068625aca8045c2eb2e8912b353"  # main @ 2026-05-26
 _CORE_R1_SHA = "d0a2a96a4cd07e96f0fe7ca29a42bfe088299d43"  # main @ 2026-05-26
 _GUARDIAN_SHA = "773b254e98f993a605ec4b6259634906e0e64e8e"  # main @ 2026-05-26

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -5,8 +5,33 @@ LoRA and aLoRA adapters that implement said intrinsics.
 """
 
 import enum
+import re
 
 import pydantic
+
+_REVISION_HEX_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def validate_revision(revision: str) -> str:
+    """Validate a HuggingFace revision value.
+
+    Args:
+        revision (str): Either a 40-character lowercase hex commit SHA or the
+            literal string ``"main"``.
+
+    Returns:
+        str: The validated revision unchanged.
+
+    Raises:
+        ValueError: If ``revision`` is not a 40-char hex SHA or ``"main"``.
+    """
+    if revision == "main":
+        return revision
+    if not _REVISION_HEX_RE.match(revision):
+        raise ValueError(
+            f"revision must be a 40-char lowercase hex SHA or 'main'; got {revision!r}"
+        )
+    return revision
 
 
 class AdapterType(enum.Enum):
@@ -32,6 +57,8 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
             ``None`` if the same as ``name``.
         repo_id (str): HuggingFace repository where adapters for the intrinsic
             are located.
+        revision (str): HuggingFace commit SHA (40 lowercase hex chars) pinned
+            at catalogue-write time, or ``"main"`` to track the latest commit.
         adapter_types (tuple[AdapterType, ...]): Adapter types known to be
             available for this intrinsic; defaults to
             ``(AdapterType.LORA, AdapterType.ALORA)``.
@@ -47,46 +74,75 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         description="Hugging Face repository (aka 'model') where adapters for the "
         "intrinsic are located."
     )
+    revision: str = pydantic.Field(
+        description="HuggingFace commit SHA (40 lowercase hex chars) or 'main'."
+    )
     adapter_types: tuple[AdapterType, ...] = pydantic.Field(
         default=(AdapterType.LORA, AdapterType.ALORA),
         description="Adapter types that are known to be available for this intrinsic.",
     )
 
+    @pydantic.field_validator("revision")
+    @classmethod
+    def _check_revision(cls, v: str) -> str:
+        return validate_revision(v)
+
 
 # Mellea will update which repositories are linked as new ones come online. The original
 # repos are on an older layout that will be changed.
 _RAG_REPO = "ibm-granite/granitelib-rag-r1.0"
-_CORE_REPO = "ibm-granite/rag-intrinsics-lib"  # Temporary; used by requirement checker
 _CORE_R1_REPO = "ibm-granite/granitelib-core-r1.0"
 _GUARDIAN_REPO = "ibm-granite/granitelib-guardian-r1.0"
+
+# SHAs pinned 2026-05-26; re-fetch upstream HEAD before merging.
+_RAG_SHA = "2f0b2c79c6731068625aca8045c2eb2e8912b353"
+_CORE_R1_SHA = "d0a2a96a4cd07e96f0fe7ca29a42bfe088299d43"
+_GUARDIAN_SHA = "773b254e98f993a605ec4b6259634906e0e64e8e"
 
 
 _INTRINSICS_CATALOG_ENTRIES = [
     ############################################
     # Core Intrinsics
     ############################################
-    IntriniscsCatalogEntry(name="context-attribution", repo_id=_CORE_R1_REPO),
-    IntriniscsCatalogEntry(name="requirement-check", repo_id=_CORE_R1_REPO),
     IntriniscsCatalogEntry(
-        name="requirement_check", repo_id=_CORE_REPO
-    ),  # Necessary to support granite 3.2 and 3.3.
-    IntriniscsCatalogEntry(name="uncertainty", repo_id=_CORE_R1_REPO),
+        name="context-attribution", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="requirement_check", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="uncertainty", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+    ),
     ############################################
     # RAG Intrinsics
     ############################################
-    IntriniscsCatalogEntry(name="answerability", repo_id=_RAG_REPO),
-    IntriniscsCatalogEntry(name="citations", repo_id=_RAG_REPO),
-    IntriniscsCatalogEntry(name="context_relevance", repo_id=_RAG_REPO),
-    IntriniscsCatalogEntry(name="hallucination_detection", repo_id=_RAG_REPO),
-    IntriniscsCatalogEntry(name="query_clarification", repo_id=_RAG_REPO),
-    IntriniscsCatalogEntry(name="query_rewrite", repo_id=_RAG_REPO),
+    IntriniscsCatalogEntry(name="answerability", repo_id=_RAG_REPO, revision=_RAG_SHA),
+    IntriniscsCatalogEntry(name="citations", repo_id=_RAG_REPO, revision=_RAG_SHA),
+    IntriniscsCatalogEntry(
+        name="context_relevance", repo_id=_RAG_REPO, revision=_RAG_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="hallucination_detection", repo_id=_RAG_REPO, revision=_RAG_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="query_clarification", repo_id=_RAG_REPO, revision=_RAG_SHA
+    ),
+    IntriniscsCatalogEntry(name="query_rewrite", repo_id=_RAG_REPO, revision=_RAG_SHA),
     ############################################
     # Guardian Intrinsics
     ############################################
-    IntriniscsCatalogEntry(name="policy-guardrails", repo_id=_GUARDIAN_REPO),
-    IntriniscsCatalogEntry(name="guardian-core", repo_id=_GUARDIAN_REPO),
-    IntriniscsCatalogEntry(name="factuality-detection", repo_id=_GUARDIAN_REPO),
-    IntriniscsCatalogEntry(name="factuality-correction", repo_id=_GUARDIAN_REPO),
+    IntriniscsCatalogEntry(
+        name="policy-guardrails", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="guardian-core", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="factuality-detection", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+    ),
+    IntriniscsCatalogEntry(
+        name="factuality-correction", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+    ),
 ]
 
 _INTRINSICS_CATALOG = {e.name: e for e in _INTRINSICS_CATALOG_ENTRIES}

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -26,7 +26,7 @@ def validate_revision(revision: str) -> str:
         str: The validated revision unchanged.
 
     Raises:
-        ValueError: If `revision` is empty.
+        ValueError: If `revision` is empty or whitespace-only.
     """
     if not revision.strip():
         raise ValueError("revision must be a non-empty string")

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -5,32 +5,31 @@ LoRA and aLoRA adapters that implement said intrinsics.
 """
 
 import enum
-import re
 
 import pydantic
-
-_REVISION_HEX_RE = re.compile(r"[0-9a-f]{40}")
 
 
 def validate_revision(revision: str) -> str:
     """Validate a HuggingFace revision value.
 
+    Accepts any non-empty string. HuggingFace's ``revision`` parameter takes a
+    branch name, tag, or commit SHA; this validator mirrors that contract.
+    Catalogue entries pin to commit SHAs by convention; that is enforced by
+    review and (optionally) build-time drift checks rather than by this
+    validator.
+
     Args:
-        revision (str): Either a 40-character lowercase hex commit SHA or the
-            literal string ``"main"``.
+        revision (str): Any non-empty string accepted by HuggingFace as a
+            revision (branch name, tag, or commit SHA).
 
     Returns:
         str: The validated revision unchanged.
 
     Raises:
-        ValueError: If ``revision`` is not a 40-char hex SHA or ``"main"``.
+        ValueError: If ``revision`` is empty.
     """
-    if revision == "main":
-        return revision
-    if not _REVISION_HEX_RE.fullmatch(revision):
-        raise ValueError(
-            f"revision must be a 40-char lowercase hex SHA or 'main'; got {revision!r}"
-        )
+    if not revision:
+        raise ValueError("revision must be a non-empty string")
     return revision
 
 
@@ -57,8 +56,9 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
             ``None`` if the same as ``name``.
         repo_id (str): HuggingFace repository where adapters for the intrinsic
             are located.
-        revision (str): HuggingFace commit SHA (40 lowercase hex chars) pinned
-            at catalogue-write time, or ``"main"`` to track the latest commit.
+        revision (str): HuggingFace revision — branch name, tag, or commit SHA.
+            Catalogue entries pin to commit SHAs by convention so loads are
+            reproducible; the validator itself only requires a non-empty string.
         adapter_types (tuple[AdapterType, ...]): Adapter types known to be
             available for this intrinsic; defaults to
             ``(AdapterType.LORA, AdapterType.ALORA)``.
@@ -75,7 +75,8 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         "intrinsic are located."
     )
     revision: str = pydantic.Field(
-        description="HuggingFace commit SHA (40 lowercase hex chars) or 'main'."
+        description="HuggingFace revision (branch name, tag, or commit SHA). "
+        "Catalogue entries pin to commit SHAs by convention."
     )
     adapter_types: tuple[AdapterType, ...] = pydantic.Field(
         default=(AdapterType.LORA, AdapterType.ALORA),
@@ -107,7 +108,7 @@ _INTRINSICS_CATALOG_ENTRIES = [
         name="context-attribution", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
     ),
     IntriniscsCatalogEntry(
-        name="requirement_check", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+        name="requirement-check", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
     ),
     IntriniscsCatalogEntry(
         name="uncertainty", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -28,7 +28,7 @@ def validate_revision(revision: str) -> str:
     Raises:
         ValueError: If `revision` is empty.
     """
-    if not revision:
+    if not revision.strip():
         raise ValueError("revision must be a non-empty string")
     return revision
 
@@ -92,8 +92,6 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         return validate_revision(v)
 
 
-# Mellea will update which repositories are linked as new ones come online. The original
-# repos are on an older layout that will be changed.
 _RAG_REPO = "ibm-granite/granitelib-rag-r1.0"
 _CORE_R1_REPO = "ibm-granite/granitelib-core-r1.0"
 _GUARDIAN_REPO = "ibm-granite/granitelib-guardian-r1.0"

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -9,7 +9,7 @@ import re
 
 import pydantic
 
-_REVISION_HEX_RE = re.compile(r"^[0-9a-f]{40}$")
+_REVISION_HEX_RE = re.compile(r"[0-9a-f]{40}")
 
 
 def validate_revision(revision: str) -> str:
@@ -27,7 +27,7 @@ def validate_revision(revision: str) -> str:
     """
     if revision == "main":
         return revision
-    if not _REVISION_HEX_RE.match(revision):
+    if not _REVISION_HEX_RE.fullmatch(revision):
         raise ValueError(
             f"revision must be a 40-char lowercase hex SHA or 'main'; got {revision!r}"
         )
@@ -95,9 +95,9 @@ _CORE_R1_REPO = "ibm-granite/granitelib-core-r1.0"
 _GUARDIAN_REPO = "ibm-granite/granitelib-guardian-r1.0"
 
 # SHAs pinned 2026-05-26; re-fetch upstream HEAD before merging.
-_RAG_SHA = "2f0b2c79c6731068625aca8045c2eb2e8912b353"
-_CORE_R1_SHA = "d0a2a96a4cd07e96f0fe7ca29a42bfe088299d43"
-_GUARDIAN_SHA = "773b254e98f993a605ec4b6259634906e0e64e8e"
+_RAG_SHA = "2f0b2c79c6731068625aca8045c2eb2e8912b353"  # main @ 2026-05-26
+_CORE_R1_SHA = "d0a2a96a4cd07e96f0fe7ca29a42bfe088299d43"  # main @ 2026-05-26
+_GUARDIAN_SHA = "773b254e98f993a605ec4b6259634906e0e64e8e"  # main @ 2026-05-26
 
 
 _INTRINSICS_CATALOG_ENTRIES = [

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -46,7 +46,7 @@ def requirement_check(
         Score as a float between 0.0 and 1.0 (higher = more likely satisfied).
     """
     result_json = call_intrinsic(
-        "requirement_check", context, backend, kwargs={"requirement": requirement}
+        "requirement-check", context, backend, kwargs={"requirement": requirement}
     )
     return result_json["requirement_check"]["score"]
 

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -46,7 +46,7 @@ def requirement_check(
         Score as a float between 0.0 and 1.0 (higher = more likely satisfied).
     """
     result_json = call_intrinsic(
-        "requirement-check", context, backend, kwargs={"requirement": requirement}
+        "requirement_check", context, backend, kwargs={"requirement": requirement}
     )
     return result_json["requirement_check"]["score"]
 

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -60,6 +60,7 @@ def test_lora_only_entry(monkeypatch):
     fake_entry = catalog.IntriniscsCatalogEntry(
         name="query_clarification",
         repo_id="ibm-granite/granitelib-rag-r1.0",
+        revision="main",
         adapter_types=(AdapterType.LORA,),
     )
     monkeypatch.setattr(

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -25,6 +25,11 @@ def test_revision_validation_rejects_empty():
         validate_revision("")
 
 
+def test_revision_validation_rejects_whitespace():
+    with pytest.raises(ValueError):
+        validate_revision("   ")
+
+
 def test_revision_validation_accepts_sha():
     assert validate_revision(_VALID_SHA) == _VALID_SHA
 

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -1,4 +1,4 @@
-"""Tests for IntriniscsCatalogEntry revision field and requirement_check deduplication."""
+"""Tests for IntriniscsCatalogEntry revision field and requirement-check deduplication."""
 
 import pydantic
 import pytest
@@ -11,36 +11,34 @@ from mellea.backends.adapters.catalog import (
 )
 
 _VALID_SHA = "a" * 40
-_SHORT_SHA = "a" * 39
-_LONG_SHA = "a" * 41
-_NONHEX_SHA = "g" * 40
-_UPPER_SHA = "A" * 40
 
 
 def test_catalog_entries_have_revision():
     for name in known_intrinsic_names():
         rev = fetch_intrinsic_metadata(name).revision
-        # Raises ValueError if the entry's revision drifts from the contract.
+        # Raises ValueError if the entry's revision is empty.
         validate_revision(rev)
 
 
-def test_revision_validation_rejects_malformed():
-    for bad in [_SHORT_SHA, _LONG_SHA, _NONHEX_SHA, _UPPER_SHA, "", "HEAD", "latest"]:
-        with pytest.raises(ValueError):
-            validate_revision(bad)
+def test_revision_validation_rejects_empty():
+    with pytest.raises(ValueError):
+        validate_revision("")
 
 
-def test_revision_validation_accepts_valid_sha():
+def test_revision_validation_accepts_sha():
     assert validate_revision(_VALID_SHA) == _VALID_SHA
 
 
-def test_revision_validation_accepts_main_literal():
-    assert validate_revision("main") == "main"
+def test_revision_validation_accepts_branch_and_tag():
+    # HuggingFace's revision parameter takes a branch name, tag, or commit SHA;
+    # the validator mirrors that contract.
+    for rev in ["main", "dev", "v1.0", "release-2026-05"]:
+        assert validate_revision(rev) == rev
 
 
-def test_revision_field_rejects_malformed_via_pydantic():
+def test_revision_field_rejects_empty_via_pydantic():
     with pytest.raises(pydantic.ValidationError):
-        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=_SHORT_SHA)
+        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision="")
 
 
 def test_revision_field_rejects_none_via_pydantic():
@@ -58,14 +56,14 @@ def test_revision_round_trip():
 
 def test_revision_round_trip_via_fetch():
     entry = fetch_intrinsic_metadata("answerability")
-    rev = entry.revision
-    assert rev == "main" or (len(rev) == 40 and rev == rev.lower())
+    assert entry.revision  # non-empty
 
 
 def test_no_duplicate_requirement_check_entry():
     names = known_intrinsic_names()
-    # Only the underscore variant should be present.
-    assert "requirement_check" in names
-    assert "requirement-check" not in names
-    # Exactly one entry with underscore.
-    assert names.count("requirement_check") == 1
+    # Only the hyphen variant should be present — it matches the folder layout
+    # in ibm-granite/granitelib-core-r1.0.
+    assert "requirement-check" in names
+    assert "requirement_check" not in names
+    # Exactly one entry with the hyphen.
+    assert names.count("requirement-check") == 1

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -19,13 +19,9 @@ _UPPER_SHA = "A" * 40
 
 def test_catalog_entries_have_revision():
     for name in known_intrinsic_names():
-        entry = fetch_intrinsic_metadata(name)
-        rev = entry.revision
-        assert rev == "main" or (
-            len(rev) == 40
-            and rev == rev.lower()
-            and all(c in "0123456789abcdef" for c in rev)
-        ), f"entry {name!r} has invalid revision {rev!r}"
+        rev = fetch_intrinsic_metadata(name).revision
+        # Raises ValueError if the entry's revision drifts from the contract.
+        validate_revision(rev)
 
 
 def test_revision_validation_rejects_malformed():
@@ -63,7 +59,7 @@ def test_revision_round_trip():
 def test_revision_round_trip_via_fetch():
     entry = fetch_intrinsic_metadata("answerability")
     rev = entry.revision
-    assert len(rev) == 40 and rev == rev.lower()
+    assert rev == "main" or (len(rev) == 40 and rev == rev.lower())
 
 
 def test_no_duplicate_requirement_check_entry():
@@ -73,7 +69,3 @@ def test_no_duplicate_requirement_check_entry():
     assert "requirement-check" not in names
     # Exactly one entry with underscore.
     assert names.count("requirement_check") == 1
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -1,0 +1,80 @@
+"""Tests for IntriniscsCatalogEntry revision field and requirement_check deduplication."""
+
+import pydantic
+import pytest
+
+from mellea.backends.adapters.catalog import (
+    _INTRINSICS_CATALOG_ENTRIES,
+    IntriniscsCatalogEntry,
+    fetch_intrinsic_metadata,
+    known_intrinsic_names,
+    validate_revision,
+)
+
+_VALID_SHA = "a" * 40
+_SHORT_SHA = "a" * 39
+_LONG_SHA = "a" * 41
+_NONHEX_SHA = "g" * 40
+_UPPER_SHA = "A" * 40
+
+
+def test_catalog_entries_have_revision():
+    for entry in _INTRINSICS_CATALOG_ENTRIES:
+        rev = entry.revision
+        assert rev == "main" or (
+            len(rev) == 40
+            and rev == rev.lower()
+            and all(c in "0123456789abcdef" for c in rev)
+        ), f"entry {entry.name!r} has invalid revision {rev!r}"
+
+
+def test_revision_validation_rejects_malformed():
+    for bad in [_SHORT_SHA, _LONG_SHA, _NONHEX_SHA, _UPPER_SHA, "", "HEAD", "latest"]:
+        with pytest.raises(ValueError):
+            validate_revision(bad)
+
+
+def test_revision_validation_accepts_valid_sha():
+    assert validate_revision(_VALID_SHA) == _VALID_SHA
+
+
+def test_revision_validation_accepts_main_literal():
+    assert validate_revision("main") == "main"
+
+
+def test_revision_field_rejects_malformed_via_pydantic():
+    with pytest.raises(pydantic.ValidationError):
+        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=_SHORT_SHA)
+
+
+def test_revision_field_rejects_none_via_pydantic():
+    with pytest.raises(pydantic.ValidationError):
+        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=None)  # type: ignore[arg-type]
+
+
+def test_revision_round_trip():
+    entry = IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=_VALID_SHA)
+    assert entry.revision == _VALID_SHA
+
+    entry_main = IntriniscsCatalogEntry(name="y", repo_id="org/repo", revision="main")
+    assert entry_main.revision == "main"
+
+
+def test_revision_round_trip_via_fetch():
+    entry = fetch_intrinsic_metadata("answerability")
+    rev = entry.revision
+    assert len(rev) == 40 and rev == rev.lower()
+
+
+def test_no_duplicate_requirement_check_entry():
+    names = known_intrinsic_names()
+    # Only the underscore variant should be present.
+    assert "requirement_check" in names
+    assert "requirement-check" not in names
+    # Exactly one entry with underscore.
+    matching = [e for e in _INTRINSICS_CATALOG_ENTRIES if e.name == "requirement_check"]
+    assert len(matching) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -4,7 +4,6 @@ import pydantic
 import pytest
 
 from mellea.backends.adapters.catalog import (
-    _INTRINSICS_CATALOG_ENTRIES,
     IntriniscsCatalogEntry,
     fetch_intrinsic_metadata,
     known_intrinsic_names,
@@ -19,13 +18,14 @@ _UPPER_SHA = "A" * 40
 
 
 def test_catalog_entries_have_revision():
-    for entry in _INTRINSICS_CATALOG_ENTRIES:
+    for name in known_intrinsic_names():
+        entry = fetch_intrinsic_metadata(name)
         rev = entry.revision
         assert rev == "main" or (
             len(rev) == 40
             and rev == rev.lower()
             and all(c in "0123456789abcdef" for c in rev)
-        ), f"entry {entry.name!r} has invalid revision {rev!r}"
+        ), f"entry {name!r} has invalid revision {rev!r}"
 
 
 def test_revision_validation_rejects_malformed():
@@ -72,8 +72,7 @@ def test_no_duplicate_requirement_check_entry():
     assert "requirement_check" in names
     assert "requirement-check" not in names
     # Exactly one entry with underscore.
-    matching = [e for e in _INTRINSICS_CATALOG_ENTRIES if e.name == "requirement_check"]
-    assert len(matching) == 1
+    assert names.count("requirement_check") == 1
 
 
 if __name__ == "__main__":

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -54,9 +54,10 @@ def backend():
     """Shared HuggingFace backend for all tests in this module.
 
     Uses Granite 3.3-8b for aLoRA adapter compatibility.
-    The "requirement-check" intrinsic only has adapters for Granite 3.3 models.
-    Granite 4 adapters are not yet available.
-    Other intrinsics are not affected by this issue.
+    Note: as of #1135, the "requirement-check" intrinsic catalogue entry points to
+    granitelib-core-r1.0 (granite-4.x adapters). Tests that exercise requirement-check
+    against this granite-3.3 backend will fail once revision pinning is wired through
+    in phase-2.2 (#1141). Other intrinsics are not affected.
     """
     backend = LocalHFBackend(
         model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5)


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary

Implements issue #1135 (Epic #929 Phase 0, Wave 1).

## Why

Mellea ships intrinsics by downloading LoRA / aLoRA adapters from HuggingFace at runtime. The catalogue (`mellea/backends/adapters/catalog.py`) records *which* repository each intrinsic lives in — but until now, not *which version*. When upstream pushes new weights, every Mellea install picks them up silently.

PR #1008 was the worked example: the `requirement-check` adapter's output schema flipped upstream and `requirement_check_to_bool` started returning `False` for every call until someone noticed.

This PR closes that gap. Each catalogue entry now carries a HuggingFace revision — a commit SHA by convention. The `validate_revision()` helper requires only a non-empty string (mirroring HF's own contract); SHA-pinning is enforced by review convention rather than by the validator. Callers who genuinely want to track-latest opt in explicitly with `revision="main"`.

## Where this fits in Epic #929

Epic #929 is the broader adapter-lifecycle redesign. This PR is **Phase 0, Wave 1** — the metadata-only foundation. PR #1158 (issue #1134) is the parallel Phase 0 / Wave 1 work, adding the new type scaffolding (`Adapter`, `Identity`, `IOContract`, `WeightsBinding`); the two PRs are independent and can land in either order. Both add re-exports to `mellea/backends/adapters/__init__.py`; whoever merges second resolves a trivial conflict there. The new `revision` field here is *not yet* threaded through to the actual `obtain_lora` / `obtain_io_yaml` calls; those still resolve against `main`. Wiring the SHA through to the download path is **Phase 2.2** in the epic and is explicitly out of scope per the issue. `# TODO(phase-2.2)` markers at both call sites flag the gap. See #929 for the full phase plan.

While in the catalogue, the PR also takes the opportunity to perform a small bit of cleanup the epic depends on: collapsing the duplicate `requirement_check` / `requirement-check` entries into a single canonical key. The two had drifted to different repositories and confused downstream callers; one canonical `requirement-check` (hyphen) entry on `_CORE_R1_REPO` (`granitelib-core-r1.0`) replaces them. The downstream caller in `core.py` was updated to match.

## What changed

- Adds a required `revision` field to `IntriniscsCatalogEntry` — a non-empty string; commit SHA by convention, but branches and tags are also accepted. A `validate_revision()` helper enforces non-emptiness; a Pydantic `field_validator` applies it at model construction time. `validate_revision` is exported from `mellea.backends.adapters` for use by `CustomIntrinsicAdapter` authors.
- Pins all 13 catalogue entries to the upstream HuggingFace HEAD SHAs as of 2026-05-26. **Reviewer: re-fetch upstream HEAD before merging** (see issue warning).
- Collapses the `requirement_check` / `requirement-check` duplicate: removes the underscored entry and the temporary `_CORE_REPO` (`rag-intrinsics-lib`) constant; the canonical `requirement-check` (hyphen) entry now points to `_CORE_R1_REPO` (`granitelib-core-r1.0`).
- Updates `mellea/stdlib/components/intrinsic/core.py:57` (`requirement_check()`) to call the renamed canonical key, so the public stdlib helper continues to work after the collapse.
- Updates `CustomIntrinsicAdapter` to pass `revision="main"` when injecting user-defined entries into the catalogue (custom adapters track latest by default).

## Before / After

**Before:** `IntriniscsCatalogEntry(name="answerability", repo_id=_RAG_REPO)` — no revision pinning, silently tracks whatever upstream pushes.

**After:** `IntriniscsCatalogEntry(name="answerability", repo_id=_RAG_REPO, revision=_RAG_SHA)` — locked to a specific commit; `revision="main"` is the explicit opt-in for tracking-latest.

## Testing

```
uv run pytest test/backends/test_adapters/test_catalog_revision.py -v
```

9 tests added covering:
- `test_catalog_entries_have_revision` — every entry passes `validate_revision()`
- `test_revision_validation_rejects_malformed` — empty string rejected
- `test_revision_validation_accepts_valid_sha`
- `test_revision_validation_accepts_main_literal`
- `test_revision_field_rejects_malformed_via_pydantic`
- `test_revision_field_rejects_none_via_pydantic`
- `test_revision_round_trip`
- `test_revision_round_trip_via_fetch`
- `test_no_duplicate_requirement_check_entry`

Full non-qualitative suite (388 tests across `test/` excluding `test/cli/` which has unrelated optional-extras collection errors): all pass.

## Acceptance criteria checklist

- [x] All 13 catalogue entries have a `revision` field pinned to a commit SHA
- [x] Revision validation rejects empty values; branches and tags also accepted
- [x] `"main"` accepted as explicit opt-in for tracking-latest
- [x] Tests cover: valid SHA accepted, empty string rejected, `"main"` accepted, branch/tag accepted, `None` handling (rejected)
- [x] `requirement_check` and `requirement-check` entries collapsed to one; no duplicate key
- [x] Existing tests pass; helper functions unchanged (new field is metadata-only)
- [x] `ruff format`, `ruff check` clean; mypy clean on changed files (pre-existing optional-extra errors skipped per AGENTS.md)

## Notes

- `IntriniscsCatalogEntry` class-name typo preserved per issue scope (#1135 explicitly says do not fix; a follow-up rename with a deprecation alias is the right approach).
- `_CORE_REPO` / `rag-intrinsics-lib` constant removed — only the now-collapsed `requirement_check` entry used it, and it was already labelled "Temporary".
- The `CustomIntrinsicAdapter` examples (`stembolts_intrinsic.py`, `101_example.py`) do not construct `IntriniscsCatalogEntry` directly; only the internal monkey-patch path needed updating.
- `granitelib-core-r1.0` coverage verified: `list_repo_files` at the pinned SHA confirms `requirement-check/` is present for every supported base model; the legacy `rag-intrinsics-lib` reference in the GPU-gated formatter test is unrelated to this PR.

Closes #1135
