### PR TITLE
feat: sandbox runtime and capability policy

### DIFF
--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -1,5 +1,6 @@
 """Requirements for Python code generation validation."""
 
+import dataclasses
 import warnings
 from collections.abc import Callable
 from typing import Literal
@@ -208,9 +209,9 @@ class PythonExecutionReq(Requirement):
                     if execution_tier in ("docker", "docker_unsafe")
                     else LOCAL_POLICY
                 )
-                policy = CapabilityPolicy(**{**vars(base), "timeout": timeout})
+                policy = dataclasses.replace(base, timeout=timeout)
             else:
-                policy = CapabilityPolicy(**{**vars(policy), "timeout": timeout})
+                policy = dataclasses.replace(policy, timeout=timeout)
 
         self._tier = execution_tier
         self._policy = policy
@@ -224,9 +225,7 @@ class PythonExecutionReq(Requirement):
             )
         else:
             environment = make_execution_environment(
-                tier=execution_tier,  # type: ignore[arg-type]
-                policy=policy,
-                allowed_imports=allowed_imports,
+                tier=execution_tier, policy=policy, allowed_imports=allowed_imports
             )
 
         if execution_tier in ("local_unsafe", "local"):

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -1,12 +1,18 @@
 """Requirements for Python code generation validation."""
 
+import warnings
 from collections.abc import Callable
+from typing import Literal
 
+from mellea.stdlib.tools.execution_policy import (
+    DOCKER_POLICY,
+    LOCAL_POLICY,
+    CapabilityPolicy,
+    ExecutionTier,
+)
 from mellea.stdlib.tools.interpreter import (
     ExecutionEnvironment,
-    LLMSandboxEnvironment,
-    StaticAnalysisEnvironment,
-    UnsafeEnvironment,
+    make_execution_environment,
 )
 
 from ...core import Context, MelleaLogger, Requirement, ValidationResult
@@ -104,16 +110,12 @@ def _has_python_code_listing(ctx: Context) -> ValidationResult:
 
 
 def _python_executes_without_error(
-    ctx: Context,
-    timeout: int = 5,
-    allow_unsafe: bool = False,
-    allowed_imports: list[str] | None = None,
-    use_sandbox: bool = False,
+    ctx: Context, environment: ExecutionEnvironment
 ) -> ValidationResult:
     """Validate that Python code executes without raising exceptions.
 
     First extracts the highest-scoring Python code block from the context,
-    then validates/executes it based on the specified execution mode.
+    then validates/executes it using the given environment.
     """
     extraction_result = _has_python_code_listing(ctx)
     if not extraction_result.as_bool():
