### PR TITLE
feat: support concurrency in base sampling strategy

### DIFF
--- a/docs/examples/instruct_validate_repair/advanced_email_with_validate_function.py
+++ b/docs/examples/instruct_validate_repair/advanced_email_with_validate_function.py
@@ -23,9 +23,9 @@ email_v1 = m.instruct(
     strategy=RejectionSamplingStrategy(loop_budget=3),
 )
 
-# Additionally, you could specify 3 concurrent requests.
-# This will potentially result in wasted samples and a high-number of
-# requests due to concurrent validation as well.
+# Additionally, you could run 3 concurrent subsamples — stopping as soon as one
+# passes validation. This cuts wall-clock latency but multiplies request count,
+# which can trigger rate limits on paid backends.
 # email_v1 = m.instruct(
 #     "Write an email to invite all interns to the office party.",
 #     requirements=["be formal", word_limit_req],

--- a/docs/examples/instruct_validate_repair/advanced_email_with_validate_function.py
+++ b/docs/examples/instruct_validate_repair/advanced_email_with_validate_function.py
@@ -23,6 +23,15 @@ email_v1 = m.instruct(
     strategy=RejectionSamplingStrategy(loop_budget=3),
 )
 
+# Additionally, you could specify 3 concurrent requests.
+# This will potentially result in wasted samples and a high-number of
+# requests due to concurrent validation as well.
+# email_v1 = m.instruct(
+#     "Write an email to invite all interns to the office party.",
+#     requirements=["be formal", word_limit_req],
+#     strategy=RejectionSamplingStrategy(loop_budget=1, concurrency_budget=3),
+# )
+
 # print result
 print(f"***** email ****\n{w(email_v1)}\n*******")
 

--- a/mellea/plugins/hooks/sampling.py
+++ b/mellea/plugins/hooks/sampling.py
@@ -32,7 +32,8 @@ class SamplingIterationPayload(MelleaBasePayload):
 
     Attributes:
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
-        iteration: 1-based iteration number within the sampling loop.
+        iteration: 1-based iteration number within the sampling loop. There is no guarantee that
+            iteration will be monotonically increasing when concurrency is enabled.
         action: The `Component` used for this attempt.
 
         result: The `ModelOutputThunk` produced by this attempt.
@@ -82,7 +83,8 @@ class SamplingLoopEndPayload(MelleaBasePayload):
     Attributes:
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
         success: `True` if at least one attempt passed all requirements.
-        iterations_used: Total number of iterations the loop executed.
+        iterations_used: Total number of iterations the executed. For concurrent sampling, this
+            corresponds to the loop_budget * concurrency budget.
         final_result: The selected `ModelOutputThunk` (best success or best failure).
         final_action: The `Component` that produced `final_result`.
 

--- a/mellea/plugins/hooks/sampling.py
+++ b/mellea/plugins/hooks/sampling.py
@@ -83,8 +83,9 @@ class SamplingLoopEndPayload(MelleaBasePayload):
     Attributes:
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
         success: `True` if at least one attempt passed all requirements.
-        iterations_used: Total number of iterations the executed. For concurrent sampling, this
-            corresponds to the loop_budget * concurrency budget.
+        iterations_used: Total number of sampling iterations that completed. With concurrency
+            enabled, this may be less than `loop_budget * concurrency_budget` if the strategy
+            exits early after a successful result.
         final_result: The selected `ModelOutputThunk` (best success or best failure).
         final_action: The `Component` that produced `final_result`.
 

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -15,7 +15,11 @@ Sampling strategies control how Mellea handles validation failures during genera
 """
 
 import abc
+import asyncio
+from collections.abc import AsyncGenerator, Callable
 from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Generic
 
 import tqdm
 
@@ -41,30 +45,105 @@ from ..components import Instruction, Message
 from ..context import ChatContext
 
 
+@dataclass
+class _SamplingResultSlice(Generic[S]):
+    """Result of a single generate/validate iteration inside a subsample."""
+
+    success: bool
+    generation: ComputedModelOutputThunk[S]
+    validation: list[tuple[Requirement, ValidationResult]]
+    context: Context
+    action: Component
+
+
+def _get_sampling_result(
+    slices: list[_SamplingResultSlice[S]],
+    select_from_failure: Callable[
+        [
+            list[Component],
+            list[ComputedModelOutputThunk],
+            list[list[tuple[Requirement, ValidationResult]]],
+        ],
+        int,
+    ],
+) -> SamplingResult[S]:
+    """Aggregate per-iteration slices into a SamplingResult.
+
+    Picks the first successful slice as the result; falls back to
+    ``select_from_failure`` over the collected slices when no slice succeeded.
+    """
+    sample_generations: list[ComputedModelOutputThunk] = []
+    sample_validations: list[list[tuple[Requirement, ValidationResult]]] = []
+    sample_actions: list[Component] = []
+    sample_contexts: list[Context] = []
+
+    success = False
+    best_index = -1
+
+    # Iterate over all entries to accumulate them but only take the first success.
+    for i, sample_slice in enumerate(slices):
+        if sample_slice.success and not success:
+            success = True
+            best_index = i
+
+        sample_generations.append(sample_slice.generation)
+        sample_validations.append(sample_slice.validation)
+        sample_actions.append(sample_slice.action)
+        sample_contexts.append(sample_slice.context)
+
+    if not success:
+        best_index = select_from_failure(
+            sample_actions, sample_generations, sample_validations
+        )
+
+    return SamplingResult(
+        result_index=best_index,
+        success=success,
+        sample_generations=sample_generations,
+        sample_validations=sample_validations,
+        sample_actions=sample_actions,
+        sample_contexts=sample_contexts,
+    )
+
+
 class BaseSamplingStrategy(SamplingStrategy):
     """Base class for multiple strategies that reject samples based on given instructions.
 
     Args:
-        loop_budget (int): Maximum number of generate/validate cycles. Must be
-            greater than 0. Defaults to `1`.
+        loop_budget (int): Maximum number of generate/validate cycles per
+            concurrent subsample. Must be greater than 0. Defaults to `1`.
+        concurrency_budget (int): Number of concurrent subsamples. Sampling
+            generates at most `loop_budget * concurrency_budget` requests
+            and stops at the first valid result. Must be greater than 0.
+            Defaults to `1` (no concurrency).
         requirements (list[Requirement] | None): Global requirements evaluated
             on every sample. When set, overrides per-call requirements.
 
