### PR TITLE
fix(hf): filter model_options for apply_chat_template via Jinja AST allowlist

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1609,10 +1609,34 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # Options that should only go to generate(), not apply_chat_template().
         # Keys are Mellea sentinel values or direct passthrough keys, evaluated
         # before _make_backend_specific_and_remove renames them downstream.
+        # Covers the most commonly-used fields from HuggingFace GenerationConfig.
+        # See: https://huggingface.co/docs/transformers/main_classes/text_generation
         generate_only = {
-            ModelOption.TEMPERATURE,  # "temperature" — sampling parameter
+            # Sampling strategy
+            ModelOption.TEMPERATURE,  # "temperature"
+            "do_sample",
+            "top_k",
+            "top_p",
+            "typical_p",
+            "repetition_penalty",
+            "no_repeat_ngram_size",
+            "length_penalty",
+            "num_beams",
+            "num_beam_groups",
+            "diversity_penalty",
+            "penalty_alpha",
+            "early_stopping",
+            # Length constraints
             ModelOption.MAX_NEW_TOKENS,  # sentinel "@@@max_new_tokens@@@"; renamed downstream to "max_new_tokens"
-            "do_sample",  # direct passthrough — sampling flag
+            "min_new_tokens",
+            # Sequence count
+            "num_return_sequences",
+            # Special token IDs
+            "pad_token_id",
+            "bos_token_id",
+            "eos_token_id",
+            "forced_bos_token_id",
+            "forced_eos_token_id",
         }
         return {k: v for k, v in model_options.items() if k not in generate_only}
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1639,15 +1639,29 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if not isinstance(template_str, str) or not template_str:
             # Non-string (None, list of alternates, dict) or empty — cannot parse.
             # apply_chat_template handles those formats internally.
+            if template_str is not None and template_str:
+                # A non-empty, non-string value (e.g. list of alternates, dict) means
+                # we cannot inspect the template's variable names.  Any caller-supplied
+                # model_options that the template would have accepted are silently dropped.
+                MelleaLogger.get_logger().warning(
+                    f"Chat template for {self._hf_model_id} is not a plain string "
+                    f"(got {type(template_str).__name__}); cannot inspect variable names. "
+                    "model_options kwargs will not be forwarded to apply_chat_template."
+                )
             return frozenset()
         # loopcontrols enables {% break %} / {% continue %} used in some HF templates.
         env = jinja2.Environment(extensions=["jinja2.ext.loopcontrols"])
         try:
             ast = env.parse(template_str)
-        except jinja2.TemplateSyntaxError:
+        except jinja2.TemplateSyntaxError as e:
             # Templates using unsupported extensions (e.g. {% generation %} from
             # transformers' AssistantTracker) cannot be parsed with a plain Jinja2
             # environment. Fall back to forwarding nothing rather than crashing.
+            MelleaLogger.get_logger().warning(
+                f"Could not parse chat template for {self._hf_model_id} ({e}); "
+                "forwarding no model_options to apply_chat_template. "
+                "Template-referenced kwargs (think, guardian_config, etc.) will be ignored."
+            )
             return frozenset()
         all_vars = jinja2.meta.find_undeclared_variables(ast)
         return frozenset(all_vars - _HF_INTERNAL_TEMPLATE_VARS)

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -14,6 +14,9 @@ import threading
 from collections.abc import Callable, Coroutine, Sequence
 from typing import Any, overload
 
+import jinja2
+import jinja2.meta
+
 try:
     import llguidance
     import llguidance.hf
@@ -773,6 +776,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # 3. apply the chat template WITHOUT tokenization.
         # Doing this without tokenization and then gluing together the tokens is necessary because
         # things that KV cache together must tokenize together.
+        # Note: add_generation_prompt is in _HF_INTERNAL_TEMPLATE_VARS, so any
+        # user-supplied value is intentionally dropped by _filter_for_chat_template.
+        # The KV-cache path formats context (not a generation turn), so
+        # add_generation_prompt=False (the HF default) is correct here.
         input_text = self._tokenizer.apply_chat_template(  # type: ignore
             ctx_as_conversation,
             tools=convert_tools_to_json(tools),  # type: ignore
@@ -1629,14 +1636,20 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             minus HF-provided variables. Empty if the tokenizer has no ``chat_template``
             (``apply_chat_template`` would raise before kwargs matter in that case).
         """
-        import jinja2.meta
-
         template_str = getattr(self._tokenizer, "chat_template", None)
-        if not template_str:
+        if not isinstance(template_str, str) or not template_str:
+            # Non-string (None, list of alternates, dict) or empty — cannot parse.
+            # apply_chat_template handles those formats internally.
             return frozenset()
-
-        env = jinja2.Environment()
-        ast = env.parse(template_str)
+        # loopcontrols enables {% break %} / {% continue %} used in some HF templates.
+        env = jinja2.Environment(extensions=["jinja2.ext.loopcontrols"])
+        try:
+            ast = env.parse(template_str)
+        except jinja2.TemplateSyntaxError:
+            # Templates using unsupported extensions (e.g. {% generation %} from
+            # transformers' AssistantTracker) cannot be parsed with a plain Jinja2
+            # environment. Fall back to forwarding nothing rather than crashing.
+            return frozenset()
         all_vars = jinja2.meta.find_undeclared_variables(ast)
         return frozenset(all_vars - _HF_INTERNAL_TEMPLATE_VARS)
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1591,9 +1591,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
     ) -> dict[str, Any]:
         """Remove options that are only for generate(), not for apply_chat_template().
 
-        Inverse of :meth:`_filter_chat_template_only_options`. Prevents generate-only
-        options from leaking into the Jinja template variable namespace, where they
-        could silently shadow template-defined variables of the same name.
+        Companion to :meth:`_filter_chat_template_only_options` for the opposite
+        direction. Prevents generate-only options from leaking into the Jinja template
+        variable namespace, where they could silently shadow template-defined variables
+        of the same name.
+
+        Note: this method receives model_options after ``_simplify_and_merge`` has run,
+        so user-supplied string keys such as ``"max_new_tokens"`` have already been
+        normalised to their Mellea sentinel equivalents.
 
         Args:
             model_options: the model_options for this call
@@ -1603,10 +1608,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         """
         # Options that should only go to generate(), not apply_chat_template().
         # Keys are Mellea sentinel values or direct passthrough keys, evaluated
-        # before _make_backend_specific_and_remove renames them.
+        # before _make_backend_specific_and_remove renames them downstream.
         generate_only = {
             ModelOption.TEMPERATURE,  # "temperature" — sampling parameter
-            ModelOption.MAX_NEW_TOKENS,  # "@@@max_new_tokens@@@" — renamed to "max_new_tokens"
+            ModelOption.MAX_NEW_TOKENS,  # sentinel "@@@max_new_tokens@@@"; renamed downstream to "max_new_tokens"
             "do_sample",  # direct passthrough — sampling flag
         }
         return {k: v for k, v in model_options.items() if k not in generate_only}

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -233,7 +233,6 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 )
 
 
-
 class LocalHFBackend(FormatterBackend, AdapterMixin):
     """The LocalHFBackend uses Huggingface's transformers library for inference, and uses a Formatter to convert `Component`s into prompts. This backend also supports Activated LoRAs (ALoras)](https://arxiv.org/pdf/2504.12397).
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -748,7 +748,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         input_text = self._tokenizer.apply_chat_template(  # type: ignore
             ctx_as_conversation,
             tools=convert_tools_to_json(tools),  # type: ignore
-            **self._make_backend_specific_and_remove(model_options),
+            **self._make_backend_specific_and_remove(
+                self._filter_generate_only_options(model_options)
+            ),
             tokenize=False,
         )
 
@@ -1030,7 +1032,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 tools=convert_tools_to_json(tools),  # type: ignore
                 add_generation_prompt=True,  # If we change this, must modify huggingface granite guardian.
                 return_tensors="pt",
-                **self._make_backend_specific_and_remove(model_options),
+                **self._make_backend_specific_and_remove(
+                    self._filter_generate_only_options(model_options)
+                ),
             ).to(self._device)  # type: ignore
 
             format_kwargs = {}
