### PR TITLE
fix: propagate generate_from_raw exceptions in OllamaModelBackend

### DIFF
--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -502,6 +502,12 @@ class OllamaModelBackend(FormatterBackend):
 
         Returns:
             list[ModelOutputThunk]: A list of model output thunks, one per action.
+
+        Raises:
+            Exception: Any exception raised by the Ollama client (e.g.,
+                ``ConnectionError``, ``ollama.ResponseError``) propagates
+                directly to the caller. Semantics are all-or-nothing: if any
+                request fails, no thunks are returned.
         """
         if len(actions) > 1:
             MelleaLogger.get_logger().info(
@@ -536,6 +542,8 @@ class OllamaModelBackend(FormatterBackend):
                 )
                 coroutines.append(co)
 
+            # All-or-nothing: first failure raises; remaining in-flight requests
+            # complete but their results are discarded.
             responses = await asyncio.gather(*coroutines)
 
         results = []

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -536,37 +536,27 @@ class OllamaModelBackend(FormatterBackend):
                 )
                 coroutines.append(co)
 
-            responses = await asyncio.gather(*coroutines, return_exceptions=True)
+            responses = await asyncio.gather(*coroutines)
 
         results = []
         date = datetime.datetime.now()
         for i, response in enumerate(responses):
-            result = None
-            error = None
-            if isinstance(response, BaseException):
-                MelleaLogger.get_logger().warning(
-                    f"generate_from_raw: request {i} failed with "
-                    f"{type(response).__name__}: {response}"
-                )
-                result = ModelOutputThunk(value="")
-                error = response
-            else:
-                result = ModelOutputThunk(
-                    value=response.response,
-                    meta={
-                        "generate_response": response.model_dump(),
-                        "usage": {
-                            "completion_tokens": response.eval_count,
-                            "prompt_tokens": response.prompt_eval_count,
-                            "total_tokens": (
-                                response.prompt_eval_count + response.eval_count
-                                if response.prompt_eval_count is not None
-                                and response.eval_count is not None
-                                else None
-                            ),
-                        },
+            result = ModelOutputThunk(
+                value=response.response,
+                meta={
+                    "generate_response": response.model_dump(),
+                    "usage": {
+                        "completion_tokens": response.eval_count,
+                        "prompt_tokens": response.prompt_eval_count,
+                        "total_tokens": (
+                            response.prompt_eval_count + response.eval_count
+                            if response.prompt_eval_count is not None
+                            and response.eval_count is not None
+                            else None
+                        ),
                     },
-                )
+                },
+            )
             action = actions[i]
             result.parsed_repr = (
                 action.parse(result) if isinstance(action, Component) else result.value
@@ -584,9 +574,6 @@ class OllamaModelBackend(FormatterBackend):
                 "seed": model_opts.get(ModelOption.SEED, None),
             }
             generate_log.action = action
-
-            if error:
-                generate_log.extra["error"] = error
             result._generate_log = generate_log
 
             results.append(result)

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -1,7 +1,7 @@
 """Unit tests for Ollama backend pure-logic helpers — no Ollama server required.
 
-Covers _simplify_and_merge, _make_backend_specific_and_remove, and
-chat_response_delta_merge.
+Covers _simplify_and_merge, _make_backend_specific_and_remove,
+chat_response_delta_merge, and generate_from_raw exception propagation.
 """
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -224,6 +224,31 @@ async def test_generate_from_raw_propagates_exception(backend):
         with pytest.raises(ConnectionError, match="ollama server unavailable"):
             await backend.generate_from_raw(
                 actions=[CBlock(value="what is 1+1?")], ctx=SimpleContext()
+            )
+
+
+async def test_generate_from_raw_multi_action_fail_fast(backend):
+    """Any failure in a multi-action batch raises immediately; no partial results.
+
+    Documents the all-or-nothing batch semantics introduced by #597. Previously
+    the failed slot was silently replaced with ModelOutputThunk(value="") and
+    the caller received a partial list. Now the first exception propagates and
+    the caller receives nothing.
+    """
+    mock_async_client = MagicMock()
+    mock_async_client.generate = AsyncMock(
+        side_effect=ConnectionError("request failed")
+    )
+
+    with patch.object(
+        type(backend),
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_async_client,
+    ):
+        with pytest.raises(ConnectionError):
+            await backend.generate_from_raw(
+                actions=[CBlock("a"), CBlock("b"), CBlock("c")], ctx=SimpleContext()
             )
 
 

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -4,14 +4,15 @@ Covers _simplify_and_merge, _make_backend_specific_and_remove, and
 chat_response_delta_merge.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import ollama
 import pytest
 
 from mellea.backends import ModelOption
 from mellea.backends.ollama import OllamaModelBackend, chat_response_delta_merge
-from mellea.core import ModelOutputThunk
+from mellea.core import CBlock, ModelOutputThunk
+from mellea.stdlib.context import SimpleContext
 
 
 def _make_backend(
@@ -199,6 +200,31 @@ def test_timeout_forwarded_to_new_async_clients_per_event_loop():
 
     _, async_kwargs = mock_async_client.call_args
     assert async_kwargs.get("timeout") == 7.0
+
+
+# --- generate_from_raw exception propagation (#597) ---
+
+
+async def test_generate_from_raw_propagates_exception(backend):
+    """Exceptions from individual Ollama requests must propagate to the caller.
+
+    Regression test for #597: previously, exceptions were silently converted to
+    ModelOutputThunk(value="") via asyncio.gather(return_exceptions=True).
+    """
+    error = ConnectionError("ollama server unavailable")
+    mock_async_client = MagicMock()
+    mock_async_client.generate = AsyncMock(side_effect=error)
+
+    with patch.object(
+        type(backend),
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_async_client,
+    ):
+        with pytest.raises(ConnectionError, match="ollama server unavailable"):
+            await backend.generate_from_raw(
+                actions=[CBlock(value="what is 1+1?")], ctx=SimpleContext()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`generate_from_raw` on the Ollama backend uses `asyncio.gather` to run requests concurrently (Ollama has no server-side batching). With `return_exceptions=True`, any exception was quietly turned into `ModelOutputThunk(value="")` — the error went into `_generate_log.extra["error"]`, a field nothing in the codebase reads. Callers had no way to know a request had failed.

The fix is a one-line change: drop `return_exceptions=True`. Exceptions now propagate to the caller, matching what OpenAI, LiteLLM, Watsonx, and HuggingFace backends already do. The dead error-handling branch and the write-only `extra["error"]` assignment are removed.

**Before:** a connection error returns `[ModelOutputThunk(value=""), ...]` — success with empty output.
**After:** the same error raises — caller gets an actionable exception.

## ⚠️ Behaviour change

Previously, if some requests in a batch failed, you'd get back a full list with empty-string sentinels for the failed slots. Now a failure raises immediately and you get nothing — all-or-nothing. If you were treating `result.value == ""` as a failure signal, switch to catching the exception instead.

This aligns Ollama with every other backend. The partial-success behaviour was the bug (#597) — an empty string is indistinguishable from a model that genuinely returned nothing.

This also helps with #599 (Ollama returning empty responses under load): previously you couldn't tell an empty response from a swallowed exception; now only real empty bodies reach the caller.

## Where this fits

Standalone fix. Closes #597. Assists #599 diagnosis.

## Testing

Two new unit tests with no live Ollama required — a single-action case asserting the exception type and message, and a three-action batch documenting the fail-fast semantics:

```
uv run pytest test/backends/test_ollama_unit.py -v  # 18/18 pass
```