+    Examples:
+        - `loop_budget=1`: no repair strategies are used.
+        - `loop_budget=3, concurrency_budget=1`: generate -> repair -> generate -> repair -> final generate.
+        - `loop_budget=2, concurrency_budget=2`: two concurrent subsamples, each with one repair.
+
+    Raises:
+        AssertionError: If `loop_budget < 1` or `concurrency_budget < 1`.
     """
 
     loop_budget: int
+    concurrency_budget: int
 
     def __init__(
-        self, *, loop_budget: int = 1, requirements: list[Requirement] | None = None
+        self,
+        *,
+        loop_budget: int = 1,
+        concurrency_budget: int = 1,
+        requirements: list[Requirement] | None = None,
     ):
-        """Initialize BaseSamplingStrategy with a loop budget and optional global requirements.
-
-        Raises:
-            AssertionError: If loop_budget is not greater than 0.
-        """
+        """Initialize BaseSamplingStrategy with budgets and optional global requirements."""
         assert loop_budget > 0, "Loop budget must be at least 1."
+        assert concurrency_budget > 0, "Concurrency budget must be at least 1."
 
         self.loop_budget = loop_budget
+        self.concurrency_budget = concurrency_budget
         self.requirements = requirements
 
     @staticmethod
@@ -148,11 +227,6 @@ class BaseSamplingStrategy(SamplingStrategy):
         flog = MelleaLogger.get_logger()
 
         with log_context(strategy=type(self).__name__, loop_budget=self.loop_budget):
-            sampled_results: list[ComputedModelOutputThunk] = []
-            sampled_scores: list[list[tuple[Requirement, ValidationResult]]] = []
-            sampled_actions: list[Component] = []
-            sample_contexts: list[Context] = []
-
             # The `logging_redirect_tqdm` approach did not work, so instead we will use the show_progress
             # flag to determine whether we should show the pbar.
             show_progress = (
@@ -167,8 +241,6 @@ class BaseSamplingStrategy(SamplingStrategy):
             elif requirements is not None:
                 reqs += requirements
             reqs = list(set(reqs))
-
-            loop_count = 0
 
             # --- sampling_loop_start hook ---
             effective_loop_budget = self.loop_budget
@@ -187,205 +259,288 @@ class BaseSamplingStrategy(SamplingStrategy):
                 )
                 effective_loop_budget = start_payload.loop_budget
 
-            loop_budget_range_iterator = (
-                tqdm.tqdm(range(effective_loop_budget))  # type: ignore
+            total_possible_generations = effective_loop_budget * self.concurrency_budget
+            progress_indicator = (
+                tqdm.tqdm(
+                    iterable=range(total_possible_generations),
+                    desc=f"{type(self).__name__}",
+                )
                 if show_progress
-                else range(effective_loop_budget)  # type: ignore
+                else None
             )
 
-            next_action = deepcopy(action)
-            next_context = context
-            for _ in loop_budget_range_iterator:  # type: ignore
-                loop_count += 1
-                if not show_progress:
-                    flog.info(f"Running loop {loop_count} of {self.loop_budget}")
+            # Create `concurrency_budget` concurrent generators that all generate up to the `loop_budget` number of generations.
+            generators: list[AsyncGenerator[_SamplingResultSlice[S], Any]] = [
+                self._subsample_iteration(
+                    subsample_index=idx,
+                    iterations=effective_loop_budget,
+                    action=action,
+                    context=context,
+                    backend=backend,
+                    requirements=reqs,
+                    validation_ctx=validation_ctx,
+                    format=format,
+                    model_options=model_options,
+                    tool_calls=tool_calls,
+                )
+                for idx in range(self.concurrency_budget)
+            ]
 
-                with with_context(sampling_iteration=loop_count):
-                    # run a generation pass
-                    result, result_ctx = await backend.generate_from_context(
-                        next_action,
-                        ctx=next_context,
-                        format=format,
-                        model_options=model_options,
-                        tool_calls=tool_calls,
-                    )
-                    await result.avalue()
-                    result = ComputedModelOutputThunk(result)
+            # Sentinel pushed by each producer when it exhausts its generator.
+            # Lets the consumer detect "all producers done" without racing
+            # queue.get() against a separate completion future.
+            _DONE = object()
 
-                    # Sampling strategies may use different components from the original
-                    # action. This might cause discrepancies in the expected parsed_repr
-                    # type / value. Explicitly overwrite that here.
-                    # TODO: See if there's a more elegant way for this so that each sampling
-                    # strategy doesn't have to re-implement it.
-                    result.parsed_repr = action.parse(result)
+            async def _producer(
+                generator: AsyncGenerator[_SamplingResultSlice, Any],
+                queue: asyncio.Queue[_SamplingResultSlice | object],
+            ) -> None:
+                """Drain an async generator into a shared queue, then signal completion."""
+                try:
+                    async for item in generator:
+                        await queue.put(item)
+                finally:
+                    await queue.put(_DONE)
 
-                    # validation pass
-                    val_scores_co = mfuncs.avalidate(
-                        reqs=reqs,
-                        context=result_ctx,
-                        backend=backend,
-                        output=result,
-                        format=None,
-                        model_options=model_options,
-                        # tool_calls=tool_calls  # Don't support using tool calls in validation strategies.
-                    )
-                    val_scores = await val_scores_co
+            # Create the queue that the samples are consumed from.
+            slice_queue: asyncio.Queue[_SamplingResultSlice | object] = asyncio.Queue()
+            producer_tasks = [
+                # Use tasks to push to the queue so that we don't need to explicitly await each generator.
+                asyncio.create_task(_producer(gen, slice_queue))
+                for gen in generators
+            ]
 
-                    # match up reqs with scores
-                    constraint_scores = list(zip(reqs, val_scores))
+            slices: list[_SamplingResultSlice] = []
 
-                    # collect all data
-                    sampled_results.append(result)
-                    sampled_scores.append(constraint_scores)
-                    sampled_actions.append(next_action)
-                    sample_contexts.append(result_ctx)
+            # Keep track of the producers left. It's the easiest way to ensure we don't deadlock
+            # if the producers finish and queue is empty at the same time.
+            remaining_producers = len(producer_tasks)
+            try:
+                while remaining_producers > 0:
+                    item = await slice_queue.get()
 
-                    all_validations_passed = all(bool(s[1]) for s in constraint_scores)
+                    if item is _DONE:
+                        remaining_producers -= 1
+                        continue
 
-                    # --- sampling_iteration hook ---
-                    if has_plugins(HookType.SAMPLING_ITERATION):
-                        from ...plugins.hooks.sampling import SamplingIterationPayload
+                    assert isinstance(item, _SamplingResultSlice)
+                    slices.append(item)
 
-                        iter_payload = SamplingIterationPayload(
-                            strategy_name=type(self).__name__,
-                            iteration=loop_count,
-                            action=next_action,
-                            result=result,
-                            validation_results=constraint_scores,
-                            all_validations_passed=all_validations_passed,
-                            valid_count=sum(1 for s in constraint_scores if bool(s[1])),
-                            total_count=len(constraint_scores),
-                        )
-                        await invoke_hook(
-                            HookType.SAMPLING_ITERATION, iter_payload, backend=backend
-                        )
+                    if progress_indicator is not None:
+                        progress_indicator.update()
 
-                    # if all vals are true -- break and return success
-                    if all_validations_passed:
-                        flog.info("SUCCESS")
-                        assert (
-                            result._generate_log is not None
-                        )  # Cannot be None after generation.
-                        result._generate_log.is_final_result = True
+                    if item.success:
+                        # Found a successful sample. Exit early.
+                        break
+            finally:
+                for t in producer_tasks:
+                    t.cancel()  # No-op if already done / cancelled.
 
-                        # --- sampling_loop_end hook (success) ---
-                        if has_plugins(HookType.SAMPLING_LOOP_END):
-                            from ...plugins.hooks.sampling import SamplingLoopEndPayload
+                # Wait for cancellations to settle so we don't leak tasks.
+                await asyncio.gather(*producer_tasks, return_exceptions=True)
 
-                            end_payload = SamplingLoopEndPayload(
-                                strategy_name=type(self).__name__,
-                                success=True,
-                                iterations_used=loop_count,
-                                final_result=result,
-                                final_action=next_action,
-                                final_context=result_ctx,
-                                all_results=sampled_results,
-                                all_validations=sampled_scores,
-                            )
-                            await invoke_hook(
-                                HookType.SAMPLING_LOOP_END, end_payload, backend=backend
-                            )
+                # Drain anything queued before producers were cancelled.
+                while not slice_queue.empty():
+                    try:
+                        item = slice_queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+                    if item is _DONE:
+                        continue
+                    assert isinstance(item, _SamplingResultSlice)
+                    slices.append(item)
+                    if progress_indicator is not None:
+                        progress_indicator.update()
 
-                        # SUCCESS !!!!
-                        return SamplingResult(
-                            result_index=len(sampled_results) - 1,
-                            success=True,
-                            sample_generations=sampled_results,
-                            sample_validations=sampled_scores,
-                            sample_contexts=sample_contexts,
-                            sample_actions=sampled_actions,
-                        )
+                if progress_indicator is not None:
+                    progress_indicator.close()
 
-                    else:
-                        # log partial success and continue
-                        failed = [s for s in constraint_scores if not bool(s[1])]
-                        count_failed = len(failed)
-                        failed_reqs = [
-                            r[0].description
-                            if r[0].description is not None
-                            else "[no description]"
-                            for r in failed
-                        ]
-                        stringify_failed = "\n\t - " + "\n\t - ".join(failed_reqs)
-                        flog.info(
-                            f"FAILED. Valid: {len(constraint_scores) - count_failed}/{len(constraint_scores)}. Failed: {stringify_failed}"
-                        )
-
-                    # If we did not pass all constraints, update the instruction and try again.
-                    next_action, next_context = self.repair(
-                        next_context,
-                        result_ctx,
-                        sampled_actions,
-                        sampled_results,
-                        sampled_scores,
-                    )
-
-                    # --- sampling_repair hook ---
-                    if has_plugins(HookType.SAMPLING_REPAIR):
-                        from ...plugins.hooks.sampling import SamplingRepairPayload
-
-                        repair_payload = SamplingRepairPayload(
-                            repair_type=getattr(
-                                self, "_get_repair_type", lambda: "unknown"
-                            )(),
-                            failed_action=sampled_actions[-1],
-                            failed_result=sampled_results[-1],
-                            failed_validations=sampled_scores[-1],
-                            repair_action=next_action,
-                            repair_context=next_context,
-                            repair_iteration=loop_count,
-                        )
-                        await invoke_hook(
-                            HookType.SAMPLING_REPAIR, repair_payload, backend=backend
-                        )
-
-            flog.info(
-                f"Invoking select_from_failure after {len(sampled_results)} failed attempts."
+            s_result = _get_sampling_result(
+                slices=slices, select_from_failure=self.select_from_failure
             )
 
-            # if no valid result could be determined, find a last resort.
-            best_failed_index = self.select_from_failure(
-                sampled_actions, sampled_results, sampled_scores
-            )
-            assert best_failed_index < len(sampled_results), (
+            if s_result.success:
+                flog.info("Sampling was successful.")
+            else:
+                flog.info(
+                    f"Invoking select_from_failure after {len(s_result.sample_generations)} failed attempts."
+                )
+
+            assert s_result.result_index < len(s_result.sample_generations), (
                 "The select_from_failure method did not return a valid result. It has to selected from failed_results."
             )
+            assert s_result.result._generate_log is not None
+            s_result.result._generate_log.is_final_result = True
 
-            assert (
-                sampled_results[best_failed_index]._generate_log is not None
-            )  # Cannot be None after generation.
-            sampled_results[best_failed_index]._generate_log.is_final_result = True  # type: ignore
-
-            # --- sampling_loop_end hook (failure) ---
+            # --- sampling_loop_end hook (success or failure) ---
             if has_plugins(HookType.SAMPLING_LOOP_END):
                 from ...plugins.hooks.sampling import SamplingLoopEndPayload
 
-                _final_ctx = (
-                    sample_contexts[best_failed_index] if sample_contexts else context
-                )
                 end_payload = SamplingLoopEndPayload(
                     strategy_name=type(self).__name__,
-                    success=False,
-                    iterations_used=loop_count,
-                    final_result=sampled_results[best_failed_index],
-                    final_action=sampled_actions[best_failed_index],
-                    final_context=_final_ctx,
-                    failure_reason=f"Budget exhausted after {loop_count} iterations",
-                    all_results=sampled_results,
-                    all_validations=sampled_scores,
+                    success=s_result.success,
+                    iterations_used=len(slices),
+                    final_result=s_result.result,
+                    final_action=s_result.result_action,
+                    final_context=s_result.result_ctx,
+                    all_results=list(s_result.sample_generations),
+                    all_validations=list(s_result.sample_validations),
+                    failure_reason=(
+                        None
+                        if s_result.success
+                        else f"Budget exhausted after {len(slices)} iterations"
+                    ),
                 )
                 await invoke_hook(
                     HookType.SAMPLING_LOOP_END, end_payload, backend=backend
                 )
 
-            return SamplingResult(
-                result_index=best_failed_index,
-                success=False,
-                sample_generations=sampled_results,
-                sample_validations=sampled_scores,
-                sample_actions=sampled_actions,
-                sample_contexts=sample_contexts,
-            )
+            return s_result
+
+    async def _subsample_iteration(
+        self,
+        subsample_index: int,
+        iterations: int,
+        action: Component[S],
+        context: Context,
+        backend: Backend,
+        requirements: list[Requirement],
+        *,
+        validation_ctx: Context | None = None,
+        format: type[BaseModelSubclass] | None = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> AsyncGenerator[_SamplingResultSlice[S], Any]:
+        """Run one concurrent subsample: up to `iterations` generate/validate/repair attempts.
+
+        Yields a :class:`_SamplingResultSlice` per attempt and ends early after the first successful slice.
+        `subsample_index` (0-based) identifies this subsample within the parent `sample()` call; it is used to derive a
+        globally unique iteration counter for telemetry and hooks.
+        """
+        flog = MelleaLogger.get_logger()
+        sampled_results: list[ComputedModelOutputThunk[S]] = []
+        sampled_scores: list[list[tuple[Requirement, ValidationResult]]] = []
+        sampled_actions: list[Component] = []
+
+        next_action = deepcopy(action)
+        next_context = context
+        for i in range(iterations):
+            # Globally unique across concurrent subsamples in the parent sample() call.
+            current_iteration = subsample_index * iterations + i + 1
+
+            with with_context(sampling_iteration=current_iteration):
+                # run a generation pass
+                result, result_ctx = await backend.generate_from_context(
+                    next_action,
+                    ctx=next_context,
+                    format=format,
+                    model_options=model_options,
+                    tool_calls=tool_calls,
+                )
+                await result.avalue()
+                result = ComputedModelOutputThunk(result)
+
+                # Sampling strategies may use different components from the original
+                # action. This might cause discrepancies in the expected parsed_repr
+                # type / value. Explicitly overwrite that here.
+                # TODO: See if there's a more elegant way for this so that each sampling
+                # strategy doesn't have to re-implement it.
+                result.parsed_repr = action.parse(result)
+
+                # validation pass
+                val_scores_co = mfuncs.avalidate(
+                    reqs=requirements,
+                    context=result_ctx,
+                    backend=backend,
+                    output=result,
+                    format=None,
+                    model_options=model_options,
+                    # tool_calls=tool_calls  # Don't support using tool calls in validation strategies.
+                )
+                val_scores = await val_scores_co
+
+                constraint_scores = list(zip(requirements, val_scores))
+                all_validations_passed = all(bool(s[1]) for s in constraint_scores)
+
+                # --- sampling_iteration hook ---
+                if has_plugins(HookType.SAMPLING_ITERATION):
+                    from ...plugins.hooks.sampling import SamplingIterationPayload
+
+                    iter_payload = SamplingIterationPayload(
+                        strategy_name=type(self).__name__,
+                        iteration=current_iteration,
+                        action=next_action,
+                        result=result,
+                        validation_results=constraint_scores,
+                        all_validations_passed=all_validations_passed,
+                        valid_count=sum(1 for s in constraint_scores if bool(s[1])),
+                        total_count=len(constraint_scores),
+                    )
+                    await invoke_hook(
+                        HookType.SAMPLING_ITERATION, iter_payload, backend=backend
+                    )
+
+                if not all_validations_passed:
+                    failed = [s for s in constraint_scores if not bool(s[1])]
+                    failed_reqs = [
+                        r[0].description
+                        if r[0].description is not None
+                        else "[no description]"
+                        for r in failed
+                    ]
+                    stringify_failed = "\n\t - " + "\n\t - ".join(failed_reqs)
+                    flog.info(
+                        f"FAILED. Valid: {len(constraint_scores) - len(failed)}/{len(constraint_scores)}. Failed: {stringify_failed}"
+                    )
+
+                yield _SamplingResultSlice(
+                    success=all_validations_passed,
+                    generation=result,
+                    validation=constraint_scores,
+                    context=result_ctx,
+                    action=next_action,
+                )
+
+                if all_validations_passed:
+                    return
+
+                if i == iterations - 1:
+                    # Final iteration: repair output would be discarded, skip it.
+                    # The generation budget has been exhausted.
+                    return
+
+                # Append failure history before computing the repair so the strategy
+                # sees the most recent failed attempt.
+                sampled_results.append(result)
+                sampled_scores.append(constraint_scores)
+                sampled_actions.append(next_action)
+
+                next_action, next_context = self.repair(
+                    next_context,
+                    result_ctx,
+                    sampled_actions,
+                    sampled_results,
+                    sampled_scores,
+                )
+
+                # --- sampling_repair hook ---
+                if has_plugins(HookType.SAMPLING_REPAIR):
+                    from ...plugins.hooks.sampling import SamplingRepairPayload
+
+                    repair_payload = SamplingRepairPayload(
+                        repair_type=getattr(
+                            self, "_get_repair_type", lambda: "unknown"
+                        )(),
+                        failed_action=sampled_actions[-1],
+                        failed_result=sampled_results[-1],
+                        failed_validations=sampled_scores[-1],
+                        repair_action=next_action,
+                        repair_context=next_context,
+                        repair_iteration=current_iteration,
+                    )
+                    await invoke_hook(
+                        HookType.SAMPLING_REPAIR, repair_payload, backend=backend
+                    )
 
 
 class RejectionSamplingStrategy(BaseSamplingStrategy):

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -116,6 +116,9 @@ class BaseSamplingStrategy(SamplingStrategy):
             generates at most `loop_budget * concurrency_budget` requests
             and stops at the first valid result. Must be greater than 0.
             Defaults to `1` (no concurrency).
+            When allowing concurrency, number of generations may substantially increase
+            (potentially causing rate-limiting issues depending on the provider)
+            and the returned order of results will no longer be deterministic.
         requirements (list[Requirement] | None): Global requirements evaluated
             on every sample. When set, overrides per-call requirements.
 
@@ -259,6 +262,15 @@ class BaseSamplingStrategy(SamplingStrategy):
                 )
                 effective_loop_budget = start_payload.loop_budget
 
+            # Hooks can override loop_budget but bypass the constructor's
+            # validation; reject non-positive values up front so the failure
+            # mode is a clear error rather than an empty-slices AssertionError.
+            if effective_loop_budget < 1:
+                raise ValueError(
+                    f"SAMPLING_LOOP_START hook returned non-positive loop_budget="
+                    f"{effective_loop_budget}; must be >= 1."
+                )
+
             total_possible_generations = effective_loop_budget * self.concurrency_budget
             progress_indicator = (
                 tqdm.tqdm(
@@ -311,6 +323,7 @@ class BaseSamplingStrategy(SamplingStrategy):
             ]
 
             slices: list[_SamplingResultSlice] = []
+            producer_results: list[Any] = []
 
             # Keep track of the producers left. It's the easiest way to ensure we don't deadlock
             # if the producers finish and queue is empty at the same time.
@@ -337,7 +350,11 @@ class BaseSamplingStrategy(SamplingStrategy):
                     t.cancel()  # No-op if already done / cancelled.
 
                 # Wait for cancellations to settle so we don't leak tasks.
-                await asyncio.gather(*producer_tasks, return_exceptions=True)
+                # Capture results so we can surface backend errors that would
+                # otherwise be swallowed when no slices made it through.
+                producer_results = await asyncio.gather(
+                    *producer_tasks, return_exceptions=True
+                )
 
                 # Drain anything queued before producers were cancelled.
                 while not slice_queue.empty():
@@ -354,6 +371,16 @@ class BaseSamplingStrategy(SamplingStrategy):
 
                 if progress_indicator is not None:
                     progress_indicator.close()
+
+            # If no slices made it through, surface the first non-cancellation
+            # exception from a producer rather than letting the empty-slices
+            # state crash later in SamplingResult with a misleading assertion.
+            if not slices:
+                for r in producer_results:
+                    if isinstance(r, BaseException) and not isinstance(
+                        r, asyncio.CancelledError
+                    ):
+                        raise r
 
             s_result = _get_sampling_result(
                 slices=slices, select_from_failure=self.select_from_failure
@@ -662,6 +689,9 @@ class MultiTurnStrategy(BaseSamplingStrategy):
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
         """Always returns the last index. The last message from the model will always be returned if all results are failures.
