### PR TITLE
fix(backends): populate mot._thinking from vLLM 'reasoning' wire key in LiteLLMBackend

### DIFF
--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -418,10 +418,11 @@ class LiteLLMBackend(FormatterBackend):
             message = choice.message
 
             # vLLM exposes the reasoning trace under "reasoning" (not "reasoning_content").
-            # Older LiteLLM versions (< ~1.83) do not remap it, so probe both keys.
-            thinking_chunk = message.get("reasoning_content") or message.get(
-                "reasoning"
-            )
+            # Some OpenAI-compatible servers (e.g. vLLM, SGLang) use this key; older LiteLLM
+            # versions do not remap it. Use is-None guard so an empty-string chunk isn't lost.
+            thinking_chunk = message.get("reasoning_content")
+            if thinking_chunk is None:
+                thinking_chunk = message.get("reasoning")
             if thinking_chunk is not None:
                 mot._thinking += thinking_chunk
 
@@ -437,10 +438,10 @@ class LiteLLMBackend(FormatterBackend):
         elif isinstance(chunk, litellm.ModelResponseStream):  # type: ignore
             message_delta = chunk.choices[0].delta
 
-            # Same dual-key probe for streaming deltas.
-            thinking_chunk = message_delta.get(
-                "reasoning_content"
-            ) or message_delta.get("reasoning")
+            # Same dual-key probe for streaming deltas (is-None guard, not or).
+            thinking_chunk = message_delta.get("reasoning_content")
+            if thinking_chunk is None:
+                thinking_chunk = message_delta.get("reasoning")
             if thinking_chunk is not None:
                 mot._thinking += thinking_chunk
 

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -438,7 +438,7 @@ class LiteLLMBackend(FormatterBackend):
         elif isinstance(chunk, litellm.ModelResponseStream):  # type: ignore
             message_delta = chunk.choices[0].delta
 
-            # Same dual-key probe for streaming deltas (is-None guard, not or).
+            # Same dual-key probe for streaming deltas.
             thinking_chunk = message_delta.get("reasoning_content")
             if thinking_chunk is None:
                 thinking_chunk = message_delta.get("reasoning")

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -417,11 +417,13 @@ class LiteLLMBackend(FormatterBackend):
 
             message = choice.message
 
-            # Sometimes a message doesn't actually have this field.
-            if hasattr(message, "reasoning_content"):
-                thinking_chunk = message.reasoning_content
-                if thinking_chunk is not None:
-                    mot._thinking += thinking_chunk
+            # vLLM exposes the reasoning trace under "reasoning" (not "reasoning_content").
+            # Older LiteLLM versions (< ~1.83) do not remap it, so probe both keys.
+            thinking_chunk = message.get("reasoning_content") or message.get(
+                "reasoning"
+            )
+            if thinking_chunk is not None:
+                mot._thinking += thinking_chunk
 
             content_chunk = message.content
             if content_chunk is not None:
@@ -435,11 +437,12 @@ class LiteLLMBackend(FormatterBackend):
         elif isinstance(chunk, litellm.ModelResponseStream):  # type: ignore
             message_delta = chunk.choices[0].delta
 
