### PR TITLE
feat: dispatch release event to mellea-contribs

### DIFF
--- a/.github/workflows/dispatch-to-contribs.yml
+++ b/.github/workflows/dispatch-to-contribs.yml
@@ -24,7 +24,7 @@ jobs:
         if: github.event_name == 'release' && github.event.release.prerelease == true
         run: |
           echo "Skipping pre-release ${GITHUB_REF}; dispatch only fires on stable releases."
-          echo "SKIP=true" >> $GITHUB_ENV
+          echo "SKIP=true" >> "$GITHUB_ENV"
 
       - name: Resolve version
         if: env.SKIP != 'true'
@@ -35,7 +35,7 @@ jobs:
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Dispatching mellea-released event to contribs with version=${VERSION}"
 
       - name: Mint GitHub App token

--- a/.github/workflows/dispatch-to-contribs.yml
+++ b/.github/workflows/dispatch-to-contribs.yml
@@ -1,0 +1,59 @@
+name: "Dispatch release event to mellea-contribs"
+
+# Sends a repository_dispatch event to mellea-contribs whenever a stable
+# mellea release is published. The contribs-side worker workflow listens
+# for `mellea-released` events and does the real work (bumps every
+# pyproject.toml's version + mellea>= constraint, opens a PR).
+#
+# This workflow is intentionally tiny — its only job is to dispatch.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Mellea version to dispatch to contribs (manual / recovery)"
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip pre-releases
+        if: github.event_name == 'release' && github.event.release.prerelease == true
+        run: |
+          echo "Skipping pre-release ${GITHUB_REF}; dispatch only fires on stable releases."
+          echo "SKIP=true" >> $GITHUB_ENV
+
+      - name: Resolve version
+        if: env.SKIP != 'true'
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Dispatching mellea-released event to contribs with version=${VERSION}"
+
+      - name: Mint GitHub App token
+        if: env.SKIP != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CONTRIBS_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.CONTRIBS_DISPATCHER_PRIVATE_KEY }}
+          owner: generative-computing
+          repositories: mellea-contribs
+
+      - name: Dispatch to mellea-contribs
+        if: env.SKIP != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/generative-computing/mellea-contribs/dispatches \
+            --method POST \
+            --field event_type=mellea-released \
+            --field 'client_payload[version]=${{ steps.version.outputs.version }}'


### PR DESCRIPTION
## Summary

Adds a workflow that fires a `repository_dispatch` event (event_type=`mellea-released`) to `generative-computing/mellea-contribs` whenever a stable mellea GitHub Release is published. The contribs receiver bumps every subpackage's `mellea>=` constraint and `project.version`, refreshes lock files, and opens a PR there — see https://github.com/generative-computing/mellea-contribs/pull/63 for that side.

Pre-releases are skipped — only stable releases dispatch.

## Files

- `.github/workflows/dispatch-to-contribs.yml` — fires on `release: published` (skipping pre-releases) and supports `workflow_dispatch` for manual recovery. Authenticates to mellea-contribs via a GitHub App; mints a short-lived installation token at runtime.

## Required setup before this lands (Setup done using `mellea-nightly` app)

This workflow authenticates to `mellea-contribs` via a **GitHub App**. One-time setup by an org admin:

1. **Create a GitHub App** under the `generative-computing` org:
   - Settings → Developer settings → GitHub Apps → New GitHub App
   - Name: e.g. `mellea-contribs-dispatcher`
   - Homepage URL: any (e.g. the mellea repo URL)
   - Webhook: **disable** (no webhook needed)
   - **Repository permissions:** `Contents: Read and write`, `Metadata: Read-only`
   - **Where can this App be installed:** Only on this account
2. **Generate a private key** for the App (download the `.pem` file).
3. **Install the App** on `generative-computing/mellea-contribs` only.
4. **Add two repo secrets** to `generative-computing/mellea` (this repo):
   - `CONTRIBS_DISPATCHER_APP_ID` — the App's numeric App ID (visible on the App settings page)
   - `CONTRIBS_DISPATCHER_PRIVATE_KEY` — the contents of the downloaded `.pem` file (paste as-is, including header/footer lines)

If either secret is missing or the App isn't installed on contribs when the workflow fires, the `actions/create-github-app-token` step fails loudly and contribs stays unchanged. The manual `workflow_dispatch` is the recovery path once setup is fixed.

## Testing

The contribs receiver was sandbox-tested independently. End-to-end (release → dispatch → contribs PR) will be exercised on the next stable mellea release; manual recovery is the documented escape hatch:

```bash
gh workflow run dispatch-to-contribs.yml \
  -R generative-computing/mellea \
  -f version=<actual-mellea-version>
```

## Status

Opened as **draft** until the GitHub App is set up and secrets are configured. Will be marked ready for review after that.

The receiver in contribs (PR #63) is safe to land independently.