+
+        If utilizing concurrency, this will always be the last turn of one of the multi-turn samples; but there is no guarantee
+        of which concurrent sampling it will be from.
 
         Args:
             sampled_actions: List of actions that have been executed (without success).

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -128,7 +128,7 @@ class BaseSamplingStrategy(SamplingStrategy):
         - `loop_budget=2, concurrency_budget=2`: two concurrent subsamples, each with one repair.
 
     Raises:
-        AssertionError: If `loop_budget < 1` or `concurrency_budget < 1`.
+        ValueError: If `loop_budget < 1` or `concurrency_budget < 1`.
     """
 
     loop_budget: int
@@ -142,8 +142,10 @@ class BaseSamplingStrategy(SamplingStrategy):
         requirements: list[Requirement] | None = None,
     ):
         """Initialize BaseSamplingStrategy with budgets and optional global requirements."""
-        assert loop_budget > 0, "Loop budget must be at least 1."
-        assert concurrency_budget > 0, "Concurrency budget must be at least 1."
+        if loop_budget < 1:
+            raise ValueError("Loop budget must be at least 1.")
+        if concurrency_budget < 1:
+            raise ValueError("Concurrency budget must be at least 1.")
 
         self.loop_budget = loop_budget
         self.concurrency_budget = concurrency_budget
@@ -224,6 +226,7 @@ class BaseSamplingStrategy(SamplingStrategy):
 
         Raises:
             AssertionError: Asserts that all required components (repair, select_from_failure, validate, and generate) are provided before proceeding with the sampling.
+            ValueError: If a `SAMPLING_LOOP_START` hook returns a non-positive `loop_budget`.
         """
         validation_ctx = validation_ctx if validation_ctx is not None else context
 