-            # Sometimes a delta doesn't actually have this field.
-            if hasattr(message_delta, "reasoning_content"):
-                thinking_chunk = message_delta.reasoning_content
-                if thinking_chunk is not None:
-                    mot._thinking += thinking_chunk
+            # Same dual-key probe for streaming deltas.
+            thinking_chunk = message_delta.get(
+                "reasoning_content"
+            ) or message_delta.get("reasoning")
+            if thinking_chunk is not None:
+                mot._thinking += thinking_chunk
 
             content_chunk = message_delta.content
             if content_chunk is not None:

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -5,8 +5,6 @@ Covers the vLLM case where the wire key is ``"reasoning"`` instead of
 it to ``"reasoning_content"`` (so both keys are exercised).
 """
 
-import asyncio
-
 import pytest
 
 pytest.importorskip("litellm", reason="litellm not installed — install mellea[litellm]")
@@ -70,7 +68,7 @@ def _fresh_mot() -> ModelOutputThunk:
 # ---------------------------------------------------------------------------
 
 
-def test_processing_non_streaming_reasoning_content_key(backend: LiteLLMBackend):
+async def test_processing_non_streaming_reasoning_content_key(backend: LiteLLMBackend):
     """reasoning_content (normalised key) is captured correctly."""
     mot = _fresh_mot()
     chunk = _make_non_streaming_chunk(
@@ -78,12 +76,12 @@ def test_processing_non_streaming_reasoning_content_key(backend: LiteLLMBackend)
         reasoning_key="reasoning_content",
         reasoning_value="France has its capital in Paris.",
     )
-    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    await backend.processing(mot, chunk)
     assert mot._thinking == "France has its capital in Paris."
     assert mot._underlying_value == "Paris"
 
 
-def test_processing_non_streaming_reasoning_raw_key(backend: LiteLLMBackend):
+async def test_processing_non_streaming_reasoning_raw_key(backend: LiteLLMBackend):
     """Fallback: vLLM 'reasoning' key (not normalised by older LiteLLM) is captured."""
     mot = _fresh_mot()
     chunk = _make_non_streaming_chunk(
@@ -91,12 +89,32 @@ def test_processing_non_streaming_reasoning_raw_key(backend: LiteLLMBackend):
         reasoning_key="reasoning",
         reasoning_value="France has its capital in Paris.",
     )
-    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    await backend.processing(mot, chunk)
     assert mot._thinking == "France has its capital in Paris."
     assert mot._underlying_value == "Paris"
 
 
-def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
+async def test_processing_non_streaming_reasoning_content_wins_over_reasoning(
+    backend: LiteLLMBackend,
+):
+    """reasoning_content takes priority when both keys are present."""
+    mot = _fresh_mot()
+    msg = Message(content="Paris", role="assistant")
+    msg["reasoning_content"] = "from_reasoning_content"
+    msg["reasoning"] = "from_reasoning"
+    choice = Choices(finish_reason="stop", index=0, message=msg)
+    chunk = ModelResponse(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="openai/qwen3",
+        object="chat.completion",
+    )
+    await backend.processing(mot, chunk)
+    assert mot._thinking == "from_reasoning_content"
+
+
+async def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
     """No reasoning key — thinking stays empty string, content is captured."""
     mot = _fresh_mot()
     chunk = _make_non_streaming_chunk(
@@ -104,7 +122,7 @@ def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
         reasoning_key="unrelated_key",
         reasoning_value="should be ignored",
     )
-    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    await backend.processing(mot, chunk)
     assert mot._thinking == ""
     assert mot._underlying_value == "Paris"
 
@@ -114,38 +132,50 @@ def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
 # ---------------------------------------------------------------------------
 
 
-def test_processing_streaming_reasoning_content_key(backend: LiteLLMBackend):
+async def test_processing_streaming_reasoning_content_key(backend: LiteLLMBackend):
     """Streaming: reasoning_content key is accumulated across chunks."""
     mot = _fresh_mot()
     for text in ("chunk1 ", "chunk2"):
         stream_chunk = _make_streaming_chunk(
             content="", reasoning_key="reasoning_content", reasoning_value=text
         )
-        asyncio.get_event_loop().run_until_complete(
-            backend.processing(mot, stream_chunk)
-        )
+        await backend.processing(mot, stream_chunk)
     assert mot._thinking == "chunk1 chunk2"
 
 
-def test_processing_streaming_reasoning_raw_key(backend: LiteLLMBackend):
+async def test_processing_streaming_reasoning_raw_key(backend: LiteLLMBackend):
     """Streaming fallback: vLLM 'reasoning' key is accumulated across chunks."""
     mot = _fresh_mot()
     for text in ("chunk1 ", "chunk2"):
         stream_chunk = _make_streaming_chunk(
             content="", reasoning_key="reasoning", reasoning_value=text
         )
-        asyncio.get_event_loop().run_until_complete(
-            backend.processing(mot, stream_chunk)
-        )
+        await backend.processing(mot, stream_chunk)
     assert mot._thinking == "chunk1 chunk2"
 
 
-def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
+async def test_processing_streaming_reasoning_content_wins_over_reasoning(
+    backend: LiteLLMBackend,
+):
+    """Streaming: reasoning_content takes priority when both keys are present."""
+    mot = _fresh_mot()
+    delta = Delta(content="")
+    delta["reasoning_content"] = "from_reasoning_content"
+    delta["reasoning"] = "from_reasoning"
+    chunk_choice = StreamingChoices(finish_reason=None, index=0, delta=delta)
+    stream_chunk = ModelResponseStream(
+        id="test", choices=[chunk_choice], created=0, model="openai/qwen3"
+    )
+    await backend.processing(mot, stream_chunk)
+    assert mot._thinking == "from_reasoning_content"
+
+
+async def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
     """Streaming: no reasoning key — thinking stays empty string."""
     mot = _fresh_mot()
     stream_chunk = _make_streaming_chunk(
         content="Paris", reasoning_key="unrelated_key", reasoning_value="ignored"
     )
-    asyncio.get_event_loop().run_until_complete(backend.processing(mot, stream_chunk))
+    await backend.processing(mot, stream_chunk)
     assert mot._thinking == ""
     assert mot._underlying_value == "Paris"

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -1,0 +1,151 @@
+"""Unit tests for LiteLLMBackend mot._thinking population.
+
+Covers the vLLM case where the wire key is ``"reasoning"`` instead of
+``"reasoning_content"``, and the case where LiteLLM has already normalised
+it to ``"reasoning_content"`` (so both keys are exercised).
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("litellm", reason="litellm not installed — install mellea[litellm]")
+
+from litellm.types.utils import (
+    Choices,
+    Delta,
+    Message,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
+)
+
+from mellea.backends.litellm import LiteLLMBackend
+from mellea.core import ModelOutputThunk
+
+
+def _make_non_streaming_chunk(
+    content: str, reasoning_key: str, reasoning_value: str
+) -> ModelResponse:
+    """Build a minimal non-streaming ModelResponse with a custom reasoning key."""
+    msg = Message(content=content, role="assistant")
+    msg[reasoning_key] = reasoning_value
+    choice = Choices(finish_reason="stop", index=0, message=msg)
+    return ModelResponse(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="openai/qwen3",
+        object="chat.completion",
+    )
+
+
+def _make_streaming_chunk(
+    content: str, reasoning_key: str, reasoning_value: str
+) -> ModelResponseStream:
+    """Build a minimal streaming delta chunk with a custom reasoning key."""
+    delta = Delta(content=content)
+    delta[reasoning_key] = reasoning_value
+    chunk_choice = StreamingChoices(finish_reason=None, index=0, delta=delta)
+    return ModelResponseStream(
+        id="test", choices=[chunk_choice], created=0, model="openai/qwen3"
+    )
+
+
+@pytest.fixture()
+def backend() -> LiteLLMBackend:
+    return LiteLLMBackend(model_id="openai/qwen3", base_url="http://localhost:8000/v1")
+
+
+def _fresh_mot() -> ModelOutputThunk:
+    mot: ModelOutputThunk = ModelOutputThunk(None)
+    mot._thinking = ""
+    mot._underlying_value = ""
+    mot._meta = {}
+    return mot
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming path
+# ---------------------------------------------------------------------------
+
+
+def test_processing_non_streaming_reasoning_content_key(backend: LiteLLMBackend):
+    """reasoning_content (normalised key) is captured correctly."""
+    mot = _fresh_mot()
+    chunk = _make_non_streaming_chunk(
+        content="Paris",
+        reasoning_key="reasoning_content",
+        reasoning_value="France has its capital in Paris.",
+    )
+    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    assert mot._thinking == "France has its capital in Paris."
+    assert mot._underlying_value == "Paris"
+
+
+def test_processing_non_streaming_reasoning_raw_key(backend: LiteLLMBackend):
+    """Fallback: vLLM 'reasoning' key (not normalised by older LiteLLM) is captured."""
+    mot = _fresh_mot()
+    chunk = _make_non_streaming_chunk(
+        content="Paris",
+        reasoning_key="reasoning",
+        reasoning_value="France has its capital in Paris.",
+    )
+    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    assert mot._thinking == "France has its capital in Paris."
+    assert mot._underlying_value == "Paris"
+
+
+def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
+    """No reasoning key — thinking stays empty string, content is captured."""
+    mot = _fresh_mot()
+    chunk = _make_non_streaming_chunk(
+        content="Paris",
+        reasoning_key="unrelated_key",
+        reasoning_value="should be ignored",
+    )
+    asyncio.get_event_loop().run_until_complete(backend.processing(mot, chunk))
+    assert mot._thinking == ""
+    assert mot._underlying_value == "Paris"
+
+
+# ---------------------------------------------------------------------------
+# Streaming path
+# ---------------------------------------------------------------------------
+
+
+def test_processing_streaming_reasoning_content_key(backend: LiteLLMBackend):
+    """Streaming: reasoning_content key is accumulated across chunks."""
+    mot = _fresh_mot()
+    for text in ("chunk1 ", "chunk2"):
+        stream_chunk = _make_streaming_chunk(
+            content="", reasoning_key="reasoning_content", reasoning_value=text
+        )
+        asyncio.get_event_loop().run_until_complete(
+            backend.processing(mot, stream_chunk)
+        )
+    assert mot._thinking == "chunk1 chunk2"
+
+
+def test_processing_streaming_reasoning_raw_key(backend: LiteLLMBackend):
+    """Streaming fallback: vLLM 'reasoning' key is accumulated across chunks."""
+    mot = _fresh_mot()
+    for text in ("chunk1 ", "chunk2"):
+        stream_chunk = _make_streaming_chunk(
+            content="", reasoning_key="reasoning", reasoning_value=text
+        )
+        asyncio.get_event_loop().run_until_complete(
+            backend.processing(mot, stream_chunk)
+        )
+    assert mot._thinking == "chunk1 chunk2"
+
+
+def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
+    """Streaming: no reasoning key — thinking stays empty string."""
+    mot = _fresh_mot()
+    stream_chunk = _make_streaming_chunk(
+        content="Paris", reasoning_key="unrelated_key", reasoning_value="ignored"
+    )
+    asyncio.get_event_loop().run_until_complete(backend.processing(mot, stream_chunk))
+    assert mot._thinking == ""
+    assert mot._underlying_value == "Paris"

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -57,8 +57,6 @@ def backend() -> LiteLLMBackend:
 
 def _fresh_mot() -> ModelOutputThunk:
     mot: ModelOutputThunk = ModelOutputThunk(None)