@@ -1581,6 +1585,31 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "documents",
         }
         return {k: v for k, v in model_options.items() if k not in chat_template_only}
+
+    def _filter_generate_only_options(
+        self, model_options: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Remove options that are only for generate(), not for apply_chat_template().
+
+        Inverse of :meth:`_filter_chat_template_only_options`. Prevents generate-only
+        options from leaking into the Jinja template variable namespace, where they
+        could silently shadow template-defined variables of the same name.
+
+        Args:
+            model_options: the model_options for this call
+
+        Returns:
+            a new dict without generate-specific options
+        """
+        # Options that should only go to generate(), not apply_chat_template().
+        # Keys are Mellea sentinel values or direct passthrough keys, evaluated
+        # before _make_backend_specific_and_remove renames them.
+        generate_only = {
+            ModelOption.TEMPERATURE,  # "temperature" — sampling parameter
+            ModelOption.MAX_NEW_TOKENS,  # "@@@max_new_tokens@@@" — renamed to "max_new_tokens"
+            "do_sample",  # direct passthrough — sampling flag
+        }
+        return {k: v for k, v in model_options.items() if k not in generate_only}
 
     # region Adapter loading, unloading, and utility functions.
     @property

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -203,6 +203,34 @@ def _cleanup_kv_cache(cache_info: HFAloraCacheInfo) -> None:
         torch.cuda.empty_cache()
 
 
+# Variables that HuggingFace injects into the Jinja template namespace automatically.
+# These must be excluded from _chat_template_allowlist because they are provided by
+# apply_chat_template itself — forwarding a model_option with the same name would
+# either cause a "got multiple values for keyword argument" TypeError (for the named-param
+# group) or silently replace a function injected by the Jinja environment (for the globals group).
+#
+# ⚠️  REVIEW NOTE: verify this set against the transformers source whenever upgrading.
+# Named params: transformers.tokenization_utils_base.PreTrainedTokenizerBase.apply_chat_template
+#               (the render_jinja_template call around line 119 in that method)
+# Jinja globals: transformers.utils.chat_template_utils._compile_jinja_template
+#               (the jinja_env.globals assignments near the bottom of that function)
+_HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
+    {
+        # --- Named parameters passed explicitly to render_jinja_template ---
+        # Forwarding these from model_options would cause duplicate-kwarg TypeError.
+        "messages",  # the conversation; always the first positional arg
+        "tools",  # tool schemas; our call sites pass tools=convert_tools_to_json(...) explicitly
+        "add_generation_prompt",  # bool; passed explicitly at the standard-generation call site
+        # --- Jinja environment globals set by _compile_jinja_template ---
+        # find_undeclared_variables cannot see env globals, so these appear as "undeclared"
+        # in templates that reference them and must be excluded manually.
+        "raise_exception",  # callable: raises jinja2.exceptions.TemplateError
+        "strftime_now",  # callable: returns datetime.now().strftime(format)
+    }
+)
+
+
+
 class LocalHFBackend(FormatterBackend, AdapterMixin):
     """The LocalHFBackend uses Huggingface's transformers library for inference, and uses a Formatter to convert `Component`s into prompts. This backend also supports Activated LoRAs (ALoras)](https://arxiv.org/pdf/2504.12397).
 
@@ -748,9 +776,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         input_text = self._tokenizer.apply_chat_template(  # type: ignore
             ctx_as_conversation,
             tools=convert_tools_to_json(tools),  # type: ignore
-            **self._make_backend_specific_and_remove(
-                self._filter_generate_only_options(model_options)
-            ),
+            **self._filter_for_chat_template(model_options),
             tokenize=False,
         )
 
@@ -1032,9 +1058,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 tools=convert_tools_to_json(tools),  # type: ignore
                 add_generation_prompt=True,  # If we change this, must modify huggingface granite guardian.
                 return_tensors="pt",
-                **self._make_backend_specific_and_remove(
-                    self._filter_generate_only_options(model_options)
-                ),
+                **self._filter_for_chat_template(model_options),
             ).to(self._device)  # type: ignore
 
             format_kwargs = {}
@@ -1586,59 +1610,57 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         }
         return {k: v for k, v in model_options.items() if k not in chat_template_only}
 