@@ -375,6 +378,12 @@ class BaseSamplingStrategy(SamplingStrategy):
             # If no slices made it through, surface the first non-cancellation
             # exception from a producer rather than letting the empty-slices
             # state crash later in SamplingResult with a misleading assertion.
+            for r in producer_results:
+                if isinstance(r, BaseException) and not isinstance(
+                    r, asyncio.CancelledError
+                ):
+                    flog.warning("A concurrent subsample raised an exception: %s", r)
+
             if not slices:
                 for r in producer_results:
                     if isinstance(r, BaseException) and not isinstance(
@@ -394,7 +403,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                 )
 
             assert s_result.result_index < len(s_result.sample_generations), (
-                "The select_from_failure method did not return a valid result. It has to selected from failed_results."
+                "The select_from_failure method did not return a valid result. It must return an index into failed_results."
             )
             assert s_result.result._generate_log is not None
             s_result.result._generate_log.is_final_result = True

--- a/test/core/test_logger_plugin_hooks.py
+++ b/test/core/test_logger_plugin_hooks.py
@@ -228,7 +228,7 @@ class TestMelleaLoggerInHooks:
     async def test_sampling_log_context_fields_present_on_success_record(
         self, caplog
     ) -> None:
-        """strategy and loop_budget context fields appear on the SUCCESS log record."""
+        """strategy and loop_budget context fields are attached to records emitted inside sample()."""
         from mellea.stdlib.components import Instruction
         from mellea.stdlib.sampling.base import RejectionSamplingStrategy
 