-    mot._thinking = ""
-    mot._underlying_value = ""
     mot._meta = {}
     return mot
 
@@ -127,6 +125,31 @@ async def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
     assert mot._underlying_value == "Paris"
 
 
+async def test_processing_non_streaming_empty_reasoning_content_does_not_fall_back(
+    backend: LiteLLMBackend,
+):
+    """Empty-string reasoning_content wins — does not fall back to reasoning key.
+
+    Validates that the is-None guard (not ``or``) is used: an empty-string
+    ``reasoning_content`` chunk is preserved as-is, not silently replaced by the
+    fallback ``reasoning`` value.
+    """
+    mot = _fresh_mot()
+    msg = Message(content="Paris", role="assistant")
+    msg["reasoning_content"] = ""
+    msg["reasoning"] = "should not appear"
+    choice = Choices(finish_reason="stop", index=0, message=msg)
+    chunk = ModelResponse(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="openai/qwen3",
+        object="chat.completion",
+    )
+    await backend.processing(mot, chunk)
+    assert mot._thinking == ""
+
+
 # ---------------------------------------------------------------------------
 # Streaming path
 # ---------------------------------------------------------------------------
@@ -179,3 +202,22 @@ async def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
     await backend.processing(mot, stream_chunk)
     assert mot._thinking == ""
     assert mot._underlying_value == "Paris"