@@ -125,15 +127,7 @@ def _python_executes_without_error(
     code = extraction_result.reason
     assert code is not None
 
-    environment: ExecutionEnvironment
-    if use_sandbox:
-        environment = LLMSandboxEnvironment(allowed_imports=allowed_imports)
-    elif allow_unsafe:
-        environment = UnsafeEnvironment(allowed_imports=allowed_imports)
-    else:
-        environment = StaticAnalysisEnvironment(allowed_imports=allowed_imports)
-
-    result = environment.execute(code, timeout)
+    result = environment.execute(code)
     return ValidationResult(
         result=result.success, reason=result.to_validationresult_reason()
     )
@@ -143,16 +137,28 @@ class PythonExecutionReq(Requirement):
     """Verifies that Python code runs without raising exceptions.
 
     Extracts the highest-scoring Python code block from the model's last output
-    and validates or executes it according to the configured execution mode.
+    and validates or executes it according to the configured execution tier.
+
+    Use ``execution_tier`` to select behavior by intent:
+
+    - ``"static"`` (default) — parse and import-check only, no execution.
+    - ``"local_unsafe"`` — subprocess execution, no policy restrictions.
+    - ``"local"`` — subprocess execution with a declared capability policy.
+    - ``"docker_unsafe"`` — Docker-isolated execution, no policy restrictions.
+    - ``"docker"`` — Docker-isolated execution with a declared capability policy.
 
     Args:
-        timeout (int): Maximum seconds to allow code to run. Defaults to `5`.
-        allow_unsafe_execution (bool): If `True`, execute code directly with
-            subprocess. Use only with trusted sources.
+        execution_tier (str): One of ``"static"``, ``"local_unsafe"``, ``"local"``,
+            ``"docker_unsafe"``, or ``"docker"``.  Defaults to ``"static"``.
+        policy (CapabilityPolicy | None): Override the tier's default policy.
+            Ignored for ``"static"`` and unsafe tiers unless explicitly provided.
         allowed_imports (list[str] | None): Allowlist of importable top-level
-            modules. `None` allows any import.
-        use_sandbox (bool): If `True`, use `llm-sandbox` for Docker-based
-            isolated execution.
+            modules.  ``None`` allows any import.
+        timeout (int | None): Deprecated.  Pass ``policy=CapabilityPolicy(timeout=N)``
+            instead.  When provided, overrides the policy timeout.
+        allow_unsafe_execution (bool): Deprecated.  Use
+            ``execution_tier="local_unsafe"`` instead.
+        use_sandbox (bool): Deprecated.  Use ``execution_tier="docker"`` instead.
 
     Attributes:
         validation_fn (Callable[[Context], ValidationResult]): The validation
@@ -161,46 +167,101 @@ class PythonExecutionReq(Requirement):
 
     def __init__(
         self,
-        timeout: int = 5,
-        allow_unsafe_execution: bool = False,
+        execution_tier: Literal[
+            "static", "local_unsafe", "local", "docker_unsafe", "docker"
+        ] = "static",
+        *,
+        policy: CapabilityPolicy | None = None,
         allowed_imports: list[str] | None = None,
+        # Deprecated kwargs — kept for backward compatibility
+        timeout: int | None = None,
+        allow_unsafe_execution: bool = False,
         use_sandbox: bool = False,
     ):
-        """Initialize PythonExecutionReq with execution mode, timeout, and import allowlist settings."""
-        self._timeout = timeout
-        self._allow_unsafe = allow_unsafe_execution
-        self._allowed_imports = allowed_imports
-        self._use_sandbox = use_sandbox
+        """Initialize PythonExecutionReq with an execution tier and optional policy."""
+        # --- Deprecation shims ---
+        if allow_unsafe_execution and execution_tier == "static":
+            warnings.warn(
+                "allow_unsafe_execution is deprecated. Use execution_tier='local_unsafe' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            execution_tier = "local_unsafe"
 
-        if allow_unsafe_execution and not use_sandbox:
-            logger.warning(
-                "⚠️ UNSAFE: Executing untrusted code directly. Only use with trusted sources!"
+        if use_sandbox and execution_tier in ("static", "local_unsafe"):
+            warnings.warn(
+                "use_sandbox is deprecated. Use execution_tier='docker' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            execution_tier = "docker"
+
+        if timeout is not None:
+            warnings.warn(
+                "timeout is deprecated. Pass policy=CapabilityPolicy(timeout=N) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if policy is None:
+                base = (
+                    DOCKER_POLICY
+                    if execution_tier in ("docker", "docker_unsafe")
+                    else LOCAL_POLICY
+                )
+                policy = CapabilityPolicy(**{**vars(base), "timeout": timeout})
+            else:
+                policy = CapabilityPolicy(**{**vars(policy), "timeout": timeout})
+
+        self._tier = execution_tier
+        self._policy = policy
+        self._allowed_imports = allowed_imports
+
+        if execution_tier == "static":
+            from mellea.stdlib.tools.interpreter import StaticAnalysisEnvironment
+
+            environment: ExecutionEnvironment = StaticAnalysisEnvironment(
+                allowed_imports=allowed_imports
+            )
+        else:
+            environment = make_execution_environment(
+                tier=execution_tier,  # type: ignore[arg-type]
+                policy=policy,
+                allowed_imports=allowed_imports,
             )
 
-        if use_sandbox and allow_unsafe_execution:
-            execution_mode = f"sandbox execution (timeout: {timeout}s)"
-        elif allow_unsafe_execution:
-            execution_mode = f"unsafe execution (timeout: {timeout}s)"
-        elif use_sandbox:
-            execution_mode = f"sandbox execution (timeout: {timeout}s)"
-        else:
-            execution_mode = "validation only"
+        if execution_tier in ("local_unsafe", "local"):
+            logger.warning(
+                "⚠️ UNSAFE: Executing untrusted code without container isolation. "
+                "Only use with trusted sources!"
+            )
+
+        tier_label = _tier_label(execution_tier, policy)
 
         super().__init__(
-            description=f"The Python code should execute without errors ({execution_mode}).",
-            validation_fn=lambda ctx: _python_executes_without_error(
-                ctx,
-                self._timeout,
-                self._allow_unsafe,
-                self._allowed_imports,
-                self._use_sandbox,
-            ),
+            description=f"The Python code should execute without errors ({tier_label}).",
+            validation_fn=lambda ctx: _python_executes_without_error(ctx, environment),
             check_only=True,
         )
 
-        # Add type hint to validation_fn here. It's always set for this requirement.
         self.validation_fn: Callable[[Context], ValidationResult]
         assert self.validation_fn is not None
+
+
+def _tier_label(tier: str, policy: CapabilityPolicy | None) -> str:
+    timeout = policy.timeout if policy else None
+    match tier:
+        case "static":
+            return "validation only"
+        case "local_unsafe":
+            return f"local execution, no policy (timeout: {timeout or 30}s)"
+        case "local":
+            return f"local execution with policy (timeout: {timeout or LOCAL_POLICY.timeout}s)"
+        case "docker_unsafe":
+            return f"docker execution, no policy (timeout: {timeout or 60}s)"
+        case "docker":
+            return f"docker execution with policy (timeout: {timeout or DOCKER_POLICY.timeout}s)"
+        case _:
+            return tier
 
 
 # endregion

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -181,37 +181,74 @@ class PythonExecutionReq(Requirement):
     ):
         """Initialize PythonExecutionReq with an execution tier and optional policy."""
         # --- Deprecation shims ---
-        if allow_unsafe_execution and execution_tier == "static":
-            warnings.warn(
-                "allow_unsafe_execution is deprecated. Use execution_tier='local_unsafe' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            execution_tier = "local_unsafe"
+        _local_tiers = ("local_unsafe", "local")
+        _docker_tiers = ("docker_unsafe", "docker")
 
-        if use_sandbox and execution_tier in ("static", "local_unsafe"):
-            warnings.warn(
-                "use_sandbox is deprecated. Use execution_tier='docker' instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            execution_tier = "docker"
+        if allow_unsafe_execution:
+            if execution_tier not in _local_tiers:
+                if execution_tier in _docker_tiers:
+                    # Caller is already on a docker tier — warn but don't downgrade.
+                    warnings.warn(
+                        f"allow_unsafe_execution is deprecated and has no effect when "
+                        f"execution_tier='{execution_tier}' is already set. "
+                        "Remove the flag.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                else:
+                    warnings.warn(
+                        "allow_unsafe_execution is deprecated. Use execution_tier='local_unsafe' instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    if execution_tier == "static":
+                        execution_tier = "local_unsafe"
+
+        if use_sandbox:
+            if execution_tier not in _docker_tiers:
+                # Only warn and promote when the flag actually changes something.
+                warnings.warn(
+                    "use_sandbox is deprecated. Use execution_tier='docker' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                if execution_tier in ("static", "local_unsafe", "local"):
+                    execution_tier = "docker"
+            elif execution_tier == "docker_unsafe":
+                # Already in Docker but without a policy — nudge toward 'docker'.
+                warnings.warn(
+                    "use_sandbox is deprecated. Use execution_tier='docker' (with policy) "
+                    "instead of 'docker_unsafe' for capability enforcement.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
         if timeout is not None:
-            warnings.warn(
-                "timeout is deprecated. Pass policy=CapabilityPolicy(timeout=N) instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if policy is None:
-                base = (
-                    DOCKER_POLICY
-                    if execution_tier in ("docker", "docker_unsafe")
-                    else LOCAL_POLICY
+            if execution_tier == "static":
+                warnings.warn(
+                    "timeout has no effect on the static tier (no code is executed).",
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
-                policy = dataclasses.replace(base, timeout=timeout)
+            elif execution_tier in ("local_unsafe", "docker_unsafe"):
+                warnings.warn(
+                    f"timeout is ignored for the '{execution_tier}' tier (no policy is applied). "
+                    "Use execution_tier='local' or 'docker' with policy=CapabilityPolicy(timeout=N) "
+                    "to enforce a custom timeout.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             else:
-                policy = dataclasses.replace(policy, timeout=timeout)
+                warnings.warn(
+                    "timeout is deprecated. Pass policy=CapabilityPolicy(timeout=N) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                if policy is None:
+                    base = DOCKER_POLICY if execution_tier == "docker" else LOCAL_POLICY
+                    policy = dataclasses.replace(base, timeout=timeout)
+                else:
+                    policy = dataclasses.replace(policy, timeout=timeout)
 
         self._tier = execution_tier
         self._policy = policy
@@ -247,18 +284,22 @@ class PythonExecutionReq(Requirement):
 
 
 def _tier_label(tier: str, policy: CapabilityPolicy | None) -> str:
-    timeout = policy.timeout if policy else None
+    timeout = policy.timeout if policy is not None else None
     match tier:
         case "static":
             return "validation only"
         case "local_unsafe":
-            return f"local execution, no policy (timeout: {timeout or 30}s)"
+            effective = timeout if timeout is not None else LOCAL_POLICY.timeout
+            return f"local execution, no policy (timeout: {effective}s)"
         case "local":
-            return f"local execution with policy (timeout: {timeout or LOCAL_POLICY.timeout}s)"
+            effective = timeout if timeout is not None else LOCAL_POLICY.timeout
+            return f"local execution with policy (timeout: {effective}s)"
         case "docker_unsafe":
-            return f"docker execution, no policy (timeout: {timeout or 60}s)"
+            effective = timeout if timeout is not None else DOCKER_POLICY.timeout
+            return f"docker execution, no policy (timeout: {effective}s)"
         case "docker":
-            return f"docker execution with policy (timeout: {timeout or DOCKER_POLICY.timeout}s)"
+            effective = timeout if timeout is not None else DOCKER_POLICY.timeout
+            return f"docker execution with policy (timeout: {effective}s)"
         case _:
             return tier
 

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -168,9 +168,7 @@ class PythonExecutionReq(Requirement):
 
     def __init__(
         self,
-        execution_tier: Literal[
-            "static", "local_unsafe", "local", "docker_unsafe", "docker"
-        ] = "static",
+        execution_tier: ExecutionTier = "static",
         *,
         policy: CapabilityPolicy | None = None,
         allowed_imports: list[str] | None = None,
@@ -180,6 +178,18 @@ class PythonExecutionReq(Requirement):
         use_sandbox: bool = False,
     ):
         """Initialize PythonExecutionReq with an execution tier and optional policy."""
+        # Legacy positional-integer shim: old signature was PythonExecutionReq(timeout: int).
+        if isinstance(execution_tier, int):
+            warnings.warn(
+                "Passing an integer as the first argument to PythonExecutionReq() is "
+                "deprecated. The first parameter is now execution_tier (a string). "
+                "Use PythonExecutionReq(policy=CapabilityPolicy(timeout=N)) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            timeout = execution_tier  # type: ignore[assignment]
+            execution_tier = "static"
+
         # --- Deprecation shims ---
         _local_tiers = ("local_unsafe", "local")
         _docker_tiers = ("docker_unsafe", "docker")
@@ -202,7 +212,12 @@ class PythonExecutionReq(Requirement):
                         stacklevel=2,
                     )
                     if execution_tier == "static":
-                        execution_tier = "local_unsafe"
+                        # Promote to "local" when timeout is also set so the
+                        # timeout shim below can synthesise a policy — "local_unsafe"
+                        # has no policy and would silently discard the timeout value.
+                        execution_tier = (
+                            "local" if timeout is not None else "local_unsafe"
+                        )
 
         if use_sandbox:
             if execution_tier not in _docker_tiers:
@@ -254,16 +269,9 @@ class PythonExecutionReq(Requirement):
         self._policy = policy
         self._allowed_imports = allowed_imports
 
-        if execution_tier == "static":
-            from mellea.stdlib.tools.interpreter import StaticAnalysisEnvironment
-
-            environment: ExecutionEnvironment = StaticAnalysisEnvironment(
-                allowed_imports=allowed_imports
-            )
-        else:
-            environment = make_execution_environment(
-                tier=execution_tier, policy=policy, allowed_imports=allowed_imports
-            )
+        environment: ExecutionEnvironment = make_execution_environment(
+            tier=execution_tier, policy=policy, allowed_imports=allowed_imports
+        )
 
         if execution_tier in ("local_unsafe", "local"):
             logger.warning(

--- a/mellea/stdlib/tools/__init__.py
+++ b/mellea/stdlib/tools/__init__.py
@@ -1,5 +1,37 @@
 """Implementations of tools."""
 
-from .interpreter import code_interpreter, local_code_interpreter
+from .execution_policy import (
+    COMPATIBILITY_MATRIX,
+    DOCKER_POLICY,
+    LOCAL_POLICY,
+    Artifact,
+    CapabilityPolicy,
+    ExecutionTier,
+)
+from .interpreter import (
+    ExecutionEnvironment,
+    ExecutionResult,
+    LLMSandboxEnvironment,
+    StaticAnalysisEnvironment,
+    UnsafeEnvironment,
+    code_interpreter,
+    local_code_interpreter,
+    make_execution_environment,
+)
 
-__all__ = ["code_interpreter", "local_code_interpreter"]
+__all__ = [
+    "COMPATIBILITY_MATRIX",
+    "DOCKER_POLICY",
+    "LOCAL_POLICY",
+    "Artifact",
+    "CapabilityPolicy",
+    "ExecutionEnvironment",
+    "ExecutionResult",
+    "ExecutionTier",
+    "LLMSandboxEnvironment",
+    "StaticAnalysisEnvironment",
+    "UnsafeEnvironment",
+    "code_interpreter",
+    "local_code_interpreter",
+    "make_execution_environment",
+]

--- a/mellea/stdlib/tools/execution_policy.py
+++ b/mellea/stdlib/tools/execution_policy.py
@@ -1,0 +1,186 @@
+"""Capability policy, artifact model, and compatibility matrix for code execution environments.
+
+Four execution tiers are available, selectable by intent rather than by class name:
+
+- ``"local_unsafe"``  — subprocess in the current Python env, no policy applied.
+- ``"local"``         — subprocess in the current Python env, policy declared and partially enforced.
+- ``"docker_unsafe"`` — Docker-isolated execution via llm-sandbox, no policy applied.
+- ``"docker"``        — Docker-isolated execution via llm-sandbox, policy declared and partially enforced.
+
+``CapabilityPolicy`` declares what a code execution environment is *allowed* to do.
+Enforcement is honest: each capability has a companion ``ENFORCED_*`` class attribute
+indicating whether the declared value is actively enforced at runtime or is informational
+only.  A UX harness can call :meth:`CapabilityPolicy.unenforced_capabilities` to decide
+which capabilities to surface as "allow once / allow always" prompts.
+
+``Artifact`` represents a file produced by execution and exported from the environment.
+
+``COMPATIBILITY_MATRIX`` records which capabilities each tier supports.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Literal
+
+ExecutionTier = Literal["local_unsafe", "local", "docker_unsafe", "docker"]
+
+
+@dataclass
+class Artifact:
+    """A file produced by code execution and exported from the execution environment.
+
+    Args:
+        path (Path): Absolute path on the host where the artifact was written.
+        size_bytes (int | None): File size in bytes, or ``None`` if unknown.
+        content_type (str | None): MIME type or informal label (e.g. ``"text/csv"``,
+            ``"image/png"``), or ``None`` if undetermined.
+    """
+
+    path: Path
+    size_bytes: int | None = None
+    content_type: str | None = None
+
+
+@dataclass
+class CapabilityPolicy:
+    """Declared capabilities and resource limits for a code execution environment.
+
+    The enforcement gap — the difference between what is *declared* and what is
+    *actively enforced at runtime* — is made explicit through per-field
+    ``ENFORCED_*`` class attributes.  Callers and UX layers can read these to
+    decide whether to prompt the user ("allow once / allow always") or display
+    a warning.
+
+    Args:
+        filesystem_read_roots (list[Path] | None): Host paths the environment may
+            read.  ``None`` means unrestricted.  Declared only — not enforced.
+        filesystem_write_roots (list[Path] | None): Host paths the environment may
+            write.  ``None`` means unrestricted.  Declared only — not enforced.
+        network_access (bool): Whether outbound network connections are allowed.
+            Declared only — not enforced.
+        package_installation (bool): Whether the environment may install packages.
+            Declared only — not enforced.
+        subprocess_execution (bool): Whether spawning child processes is allowed.
+            Declared only — not enforced.
+        env_var_access (bool): Whether environment variables are readable.
+            Declared only — not enforced.
+        timeout (int): Wall-clock seconds before execution is killed.  Enforced.
+        stdout_max_bytes (int | None): Truncate stdout to this byte count; ``None``
+            disables truncation.  Enforced.
+        stderr_max_bytes (int | None): Truncate stderr to this byte count; ``None``
+            disables truncation.  Enforced.
+        artifact_export_paths (list[Path]): Paths inside the container/environment
+            to copy out after execution as :class:`Artifact` objects.  Enforced.
+    """
+
+    filesystem_read_roots: list[Path] | None = None
+    filesystem_write_roots: list[Path] | None = None
+    network_access: bool = True
+    package_installation: bool = False
+    subprocess_execution: bool = False
+    env_var_access: bool = True
+    timeout: int = 30
+    stdout_max_bytes: int | None = None
+    stderr_max_bytes: int | None = None
+    artifact_export_paths: list[Path] = field(default_factory=list)
+
+    # True  = this policy value is actively enforced by the runtime.
+    # False = this policy value is declarative only (honest gap).
+    ENFORCED_filesystem_read_roots: ClassVar[bool] = False
+    ENFORCED_filesystem_write_roots: ClassVar[bool] = False
+    ENFORCED_network_access: ClassVar[bool] = False
+    ENFORCED_package_installation: ClassVar[bool] = False
+    ENFORCED_subprocess_execution: ClassVar[bool] = False
+    ENFORCED_env_var_access: ClassVar[bool] = False
+    ENFORCED_timeout: ClassVar[bool] = True
+    ENFORCED_stdout_max_bytes: ClassVar[bool] = True
+    ENFORCED_stderr_max_bytes: ClassVar[bool] = True
+    ENFORCED_artifact_export_paths: ClassVar[bool] = True
+
+    def unenforced_capabilities(self) -> list[str]:
+        """Return capability names that are declared but not enforced at runtime.
+
+        Returns:
+            list[str]: Field names whose declared values are informational only.
+        """
+        return [
+            name.removeprefix("ENFORCED_")
+            for name, val in vars(type(self)).items()
+            if name.startswith("ENFORCED_") and val is False
+        ]
+
+    def enforced_capabilities(self) -> list[str]:
+        """Return capability names that are actively enforced at runtime.
+
+        Returns:
+            list[str]: Field names whose declared values are honoured by the runtime.
+        """
+        return [
+            name.removeprefix("ENFORCED_")
+            for name, val in vars(type(self)).items()
+            if name.startswith("ENFORCED_") and val is True
+        ]
+
+
+# Canonical default policies for each execution tier.
+# "unsafe" tiers carry no policy — pass None to make_execution_environment.
+
+LOCAL_POLICY = CapabilityPolicy(
+    network_access=True,
+    package_installation=False,
+    subprocess_execution=True,
+    env_var_access=True,
+    timeout=30,
+)
+
+DOCKER_POLICY = CapabilityPolicy(
+    network_access=True,
+    package_installation=True,
+    subprocess_execution=True,
+    env_var_access=True,
+    timeout=60,
+)
+
+
+COMPATIBILITY_MATRIX: dict[str, dict[str, bool]] = {
+    "local_unsafe": {
+        "execute_code": True,
+        "timeout_enforcement": True,
+        "import_allowlist": True,
+        "policy_applied": False,
+        "copy_in": False,
+        "copy_out": False,
+        "package_installation": False,
+        "docker_isolation": False,
+    },
+    "local": {
+        "execute_code": True,
+        "timeout_enforcement": True,
+        "import_allowlist": True,
+        "policy_applied": True,
+        "copy_in": False,
+        "copy_out": False,
+        "package_installation": False,
+        "docker_isolation": False,
+    },
+    "docker_unsafe": {
+        "execute_code": True,
+        "timeout_enforcement": True,
+        "import_allowlist": True,
+        "policy_applied": False,
+        "copy_in": True,
+        "copy_out": True,
+        "package_installation": True,
+        "docker_isolation": True,
+    },
+    "docker": {
+        "execute_code": True,
+        "timeout_enforcement": True,
+        "import_allowlist": True,
+        "policy_applied": True,
+        "copy_in": True,
+        "copy_out": True,
+        "package_installation": True,
+        "docker_isolation": True,
+    },
+}

--- a/mellea/stdlib/tools/execution_policy.py
+++ b/mellea/stdlib/tools/execution_policy.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, Literal
 
-ExecutionTier = Literal["local_unsafe", "local", "docker_unsafe", "docker"]
+ExecutionTier = Literal["static", "local_unsafe", "local", "docker_unsafe", "docker"]
 
 
 @dataclass
@@ -105,8 +105,8 @@ class CapabilityPolicy:
         """
         return [
             name.removeprefix("ENFORCED_")
-            for name, val in vars(type(self)).items()
-            if name.startswith("ENFORCED_") and val is False
+            for name, val in _iter_enforced_flags(type(self))
+            if val is False
         ]
 
     def enforced_capabilities(self) -> list[str]:
@@ -117,16 +117,27 @@ class CapabilityPolicy:
         """
         return [
             name.removeprefix("ENFORCED_")
-            for name, val in vars(type(self)).items()
-            if name.startswith("ENFORCED_") and val is True
+            for name, val in _iter_enforced_flags(type(self))
+            if val is True
         ]
+
+
+def _iter_enforced_flags(cls: type) -> list[tuple[str, bool]]:
+    """Collect ENFORCED_* class attributes across the MRO, innermost class wins."""
+    seen: dict[str, bool] = {}
+    # Reverse so base-class values are overwritten by subclass values.
+    for klass in reversed(cls.__mro__):
+        for name, val in vars(klass).items():
+            if name.startswith("ENFORCED_") and isinstance(val, bool):
+                seen[name] = val
+    return list(seen.items())
 
 
 # Canonical default policies for each execution tier.
 # "unsafe" tiers carry no policy — pass None to make_execution_environment.
 
 LOCAL_POLICY = CapabilityPolicy(
-    network_access=True,
+    network_access=False,
     package_installation=False,
     subprocess_execution=True,
     env_var_access=True,

--- a/mellea/stdlib/tools/execution_policy.py
+++ b/mellea/stdlib/tools/execution_policy.py
@@ -10,8 +10,7 @@ Four execution tiers are available, selectable by intent rather than by class na
 ``CapabilityPolicy`` declares what a code execution environment is *allowed* to do.
 Enforcement is honest: each capability has a companion ``ENFORCED_*`` class attribute
 indicating whether the declared value is actively enforced at runtime or is informational
-only.  A UX harness can call :meth:`CapabilityPolicy.unenforced_capabilities` to decide
-which capabilities to surface as "allow once / allow always" prompts.
+only.
 
 ``Artifact`` represents a file produced by execution and exported from the environment.
 
@@ -57,7 +56,7 @@ class CapabilityPolicy:
         filesystem_write_roots (list[Path] | None): Host paths the environment may
             write.  ``None`` means unrestricted.  Declared only — not enforced.
         network_access (bool): Whether outbound network connections are allowed.
-            Declared only — not enforced.
+            Defaults to ``False``.  Declared only — not enforced.
         package_installation (bool): Whether the environment may install packages.
             Declared only — not enforced.
         subprocess_execution (bool): Whether spawning child processes is allowed.
@@ -75,7 +74,7 @@ class CapabilityPolicy:
 
     filesystem_read_roots: list[Path] | None = None
     filesystem_write_roots: list[Path] | None = None
-    network_access: bool = True
+    network_access: bool = False
     package_installation: bool = False
     subprocess_execution: bool = False
     env_var_access: bool = True
@@ -145,7 +144,7 @@ LOCAL_POLICY = CapabilityPolicy(
 )
 
 DOCKER_POLICY = CapabilityPolicy(
-    network_access=True,
+    network_access=False,
     package_installation=True,
     subprocess_execution=True,
     env_var_access=True,

--- a/mellea/stdlib/tools/execution_policy.py
+++ b/mellea/stdlib/tools/execution_policy.py
@@ -153,6 +153,16 @@ DOCKER_POLICY = CapabilityPolicy(
 
 
 COMPATIBILITY_MATRIX: dict[str, dict[str, bool]] = {
+    "static": {
+        "execute_code": False,
+        "timeout_enforcement": False,
+        "import_allowlist": True,
+        "policy_applied": False,
+        "copy_in": False,
+        "copy_out": False,
+        "package_installation": False,
+        "docker_isolation": False,
+    },
     "local_unsafe": {
         "execute_code": True,
         "timeout_enforcement": True,

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -23,7 +23,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from ...core import MelleaLogger
 from .execution_policy import (
@@ -33,9 +33,6 @@ from .execution_policy import (
     CapabilityPolicy,
     ExecutionTier,
 )
-
-if TYPE_CHECKING:
-    pass
 
 logger = MelleaLogger.get_logger()
 
@@ -90,8 +87,8 @@ class ExecutionResult:
         execution_mode (str): Tier name used for this execution
             (``"local_unsafe"``, ``"local"``, ``"docker_unsafe"``, ``"docker"``,
             ``"static"``, or ``"unknown"``).
-        working_directory (str | None): Working directory inside the environment,
-            or ``None`` if not applicable.
+        working_directory (str | None): The working directory used for execution,
+            or ``None`` if the default was used or not applicable.
     """
 
     success: bool
@@ -138,16 +135,21 @@ class ExecutionEnvironment(ABC):
             that generated code may import.  ``None`` disables the import check.
         policy (CapabilityPolicy | None): Capability policy for this environment.
             ``None`` means no policy is applied (unsafe tiers).
+        working_directory (str | None): Directory to use as cwd during execution.
+            ``None`` means use the process default.  Only honoured by environments
+            that spawn subprocesses (``UnsafeEnvironment``); ignored otherwise.
     """
 
     def __init__(
         self,
         allowed_imports: list[str] | None = None,
         policy: CapabilityPolicy | None = None,
+        working_directory: str | None = None,
     ):
-        """Initialize with an optional import allowlist and capability policy."""
+        """Initialize with an optional import allowlist, capability policy, and working directory."""
         self.allowed_imports = allowed_imports
         self.policy = policy
+        self.working_directory = working_directory
 
     @abstractmethod
     def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
@@ -303,6 +305,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                cwd=self.working_directory,
             )
             stdout = _truncate(
                 result.stdout.strip(),
@@ -318,6 +321,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 stderr=stderr,
                 exit_code=result.returncode,
                 execution_mode=self._mode(),
+                working_directory=self.working_directory,
             )
         except subprocess.TimeoutExpired:
             return ExecutionResult(
@@ -328,6 +332,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 skip_message="Execution timed out.",
                 timed_out=True,
                 execution_mode=self._mode(),
+                working_directory=self.working_directory,
             )
         except Exception as e:
             return ExecutionResult(
@@ -337,6 +342,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 skipped=True,
                 skip_message=f"Exception encountered in Mellea process (*not* the code interpreter process) when trying to run code_interpreter: {e!s}",
                 execution_mode=self._mode(),
+                working_directory=self.working_directory,
             )
         finally:
             try:
@@ -367,9 +373,14 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
         self,
         allowed_imports: list[str] | None = None,
         policy: CapabilityPolicy | None = None,
+        working_directory: str | None = None,
     ):
-        """Initialize with an optional import allowlist and capability policy."""
-        super().__init__(allowed_imports=allowed_imports, policy=policy)
+        """Initialize with an optional import allowlist, capability policy, and working directory."""
+        super().__init__(
+            allowed_imports=allowed_imports,
+            policy=policy,
+            working_directory=working_directory,
+        )
         self._session: Any = None  # SandboxSession when open via context manager
         self._container_id: str | None = None  # set after session opens
 
@@ -516,6 +527,16 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             if (
                 self.policy
                 and self.policy.artifact_export_paths
+                and self._session is None
+            ):
+                logger.warning(
+                    "artifact_export_paths is set but LLMSandboxEnvironment is running "
+                    "in one-shot mode (no context manager). Artifacts will not be exported. "
+                    "Use 'with env:' to enable artifact export."
+                )
+            if (
+                self.policy
+                and self.policy.artifact_export_paths
                 and self._session is not None
             ):
                 for container_path in self.policy.artifact_export_paths:
@@ -591,6 +612,7 @@ def make_execution_environment(
     tier: ExecutionTier,
     policy: CapabilityPolicy | None = None,
     allowed_imports: list[str] | None = None,
+    working_directory: str | None = None,
 ) -> ExecutionEnvironment:
     """Create an :class:`ExecutionEnvironment` for the given tier.
 
@@ -607,36 +629,49 @@ def make_execution_environment(
             for policy tiers; ``None`` for unsafe tiers).
         allowed_imports (list[str] | None): Allowlist of importable top-level
             modules.  ``None`` allows any import.
+        working_directory (str | None): Directory to use as cwd during execution.
+            Only honoured by ``UnsafeEnvironment`` (local tiers); ignored for
+            Docker and static tiers.
 
     Returns:
         ExecutionEnvironment: Configured environment instance.
     """
     resolved_policy: CapabilityPolicy | None
     match tier:
+        case "static":
+            return StaticAnalysisEnvironment(allowed_imports=allowed_imports)
         case "local_unsafe":
             resolved_policy = policy  # None by default — no policy
             return UnsafeEnvironment(
-                allowed_imports=allowed_imports, policy=resolved_policy
+                allowed_imports=allowed_imports,
+                policy=resolved_policy,
+                working_directory=working_directory,
             )
         case "local":
             resolved_policy = policy if policy is not None else LOCAL_POLICY
             return UnsafeEnvironment(
-                allowed_imports=allowed_imports, policy=resolved_policy
+                allowed_imports=allowed_imports,
+                policy=resolved_policy,
+                working_directory=working_directory,
             )
         case "docker_unsafe":
             resolved_policy = policy  # None by default — no policy
             return LLMSandboxEnvironment(
-                allowed_imports=allowed_imports, policy=resolved_policy
+                allowed_imports=allowed_imports,
+                policy=resolved_policy,
+                working_directory=working_directory,
             )
         case "docker":
             resolved_policy = policy if policy is not None else DOCKER_POLICY
             return LLMSandboxEnvironment(
-                allowed_imports=allowed_imports, policy=resolved_policy
+                allowed_imports=allowed_imports,
+                policy=resolved_policy,
+                working_directory=working_directory,
             )
         case _:
             raise ValueError(
                 f"Unknown execution tier {tier!r}. "
-                "Valid tiers: 'local_unsafe', 'local', 'docker_unsafe', 'docker'."
+                "Valid tiers: 'static', 'local_unsafe', 'local', 'docker_unsafe', 'docker'."
             )
 
 

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -636,6 +636,9 @@ def make_execution_environment(
 
     Returns:
         ExecutionEnvironment: Configured environment instance.
+
+    Raises:
+        ValueError: If ``tier`` is not one of the recognised execution tier strings.
     """
     resolved_policy: CapabilityPolicy | None
     match tier:

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -1,13 +1,19 @@
 """Code interpreter tool and execution environments for agentic workflows.
 
-Provides `ExecutionResult` (capturing stdout, stderr, success, and optional static
-analysis output) and three concrete `ExecutionEnvironment` implementations:
-`StaticAnalysisEnvironment` (parse and import-check only, no execution),
-`UnsafeEnvironment` (subprocess execution in the current Python environment), and
-`LLMSandboxEnvironment` (Docker-isolated execution via `llm-sandbox`). All
-environments support an optional `allowed_imports` allowlist. The top-level
-`code_interpreter` and `local_code_interpreter` functions are ready to be wrapped
-as `MelleaTool` instances for ReACT or other agentic loops.
+Provides ``ExecutionResult`` (capturing stdout, stderr, exit code, artifacts, and
+optional static analysis output) and three concrete ``ExecutionEnvironment``
+implementations:
+
+- ``StaticAnalysisEnvironment`` — parse and import-check only, no execution.
+- ``UnsafeEnvironment`` — subprocess execution in the current Python environment.
+- ``LLMSandboxEnvironment`` — Docker-isolated execution via ``llm-sandbox``, with
+  ``copy_in`` / ``copy_out`` support via ``docker cp``.
+
+Use :func:`make_execution_environment` to select an environment by tier name
+(``"local_unsafe"``, ``"local"``, ``"docker_unsafe"``, ``"docker"``) rather than
+constructing classes directly.  The top-level :func:`code_interpreter` and
+:func:`local_code_interpreter` functions are ready to be wrapped as ``MelleaTool``
+instances for ReACT or other agentic loops.
 """
 
 import ast
@@ -15,29 +21,55 @@ import subprocess
 import sys
 import tempfile
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ...core import MelleaLogger
+from .execution_policy import (
+    DOCKER_POLICY,
+    LOCAL_POLICY,
+    Artifact,
+    CapabilityPolicy,
+    ExecutionTier,
+)
+
+if TYPE_CHECKING:
+    pass
 
 logger = MelleaLogger.get_logger()
+
+_TRUNCATION_MARKER = "... [truncated]"
+
+
+def _truncate(text: str | None, max_bytes: int | None) -> str | None:
+    """Truncate text to at most max_bytes encoded bytes, appending a marker.
+
+    Args:
+        text (str | None): The text to truncate.
+        max_bytes (int | None): Maximum byte length.  ``None`` disables truncation.
+
+    Returns:
+        str | None: Original text, truncated text with marker, or ``None``.
+    """
+    if text is None or max_bytes is None:
+        return text
+    encoded = text.encode()
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode(errors="ignore") + _TRUNCATION_MARKER
 
 
 @dataclass
 class ExecutionResult:
     """Result of code execution.
 
-    Code execution can be aborted prior to spinning up an interpreter (e.g., if prohibited imports are used).
-    In these cases, the `success` flag is set to False and the `skipped` flag is set to True.
+    Code execution can be aborted prior to spinning up an interpreter (e.g., if
+    prohibited imports are used).  In these cases, ``success`` is ``False`` and
+    ``skipped`` is ``True``.
 
-    If code is executed, then `success` is set to true iff the exit code is 0, and the `stdout` and `stderr` outputs
-    are set to non-None values.
-
-    We also use the `ExecutionResult` object to communicate the result of static and dynamic analyses. Those are passed back
-    using the `analysis_result` field.
-
-    TODO: should we also be trying to pass back the value of the final expression evaluated, or the value of locals() and globals()?
+    If code is executed, ``success`` is ``True`` iff the exit code is 0, and
+    ``stdout`` / ``stderr`` are non-``None``.
 
     Args:
         success (bool): `True` if execution succeeded (exit code 0 or
@@ -50,26 +82,32 @@ class ExecutionResult:
         skip_message (str | None): Explanation of why execution was skipped.
         analysis_result (Any | None): Optional payload from static-analysis
             environments.
-
+        exit_code (int | None): Raw process exit code, or ``None`` if not
+            available (skipped or static analysis).
+        timed_out (bool): ``True`` when execution was killed due to timeout.
+        artifacts (list[Artifact]): Files exported from the execution environment
+            after execution.
+        execution_mode (str): Tier name used for this execution
+            (``"local_unsafe"``, ``"local"``, ``"docker_unsafe"``, ``"docker"``,
+            ``"static"``, or ``"unknown"``).
+        working_directory (str | None): Working directory inside the environment,
+            or ``None`` if not applicable.
     """
 
     success: bool
-
     stdout: str | None
-
     stderr: str | None
-
-    """ Indicates whether execution was skipped. """
     skipped: bool = False
-
-    """ If execution is skipped, this message indicates why. """
     skip_message: str | None = None
-
-    """ Used for returning results from static analyses. """
     analysis_result: Any | None = None
+    exit_code: int | None = None
+    timed_out: bool = False
+    artifacts: list[Artifact] = field(default_factory=list)
+    execution_mode: str = "unknown"
+    working_directory: str | None = None
 
     def to_validationresult_reason(self) -> str:
-        """Maps an ExecutionResult to a ValidationResult reason.
+        """Map an ExecutionResult to a ValidationResult reason string.
 
         Returns:
             The skip message if the execution was skipped, stdout on success,
@@ -97,37 +135,82 @@ class ExecutionEnvironment(ABC):
 
     Args:
         allowed_imports (list[str] | None): Allowlist of top-level module names
-            that generated code may import. `None` disables the import check.
-
+            that generated code may import.  ``None`` disables the import check.
+        policy (CapabilityPolicy | None): Capability policy for this environment.
+            ``None`` means no policy is applied (unsafe tiers).
     """
 
-    def __init__(self, allowed_imports: list[str] | None = None):
-        """Initialize ExecutionEnvironment with an optional import allowlist."""
+    def __init__(
+        self,
+        allowed_imports: list[str] | None = None,
+        policy: CapabilityPolicy | None = None,
+    ):
+        """Initialize with an optional import allowlist and capability policy."""
         self.allowed_imports = allowed_imports
+        self.policy = policy
 
     @abstractmethod
-    def execute(self, code: str, timeout: int) -> ExecutionResult:
+    def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
         """Execute the given code and return the result.
 
         Args:
             code (str): The Python source code to execute.
-            timeout (int): Maximum number of seconds to allow the code to run.
+            timeout (int | None): Maximum seconds to allow the code to run.
+                When ``None``, the environment's policy timeout is used, or a
+                built-in default if no policy is set.
 
         Returns:
             ExecutionResult: Execution outcome including stdout, stderr, and
             success flag.
         """
 
+    def _resolve_timeout(self, timeout: int | None, default: int = 30) -> int:
+        if timeout is not None:
+            return timeout
+        if self.policy is not None:
+            return self.policy.timeout
+        return default
+
+    def copy_in(self, host_path: Path, container_path: str) -> None:
+        """Copy a file from the host into the execution environment.
+
+        Args:
+            host_path (Path): Absolute path on the host filesystem.
+            container_path (str): Destination path inside the environment.
+
+        Raises:
+            NotImplementedError: If this environment does not support file I/O.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support copy_in. "
+            "Use LLMSandboxEnvironment (docker or docker_unsafe tier) for file I/O."
+        )
+
+    def copy_out(self, container_path: str, host_path: Path) -> None:
+        """Copy a file from the execution environment to the host.
+
+        Args:
+            container_path (str): Source path inside the environment.
+            host_path (Path): Destination path on the host filesystem.
+
+        Raises:
+            NotImplementedError: If this environment does not support file I/O.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support copy_out. "
+            "Use LLMSandboxEnvironment (docker or docker_unsafe tier) for file I/O."
+        )
+
 
 class StaticAnalysisEnvironment(ExecutionEnvironment):
     """Safe environment that validates but does not execute code."""
 
-    def execute(self, code: str, timeout: int) -> ExecutionResult:
+    def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
         """Validate code syntax and imports without executing.
 
         Args:
             code (str): The Python source code to validate.
-            timeout (int): Ignored for static analysis; present for interface
+            timeout (int | None): Ignored for static analysis; present for interface
                 compatibility.
 
         Returns:
@@ -145,6 +228,7 @@ class StaticAnalysisEnvironment(ExecutionEnvironment):
                 skipped=True,
                 skip_message="Parse failed.",
                 analysis_result=e,
+                execution_mode="static",
             )
 
         if self.allowed_imports:
@@ -156,6 +240,7 @@ class StaticAnalysisEnvironment(ExecutionEnvironment):
                     stderr=None,
                     skipped=True,
                     skip_message=f"Unauthorized imports detected: {', '.join(unauthorized)}",
+                    execution_mode="static",
                 )
 
         return ExecutionResult(
@@ -165,24 +250,29 @@ class StaticAnalysisEnvironment(ExecutionEnvironment):
             skipped=True,
             skip_message="Code parses successful; the parse result is in the analysis_result field of the ExecutionResult object. The static analysis execution environment does not execute code. To execute code, use one of the other execution environments.",
             analysis_result=parse_tree,
+            execution_mode="static",
         )
 
 
 class UnsafeEnvironment(ExecutionEnvironment):
-    """Unsafe environment that executes code directly with subprocess."""
+    """Environment that executes code directly via subprocess.
 
-    def execute(self, code: str, timeout: int) -> ExecutionResult:
+    No container isolation.  Use ``policy`` to declare (but not enforce)
+    capabilities; ``timeout`` and stdout/stderr truncation from ``policy``
+    are actively enforced.
+    """
+
+    def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
         """Execute code with subprocess after checking imports.
 
         Args:
             code (str): The Python source code to execute.
-            timeout (int): Maximum number of seconds before the subprocess is
-                killed and a timeout result is returned.
+            timeout (int | None): Maximum seconds before the subprocess is killed.
+                Falls back to ``policy.timeout`` if set, then to 30 s.
 
         Returns:
             ExecutionResult: Execution outcome with captured stdout/stderr and
-            success flag, or a skipped result if imports are unauthorized or an
-            unexpected error occurs.
+            success flag, or a skipped result if imports are unauthorized.
         """
         if self.allowed_imports:
             unauthorized = _get_unauthorized_imports(code, self.allowed_imports)
@@ -193,9 +283,14 @@ class UnsafeEnvironment(ExecutionEnvironment):
                     stderr=None,
                     skipped=True,
                     skip_message=f"Unauthorized imports detected: {', '.join(unauthorized)}",
+                    execution_mode=self._mode(),
                 )
 
-        return self._execute_subprocess(code, timeout)
+        resolved_timeout = self._resolve_timeout(timeout)
+        return self._execute_subprocess(code, resolved_timeout)
+
+    def _mode(self) -> str:
+        return "local" if self.policy is not None else "local_unsafe"
 
     def _execute_subprocess(self, code: str, timeout: int) -> ExecutionResult:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -203,18 +298,26 @@ class UnsafeEnvironment(ExecutionEnvironment):
             temp_file = f.name
 
         try:
-            # Execute code using the same Python interpreter and environment as the current process
-            # This ensures the code has access to all installed packages and dependencies
             result = subprocess.run(
                 [sys.executable, temp_file],
                 capture_output=True,
                 text=True,
                 timeout=timeout,
             )
+            stdout = _truncate(
+                result.stdout.strip(),
+                self.policy.stdout_max_bytes if self.policy else None,
+            )
+            stderr = _truncate(
+                result.stderr.strip(),
+                self.policy.stderr_max_bytes if self.policy else None,
+            )
             return ExecutionResult(
                 success=result.returncode == 0,
-                stdout=result.stdout.strip(),
-                stderr=result.stderr.strip(),
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=result.returncode,
+                execution_mode=self._mode(),
             )
         except subprocess.TimeoutExpired:
             return ExecutionResult(
@@ -223,6 +326,8 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 stderr=None,
                 skipped=True,
                 skip_message="Execution timed out.",
+                timed_out=True,
+                execution_mode=self._mode(),
             )
         except Exception as e:
             return ExecutionResult(
@@ -231,6 +336,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
                 stderr=None,
                 skipped=True,
                 skip_message=f"Exception encountered in Mellea process (*not* the code interpreter process) when trying to run code_interpreter: {e!s}",
+                execution_mode=self._mode(),
             )
         finally:
             try:
@@ -240,23 +346,127 @@ class UnsafeEnvironment(ExecutionEnvironment):
 
 
 class LLMSandboxEnvironment(ExecutionEnvironment):
-    """Environment using llm-sandbox for secure Docker-based execution."""
+    """Docker-isolated execution environment via ``llm-sandbox``.
 
-    def execute(self, code: str, timeout: int) -> ExecutionResult:
-        """Execute code using llm-sandbox in an isolated Docker container.
+    Supports :meth:`copy_in` and :meth:`copy_out` via ``docker cp``.  Both
+    methods require the environment to be used as a context manager so that a
+    single container session persists across calls.
 
-        Checks the import allowlist first, then delegates to a `SandboxSession`
-        from the `llm-sandbox` package. Returns a skipped result if
-        `llm-sandbox` is not installed.
+    When used without a context manager, :meth:`execute` opens and closes a
+    fresh container per call (one-shot mode), which is sufficient when file I/O
+    is not needed.
+
+    Args:
+        allowed_imports (list[str] | None): Allowlist of importable top-level
+            modules.  ``None`` allows any import.
+        policy (CapabilityPolicy | None): Capability policy.  ``None`` means
+            no policy is applied (``docker_unsafe`` tier).
+    """
+
+    def __init__(
+        self,
+        allowed_imports: list[str] | None = None,
+        policy: CapabilityPolicy | None = None,
+    ):
+        """Initialize with an optional import allowlist and capability policy."""
+        super().__init__(allowed_imports=allowed_imports, policy=policy)
+        self._session: Any = None  # SandboxSession when open via context manager
+        self._container_id: str | None = None  # set after session opens
+
+    def _mode(self) -> str:
+        return "docker" if self.policy is not None else "docker_unsafe"
+
+    def __enter__(self) -> "LLMSandboxEnvironment":
+        """Open the Docker session for use across multiple calls."""
+        try:
+            from llm_sandbox import SandboxSession
+        except ImportError:
+            raise ImportError(
+                "llm-sandbox not installed. Install with: pip install 'mellea[sandbox]'"
+            )
+        self._session = SandboxSession(
+            lang="python", verbose=False, keep_template=False
+        )
+        self._session.open()
+        self._container_id = getattr(self._session, "container_id", None) or getattr(
+            self._session, "container", None
+        )
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        """Close the Docker session."""
+        if self._session is not None:
+            try:
+                self._session.close()
+            except Exception:
+                pass
+            self._session = None
+            self._container_id = None
+
+    def copy_in(self, host_path: Path, container_path: str) -> None:
+        """Copy a file from the host into the running Docker container via ``docker cp``.
+
+        Args:
+            host_path (Path): Absolute path on the host filesystem.
+            container_path (str): Destination path inside the container.
+
+        Raises:
+            RuntimeError: If the environment is not open as a context manager.
+            RuntimeError: If the container ID cannot be determined.
+            subprocess.CalledProcessError: If ``docker cp`` fails.
+        """
+        container_id = self._require_container_id()
+        subprocess.run(
+            ["docker", "cp", str(host_path), f"{container_id}:{container_path}"],
+            check=True,
+            capture_output=True,
+        )
+
+    def copy_out(self, container_path: str, host_path: Path) -> None:
+        """Copy a file from the running Docker container to the host via ``docker cp``.
+
+        Args:
+            container_path (str): Source path inside the container.
+            host_path (Path): Destination path on the host filesystem.
+
+        Raises:
+            RuntimeError: If the environment is not open as a context manager.
+            RuntimeError: If the container ID cannot be determined.
+            subprocess.CalledProcessError: If ``docker cp`` fails.
+        """
+        container_id = self._require_container_id()
+        subprocess.run(
+            ["docker", "cp", f"{container_id}:{container_path}", str(host_path)],
+            check=True,
+            capture_output=True,
+        )
+
+    def _require_container_id(self) -> str:
+        if self._session is None:
+            raise RuntimeError(
+                "LLMSandboxEnvironment must be used as a context manager to call copy_in/copy_out."
+            )
+        if not self._container_id:
+            raise RuntimeError(
+                "Could not determine Docker container ID from llm-sandbox session. "
+                "The llm-sandbox version may not expose container_id."
+            )
+        return self._container_id
+
+    def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
+        """Execute code in a Docker container.
+
+        When used as a context manager, reuses the open session.  Otherwise opens
+        a fresh container, runs the code, and closes it immediately.
 
         Args:
             code (str): The Python source code to execute.
-            timeout (int): Maximum number of seconds to allow the sandboxed
-                process to run.
+            timeout (int | None): Maximum seconds to allow the sandboxed process to
+                run.  Falls back to ``policy.timeout`` if set, then to 60 s.
 
         Returns:
-            ExecutionResult: Execution outcome with stdout/stderr and success
-            flag, or a skipped result on import violation or sandbox error.
+            ExecutionResult: Execution outcome with stdout/stderr and success flag,
+            or a skipped result on import violation or sandbox error.
         """
         if self.allowed_imports:
             unauthorized = _get_unauthorized_imports(code, self.allowed_imports)
@@ -267,7 +477,10 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                     stderr=None,
                     skipped=True,
                     skip_message=f"Unauthorized imports detected: {', '.join(unauthorized)}",
+                    execution_mode=self._mode(),
                 )
+
+        resolved_timeout = self._resolve_timeout(timeout, default=60)
 
         try:
             from llm_sandbox import SandboxSession
@@ -278,19 +491,58 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                 stderr=None,
                 skipped=True,
                 skip_message="llm-sandbox not installed. Install with: pip install 'mellea[sandbox]'",
+                execution_mode=self._mode(),
             )
 
         try:
-            with SandboxSession(
-                lang="python", verbose=False, keep_template=False
-            ) as session:
-                result = session.run(code, timeout=timeout)
+            if self._session is not None:
+                result = self._session.run(code, timeout=resolved_timeout)
+            else:
+                with SandboxSession(
+                    lang="python", verbose=False, keep_template=False
+                ) as session:
+                    result = session.run(code, timeout=resolved_timeout)
 
-                return ExecutionResult(
-                    success=result.exit_code == 0,
-                    stdout=result.stdout.strip(),
-                    stderr=result.stderr.strip(),
-                )
+            stdout = _truncate(
+                result.stdout.strip(),
+                self.policy.stdout_max_bytes if self.policy else None,
+            )
+            stderr = _truncate(
+                result.stderr.strip(),
+                self.policy.stderr_max_bytes if self.policy else None,
+            )
+
+            artifacts: list[Artifact] = []
+            if (
+                self.policy
+                and self.policy.artifact_export_paths
+                and self._session is not None
+            ):
+                for container_path in self.policy.artifact_export_paths:
+                    host_tmp = Path(tempfile.mkdtemp()) / container_path.name
+                    try:
+                        self.copy_out(str(container_path), host_tmp)
+                        artifacts.append(
+                            Artifact(
+                                path=host_tmp,
+                                size_bytes=host_tmp.stat().st_size
+                                if host_tmp.exists()
+                                else None,
+                            )
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to export artifact %s: %s", container_path, e
+                        )
+
+            return ExecutionResult(
+                success=result.exit_code == 0,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=result.exit_code,
+                artifacts=artifacts,
+                execution_mode=self._mode(),
+            )
         except Exception as e:
             return ExecutionResult(
                 success=False,
@@ -298,6 +550,7 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                 stderr=None,
                 skipped=True,
                 skip_message=f"Sandbox execution error: {e!s}",
+                execution_mode=self._mode(),
             )
 
 
@@ -334,8 +587,61 @@ def _check_allowed_imports(code: str, allowed_imports: list[str]) -> bool:
     return len(_get_unauthorized_imports(code, allowed_imports)) == 0
 
 
+def make_execution_environment(
+    tier: ExecutionTier,
+    policy: CapabilityPolicy | None = None,
+    allowed_imports: list[str] | None = None,
+) -> ExecutionEnvironment:
+    """Create an :class:`ExecutionEnvironment` for the given tier.
+
+    The ``policy`` argument overrides the tier's default policy.  For unsafe
+    tiers (``"local_unsafe"``, ``"docker_unsafe"``) the policy defaults to
+    ``None`` — pass an explicit policy to add declaration without changing the
+    tier.
+
+    Args:
+        tier (ExecutionTier): One of ``"local_unsafe"``, ``"local"``,
+            ``"docker_unsafe"``, or ``"docker"``.
+        policy (CapabilityPolicy | None): Override the tier's default policy.
+            ``None`` uses the tier default (``LOCAL_POLICY`` / ``DOCKER_POLICY``
+            for policy tiers; ``None`` for unsafe tiers).
+        allowed_imports (list[str] | None): Allowlist of importable top-level
+            modules.  ``None`` allows any import.
+
+    Returns:
+        ExecutionEnvironment: Configured environment instance.
+    """
+    resolved_policy: CapabilityPolicy | None
+    match tier:
+        case "local_unsafe":
+            resolved_policy = policy  # None by default — no policy
+            return UnsafeEnvironment(
+                allowed_imports=allowed_imports, policy=resolved_policy
+            )
+        case "local":
+            resolved_policy = policy if policy is not None else LOCAL_POLICY
+            return UnsafeEnvironment(
+                allowed_imports=allowed_imports, policy=resolved_policy
+            )
+        case "docker_unsafe":
+            resolved_policy = policy  # None by default — no policy
+            return LLMSandboxEnvironment(
+                allowed_imports=allowed_imports, policy=resolved_policy
+            )
+        case "docker":
+            resolved_policy = policy if policy is not None else DOCKER_POLICY
+            return LLMSandboxEnvironment(
+                allowed_imports=allowed_imports, policy=resolved_policy
+            )
+        case _:
+            raise ValueError(
+                f"Unknown execution tier {tier!r}. "
+                "Valid tiers: 'local_unsafe', 'local', 'docker_unsafe', 'docker'."
+            )
+
+
 def code_interpreter(code: str) -> ExecutionResult:
-    """Executes python code.
+    """Execute Python code in a Docker sandbox (docker_unsafe tier).
 
     Args:
         code: The Python code to execute.
@@ -343,12 +649,12 @@ def code_interpreter(code: str) -> ExecutionResult:
     Returns:
         An `ExecutionResult` with stdout, stderr, and a success flag.
     """
-    exec_env = LLMSandboxEnvironment(allowed_imports=None)
-    return exec_env.execute(code, 60)
+    env = make_execution_environment("docker_unsafe")
+    return env.execute(code)
 
 
 def local_code_interpreter(code: str) -> ExecutionResult:
-    """Executes python code in the cwd.
+    """Execute Python code in the current process environment (local_unsafe tier).
 
     Args:
         code: The Python code to execute.
@@ -356,5 +662,5 @@ def local_code_interpreter(code: str) -> ExecutionResult:
     Returns:
         An `ExecutionResult` with stdout, stderr, and a success flag.
     """
-    exec_env = UnsafeEnvironment(allowed_imports=None)
-    return exec_env.execute(code, 60)
+    env = make_execution_environment("local_unsafe")
+    return env.execute(code)

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -17,6 +17,7 @@ instances for ReACT or other agentic loops.
 """
 
 import ast
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -24,7 +25,7 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from ...core import MelleaLogger
 from .execution_policy import (
@@ -57,6 +58,8 @@ def _truncate(text: str | None, max_bytes: int | None) -> str | None:
         return text
     marker = _TRUNCATION_MARKER.encode()
     keep = max(0, max_bytes - len(marker))
+    if keep == 0:
+        return encoded[:max_bytes].decode(errors="ignore")
     return encoded[:keep].decode(errors="ignore") + _TRUNCATION_MARKER
 
 
@@ -386,14 +389,6 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
         )
         self._session: Any = None  # SandboxSession when open via context manager
         self._container_id: str | None = None  # set after session opens
-        if policy and policy.artifact_export_paths:
-            warnings.warn(
-                "artifact_export_paths is set but this LLMSandboxEnvironment will only "
-                "export artifacts when used as a context manager ('with env:'). "
-                "In one-shot mode (env.execute(...)) artifacts are not exported.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
 
     def _mode(self) -> str:
         return "docker" if self.policy is not None else "docker_unsafe"
@@ -410,9 +405,13 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             lang="python", verbose=False, keep_template=False
         )
         self._session.open()
-        self._container_id = getattr(self._session, "container_id", None) or getattr(
-            self._session, "container", None
-        )
+        _cid = getattr(self._session, "container_id", None)
+        if _cid is None:
+            _fallback = getattr(self._session, "container", None)
+            _cid = (
+                getattr(_fallback, "short_id", None) if _fallback is not None else None
+            )
+        self._container_id = _cid
         return self
 
     def __exit__(self, *_: object) -> None:
@@ -420,8 +419,8 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
         if self._session is not None:
             try:
                 self._session.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to close sandbox session: %s", e)
             self._session = None
             self._container_id = None
 
@@ -490,6 +489,15 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             ExecutionResult: Execution outcome with stdout/stderr and success flag,
             or a skipped result on import violation or sandbox error.
         """
+        if self._session is None and self.policy and self.policy.artifact_export_paths:
+            warnings.warn(
+                "artifact_export_paths is set but this LLMSandboxEnvironment will only "
+                "export artifacts when used as a context manager ('with env:'). "
+                "In one-shot mode (env.execute(...)) artifacts are not exported.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
         if self.allowed_imports:
             unauthorized = _get_unauthorized_imports(code, self.allowed_imports)
             if unauthorized:
@@ -541,21 +549,24 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                 and self._session is not None
             ):
                 for container_path in self.policy.artifact_export_paths:
-                    host_tmp = Path(tempfile.mkdtemp()) / container_path.name
-                    try:
-                        self.copy_out(str(container_path), host_tmp)
-                        artifacts.append(
-                            Artifact(
-                                path=host_tmp,
-                                size_bytes=host_tmp.stat().st_size
-                                if host_tmp.exists()
-                                else None,
+                    with tempfile.TemporaryDirectory() as tmp_dir:
+                        staging = Path(tmp_dir) / container_path.name
+                        try:
+                            self.copy_out(str(container_path), staging)
+                            dest = Path(tempfile.gettempdir()) / container_path.name
+                            shutil.copy2(staging, dest)
+                            artifacts.append(
+                                Artifact(
+                                    path=dest,
+                                    size_bytes=dest.stat().st_size
+                                    if dest.exists()
+                                    else None,
+                                )
                             )
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to export artifact %s: %s", container_path, e
-                        )
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to export artifact %s: %s", container_path, e
+                            )
 
             return ExecutionResult(
                 success=result.exit_code == 0,
@@ -702,4 +713,4 @@ def local_code_interpreter(code: str) -> ExecutionResult:
         An `ExecutionResult` with stdout, stderr, and a success flag.
     """
     env = make_execution_environment("local_unsafe")
-    return env.execute(code)
+    return env.execute(code, timeout=60)

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -20,6 +20,7 @@ import ast
 import subprocess
 import sys
 import tempfile
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -54,7 +55,9 @@ def _truncate(text: str | None, max_bytes: int | None) -> str | None:
     encoded = text.encode()
     if len(encoded) <= max_bytes:
         return text
-    return encoded[:max_bytes].decode(errors="ignore") + _TRUNCATION_MARKER
+    marker = _TRUNCATION_MARKER.encode()
+    keep = max(0, max_bytes - len(marker))
+    return encoded[:keep].decode(errors="ignore") + _TRUNCATION_MARKER
 
 
 @dataclass
@@ -383,6 +386,14 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
         )
         self._session: Any = None  # SandboxSession when open via context manager
         self._container_id: str | None = None  # set after session opens
+        if policy and policy.artifact_export_paths:
+            warnings.warn(
+                "artifact_export_paths is set but this LLMSandboxEnvironment will only "
+                "export artifacts when used as a context manager ('with env:'). "
+                "In one-shot mode (env.execute(...)) artifacts are not exported.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def _mode(self) -> str:
         return "docker" if self.policy is not None else "docker_unsafe"
@@ -491,7 +502,7 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                     execution_mode=self._mode(),
                 )
 
-        resolved_timeout = self._resolve_timeout(timeout, default=60)
+        resolved_timeout = self._resolve_timeout(timeout, default=DOCKER_POLICY.timeout)
 
         try:
             from llm_sandbox import SandboxSession
@@ -524,16 +535,6 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             )
 
             artifacts: list[Artifact] = []
-            if (
-                self.policy
-                and self.policy.artifact_export_paths
-                and self._session is None
-            ):
-                logger.warning(
-                    "artifact_export_paths is set but LLMSandboxEnvironment is running "
-                    "in one-shot mode (no context manager). Artifacts will not be exported. "
-                    "Use 'with env:' to enable artifact export."
-                )
             if (
                 self.policy
                 and self.policy.artifact_export_paths
@@ -622,7 +623,7 @@ def make_execution_environment(
     tier.
 
     Args:
-        tier (ExecutionTier): One of ``"local_unsafe"``, ``"local"``,
+        tier (ExecutionTier): One of ``"static"``, ``"local_unsafe"``, ``"local"``,
             ``"docker_unsafe"``, or ``"docker"``.
         policy (CapabilityPolicy | None): Override the tier's default policy.
             ``None`` uses the tier default (``LOCAL_POLICY`` / ``DOCKER_POLICY``

--- a/test/stdlib/requirements/test_reqlib_python.py
+++ b/test/stdlib/requirements/test_reqlib_python.py
@@ -387,8 +387,9 @@ def test_docker_policy_has_expected_defaults():
 
 
 def test_compatibility_matrix_has_all_tiers():
-    """COMPATIBILITY_MATRIX covers all four execution tiers."""
+    """COMPATIBILITY_MATRIX covers all five execution tiers."""
     assert set(COMPATIBILITY_MATRIX.keys()) == {
+        "static",
         "local_unsafe",
         "local",
         "docker_unsafe",

--- a/test/stdlib/requirements/test_reqlib_python.py
+++ b/test/stdlib/requirements/test_reqlib_python.py
@@ -16,12 +16,23 @@ try:
 except ImportError:
     _llm_sandbox_available = False
 
+from pathlib import Path
+
 from mellea.core import Context, ModelOutputThunk
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements.python_reqs import (
     PythonExecutionReq,
     _has_python_code_listing,
     _python_executes_without_error,
+)
+from mellea.stdlib.tools import (
+    COMPATIBILITY_MATRIX,
+    DOCKER_POLICY,
+    LOCAL_POLICY,
+    Artifact,
+    CapabilityPolicy,
+    StaticAnalysisEnvironment,
+    UnsafeEnvironment,
 )
 
 
@@ -262,40 +273,34 @@ def test_sandbox_without_llm_sandbox_installed():
 
 
 def test_description_updates_based_on_mode():
-    """Test that requirement description reflects execution mode."""
+    """Test that requirement description reflects execution tier."""
     safe_req = PythonExecutionReq()
     assert "validation only" in safe_req.description  # type: ignore
 
-    unsafe_req = PythonExecutionReq(allow_unsafe_execution=True, timeout=5)
-    assert "unsafe execution" in unsafe_req.description  # type: ignore
-    assert "timeout: 5s" in unsafe_req.description  # type: ignore
+    local_req = PythonExecutionReq("local_unsafe")
+    assert "local execution" in local_req.description  # type: ignore
 
-    sandbox_req = PythonExecutionReq(use_sandbox=True, timeout=10)
-    assert "sandbox execution" in sandbox_req.description  # type: ignore
-    assert "timeout: 10s" in sandbox_req.description  # type: ignore
+    docker_req = PythonExecutionReq("docker")
+    assert "docker execution" in docker_req.description  # type: ignore
+    assert "timeout" in docker_req.description  # type: ignore
 
 
 def test_parameter_combinations():
-    """Test various parameter combinations."""
-    # Safe mode (default)
+    """Test various tier combinations."""
     req1 = PythonExecutionReq()
-    assert req1._allow_unsafe is False
-    assert req1._use_sandbox is False
+    assert req1._tier == "static"
 
-    # Unsafe mode
-    req2 = PythonExecutionReq(allow_unsafe_execution=True)
-    assert req2._allow_unsafe is True
-    assert req2._use_sandbox is False
+    req2 = PythonExecutionReq("local_unsafe")
+    assert req2._tier == "local_unsafe"
 
-    # Sandbox mode
-    req3 = PythonExecutionReq(use_sandbox=True)
-    assert req3._allow_unsafe is False
-    assert req3._use_sandbox is True
+    req3 = PythonExecutionReq("local")
+    assert req3._tier == "local"
 
-    # Sandbox + unsafe (sandbox takes precedence)
-    req4 = PythonExecutionReq(allow_unsafe_execution=True, use_sandbox=True)
-    assert req4._allow_unsafe is True
-    assert req4._use_sandbox is True
+    req4 = PythonExecutionReq("docker_unsafe")
+    assert req4._tier == "docker_unsafe"
+
+    req5 = PythonExecutionReq("docker")
+    assert req5._tier == "docker"
 
 
 # endregion
@@ -305,14 +310,11 @@ def test_parameter_combinations():
 
 def test_direct_validation_function():
     """Test calling validation function directly."""
-    result = _python_executes_without_error(
-        VALID_PYTHON_CTX, timeout=5, allow_unsafe=False, use_sandbox=False
-    )
+    env = StaticAnalysisEnvironment()
+    result = _python_executes_without_error(VALID_PYTHON_CTX, env)
     assert result.as_bool() is True
 
-    result = _python_executes_without_error(
-        SYNTAX_ERROR_CTX, timeout=5, allow_unsafe=False, use_sandbox=False
-    )
+    result = _python_executes_without_error(SYNTAX_ERROR_CTX, env)
     assert result.as_bool() is False
 
 
@@ -322,6 +324,311 @@ def test_no_code_extraction():
     result = req.validation_fn(NO_PYTHON_CTX)
     assert result.as_bool() is False
     assert "Could not extract Python code" in result.reason  # type: ignore
+
+
+# endregion
+
+# region: CapabilityPolicy tests
+
+
+def test_capability_policy_defaults():
+    """Default policy has timeout=30 and empty artifact_export_paths."""
+    policy = CapabilityPolicy()
+    assert policy.timeout == 30
+    assert policy.artifact_export_paths == []
+    assert policy.stdout_max_bytes is None
+    assert policy.stderr_max_bytes is None
+
+
+def test_capability_policy_unenforced_returns_expected_fields():
+    """Filesystem and network fields are declared but not enforced."""
+    policy = CapabilityPolicy()
+    unenforced = policy.unenforced_capabilities()
+    assert "filesystem_read_roots" in unenforced
+    assert "filesystem_write_roots" in unenforced
+    assert "network_access" in unenforced
+    assert "package_installation" in unenforced
+    assert "subprocess_execution" in unenforced
+    assert "env_var_access" in unenforced
+
+
+def test_capability_policy_enforced_returns_expected_fields():
+    """timeout, stdout_max_bytes, stderr_max_bytes, and artifact_export_paths are enforced."""
+    policy = CapabilityPolicy()
+    enforced = policy.enforced_capabilities()
+    assert "timeout" in enforced
+    assert "stdout_max_bytes" in enforced
+    assert "stderr_max_bytes" in enforced
+    assert "artifact_export_paths" in enforced
+
+
+def test_capability_policy_enforced_and_unenforced_are_disjoint():
+    """No capability appears in both enforced and unenforced lists."""
+    policy = CapabilityPolicy()
+    assert set(policy.enforced_capabilities()).isdisjoint(
+        policy.unenforced_capabilities()
+    )
+
+
+def test_local_policy_has_expected_defaults():
+    """LOCAL_POLICY declares subprocess and env_var access, no package installation."""
+    assert LOCAL_POLICY.subprocess_execution is True
+    assert LOCAL_POLICY.env_var_access is True
+    assert LOCAL_POLICY.package_installation is False
+    assert LOCAL_POLICY.timeout == 30
+
+
+def test_docker_policy_has_expected_defaults():
+    """DOCKER_POLICY allows package installation and has a longer timeout."""
+    assert DOCKER_POLICY.package_installation is True
+    assert DOCKER_POLICY.timeout == 60
+
+
+def test_compatibility_matrix_has_all_tiers():
+    """COMPATIBILITY_MATRIX covers all four execution tiers."""
+    assert set(COMPATIBILITY_MATRIX.keys()) == {
+        "local_unsafe",
+        "local",
+        "docker_unsafe",
+        "docker",
+    }
+
+
+def test_compatibility_matrix_local_tiers_no_file_io():
+    """Local tiers do not support copy_in or copy_out."""
+    for tier in ("local_unsafe", "local"):
+        assert COMPATIBILITY_MATRIX[tier]["copy_in"] is False
+        assert COMPATIBILITY_MATRIX[tier]["copy_out"] is False
+
+
+def test_compatibility_matrix_docker_tiers_have_file_io():
+    """Docker tiers support copy_in and copy_out."""
+    for tier in ("docker_unsafe", "docker"):
+        assert COMPATIBILITY_MATRIX[tier]["copy_in"] is True
+        assert COMPATIBILITY_MATRIX[tier]["copy_out"] is True
+
+
+def test_compatibility_matrix_policy_applied_flag():
+    """Only policy tiers have policy_applied=True."""
+    assert COMPATIBILITY_MATRIX["local_unsafe"]["policy_applied"] is False
+    assert COMPATIBILITY_MATRIX["docker_unsafe"]["policy_applied"] is False
+    assert COMPATIBILITY_MATRIX["local"]["policy_applied"] is True
+    assert COMPATIBILITY_MATRIX["docker"]["policy_applied"] is True
+
+
+# endregion
+
+# region: ExecutionResult structured fields
+
+
+def test_execution_result_exit_code_none_by_default():
+    """ExecutionResult has exit_code=None when not set."""
+    from mellea.stdlib.tools import ExecutionResult
+
+    result = ExecutionResult(success=True, stdout="", stderr="")
+    assert result.exit_code is None
+
+
+def test_execution_result_timed_out_false_by_default():
+    """ExecutionResult has timed_out=False when not set."""
+    from mellea.stdlib.tools import ExecutionResult
+
+    result = ExecutionResult(success=False, stdout=None, stderr=None)
+    assert result.timed_out is False
+
+
+def test_execution_result_artifacts_empty_by_default():
+    """ExecutionResult has empty artifacts list by default."""
+    from mellea.stdlib.tools import ExecutionResult
+
+    result = ExecutionResult(success=True, stdout="", stderr="")
+    assert result.artifacts == []
+
+
+def test_execution_result_execution_mode_unknown_by_default():
+    """ExecutionResult has execution_mode='unknown' when not set."""
+    from mellea.stdlib.tools import ExecutionResult
+
+    result = ExecutionResult(success=True, stdout="", stderr="")
+    assert result.execution_mode == "unknown"
+
+
+def test_static_execution_sets_execution_mode():
+    """StaticAnalysisEnvironment sets execution_mode='static' on result."""
+    env = StaticAnalysisEnvironment()
+    result = env.execute("x = 1")
+    assert result.execution_mode == "static"
+
+
+def test_local_unsafe_execution_sets_execution_mode():
+    """UnsafeEnvironment with no policy sets execution_mode='local_unsafe'."""
+    env = UnsafeEnvironment()
+    result = env.execute("print('hi')")
+    assert result.execution_mode == "local_unsafe"
+
+
+def test_local_policy_execution_sets_execution_mode():
+    """UnsafeEnvironment with a policy sets execution_mode='local'."""
+    env = UnsafeEnvironment(policy=LOCAL_POLICY)
+    result = env.execute("print('hi')")
+    assert result.execution_mode == "local"
+
+
+def test_local_unsafe_execution_sets_exit_code():
+    """UnsafeEnvironment sets exit_code=0 on success."""
+    env = UnsafeEnvironment()
+    result = env.execute("print('ok')")
+    assert result.exit_code == 0
+
+
+def test_local_unsafe_execution_nonzero_exit_code():
+    """UnsafeEnvironment sets non-zero exit_code on failure."""
+    env = UnsafeEnvironment()
+    result = env.execute("raise ValueError('boom')")
+    assert result.exit_code is not None
+    assert result.exit_code != 0
+
+
+def test_timed_out_flag_set_on_timeout():
+    """UnsafeEnvironment sets timed_out=True when execution times out."""
+    env = UnsafeEnvironment()
+    result = env.execute("import time; time.sleep(999)", timeout=1)
+    assert result.timed_out is True
+    assert result.skipped is True
+
+
+def test_stdout_truncation_via_policy():
+    """Policy stdout_max_bytes truncates long output."""
+    policy = CapabilityPolicy(timeout=5, stdout_max_bytes=10)
+    env = UnsafeEnvironment(policy=policy)
+    result = env.execute("print('a' * 100)")
+    assert result.stdout is not None
+    assert "... [truncated]" in result.stdout
+
+
+def test_stderr_truncation_via_policy():
+    """Policy stderr_max_bytes truncates long stderr."""
+    policy = CapabilityPolicy(timeout=5, stderr_max_bytes=10)
+    env = UnsafeEnvironment(policy=policy)
+    result = env.execute("import sys; sys.stderr.write('e' * 100)")
+    assert result.stderr is not None
+    assert "... [truncated]" in result.stderr
+
+
+# endregion
+
+# region: copy_in / copy_out stubs
+
+
+def test_static_environment_copy_in_raises():
+    """StaticAnalysisEnvironment raises NotImplementedError for copy_in."""
+    env = StaticAnalysisEnvironment()
+    with pytest.raises(NotImplementedError, match="does not support copy_in"):
+        env.copy_in(Path("/tmp/x.py"), "/sandbox/x.py")
+
+
+def test_static_environment_copy_out_raises():
+    """StaticAnalysisEnvironment raises NotImplementedError for copy_out."""
+    env = StaticAnalysisEnvironment()
+    with pytest.raises(NotImplementedError, match="does not support copy_out"):
+        env.copy_out("/sandbox/out.csv", Path("/tmp/out.csv"))
+
+
+def test_unsafe_environment_copy_in_raises():
+    """UnsafeEnvironment raises NotImplementedError for copy_in."""
+    env = UnsafeEnvironment()
+    with pytest.raises(NotImplementedError, match="does not support copy_in"):
+        env.copy_in(Path("/tmp/x.py"), "/sandbox/x.py")
+
+
+def test_unsafe_environment_copy_out_raises():
+    """UnsafeEnvironment raises NotImplementedError for copy_out."""
+    env = UnsafeEnvironment()
+    with pytest.raises(NotImplementedError, match="does not support copy_out"):
+        env.copy_out("/sandbox/out.csv", Path("/tmp/out.csv"))
+
+
+# endregion
+
+# region: Execution tier UX / deprecation
+
+
+def test_tier_static_is_default():
+    """PythonExecutionReq defaults to the static tier."""
+    req = PythonExecutionReq()
+    assert req._tier == "static"
+
+
+def test_tier_explicit_local_unsafe():
+    """PythonExecutionReq accepts local_unsafe tier."""
+    req = PythonExecutionReq("local_unsafe")
+    assert req._tier == "local_unsafe"
+
+
+def test_tier_explicit_local():
+    """PythonExecutionReq accepts local tier."""
+    req = PythonExecutionReq("local")
+    assert req._tier == "local"
+
+
+def test_tier_explicit_docker_unsafe():
+    """PythonExecutionReq accepts docker_unsafe tier without raising."""
+    req = PythonExecutionReq("docker_unsafe")
+    assert req._tier == "docker_unsafe"
+
+
+def test_tier_explicit_docker():
+    """PythonExecutionReq accepts docker tier without raising."""
+    req = PythonExecutionReq("docker")
+    assert req._tier == "docker"
+
+
+def test_deprecated_allow_unsafe_promoted_to_local_unsafe(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    """allow_unsafe_execution=True is promoted to local_unsafe with a DeprecationWarning."""
+    req = PythonExecutionReq(allow_unsafe_execution=True)
+    assert req._tier == "local_unsafe"
+    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
+
+
+def test_deprecated_use_sandbox_promoted_to_docker(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    """use_sandbox=True is promoted to docker with a DeprecationWarning."""
+    req = PythonExecutionReq(use_sandbox=True)
+    assert req._tier == "docker"
+    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
+
+
+def test_deprecated_timeout_issues_warning(recwarn: pytest.WarningsRecorder) -> None:
+    """timeout kwarg issues a DeprecationWarning."""
+    req = PythonExecutionReq("local", timeout=10)
+    assert req._tier == "local"
+    assert req._policy is not None
+    assert req._policy.timeout == 10
+    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
+
+
+def test_policy_timeout_overrides_default():
+    """An explicit policy timeout is reflected in the description."""
+    policy = CapabilityPolicy(timeout=42)
+    req = PythonExecutionReq("docker", policy=policy)
+    assert "42s" in req.description  # type: ignore
+
+
+def test_static_tier_still_validates():
+    """Static tier still validates syntax correctly."""
+    req = PythonExecutionReq("static")
+    assert req.validation_fn(VALID_PYTHON_CTX).as_bool() is True
+    assert req.validation_fn(SYNTAX_ERROR_CTX).as_bool() is False
+
+
+def test_local_unsafe_executes_code():
+    """local_unsafe tier actually executes code."""
+    req = PythonExecutionReq("local_unsafe")
+    assert req.validation_fn(VALID_PYTHON_CTX).as_bool() is True
+    assert req.validation_fn(RUNTIME_ERROR_CTX).as_bool() is False
 
 
 # endregion

--- a/test/stdlib/requirements/test_reqlib_python.py
+++ b/test/stdlib/requirements/test_reqlib_python.py
@@ -371,10 +371,11 @@ def test_capability_policy_enforced_and_unenforced_are_disjoint():
 
 
 def test_local_policy_has_expected_defaults():
-    """LOCAL_POLICY declares subprocess and env_var access, no package installation."""
+    """LOCAL_POLICY declares subprocess and env_var access, no package installation, no network."""
     assert LOCAL_POLICY.subprocess_execution is True
     assert LOCAL_POLICY.env_var_access is True
     assert LOCAL_POLICY.package_installation is False
+    assert LOCAL_POLICY.network_access is False
     assert LOCAL_POLICY.timeout == 30
 
 
@@ -513,6 +514,23 @@ def test_stderr_truncation_via_policy():
     result = env.execute("import sys; sys.stderr.write('e' * 100)")
     assert result.stderr is not None
     assert "... [truncated]" in result.stderr
+
+
+def test_working_directory_passed_to_subprocess(tmp_path: Path):
+    """UnsafeEnvironment uses working_directory as cwd and reflects it on the result."""
+    env = UnsafeEnvironment(working_directory=str(tmp_path))
+    result = env.execute("import os; print(os.getcwd())")
+    assert result.success
+    assert result.stdout is not None
+    assert str(tmp_path) in result.stdout
+    assert result.working_directory == str(tmp_path)
+
+
+def test_working_directory_none_by_default():
+    """UnsafeEnvironment with no working_directory has working_directory=None on result."""
+    env = UnsafeEnvironment()
+    result = env.execute("print('ok')")
+    assert result.working_directory is None
 
 
 # endregion

--- a/test/stdlib/requirements/test_reqlib_python.py
+++ b/test/stdlib/requirements/test_reqlib_python.py
@@ -380,8 +380,9 @@ def test_local_policy_has_expected_defaults():
 
 
 def test_docker_policy_has_expected_defaults():
-    """DOCKER_POLICY allows package installation and has a longer timeout."""
+    """DOCKER_POLICY allows package installation, restricts network, and has a longer timeout."""
     assert DOCKER_POLICY.package_installation is True
+    assert DOCKER_POLICY.network_access is False
     assert DOCKER_POLICY.timeout == 60
 
 
@@ -499,21 +500,23 @@ def test_timed_out_flag_set_on_timeout():
 
 
 def test_stdout_truncation_via_policy():
-    """Policy stdout_max_bytes truncates long output."""
-    policy = CapabilityPolicy(timeout=5, stdout_max_bytes=10)
+    """Policy stdout_max_bytes truncates long output and total length stays within budget."""
+    policy = CapabilityPolicy(timeout=5, stdout_max_bytes=30)
     env = UnsafeEnvironment(policy=policy)
     result = env.execute("print('a' * 100)")
     assert result.stdout is not None
     assert "... [truncated]" in result.stdout
+    assert len(result.stdout.encode()) <= 30
 
 
 def test_stderr_truncation_via_policy():
-    """Policy stderr_max_bytes truncates long stderr."""
-    policy = CapabilityPolicy(timeout=5, stderr_max_bytes=10)
+    """Policy stderr_max_bytes truncates long stderr and total length stays within budget."""
+    policy = CapabilityPolicy(timeout=5, stderr_max_bytes=30)
     env = UnsafeEnvironment(policy=policy)
     result = env.execute("import sys; sys.stderr.write('e' * 100)")
     assert result.stderr is not None
     assert "... [truncated]" in result.stderr
+    assert len(result.stderr.encode()) <= 30
 
 
 def test_working_directory_passed_to_subprocess(tmp_path: Path):
@@ -601,31 +604,104 @@ def test_tier_explicit_docker():
     assert req._tier == "docker"
 
 
-def test_deprecated_allow_unsafe_promoted_to_local_unsafe(
-    recwarn: pytest.WarningsRecorder,
-) -> None:
+def test_deprecated_allow_unsafe_promoted_to_local_unsafe() -> None:
     """allow_unsafe_execution=True is promoted to local_unsafe with a DeprecationWarning."""
-    req = PythonExecutionReq(allow_unsafe_execution=True)
+    with pytest.warns(DeprecationWarning, match="allow_unsafe_execution is deprecated"):
+        req = PythonExecutionReq(allow_unsafe_execution=True)
     assert req._tier == "local_unsafe"
-    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
 
 
-def test_deprecated_use_sandbox_promoted_to_docker(
-    recwarn: pytest.WarningsRecorder,
-) -> None:
+def test_deprecated_allow_unsafe_silent_when_tier_already_local() -> None:
+    """allow_unsafe_execution=True is a no-op (no warning) when a local tier is already set."""
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", DeprecationWarning)
+        req = PythonExecutionReq("local", allow_unsafe_execution=True)
+    assert req._tier == "local"
+
+
+def test_deprecated_use_sandbox_promoted_to_docker() -> None:
     """use_sandbox=True is promoted to docker with a DeprecationWarning."""
-    req = PythonExecutionReq(use_sandbox=True)
+    with pytest.warns(DeprecationWarning, match="use_sandbox is deprecated"):
+        req = PythonExecutionReq(use_sandbox=True)
     assert req._tier == "docker"
-    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
 
 
-def test_deprecated_timeout_issues_warning(recwarn: pytest.WarningsRecorder) -> None:
+def test_deprecated_use_sandbox_silent_when_tier_already_docker() -> None:
+    """use_sandbox=True is a no-op (no warning) when execution_tier='docker' is already set."""
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", DeprecationWarning)
+        req = PythonExecutionReq("docker", use_sandbox=True)
+    assert req._tier == "docker"
+
+
+def test_deprecated_use_sandbox_with_local_promotes_to_docker() -> None:
+    """use_sandbox=True with execution_tier='local' promotes to 'docker' with a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="use_sandbox is deprecated"):
+        req = PythonExecutionReq("local", use_sandbox=True)
+    assert req._tier == "docker"
+
+
+def test_deprecated_use_sandbox_with_docker_unsafe_warns() -> None:
+    """use_sandbox=True with execution_tier='docker_unsafe' warns to prefer 'docker' for policy enforcement."""
+    with pytest.warns(DeprecationWarning, match="use_sandbox is deprecated"):
+        req = PythonExecutionReq("docker_unsafe", use_sandbox=True)
+    assert req._tier == "docker_unsafe"
+
+
+def test_deprecated_allow_unsafe_with_docker_tier_warns_correctly() -> None:
+    """allow_unsafe_execution=True with a docker tier warns without suggesting local_unsafe."""
+    with pytest.warns(DeprecationWarning, match="has no effect"):
+        req = PythonExecutionReq("docker_unsafe", allow_unsafe_execution=True)
+    assert req._tier == "docker_unsafe"
+
+
+def test_deprecated_timeout_issues_warning() -> None:
     """timeout kwarg issues a DeprecationWarning."""
-    req = PythonExecutionReq("local", timeout=10)
+    with pytest.warns(DeprecationWarning, match="timeout is deprecated"):
+        req = PythonExecutionReq("local", timeout=10)
     assert req._tier == "local"
     assert req._policy is not None
     assert req._policy.timeout == 10
-    assert any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
+
+
+def test_deprecated_timeout_on_static_warns_no_effect() -> None:
+    """timeout on the static tier warns that it has no effect."""
+    with pytest.warns(DeprecationWarning, match="no effect on the static tier"):
+        req = PythonExecutionReq("static", timeout=5)
+    assert req._tier == "static"
+
+
+def test_deprecated_timeout_on_unsafe_tiers_does_not_attach_policy() -> None:
+    """timeout on local_unsafe/docker_unsafe warns that it is ignored and does not attach a policy."""
+    with pytest.warns(DeprecationWarning, match="ignored for the 'local_unsafe' tier"):
+        req_local = PythonExecutionReq("local_unsafe", timeout=5)
+    assert req_local._policy is None
+
+    with pytest.warns(DeprecationWarning, match="ignored for the 'docker_unsafe' tier"):
+        req_docker = PythonExecutionReq("docker_unsafe", timeout=5)
+    assert req_docker._policy is None
+
+
+def test_combined_deprecated_flags_both_warn() -> None:
+    """Passing both allow_unsafe_execution and use_sandbox emits two DeprecationWarnings."""
+    with pytest.warns(DeprecationWarning) as record:
+        req = PythonExecutionReq(allow_unsafe_execution=True, use_sandbox=True)
+    categories = [w.category for w in record.list]
+    assert categories.count(DeprecationWarning) >= 2
+    assert req._tier == "docker"
+
+
+def test_tier_label_timeout_zero_displays_correctly() -> None:
+    """A policy timeout of 0 is displayed as 0s, not the policy default."""
+    from mellea.stdlib.requirements.python_reqs import _tier_label
+
+    policy = CapabilityPolicy(timeout=0)
+    assert "0s" in _tier_label("local", policy)
+    assert "0s" in _tier_label("docker", policy)
 
 
 def test_policy_timeout_overrides_default():


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1021

## Description
<!-- What does this PR do and why? -->
Allow more granular permissions to be used during sandboxing via capability policy. 

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [x] Requirement
- [ ] Sampling Strategy
- [x] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