@@ -244,8 +244,10 @@ class TestMelleaLoggerInHooks:
                 show_progress=False,
             )
 
-        success_records = [r for r in caplog.records if r.getMessage() == "SUCCESS"]
-        assert success_records, "No SUCCESS record found"
-        record = success_records[0]
-        assert getattr(record, "strategy", None) == "RejectionSamplingStrategy"
-        assert getattr(record, "loop_budget", None) == 2
+        tagged = [
+            r
+            for r in caplog.records
+            if getattr(r, "strategy", None) == "RejectionSamplingStrategy"
+            and getattr(r, "loop_budget", None) == 2
+        ]
+        assert tagged, "No log record carried the expected log_context fields"

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -28,8 +28,11 @@ from mellea.core.base import (
     GenerateType,
     ModelOutputThunk,
 )
+from mellea.core.requirement import Requirement, ValidationResult
 from mellea.plugins import HookType, PluginResult, hook, register
+from mellea.stdlib.components import Instruction
 from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.sampling.base import RejectionSamplingStrategy
 
 # ---------------------------------------------------------------------------
 # Mock backend (module-level so it can be used as a class in session tests)
@@ -525,6 +528,54 @@ class TestSamplingHookCallSites:
         assert observed[0].iteration == 1
         assert observed[0].all_validations_passed is True  # no requirements → all pass
 