+
+
+async def test_processing_streaming_empty_reasoning_content_does_not_fall_back(
+    backend: LiteLLMBackend,
+):
+    """Streaming: empty-string reasoning_content wins — does not fall back to reasoning key.
+
+    Validates that the is-None guard (not ``or``) is used in the streaming branch too.
+    """
+    mot = _fresh_mot()
+    delta = Delta(content="")
+    delta["reasoning_content"] = ""
+    delta["reasoning"] = "should not appear"
+    chunk_choice = StreamingChoices(finish_reason=None, index=0, delta=delta)
+    stream_chunk = ModelResponseStream(
+        id="test", choices=[chunk_choice], created=0, model="openai/qwen3"
+    )
+    await backend.processing(mot, stream_chunk)
+    assert mot._thinking == ""


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->
# Bug Fix

## Type of PR

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

## Description
- [x] Link to Issue: Fixes #1070

When `LiteLLMBackend` is used to route requests to a vLLM-served thinking
model (e.g. Qwen3 with `--reasoning-parser qwen3`), `mot._thinking` was
never populated — the reasoning trace was silently discarded.

The root cause is a wire-level key mismatch. vLLM exposes the reasoning
trace under the JSON key `"reasoning"`, not `"reasoning_content"`. The
previous `processing()` code used `hasattr(message, "reasoning_content")`
guards, which evaluate `False` when LiteLLM has not remapped the field —
leaving `mot._thinking` as an empty string.