-    def _filter_generate_only_options(
-        self, model_options: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Remove options that are only for generate(), not for apply_chat_template().
+    @functools.cached_property
+    def _chat_template_allowlist(self) -> frozenset[str]:
+        """Variable names the tokenizer's chat template can accept from caller-supplied kwargs.
 
-        Companion to :meth:`_filter_chat_template_only_options` for the opposite
-        direction. Prevents generate-only options from leaking into the Jinja template
-        variable namespace, where they could silently shadow template-defined variables
-        of the same name.
+        Parses the Jinja2 template with :func:`jinja2.meta.find_undeclared_variables` to
+        find every variable the template references but does not define itself, then
+        subtracts :data:`_HF_INTERNAL_TEMPLATE_VARS` (variables HuggingFace provides
+        automatically). What remains is the exact set of keys a caller may legitimately
+        forward from ``model_options`` to ``apply_chat_template``.
 
-        Note: this method receives model_options after ``_simplify_and_merge`` has run,
-        so user-supplied string keys such as ``"max_new_tokens"`` have already been
-        normalised to their Mellea sentinel equivalents.
-
-        Args:
-            model_options: the model_options for this call
+        This is the self-maintaining alternative to a hand-written denylist: it adapts
+        automatically as the loaded model's Jinja template changes without any manual
+        enumeration of generate()-only option names.
 
         Returns:
-            a new dict without generate-specific options
+            frozenset of kwarg names valid for ``apply_chat_template`` on this tokenizer,
+            minus HF-provided variables. Empty if the tokenizer has no ``chat_template``
+            (``apply_chat_template`` would raise before kwargs matter in that case).
         """
-        # Options that should only go to generate(), not apply_chat_template().
-        # Keys are Mellea sentinel values or direct passthrough keys, evaluated
-        # before _make_backend_specific_and_remove renames them downstream.
-        # Covers the most commonly-used fields from HuggingFace GenerationConfig.
-        # See: https://huggingface.co/docs/transformers/main_classes/text_generation
-        generate_only = {
-            # Sampling strategy
-            ModelOption.TEMPERATURE,  # "temperature"
-            "do_sample",
-            "top_k",
-            "top_p",
-            "typical_p",
-            "repetition_penalty",
-            "no_repeat_ngram_size",
-            "length_penalty",
-            "num_beams",
-            "num_beam_groups",
-            "diversity_penalty",
-            "penalty_alpha",
-            "early_stopping",
-            # Length constraints
-            ModelOption.MAX_NEW_TOKENS,  # sentinel "@@@max_new_tokens@@@"; renamed downstream to "max_new_tokens"
-            "min_new_tokens",
-            # Sequence count
-            "num_return_sequences",
-            # Special token IDs
-            "pad_token_id",
-            "bos_token_id",
-            "eos_token_id",
-            "forced_bos_token_id",
-            "forced_eos_token_id",
+        import jinja2.meta
+
+        template_str = getattr(self._tokenizer, "chat_template", None)
+        if not template_str:
+            return frozenset()
+
+        env = jinja2.Environment()
+        ast = env.parse(template_str)
+        all_vars = jinja2.meta.find_undeclared_variables(ast)
+        return frozenset(all_vars - _HF_INTERNAL_TEMPLATE_VARS)
+
+    def _filter_for_chat_template(
+        self, model_options: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return only the model_options that the chat template can actually consume.
+
+        Renames Mellea sentinels via :meth:`_make_backend_specific_and_remove`, then
+        keeps only keys that appear in :attr:`_chat_template_allowlist` — the set of
+        variables the tokenizer's Jinja template actually references. Generation-only
+        options that the template does not reference are silently dropped, so they
+        cannot pollute the Jinja template variable namespace.
+
+        Args:
+            model_options: raw model options (may contain Mellea sentinel keys)
+
+        Returns:
+            dict of kwargs safe to splat into ``apply_chat_template``
+        """
+        backend_opts = self._make_backend_specific_and_remove(model_options)
+        return {
+            k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist
         }
-        return {k: v for k, v in model_options.items() if k not in generate_only}
 
     # region Adapter loading, unloading, and utility functions.
     @property

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -570,11 +570,14 @@ async def test_error_during_generate_with_lock(backend) -> None:
 
 @pytest.mark.qualitative
 def test_generate_only_options_do_not_break_generation(session) -> None:
-    """Regression: passing generate-only options (temperature, max_new_tokens, do_sample)
-    must not corrupt apply_chat_template and must still produce a valid response.
+    """Non-regression: generation still works when temperature, max_new_tokens, and
+    do_sample are passed as model_options alongside a chat call.
 
-    Before the fix for issue #1154, these options were splatted directly into the
-    Jinja template's variable namespace, where they could silently shadow template vars.
+    Note: this test verifies that the overall generate pipeline is not broken by the
+    filter change, not that the filter itself is exercised end-to-end (the Granite chat
+    template silently ignores unknown kwargs, so a missing filter would still produce
+    the correct answer). Filter correctness is covered by the unit tests in
+    test_huggingface_filter_options.py.
     """
     output = session.chat(
         "What is 1+1?",

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -568,6 +568,28 @@ async def test_error_during_generate_with_lock(backend) -> None:
     await req_mot.avalue()
 
 
+@pytest.mark.qualitative
+def test_generate_only_options_do_not_break_generation(session) -> None:
+    """Regression: passing generate-only options (temperature, max_new_tokens, do_sample)
+    must not corrupt apply_chat_template and must still produce a valid response.
+
+    Before the fix for issue #1154, these options were splatted directly into the
+    Jinja template's variable namespace, where they could silently shadow template vars.
+    """
+    output = session.chat(
+        "What is 1+1?",
+        model_options={
+            ModelOption.TEMPERATURE: 0.0,
+            ModelOption.MAX_NEW_TOKENS: 64,
+            "do_sample": False,
+        },
+    )
+    assert output is not None
+    assert "2" in output.content, (
+        f"Expected response containing '2' but got: {output.content!r}"
+    )
+
+
 def test_assert_correct_adapters() -> None:
     model = Mock()
 

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -32,7 +32,7 @@ def _make_backend(template: str) -> LocalHFBackend:
         chat_template = template
 
     b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
-    b._tokenizer = _FakeTokenizer()
+    object.__setattr__(b, "_tokenizer", _FakeTokenizer())
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -3,7 +3,10 @@
 These tests verify that generate-only options are excluded from apply_chat_template
 kwargs, and that template-only options are excluded from generate() kwargs.
 
-No GPU or real model is required — the filter methods are pure dict operations.
+No GPU or real model is needed to run these tests — the filter methods are pure dict
+operations and the fixture bypasses __init__ entirely. However, torch must be
+importable because importing LocalHFBackend triggers the top-level ``import torch``
+in huggingface.py. Install mellea[hf] to satisfy this requirement.
 """
 
 import pytest
@@ -16,9 +19,15 @@ from mellea.backends.huggingface import LocalHFBackend
 
 @pytest.fixture
 def backend() -> LocalHFBackend:
-    """A LocalHFBackend instance with no model loaded, sufficient for testing filter helpers."""
+    """A LocalHFBackend instance with no model loaded, sufficient for testing filter helpers.
+
+    Uses __new__ to bypass __init__ (which would load model weights). Only
+    from_mellea_model_opts_map is set because that is the sole instance attribute
+    accessed by _filter_generate_only_options, _filter_chat_template_only_options,
+    and _make_backend_specific_and_remove. If any of those methods gains a new
+    self.* dependency, update this fixture.
+    """
     b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
-    # _make_backend_specific_and_remove needs this map (mirrors __init__)
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -20,7 +20,7 @@ from mellea.backends import ModelOption
 from mellea.backends.huggingface import _HF_INTERNAL_TEMPLATE_VARS, LocalHFBackend
 
 
-def _make_backend(template: str) -> LocalHFBackend:
+def _make_backend(template: object) -> LocalHFBackend:
     """Return a LocalHFBackend with __init__ bypassed, wired with a known template.
 
     Only the attributes accessed by _chat_template_allowlist, _filter_for_chat_template,
@@ -122,7 +122,7 @@ def test_allowlist_excludes_generate_only_options() -> None:
 
 def test_allowlist_empty_for_missing_chat_template() -> None:
     """No crash and empty allowlist when the tokenizer has no chat_template."""
-    b = _make_backend(None)  # type: ignore[arg-type]
+    b = _make_backend(None)
     assert b._chat_template_allowlist == frozenset()
 
 
@@ -132,6 +132,55 @@ def test_allowlist_is_cached() -> None:
     first = b._chat_template_allowlist
     second = b._chat_template_allowlist
     assert first is second
+
+
+def test_allowlist_non_string_template_returns_empty() -> None:
+    """Non-string chat_template (e.g. list of alternates) returns empty frozenset.
+
+    Some tokenizers store chat_template as a list-of-dicts (multiple named templates).
+    apply_chat_template handles that format internally; we must not crash trying to
+    parse it as a Jinja string.
+    """
+    b = _make_backend([{"name": "default", "template": "{{ think }}"}])
+    assert b._chat_template_allowlist == frozenset()
+
+
+def test_allowlist_graceful_on_generation_tag() -> None:
+    """Templates using {% generation %} / {% endgeneration %} return empty frozenset.
+
+    The {% generation %} tag comes from transformers' AssistantTracker extension and
+    is not registered in a plain jinja2.Environment. Parsing must not raise; instead
+    _chat_template_allowlist returns frozenset() so _filter_for_chat_template forwards
+    nothing (safe default) rather than crashing during inference.
+
+    Used by DeepSeek-R1, Qwen3, and other models as of transformers ≥ 4.47.
+    """
+    template = (
+        "{% for message in messages %}"
+        "{% generation %}{{ message.content }}{% endgeneration %}"
+        "{% endfor %}"
+        "{{ think }}"
+    )
+    b = _make_backend(template)
+    assert b._chat_template_allowlist == frozenset()
+
+
+def test_allowlist_break_continue_tags_parsed_correctly() -> None:
+    """Templates using {% break %} / {% continue %} are parsed without error.
+
+    jinja2.ext.loopcontrols must be registered so that {% break %} inside a for
+    loop does not raise TemplateSyntaxError. Variables outside the loop body must
+    still appear in the allowlist.
+    """
+    template = (
+        "{% for message in messages %}"
+        "{% if message.role == 'system' %}{% break %}{% endif %}"
+        "{{ message.content }}"
+        "{% endfor %}"
+        "{% if think %}Think step by step.{% endif %}"
+    )
+    b = _make_backend(template)
+    assert "think" in b._chat_template_allowlist
 
 
 # ---------------------------------------------------------------------------

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -1,12 +1,15 @@
-"""Unit tests for LocalHFBackend option-filter helpers.
+"""Unit tests for LocalHFBackend chat-template kwarg filtering.
 
-These tests verify that generate-only options are excluded from apply_chat_template
-kwargs, and that template-only options are excluded from generate() kwargs.
+These tests verify that _filter_for_chat_template passes only the variables the
+tokenizer's Jinja template actually references, and that _HF_INTERNAL_TEMPLATE_VARS
+are correctly excluded from the allowlist regardless of whether the template uses them.
 
-No GPU or real model is needed to run these tests — the filter methods are pure dict
-operations and the fixture bypasses __init__ entirely. However, torch must be
-importable because importing LocalHFBackend triggers the top-level ``import torch``
-in huggingface.py. Install mellea[hf] to satisfy this requirement.
+No GPU or real model is needed — the methods under test are pure dict operations that
+happen to read self._tokenizer.chat_template.  The fixture sets that attribute to a
+known Jinja string, bypassing __init__ (and therefore model loading) entirely.
+
+torch must be importable because importing LocalHFBackend triggers the top-level
+``import torch`` in huggingface.py.  Install mellea[hf] to satisfy this requirement.
 """
 
 import pytest
@@ -14,240 +17,229 @@ import pytest
 torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
 
 from mellea.backends import ModelOption
-from mellea.backends.huggingface import LocalHFBackend
+from mellea.backends.huggingface import _HF_INTERNAL_TEMPLATE_VARS, LocalHFBackend
 
 
-@pytest.fixture
-def backend() -> LocalHFBackend:
-    """A LocalHFBackend instance with no model loaded, sufficient for testing filter helpers.
+def _make_backend(template: str) -> LocalHFBackend:
+    """Return a LocalHFBackend with __init__ bypassed, wired with a known template.
 
-    Uses __new__ to bypass __init__ (which would load model weights). Only
-    from_mellea_model_opts_map is set because that is the sole instance attribute
-    accessed by _filter_generate_only_options, _filter_chat_template_only_options,
-    and _make_backend_specific_and_remove. If any of those methods gains a new
-    self.* dependency, update this fixture.
+    Only the attributes accessed by _chat_template_allowlist, _filter_for_chat_template,
+    _filter_chat_template_only_options, and _make_backend_specific_and_remove are set.
+    If any of those methods gains a new self.* dependency, update this helper.
     """
+
+    class _FakeTokenizer:
+        chat_template = template
+
     b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = _FakeTokenizer()
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 
 
 # ---------------------------------------------------------------------------
-# _filter_generate_only_options
+# _HF_INTERNAL_TEMPLATE_VARS — contents are load-bearing; review on each
+# transformers upgrade.  This test makes the expected set explicit so that any
+# unintentional change to the constant is caught immediately.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_INTERNAL_VARS = {
+    # Named parameters wired by apply_chat_template / render_jinja_template
+    "messages",
+    "tools",
+    "add_generation_prompt",
+    # Jinja environment globals from _compile_jinja_template
+    "raise_exception",
+    "strftime_now",
+}
+
+
+def test_hf_internal_template_vars_contents() -> None:
+    """_HF_INTERNAL_TEMPLATE_VARS must contain exactly the expected set.
+
+    This test is intentionally strict: it catches both missing entries (a new HF
+    internal variable not yet excluded) and accidental additions (a variable
+    incorrectly labelled as HF-internal that users might legitimately pass).
+    If transformers changes what it injects, update _HF_INTERNAL_TEMPLATE_VARS
+    AND update _EXPECTED_INTERNAL_VARS here to match.
+    """
+    assert _HF_INTERNAL_TEMPLATE_VARS == _EXPECTED_INTERNAL_VARS
+
+
+# ---------------------------------------------------------------------------
+# _chat_template_allowlist — verify the Jinja AST parsing logic
 # ---------------------------------------------------------------------------
 
 
-def test_filter_generate_only_removes_temperature(backend: LocalHFBackend) -> None:
-    opts = {ModelOption.TEMPERATURE: 0.7, "think": True}
-    result = backend._filter_generate_only_options(opts)
-    assert ModelOption.TEMPERATURE not in result
-    assert "think" in result
+def test_allowlist_includes_template_variables() -> None:
+    """Variables declared in the template appear in the allowlist."""
+    template = "{% for m in messages %}{{ m.role }}: {{ think }}{% endfor %}"
+    b = _make_backend(template)
+    assert "think" in b._chat_template_allowlist
 
 
-def test_filter_generate_only_removes_max_new_tokens(backend: LocalHFBackend) -> None:
-    opts = {ModelOption.MAX_NEW_TOKENS: 256, "guardian_config": {"foo": "bar"}}
-    result = backend._filter_generate_only_options(opts)
-    assert ModelOption.MAX_NEW_TOKENS not in result
-    assert "guardian_config" in result
+def test_allowlist_excludes_hf_internal_vars() -> None:
+    """HF-internal variables are excluded even when the template references them."""
+    # A template that uses every internal variable
+    template = (
+        "{% if raise_exception %}{{ messages }}{% endif %}"
+        "{{ strftime_now('%Y') }}{{ tools }}{{ add_generation_prompt }}"
+    )
+    b = _make_backend(template)
+    for var in _HF_INTERNAL_TEMPLATE_VARS:
+        assert var not in b._chat_template_allowlist, (
+            f"HF-internal var '{var}' leaked into allowlist"
+        )
 
 
-def test_filter_generate_only_removes_do_sample(backend: LocalHFBackend) -> None:
-    opts = {"do_sample": True, "add_generation_prompt": True}
-    result = backend._filter_generate_only_options(opts)
-    assert "do_sample" not in result
-    assert "add_generation_prompt" in result
+def test_allowlist_excludes_generate_only_options() -> None:
+    """Generate-only option names are not in the allowlist of a typical chat template.
+
+    Real HF templates do not reference GenerationConfig parameter names as Jinja
+    variables.  This test uses a realistic (but minimal) template to confirm that
+    common generation options are absent from the computed allowlist.
+    """
+    template = (
+        "{% for message in messages %}"
+        "{{ message.role }}: {{ message.content }}"
+        "{% endfor %}"
+        "{% if think %}Think step by step.{% endif %}"
+    )
+    b = _make_backend(template)
+    generate_only_examples = [
+        "temperature",
+        "max_new_tokens",
+        "do_sample",
+        "top_k",
+        "top_p",
+        "num_beams",
+    ]
+    for key in generate_only_examples:
+        assert key not in b._chat_template_allowlist, (
+            f"generate-only key '{key}' unexpectedly in allowlist"
+        )
 
 
-def test_filter_generate_only_removes_all_three(backend: LocalHFBackend) -> None:
-    opts = {
-        ModelOption.TEMPERATURE: 0.9,
-        ModelOption.MAX_NEW_TOKENS: 128,
-        "do_sample": True,
-        "think": True,
-        "guardian_config": {"key": "val"},
-    }
-    result = backend._filter_generate_only_options(opts)
-    assert ModelOption.TEMPERATURE not in result
-    assert ModelOption.MAX_NEW_TOKENS not in result
-    assert "do_sample" not in result
-    # Template-only keys must survive
+def test_allowlist_empty_for_missing_chat_template() -> None:
+    """No crash and empty allowlist when the tokenizer has no chat_template."""
+    b = _make_backend(None)  # type: ignore[arg-type]
+    assert b._chat_template_allowlist == frozenset()
+
+
+def test_allowlist_is_cached() -> None:
+    """_chat_template_allowlist is computed once and reused (cached_property)."""
+    b = _make_backend("{{ think }}")
+    first = b._chat_template_allowlist
+    second = b._chat_template_allowlist
+    assert first is second
+
+
+# ---------------------------------------------------------------------------
+# _filter_for_chat_template — end-to-end: sentinel renaming + allowlist filter
+# ---------------------------------------------------------------------------
+
+
+def test_filter_for_chat_template_passes_template_vars() -> None:
+    """Variables the template references survive the filter."""
+    template = "{{ think }}{{ guardian_config }}"
+    b = _make_backend(template)
+    result = b._filter_for_chat_template(
+        {"think": True, "guardian_config": {"key": "val"}}
+    )
     assert result["think"] is True
     assert result["guardian_config"] == {"key": "val"}
 
 
-def test_filter_generate_only_empty_input(backend: LocalHFBackend) -> None:
-    assert backend._filter_generate_only_options({}) == {}
+def test_filter_for_chat_template_drops_generate_only() -> None:
+    """Generate-only options not referenced by the template are filtered out."""
+    template = "{% for m in messages %}{{ m.content }}{% endfor %}{{ think }}"
+    b = _make_backend(template)
+    result = b._filter_for_chat_template(
+        {
+            ModelOption.TEMPERATURE: 0.8,
+            ModelOption.MAX_NEW_TOKENS: 200,
+            "do_sample": True,
+            "top_k": 50,
+            "num_beams": 4,
+            "think": True,
+        }
+    )
+    # Template only uses 'think' (messages is HF-internal, excluded from allowlist)
+    assert result == {"think": True}
 
 
-def test_filter_generate_only_passthrough_keys_preserved(
-    backend: LocalHFBackend,
-) -> None:
-    opts = {"some_custom_template_var": 42, "documents": [{"text": "hi"}]}
-    result = backend._filter_generate_only_options(opts)
-    assert result == opts
+def test_filter_for_chat_template_renames_sentinel() -> None:
+    """Mellea sentinels are renamed before the allowlist check.
+
+    If a (hypothetical) template used 'max_new_tokens' as a Jinja variable,
+    _filter_for_chat_template would rename the sentinel and then keep the key.
+    """
+    template = "{{ max_new_tokens }}"  # unusual but valid for testing rename path
+    b = _make_backend(template)
+    result = b._filter_for_chat_template({ModelOption.MAX_NEW_TOKENS: 256})
+    assert result == {"max_new_tokens": 256}
+
+
+def test_filter_for_chat_template_empty_input() -> None:
+    """Empty model_options produces an empty dict."""
+    b = _make_backend("{{ think }}")
+    assert b._filter_for_chat_template({}) == {}
+
+
+def test_filter_for_chat_template_unknown_key_dropped() -> None:
+    """A key that is not in the template is silently dropped."""
+    template = "{{ think }}"
+    b = _make_backend(template)
+    result = b._filter_for_chat_template({"think": True, "not_in_template": 99})
+    assert result == {"think": True}
+    assert "not_in_template" not in result
 
 
 # ---------------------------------------------------------------------------
-# _filter_chat_template_only_options (existing method — regression guard)
+# _filter_chat_template_only_options (pre-existing method — regression guard)
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def plain_backend() -> LocalHFBackend:
+    """Backend fixture without a tokenizer — sufficient for the pre-existing filter."""
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+    return b
 
 
 def test_filter_chat_template_only_removes_guardian_config(
-    backend: LocalHFBackend,
+    plain_backend: LocalHFBackend,
 ) -> None:
     opts = {"guardian_config": {"foo": "bar"}, ModelOption.TEMPERATURE: 0.5}
-    result = backend._filter_chat_template_only_options(opts)
+    result = plain_backend._filter_chat_template_only_options(opts)
     assert "guardian_config" not in result
     assert ModelOption.TEMPERATURE in result
 
 
-def test_filter_chat_template_only_removes_think(backend: LocalHFBackend) -> None:
+def test_filter_chat_template_only_removes_think(plain_backend: LocalHFBackend) -> None:
     opts = {"think": True, "max_new_tokens": 64}
-    result = backend._filter_chat_template_only_options(opts)
+    result = plain_backend._filter_chat_template_only_options(opts)
     assert "think" not in result
     assert "max_new_tokens" in result
 
 
 def test_filter_chat_template_only_removes_add_generation_prompt(
-    backend: LocalHFBackend,
+    plain_backend: LocalHFBackend,
 ) -> None:
     opts = {"add_generation_prompt": True, "temperature": 1.0}
-    result = backend._filter_chat_template_only_options(opts)
+    result = plain_backend._filter_chat_template_only_options(opts)
     assert "add_generation_prompt" not in result
     assert "temperature" in result
 
 
-def test_filter_chat_template_only_removes_documents(backend: LocalHFBackend) -> None:
+def test_filter_chat_template_only_removes_documents(
+    plain_backend: LocalHFBackend,
+) -> None:
     opts = {"documents": [{"text": "hello"}], "do_sample": False}
-    result = backend._filter_chat_template_only_options(opts)
+    result = plain_backend._filter_chat_template_only_options(opts)
     assert "documents" not in result
     assert "do_sample" in result
-
-
-# ---------------------------------------------------------------------------
-# Integration: filter_generate_only → _make_backend_specific_and_remove
-# Mirrors the exact chain used at both apply_chat_template call sites.
-# ---------------------------------------------------------------------------
-
-
-def test_apply_chat_template_kwargs_exclude_generate_only(
-    backend: LocalHFBackend,
-) -> None:
-    """Full chain: after filtering and renaming, no generate-only key reaches apply_chat_template."""
-    model_options = {
-        ModelOption.TEMPERATURE: 0.8,
-        ModelOption.MAX_NEW_TOKENS: 200,
-        "do_sample": True,
-        "think": True,
-        "guardian_config": {"harm_categories": []},
-        "add_generation_prompt": True,
-    }
-
-    kwargs = backend._make_backend_specific_and_remove(
-        backend._filter_generate_only_options(model_options)
-    )
-
-    # Generate-only options must not appear
-    assert "temperature" not in kwargs, (
-        "temperature leaked into apply_chat_template kwargs"
-    )
-    assert "max_new_tokens" not in kwargs, (
-        "max_new_tokens leaked into apply_chat_template kwargs"
-    )
-    assert "do_sample" not in kwargs, "do_sample leaked into apply_chat_template kwargs"
-
-    # Template-only options must still be present
-    assert kwargs.get("think") is True
-    assert kwargs.get("guardian_config") == {"harm_categories": []}
-    assert kwargs.get("add_generation_prompt") is True
-
-
-def test_generate_kwargs_exclude_chat_template_only(backend: LocalHFBackend) -> None:
-    """Inverse chain: after filtering template-only keys, none reach generate()."""
-    model_options = {
-        ModelOption.TEMPERATURE: 0.8,
-        ModelOption.MAX_NEW_TOKENS: 200,
-        "do_sample": True,
-        "think": True,
-        "guardian_config": {"harm_categories": []},
-        "add_generation_prompt": True,
-    }
-
-    generate_options = backend._filter_chat_template_only_options(model_options)
-    kwargs = backend._make_backend_specific_and_remove(generate_options)
-
-    # Template-only options must not appear
-    assert "think" not in kwargs
-    assert "guardian_config" not in kwargs
-    assert "add_generation_prompt" not in kwargs
-
-    # Generate-only options must still be present
-    assert kwargs.get("temperature") == 0.8
-    assert kwargs.get("max_new_tokens") == 200
-    assert kwargs.get("do_sample") is True
-
-
-# ---------------------------------------------------------------------------
-# Expanded denylist — sampling, length, and token-ID keys
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "key,value",
-    [
-        ("top_k", 50),
-        ("top_p", 0.9),
-        ("typical_p", 0.95),
-        ("repetition_penalty", 1.2),
-        ("no_repeat_ngram_size", 3),
-        ("length_penalty", 1.0),
-        ("num_beams", 4),
-        ("num_beam_groups", 2),
-        ("diversity_penalty", 0.5),
-        ("penalty_alpha", 0.6),
-        ("early_stopping", True),
-        ("min_new_tokens", 10),
-        ("num_return_sequences", 3),
-        ("pad_token_id", 0),
-        ("bos_token_id", 1),
-        ("eos_token_id", 2),
-        ("forced_bos_token_id", 1),
-        ("forced_eos_token_id", 2),
-    ],
-)
-def test_filter_generate_only_removes_expanded_keys(
-    backend: LocalHFBackend, key: str, value: object
-) -> None:
-    """Every key in the extended denylist is stripped from apply_chat_template kwargs."""
-    opts = {key: value, "think": True}
-    result = backend._filter_generate_only_options(opts)
-    assert key not in result
-    assert result["think"] is True
-
-
-def test_filter_generate_only_leaves_template_keys_intact(
-    backend: LocalHFBackend,
-) -> None:
-    """Template-specific keys survive when mixed with every expanded denylist key."""
-    template_keys = {
-        "think": True,
-        "guardian_config": {"harm_categories": []},
-        "add_generation_prompt": True,
-        "documents": [{"text": "hello"}],
-    }
-    generate_keys = {
-        "top_k": 40,
-        "top_p": 0.95,
-        "num_beams": 2,
-        "repetition_penalty": 1.1,
-        "min_new_tokens": 5,
-        "pad_token_id": 0,
-    }
-    result = backend._filter_generate_only_options({**template_keys, **generate_keys})
-    for key in generate_keys:
-        assert key not in result
-    for key, val in template_keys.items():
-        assert result[key] == val
 
 
 if __name__ == "__main__":

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -12,6 +12,8 @@ torch must be importable because importing LocalHFBackend triggers the top-level
 ``import torch`` in huggingface.py.  Install mellea[hf] to satisfy this requirement.
 """
 
+import logging
+
 import pytest
 
 torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
@@ -33,6 +35,7 @@ def _make_backend(template: object) -> LocalHFBackend:
 
     b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
     object.__setattr__(b, "_tokenizer", _FakeTokenizer())
+    b._hf_model_id = "test-org/test-model"
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 
@@ -163,6 +166,52 @@ def test_allowlist_graceful_on_generation_tag() -> None:
     )
     b = _make_backend(template)
     assert b._chat_template_allowlist == frozenset()
+
+
+def test_allowlist_warns_on_generation_tag(caplog: pytest.LogCaptureFixture) -> None:
+    """A warning is emitted when the template cannot be parsed due to unknown tags.
+
+    Callers passing model_options (e.g. think=True) to a DeepSeek-R1/Qwen3 model
+    would otherwise see their options silently dropped with no diagnostic.
+    """
+    template = (
+        "{% for message in messages %}"
+        "{% generation %}{{ message.content }}{% endgeneration %}"
+        "{% endfor %}"
+        "{{ think }}"
+    )
+    b = _make_backend(template)
+    with caplog.at_level(logging.WARNING, logger="mellea"):
+        _ = b._chat_template_allowlist
+    assert any("Could not parse chat template" in r.message for r in caplog.records)
+    assert any("test-org/test-model" in r.message for r in caplog.records)
+
+
+def test_allowlist_warns_on_non_string_template(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A warning is emitted when chat_template is a list or dict (not a plain string).
+
+    Some tokenizers store multiple named templates as a list-of-dicts.  The warning
+    tells the caller that their model_options will not be forwarded.
+    """
+    b = _make_backend([{"name": "default", "template": "{{ think }}"}])
+    with caplog.at_level(logging.WARNING, logger="mellea"):
+        _ = b._chat_template_allowlist
+    assert any("not a plain string" in r.message for r in caplog.records)
+
+
+def test_allowlist_no_warning_for_none_template(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning is emitted when chat_template is None (model has no chat template).
+
+    A missing chat_template is normal and expected for base models — no diagnostic needed.
+    """
+    b = _make_backend(None)
+    with caplog.at_level(logging.WARNING, logger="mellea"):
+        _ = b._chat_template_allowlist
+    assert not any("chat template" in r.message.lower() for r in caplog.records)
 
 
 def test_allowlist_break_continue_tags_parsed_correctly() -> None:

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -187,5 +187,68 @@ def test_generate_kwargs_exclude_chat_template_only(backend: LocalHFBackend) -> 
     assert kwargs.get("do_sample") is True
 
 
+# ---------------------------------------------------------------------------
+# Expanded denylist — sampling, length, and token-ID keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("top_k", 50),
+        ("top_p", 0.9),
+        ("typical_p", 0.95),
+        ("repetition_penalty", 1.2),
+        ("no_repeat_ngram_size", 3),
+        ("length_penalty", 1.0),
+        ("num_beams", 4),
+        ("num_beam_groups", 2),
+        ("diversity_penalty", 0.5),
+        ("penalty_alpha", 0.6),
+        ("early_stopping", True),
+        ("min_new_tokens", 10),
+        ("num_return_sequences", 3),
+        ("pad_token_id", 0),
+        ("bos_token_id", 1),
+        ("eos_token_id", 2),
+        ("forced_bos_token_id", 1),
+        ("forced_eos_token_id", 2),
+    ],
+)
+def test_filter_generate_only_removes_expanded_keys(
+    backend: LocalHFBackend, key: str, value: object
+) -> None:
+    """Every key in the extended denylist is stripped from apply_chat_template kwargs."""
+    opts = {key: value, "think": True}
+    result = backend._filter_generate_only_options(opts)
+    assert key not in result
+    assert result["think"] is True
+
+
+def test_filter_generate_only_leaves_template_keys_intact(
+    backend: LocalHFBackend,
+) -> None:
+    """Template-specific keys survive when mixed with every expanded denylist key."""
+    template_keys = {
+        "think": True,
+        "guardian_config": {"harm_categories": []},
+        "add_generation_prompt": True,
+        "documents": [{"text": "hello"}],
+    }
+    generate_keys = {
+        "top_k": 40,
+        "top_p": 0.95,
+        "num_beams": 2,
+        "repetition_penalty": 1.1,
+        "min_new_tokens": 5,
+        "pad_token_id": 0,
+    }
+    result = backend._filter_generate_only_options({**template_keys, **generate_keys})
+    for key in generate_keys:
+        assert key not in result
+    for key, val in template_keys.items():
+        assert result[key] == val
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -1,0 +1,182 @@
+"""Unit tests for LocalHFBackend option-filter helpers.
+
+These tests verify that generate-only options are excluded from apply_chat_template
+kwargs, and that template-only options are excluded from generate() kwargs.
+
+No GPU or real model is required — the filter methods are pure dict operations.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
+
+from mellea.backends import ModelOption
+from mellea.backends.huggingface import LocalHFBackend
+
+
+@pytest.fixture
+def backend() -> LocalHFBackend:
+    """A LocalHFBackend instance with no model loaded, sufficient for testing filter helpers."""
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    # _make_backend_specific_and_remove needs this map (mirrors __init__)
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+    return b
+
+
+# ---------------------------------------------------------------------------
+# _filter_generate_only_options
+# ---------------------------------------------------------------------------
+
+
+def test_filter_generate_only_removes_temperature(backend: LocalHFBackend) -> None:
+    opts = {ModelOption.TEMPERATURE: 0.7, "think": True}
+    result = backend._filter_generate_only_options(opts)
+    assert ModelOption.TEMPERATURE not in result
+    assert "think" in result
+
+
+def test_filter_generate_only_removes_max_new_tokens(backend: LocalHFBackend) -> None:
+    opts = {ModelOption.MAX_NEW_TOKENS: 256, "guardian_config": {"foo": "bar"}}
+    result = backend._filter_generate_only_options(opts)
+    assert ModelOption.MAX_NEW_TOKENS not in result
+    assert "guardian_config" in result
+
+
+def test_filter_generate_only_removes_do_sample(backend: LocalHFBackend) -> None:
+    opts = {"do_sample": True, "add_generation_prompt": True}
+    result = backend._filter_generate_only_options(opts)
+    assert "do_sample" not in result
+    assert "add_generation_prompt" in result
+
+
+def test_filter_generate_only_removes_all_three(backend: LocalHFBackend) -> None:
+    opts = {
+        ModelOption.TEMPERATURE: 0.9,
+        ModelOption.MAX_NEW_TOKENS: 128,
+        "do_sample": True,
+        "think": True,
+        "guardian_config": {"key": "val"},
+    }
+    result = backend._filter_generate_only_options(opts)
+    assert ModelOption.TEMPERATURE not in result
+    assert ModelOption.MAX_NEW_TOKENS not in result
+    assert "do_sample" not in result
+    # Template-only keys must survive
+    assert result["think"] is True
+    assert result["guardian_config"] == {"key": "val"}
+
+
+def test_filter_generate_only_empty_input(backend: LocalHFBackend) -> None:
+    assert backend._filter_generate_only_options({}) == {}
+
+
+def test_filter_generate_only_passthrough_keys_preserved(
+    backend: LocalHFBackend,
+) -> None:
+    opts = {"some_custom_template_var": 42, "documents": [{"text": "hi"}]}
+    result = backend._filter_generate_only_options(opts)
+    assert result == opts
+
+
+# ---------------------------------------------------------------------------
+# _filter_chat_template_only_options (existing method — regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_chat_template_only_removes_guardian_config(
+    backend: LocalHFBackend,
+) -> None:
+    opts = {"guardian_config": {"foo": "bar"}, ModelOption.TEMPERATURE: 0.5}
+    result = backend._filter_chat_template_only_options(opts)
+    assert "guardian_config" not in result
+    assert ModelOption.TEMPERATURE in result
+
+
+def test_filter_chat_template_only_removes_think(backend: LocalHFBackend) -> None:
+    opts = {"think": True, "max_new_tokens": 64}
+    result = backend._filter_chat_template_only_options(opts)
+    assert "think" not in result
+    assert "max_new_tokens" in result
+
+
+def test_filter_chat_template_only_removes_add_generation_prompt(
+    backend: LocalHFBackend,
+) -> None:
+    opts = {"add_generation_prompt": True, "temperature": 1.0}
+    result = backend._filter_chat_template_only_options(opts)
+    assert "add_generation_prompt" not in result
+    assert "temperature" in result
+
+
+def test_filter_chat_template_only_removes_documents(backend: LocalHFBackend) -> None:
+    opts = {"documents": [{"text": "hello"}], "do_sample": False}
+    result = backend._filter_chat_template_only_options(opts)
+    assert "documents" not in result
+    assert "do_sample" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: filter_generate_only → _make_backend_specific_and_remove
+# Mirrors the exact chain used at both apply_chat_template call sites.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_chat_template_kwargs_exclude_generate_only(
+    backend: LocalHFBackend,
+) -> None:
+    """Full chain: after filtering and renaming, no generate-only key reaches apply_chat_template."""
+    model_options = {
+        ModelOption.TEMPERATURE: 0.8,
+        ModelOption.MAX_NEW_TOKENS: 200,
+        "do_sample": True,
+        "think": True,
+        "guardian_config": {"harm_categories": []},
+        "add_generation_prompt": True,
+    }
+
+    kwargs = backend._make_backend_specific_and_remove(
+        backend._filter_generate_only_options(model_options)
+    )
+
+    # Generate-only options must not appear
+    assert "temperature" not in kwargs, (
+        "temperature leaked into apply_chat_template kwargs"
+    )
+    assert "max_new_tokens" not in kwargs, (
+        "max_new_tokens leaked into apply_chat_template kwargs"
+    )
+    assert "do_sample" not in kwargs, "do_sample leaked into apply_chat_template kwargs"
+
+    # Template-only options must still be present
+    assert kwargs.get("think") is True
+    assert kwargs.get("guardian_config") == {"harm_categories": []}
+    assert kwargs.get("add_generation_prompt") is True
+
+
+def test_generate_kwargs_exclude_chat_template_only(backend: LocalHFBackend) -> None:
+    """Inverse chain: after filtering template-only keys, none reach generate()."""
+    model_options = {
+        ModelOption.TEMPERATURE: 0.8,
+        ModelOption.MAX_NEW_TOKENS: 200,
+        "do_sample": True,
+        "think": True,
+        "guardian_config": {"harm_categories": []},
+        "add_generation_prompt": True,
+    }
+
+    generate_options = backend._filter_chat_template_only_options(model_options)
+    kwargs = backend._make_backend_specific_and_remove(generate_options)
+
+    # Template-only options must not appear
+    assert "think" not in kwargs
+    assert "guardian_config" not in kwargs
+    assert "add_generation_prompt" not in kwargs
+
+    # Generate-only options must still be present
+    assert kwargs.get("temperature") == 0.8
+    assert kwargs.get("max_new_tokens") == 200
+    assert kwargs.get("do_sample") is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -242,5 +242,131 @@ def test_filter_chat_template_only_removes_documents(
     assert "do_sample" in result
 
 
+# ---------------------------------------------------------------------------
+# Integration: real Granite tokenizer — verifies the allowlist against the
+# actual production template rather than a hand-crafted synthetic one.
+#
+# Marked huggingface because it reads from the HuggingFace model cache.
+# Skips automatically if the tokenizer is not cached locally.
+# No GPU required — only the tokenizer files are loaded.
+# ---------------------------------------------------------------------------
+
+_GRANITE_MODEL_ID = "ibm-granite/granite-3.3-8b-instruct"
+
+
+def _try_load_granite_tokenizer():
+    """Return the Granite tokenizer if cached locally, else None."""
+    try:
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(_GRANITE_MODEL_ID, local_files_only=True)
+    except Exception:
+        return None
+
+
+@pytest.mark.huggingface
+def test_granite_allowlist_includes_known_template_vars() -> None:
+    """Granite's chat template exposes 'think' and 'guardian_config' as Jinja vars.
+
+    This test loads the real tokenizer (tokenizer files only — no GPU, no model
+    weights) and asserts the computed allowlist includes the template-specific
+    options that Mellea passes for Granite models.
+
+    If the allowlist is empty or missing these keys after a transformers upgrade,
+    it means either the Granite template changed or _HF_INTERNAL_TEMPLATE_VARS
+    is now incorrectly excluding something it should not.
+    """
+    tok = _try_load_granite_tokenizer()
+    if tok is None:
+        pytest.skip(
+            f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
+        )
+
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = tok
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+
+    allowlist = b._chat_template_allowlist
+
+    # These are Granite-specific Jinja variables that must survive the filter.
+    # If either is absent the filter is over-aggressive and will break Granite
+    # think-mode and guardian calls.
+    assert "think" in allowlist, (
+        f"'think' missing from allowlist; got: {sorted(allowlist)}"
+    )
+    assert "guardian_config" in allowlist, (
+        f"'guardian_config' missing from allowlist; got: {sorted(allowlist)}"
+    )
+
+
+@pytest.mark.huggingface
+def test_granite_allowlist_excludes_generate_only_options() -> None:
+    """The Granite template does not reference GenerationConfig param names as Jinja vars.
+
+    This is the integration-level proof that the allowlist approach correctly
+    drops generate-only options for the real production model — and that the
+    approach remains valid after a transformers upgrade.
+
+    Failure here means the Granite template now references a GenerationConfig
+    parameter name as a Jinja variable, which would require revisiting the design.
+    """
+    tok = _try_load_granite_tokenizer()
+    if tok is None:
+        pytest.skip(
+            f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
+        )
+
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = tok
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+
+    allowlist = b._chat_template_allowlist
+
+    generate_only = [
+        "temperature",
+        "max_new_tokens",
+        "do_sample",
+        "top_k",
+        "top_p",
+        "num_beams",
+        "repetition_penalty",
+        "min_new_tokens",
+        "pad_token_id",
+    ]
+    for key in generate_only:
+        assert key not in allowlist, (
+            f"generate-only key '{key}' appeared in Granite allowlist — "
+            f"the template may now reference it as a Jinja variable"
+        )
+
+
+@pytest.mark.huggingface
+def test_granite_allowlist_excludes_hf_internal_vars() -> None:
+    """HF-internal vars are excluded from the Granite allowlist.
+
+    Verifies that _HF_INTERNAL_TEMPLATE_VARS correctly covers all variables
+    HuggingFace injects for the real production template. If any internal var
+    leaks into the allowlist, forwarding it from model_options would duplicate
+    a kwarg that apply_chat_template already provides, causing a TypeError.
+    """
+    tok = _try_load_granite_tokenizer()
+    if tok is None:
+        pytest.skip(
+            f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
+        )
+
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = tok
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+
+    allowlist = b._chat_template_allowlist
+
+    for var in _HF_INTERNAL_TEMPLATE_VARS:
+        assert var not in allowlist, (
+            f"HF-internal var '{var}' leaked into Granite allowlist — "
+            f"check _HF_INTERNAL_TEMPLATE_VARS against the installed transformers version"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## The problem

When you pass generation options like `temperature`, `max_new_tokens`, or `do_sample` to `LocalHFBackend`, those options were being forwarded into HuggingFace's `apply_chat_template`. The method accepts arbitrary `**kwargs` and passes them straight into the Jinja template's variable namespace.

Standard HF templates silently ignore variables they don't recognise, so nothing breaks for today's models. But this is a latent correctness hazard: any model whose Jinja template happens to define a variable named `temperature`, `num_beams`, or any other `GenerationConfig` parameter would silently receive the caller's generation setting instead of the template author's intended value. It also makes the calling contract of `model_options` opaque — there's no principled boundary between what goes to `apply_chat_template` and what goes to `generate()`.

## How other backends handle this

For comparison, the OpenAI backend uses `inspect.signature(Completions.create)` to build a self-maintaining filter: it forwards only kwargs that appear in the API client's call signature. The HF backend's equivalent interface is the Jinja template itself — template variables are the "declared parameters" for `apply_chat_template`.

## The fix

Rather than maintaining a hand-written denylist of `GenerationConfig` parameter names (which can never be complete — transformers has 60+ generation parameters), this PR uses the Jinja2 template as the source of truth.

At both `apply_chat_template` call sites, a new `_filter_for_chat_template` method is applied. It:

1. Parses the tokenizer's Jinja2 template with `jinja2.meta.find_undeclared_variables` to get the exact set of variables the template references.
2. Subtracts `_HF_INTERNAL_TEMPLATE_VARS` — the 5 variables HuggingFace injects automatically (see below).
3. Forwards only the keys that are in the resulting allowlist.

Generation-only options like `temperature` are dropped not because they appear on any list, but because no standard HF chat template ever references them as Jinja variables. The allowlist is computed once per backend instance (via `functools.cached_property`) and adapts automatically as models evolve.

### The exclusion set — please review carefully

`_HF_INTERNAL_TEMPLATE_VARS` is the small set of variables that HuggingFace injects into the template namespace unconditionally. These must be excluded from the allowlist to avoid `"got multiple values for keyword argument"` TypeErrors or silent replacement of injected callables.

| Variable | Source | Why excluded |
|---|---|---|
| `messages` | `render_jinja_template` named param | always injected as the first positional arg |
| `tools` | `render_jinja_template` named param | our call sites pass `tools=convert_tools_to_json(...)` explicitly |
| `add_generation_prompt` | `render_jinja_template` named param | passed as `add_generation_prompt=True` at the standard-generation call site |
| `raise_exception` | `_compile_jinja_template` Jinja env global | `find_undeclared_variables` cannot see env globals; treats this as undeclared |
| `strftime_now` | `_compile_jinja_template` Jinja env global | same as above |

**Relevant transformers source locations** (verified against installed version):
- Named params: `PreTrainedTokenizerBase.apply_chat_template` — the `render_jinja_template(...)` call
- Jinja globals: `transformers.utils.chat_template_utils._compile_jinja_template` — the `jinja_env.globals["raise_exception"]` and `jinja_env.globals["strftime_now"]` assignments

⚠️ If transformers is upgraded, verify that this set is still accurate. The test `test_hf_internal_template_vars_contents` fails immediately if the constant changes without a corresponding test update — making the exclusion set an explicit, auditable contract.

## Behaviour changes reviewers should be aware of

1. **`add_generation_prompt` on the KV-cache path**: because `add_generation_prompt` is in `_HF_INTERNAL_TEMPLATE_VARS`, any user-supplied value is now dropped rather than forwarded. This is correct: the KV-cache path formats context (not a generation turn), so HF's default of `False` is the right behaviour. A comment at the call site documents this explicitly.

2. **Graceful degradation for unsupported template extensions**: templates using `{% generation %} / {% endgeneration %}` (DeepSeek-R1, Qwen3, transformers ≥ 4.47) or unusual Jinja extensions that cannot be parsed by a plain `jinja2.Environment` return `frozenset()` — the filter forwards nothing to `apply_chat_template` rather than crashing. `{% break %} / {% continue %}` are handled correctly via `jinja2.ext.loopcontrols`.

3. **Non-string `chat_template`**: some tokenizers store `chat_template` as a list of named template dicts. The filter now guards against this with an `isinstance(str)` check and returns `frozenset()` for non-string values, leaving `apply_chat_template` to handle that format itself.

## Changes

- **`mellea/backends/huggingface.py`**
  - New module-level constant `_HF_INTERNAL_TEMPLATE_VARS` (5 entries, documented above)
  - New `_chat_template_allowlist` cached property — parses the Jinja AST once per backend instance, with `loopcontrols` extension registered and graceful fallback on parse failure
  - New `_filter_for_chat_template` method — renames sentinels then filters by allowlist
  - Both `apply_chat_template` call sites updated to use `_filter_for_chat_template`
  - `_filter_generate_only_options` removed (the 21-key denylist is gone)
  - `jinja2` and `jinja2.meta` imported at module level

- **`test/backends/test_huggingface_filter_options.py`** — 21 unit tests (no GPU needed):
  - Strict equality check on `_HF_INTERNAL_TEMPLATE_VARS` contents
  - Allowlist: Jinja AST parsing, exclusion of all 5 HF-internal vars, absence of generate-only names in a realistic template, caching, empty template
  - Robustness: `{% generation %}` tag (graceful degradation), `{% break %}` (loopcontrols), non-string template (isinstance guard)
  - `_filter_for_chat_template`: sentinel renaming, generate-only drop, template-var pass-through, empty input, unknown key drop
  - `_filter_chat_template_only_options`: regression guard on pre-existing method
  - Integration tests (marked `huggingface`): Granite tokenizer allowlist includes `think` + `guardian_config`, excludes generate-only keys and HF-internal vars

## Testing

```
uv run pytest test/backends/test_huggingface_filter_options.py -m "not huggingface" -v
# 18 passed
```

The e2e test `test_generate_only_options_do_not_break_generation` is `@pytest.mark.qualitative` and requires the real model fixture.

### CI noise — unrelated pre-existing failure

`test/backends/test_vision_ollama.py::test_image_block_in_instruction` and `::test_image_block_in_chat` fail in the `code-checks / quality` matrix. These are **not caused by this PR** — the diff touches only `mellea/backends/huggingface.py` and `test/backends/test_huggingface_filter_options.py`. The failures are caused by a pre-existing fixture bug where the CI branch of `m_session` uses the default non-vision model (`granite4.1:3b`) instead of `granite3.2-vision`, resulting in a `400 Bad Request` from Ollama. Tracked in #1185.

## Where this fits

Standalone bugfix. No other phases.

Closes #1154