+    async def test_sampling_iteration_ids_unique_under_concurrency(self) -> None:
+        """Each generate/validate of the base sampling strategy should report a unique `iteration` to the sampling iteration hook.
+
+        With `concurrency_budget=3, loop_budget=2`, six generations run; their `SAMPLING_ITERATION`
+        payloads must carry six distinct `iteration` values (computed as `subsample_index * loop_budget + i + 1`),
+        not three duplicated `{1, 2}` pairs.
+        """
+
+        observed: list[int] = []
+
+        @hook("sampling_iteration")
+        async def recorder(payload: Any, ctx: Any) -> Any:
+            observed.append(payload.iteration)
+            return None
+
+        register(recorder)
+        backend = _MockBackend()
+        ctx = SimpleContext()
+
+        always_fail = Requirement(
+            description="always fails",
+            validation_fn=lambda _ctx: ValidationResult(
+                result=False, reason="forced failure"
+            ),
+        )
+        loop_budget = 2
+        concurrency_budget = 3
+        strategy = RejectionSamplingStrategy(
+            loop_budget=loop_budget, concurrency_budget=concurrency_budget
+        )
+
+        await strategy.sample(
+            Instruction("Concurrency iteration id test"),
+            context=ctx,
+            backend=backend,
+            requirements=[always_fail],
+            format=None,
+            model_options=None,
+            tool_calls=False,
+            show_progress=False,
+        )
+
+        expected = set(range(1, loop_budget * concurrency_budget + 1))
+        assert set(observed) == expected, (
+            f"iteration ids should be {sorted(expected)} (one per generation, unique "
+            f"across subsamples), got {sorted(observed)}"
+        )
+
     async def test_sampling_loop_end_fires_on_success_path(self) -> None:
         """SAMPLING_LOOP_END fires with success=True when sampling succeeds."""
         from mellea.stdlib.components import Instruction
@@ -663,6 +714,82 @@ class TestSamplingHookCallSites:
             show_progress=False,
         )
         assert order == ["loop_start", "iteration", "loop_end"]
+
+    async def test_sampling_repair_skipped_on_final_iteration(self) -> None:
+        """SAMPLING_REPAIR fires only between iterations, never after the last one.
+
+        With loop_budget=N and all-failing requirements, repair runs N-1 times:
+        once after each failed attempt that has a successor, but not after the
+        final attempt (its repair output would be discarded).
+        """
+        observed: list[Any] = []
+
+        @hook("sampling_repair")
+        async def recorder(payload: Any, ctx: Any) -> Any:
+            observed.append(payload)
+            return None
+
+        register(recorder)
+        backend = _MockBackend()
+        ctx = SimpleContext()
+
+        always_fail = Requirement(
+            description="always fails",
+            validation_fn=lambda _ctx: ValidationResult(
+                result=False, reason="forced failure"
+            ),
+        )
+        loop_budget = 3
+        strategy = RejectionSamplingStrategy(loop_budget=loop_budget)
+
+        await strategy.sample(
+            Instruction("Repair-skip test"),
+            context=ctx,
+            backend=backend,
+            requirements=[always_fail],
+            format=None,
+            model_options=None,
+            tool_calls=False,
+            show_progress=False,
+        )
+
+        assert len(observed) == loop_budget - 1, (
+            f"repair should fire N-1 times for N iterations, got {len(observed)}"
+        )
+
+    async def test_sampling_repair_not_fired_when_loop_budget_is_one(self) -> None:
+        """With loop_budget=1, SAMPLING_REPAIR must never fire even on validation failure."""
+        observed: list[Any] = []
+
+        @hook("sampling_repair")
+        async def recorder(payload: Any, ctx: Any) -> Any:
+            observed.append(payload)
+            return None
+
+        register(recorder)
+        backend = _MockBackend()
+        ctx = SimpleContext()
+
+        always_fail = Requirement(
+            description="always fails",
+            validation_fn=lambda _ctx: ValidationResult(result=False),
+        )
+        strategy = RejectionSamplingStrategy(loop_budget=1)
+
+        await strategy.sample(
+            Instruction("Single-iteration test"),
+            context=ctx,
+            backend=backend,
+            requirements=[always_fail],
+            format=None,
+            model_options=None,
+            tool_calls=False,
+            show_progress=False,
+        )
+
+        assert observed == [], (
+            "loop_budget=1 should never invoke repair (no next iteration to feed)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -496,6 +496,45 @@ class TestSamplingHookCallSites:
         )
         assert observed[0].loop_budget == 3
 
+    @pytest.mark.parametrize("bad_budget", [0, -1])
+    async def test_sampling_loop_start_rejects_non_positive_loop_budget(
+        self, bad_budget: int
+    ) -> None:
+        """A SAMPLING_LOOP_START hook that returns loop_budget < 1 must raise ValueError.
+
+        The constructor enforces loop_budget >= 1 but a hook can override it
+        post-construction; without explicit validation this collapses
+        total_possible_generations to 0, no slices are produced, and the user
+        sees an opaque AssertionError from SamplingResult.__init__ instead of
+        a clear cause.
+        """
+        from mellea.stdlib.components import Instruction
+        from mellea.stdlib.sampling.base import RejectionSamplingStrategy
+
+        @hook("sampling_loop_start")
+        async def shrink_budget(payload: Any, ctx: Any) -> Any:
+            return PluginResult(
+                continue_processing=True,
+                modified_payload=payload.model_copy(update={"loop_budget": bad_budget}),
+            )
+
+        register(shrink_budget)
+        backend = _MockBackend()
+        ctx = SimpleContext()
+        strategy = RejectionSamplingStrategy(loop_budget=1)
+
+        with pytest.raises(ValueError, match="non-positive loop_budget"):
+            await strategy.sample(
+                Instruction("Bad budget test"),
+                context=ctx,
+                backend=backend,
+                requirements=[],
+                format=None,
+                model_options=None,
+                tool_calls=False,
+                show_progress=False,
+            )
+
     async def test_sampling_iteration_fires_once_per_loop_iteration(self) -> None:
         """SAMPLING_ITERATION fires once per loop iteration."""
         from mellea.stdlib.components import Instruction

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -1,16 +1,22 @@
 """Unit tests for sampling/base.py static repair() logic — no backend required."""
 