**Why bumping the LiteLLM minimum version is not sufficient**

LiteLLM v1.83 added a `reasoning` → `reasoning_content` remap in
`gpt_transformation.py`, but only for the `openai/` provider path. Two
cases remain unhandled even on v1.83:

1. **Non-streaming `Message` objects** — `Message.__init__` has no
   `reasoning`-fallback; the remap only happens inside `gpt_transformation`
   and is therefore provider-specific.
2. **Any other provider prefix** — if a user routes vLLM through a provider
   that has no equivalent transform (e.g. a bare `base_url` without an
   `openai/` prefix), the field is dropped before Mellea ever sees it.

Mellea already requires `litellm>=1.76`; tightening that constraint to `>=1.83`
for a single thinking-model edge case would be a disproportionate blast radius.

**The fix**

Replace both `hasattr` guards in `LiteLLMBackend.processing()` — one for the
non-streaming `ModelResponse` branch and one for the streaming
`ModelResponseStream` branch — with a dual-key probe:

```python
thinking_chunk = message.get("reasoning_content")
if thinking_chunk is None:
    thinking_chunk = message.get("reasoning")
if thinking_chunk is not None:
    mot._thinking += thinking_chunk
```

Both `litellm.Message` and `litellm.Delta` extend `SafeAttributeModel` /
`OpenAIObject` and support `.get()`, so this works across both paths.
`reasoning_content` takes priority, so any provider that LiteLLM has already
normalised behaves identically to before.

The `"reasoning"` key is confirmed by:
- vLLM's own [reasoning parser documentation](https://docs.vllm.ai/en/latest/features/reasoning_outputs.html)
- LiteLLM's own comment in `gpt_transformation.py`: *"Map 'reasoning' field to 'reasoning_content' field in delta. vLLM returns `delta.reasoning`, but LiteLLM expects `delta.reasoning_content`."*
- The same `"reasoning"` key appearing in LiteLLM's Groq, OpenRouter, OVHcloud, and CometAPI provider transforms

## Testing

Ten new unit tests in `test/backends/test_litellm_thinking.py` cover all
combinations:

| Path | Key present | Expected |
|---|---|---|
| Non-streaming | `reasoning_content` | `mot._thinking` populated |
| Non-streaming | `reasoning` (vLLM raw) | `mot._thinking` populated |
| Non-streaming | both | `reasoning_content` wins |
| Non-streaming | `reasoning_content = ""` (empty) | `""` wins — no fallback |
| Non-streaming | neither | `mot._thinking` stays `""` |
| Streaming | `reasoning_content` | accumulated across chunks |
| Streaming | `reasoning` (vLLM raw) | accumulated across chunks |
| Streaming | both | `reasoning_content` wins |
| Streaming | `reasoning_content = ""` (empty) | `""` wins — no fallback |
| Streaming | neither | `mot._thinking` stays `""` |

All ten pass. The existing backend and stdlib test suites (208 tests) pass
with no regressions.