+import asyncio
+from unittest.mock import Mock
+
 import pytest
 
 from mellea.core import (
     ComputedModelOutputThunk,
+    Context,
+    GenerateLog,
     ModelOutputThunk,
     Requirement,
     ValidationResult,
 )
 from mellea.stdlib.components import Instruction, Message
 from mellea.stdlib.context import ChatContext
-from mellea.stdlib.sampling.base import RepairTemplateStrategy
+from mellea.stdlib.sampling import MultiTurnStrategy, RejectionSamplingStrategy
+from mellea.stdlib.sampling.base import RepairTemplateStrategy, _SamplingResultSlice
 
 # --- BaseSamplingStrategy.repair ---
 
@@ -102,6 +108,232 @@ def test_repair_passed_requirements_excluded():
     )
     assert "format ok" not in action._repair_string
     assert "incorrect" in action._repair_string
+
+
+# --- concurrency_budget integration tests (mocked backend) ---
+
+
+@pytest.fixture(scope="function")
+def mocked_context_backend():
+    """Backend whose generate_from_context sleeps then returns a mocked thunk."""
+    backend = Mock()
+
+    async def mock_generate(*args, **kwargs):
+        # Mirrors how BaseSamplingStrategy._subsample_iteration calls it: action
+        # is positional; ctx + others are keyword.
+        action = args[0] if args else kwargs["action"]
+        ctx = kwargs["ctx"]
+        await asyncio.sleep(0.05)
+        output = ModelOutputThunk("mocked")
+        output._generate_log = GenerateLog()
+        return output, ctx.add(action).add(output)
+
+    backend.generate_from_context = mock_generate
+    return backend
+
+
+# Module-level counter used by the "every 5th call passes" requirement below.
+_validation_counter = 0
+
+
+async def test_rejection_sampling_with_concurrency_early_success(
+    mocked_context_backend,
+):
+    """With concurrency, sampling stops once any subsample succeeds.
+
+    Validation passes only on every 5th call, so the 5th request succeeds
+    and the strategy must stop before exhausting the 9-request budget.
+    """
+    global _validation_counter
+    _validation_counter = 0
+
+    def sometimes_pass(_ctx: Context) -> ValidationResult:
+        global _validation_counter
+        _validation_counter += 1
+        return ValidationResult(_validation_counter % 5 == 0)
+
+    sometimes_pass_req = Requirement("sometimes_pass", validation_fn=sometimes_pass)
+
+    loop_budget = 3
+    concurrency_budget = 3
+    strategy = RejectionSamplingStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    result = await strategy.sample(
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[sometimes_pass_req],
+    )
+
+    # The 5th validation call is the first to succeed, so at least 5 slices
+    # must be observed; the strategy must also stop before exhausting the
+    # full 9-request budget.
+    assert 5 <= len(result.sample_actions) < loop_budget * concurrency_budget, (
+        "early success should occur on/after the 5th call but before exhausting the budget"
+    )
+
+
+async def test_subsample_iteration_ends_after_success(mocked_context_backend):
+    """The async generator must emit exactly one slice and then StopAsyncIteration."""
+    always_pass = Requirement(
+        "always pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+
+    strategy = RejectionSamplingStrategy(loop_budget=5, concurrency_budget=5)
+
+    generator = strategy._subsample_iteration(
+        subsample_index=0,
+        iterations=2,
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_pass],
+    )
+
+    first = await generator.__anext__()
+    assert isinstance(first, _SamplingResultSlice)
+    assert first.success is True
+
+    with pytest.raises(StopAsyncIteration):
+        await generator.__anext__()
+
+
+async def test_repair_strategy_with_concurrency(mocked_context_backend):
+    """All slices are produced when every requirement fails, and the last
+    iteration's action carries a repair string.
+    """
+    always_fail = Requirement(
+        "always fail", validation_fn=lambda _ctx: ValidationResult(result=False)
+    )
+
+    loop_budget = 5
+    concurrency_budget = 5
+    strategy = RepairTemplateStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    result = await strategy.sample(
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_fail],
+    )
+
+    assert len(result.sample_actions) == loop_budget * concurrency_budget, (
+        "forced failures should exhaust the full loop * concurrency budget"
+    )
+    last_ctx = result.sample_contexts[-1]
+    first_node = last_ctx.view_for_generation()[0]  # type: ignore[union-attr]
+    assert first_node._repair_string is not None, (
+        "last batch of retries should carry a repair_string with RepairTemplateStrategy"
+    )
+
+
+async def test_multi_turn_strategy_with_concurrency(mocked_context_backend):
+    """MultiTurnStrategy with concurrency: budget exhausted, last context is 2*loop_budget long."""
+    always_fail = Requirement(
+        "always fail", validation_fn=lambda _ctx: ValidationResult(result=False)
+    )
+
+    loop_budget = 2
+    concurrency_budget = 3
+    strategy = MultiTurnStrategy(
+        loop_budget=loop_budget, concurrency_budget=concurrency_budget
+    )
+
+    result = await strategy.sample(
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_fail],
+    )
+
+    assert len(result.sample_actions) == loop_budget * concurrency_budget, (
+        "forced failures should exhaust the full loop * concurrency budget"
+    )
+    last_ctx = result.sample_contexts[-1]
+    assert len(last_ctx.view_for_generation()) == loop_budget * 2, (  # type: ignore[union-attr]
+        "MultiTurnStrategy: last context should be 2*loop_budget long after repair"
+    )
+
+
+# --- Constructor validation ---
+
+
+def test_loop_budget_must_be_positive():
+    with pytest.raises(AssertionError, match="Loop budget"):
+        RejectionSamplingStrategy(loop_budget=0)
+
+
+def test_concurrency_budget_must_be_positive():
+    with pytest.raises(AssertionError, match="Concurrency budget"):
+        RejectionSamplingStrategy(concurrency_budget=0)
+
+
+# --- Global vs per-call requirements ---
+
+
+async def test_global_requirements_override_per_call(mocked_context_backend):
+    """When `requirements` is set on the strategy, it supersedes the per-call list."""
+    global_req_calls = 0
+    per_call_req_calls = 0
+
+    def global_validator(_ctx: Context) -> ValidationResult:
+        nonlocal global_req_calls
+        global_req_calls += 1
+        return ValidationResult(result=True)
+
+    def per_call_validator(_ctx: Context) -> ValidationResult:
+        nonlocal per_call_req_calls
+        per_call_req_calls += 1
+        return ValidationResult(result=True)
+
+    global_req = Requirement("global", validation_fn=global_validator)
+    per_call_req = Requirement("per_call", validation_fn=per_call_validator)
+
+    strategy = RejectionSamplingStrategy(loop_budget=1, requirements=[global_req])
+
+    await strategy.sample(
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[per_call_req],
+    )
+
+    assert global_req_calls == 1, "global requirement should be evaluated"
+    assert per_call_req_calls == 0, (
+        "per-call requirement must be ignored when global is set"
+    )
+
+
+# --- Drain on early success: no slices lost ---
+
+
+async def test_early_success_does_not_lose_in_flight_slices(mocked_context_backend):
+    """On early success the result should still contain at least the successful slice.
+
+    The drain in the finally block is best-effort; this test guards against the
+    regression where the sentinel/cancellation logic silently dropped the winning
+    slice itself.
+    """
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=2, concurrency_budget=4)
+
+    result = await strategy.sample(
+        action=Instruction(description=""),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_pass],
+    )
+
+    assert result.success is True
+    assert len(result.sample_generations) >= 1, (
+        "the winning slice must be retained even after producer cancellation"
+    )
 
 
 if __name__ == "__main__":

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -258,12 +258,12 @@ async def test_multi_turn_strategy_with_concurrency(mocked_context_backend):
 
 
 def test_loop_budget_must_be_positive():
-    with pytest.raises(AssertionError, match="Loop budget"):
+    with pytest.raises(ValueError, match="Loop budget"):
         RejectionSamplingStrategy(loop_budget=0)
 
 
 def test_concurrency_budget_must_be_positive():
-    with pytest.raises(AssertionError, match="Concurrency budget"):
+    with pytest.raises(ValueError, match="Concurrency budget"):
         RejectionSamplingStrategy(concurrency_budget=0)
 
 

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -132,10 +132,6 @@ def mocked_context_backend():
     return backend
 
 
-# Module-level counter used by the "every 5th call passes" requirement below.
-_validation_counter = 0
-
-
 async def test_rejection_sampling_with_concurrency_early_success(
     mocked_context_backend,
 ):
@@ -144,13 +140,12 @@ async def test_rejection_sampling_with_concurrency_early_success(
     Validation passes only on every 5th call, so the 5th request succeeds
     and the strategy must stop before exhausting the 9-request budget.
     """
-    global _validation_counter
-    _validation_counter = 0
+    validation_counter = 0
 
     def sometimes_pass(_ctx: Context) -> ValidationResult:
-        global _validation_counter
-        _validation_counter += 1
-        return ValidationResult(_validation_counter % 5 == 0)
+        nonlocal validation_counter
+        validation_counter += 1
+        return ValidationResult(validation_counter % 5 == 0)
 
     sometimes_pass_req = Requirement("sometimes_pass", validation_fn=sometimes_pass)
 
@@ -334,6 +329,118 @@ async def test_early_success_does_not_lose_in_flight_slices(mocked_context_backe
     assert len(result.sample_generations) >= 1, (
         "the winning slice must be retained even after producer cancellation"
     )
+
+
+# --- Backend errors are surfaced, not swallowed ---
+
+
+async def test_backend_exception_is_reraised_when_no_slices():
+    """A backend generation error should propagate when no generate request was successful."""
+
+    class _BackendGenerateException(RuntimeError):
+        pass
+
+    backend = Mock()
+
+    async def raising_generate(*_args, **_kwargs):
+        raise _BackendGenerateException("backend failed")
+
+    backend.generate_from_context = raising_generate
+
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=1, concurrency_budget=1)
+
+    with pytest.raises(_BackendGenerateException, match="backend failed"):
+        await strategy.sample(
+            action=Instruction(description=""),
+            context=ChatContext(),
+            backend=backend,
+            requirements=[always_pass],
+        )
+
+
+async def test_backend_exception_with_concurrency_propagates():
+    """With concurrency_budget > 1, a backend error in every subsample still propagates."""
+
+    class _BackendGenerateException(RuntimeError):
+        pass
+
+    backend = Mock()
+
+    async def raising_generate(*_args, **_kwargs):
+        raise _BackendGenerateException("concurrent boom")
+
+    backend.generate_from_context = raising_generate
+
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=2, concurrency_budget=3)
+
+    with pytest.raises(_BackendGenerateException, match="concurrent boom"):
+        await strategy.sample(
+            action=Instruction(description=""),
+            context=ChatContext(),
+            backend=backend,
+            requirements=[always_pass],
+        )
+
+
+async def test_backend_exception_does_not_mask_concurrent_success():
+    """If one subsample raises but another produces a successful slice, sample()
+    should return the success rather than re-raising.
+
+    The re-raise path only fires when no slices made it through; a real success
+    from a sibling subsample must not be masked by a peer's backend error.
+    """
+
+    class _BackendGenerateException(RuntimeError):
+        pass
+
+    call_count = 0
+    backend = Mock()
+
+    async def sometimes_raising_generate(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # First call raises; subsequent calls return a normal successful generation.
+        # Sleep a touch so the raising producer has a chance to fail before the
+        # other subsample yields its slice.
+        if call_count == 1:
+            await asyncio.sleep(0.01)
+            raise _BackendGenerateException("first call failed")
+        await asyncio.sleep(0.05)
+        action = args[0] if args else kwargs["action"]
+        ctx = kwargs["ctx"]
+        output = ModelOutputThunk("mocked")
+        output._generate_log = GenerateLog()
+        return output, ctx.add(action).add(output)
+
+    backend.generate_from_context = sometimes_raising_generate
+
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=1, concurrency_budget=3)
+
+    try:
+        result = await strategy.sample(
+            action=Instruction(description=""),
+            context=ChatContext(),
+            backend=backend,
+            requirements=[always_pass],
+        )
+    except _BackendGenerateException:
+        pytest.fail(
+            "subsample peer raised an exception and prevented a successful sample from being returned"
+        )
+
+    assert result.success is True, (
+        "subsample peer raised an exception and prevented result from being successful"
+    )
+    assert len(result.sample_generations) >= 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes N/A; builds on previously closed PR (https://github.com/generative-computing/mellea/pull/240)

## Description
<!-- What does this PR do and why? -->
Adds concurrency to our base sampling strategy. We lacked a way to concurrently sample and were only able to sample iteratively. The `sample()` now manages distinct generators. `subsample_iteration` replaces the actual sampling code that was previously in `sample()`.

The total number of sampling iterations is now loop_budget * concurrency_budget. Concurrency budget is the breadth of the tree, loop_budget is the depth of the tree. At any time only concurrency_budget number of sampling iterations are running.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used; marked in commit

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
