### PR TITLE
test(backends): fix vision Ollama tests failing in CI with 400 model does not support vision (#1185)

### DIFF
--- a/test/backends/conftest.py
+++ b/test/backends/conftest.py
@@ -1,0 +1,42 @@
+"""Shared fixtures for backend tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mellea.backends.ollama import OllamaModelBackend
+
+
+@pytest.fixture
+def mock_ollama_backend():
+    """Factory fixture: returns an OllamaModelBackend with all network calls patched out.
+
+    No live Ollama server or pulled model is required. The returned backend has
+    real client objects replaced with MagicMocks, so subsequent tests can set
+    attributes such as ``backend._async_client.chat`` to control behaviour.
+
+    Usage::
+
+        def test_something(mock_ollama_backend):
+            backend = mock_ollama_backend(model_options={ModelOption.MAX_NEW_TOKENS: 5})
+            backend._async_client.chat = AsyncMock(return_value=canned_response)
+    """
+
+    def _make(
+        model_id: str = "granite4.1:3b",
+        model_options: dict | None = None,
+        timeout: float | None = None,
+    ) -> OllamaModelBackend:
+        with (
+            patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+            patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+            patch("mellea.backends.ollama.ollama.Client", return_value=MagicMock()),
+            patch(
+                "mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()
+            ),
+        ):
+            return OllamaModelBackend(
+                model_id=model_id, model_options=model_options, timeout=timeout
+            )
+
+    return _make

--- a/test/backends/conftest.py
+++ b/test/backends/conftest.py
@@ -19,7 +19,15 @@ def mock_ollama_backend():
 
         def test_something(mock_ollama_backend):
             backend = mock_ollama_backend(model_options={ModelOption.MAX_NEW_TOKENS: 5})
-            backend._async_client.chat = AsyncMock(return_value=canned_response)
+            # _async_client is an event-loop-keyed property; instance assignment won't
+            # override it for tests that call through _run_async_in_thread.  Patch at
+            # the class level instead:
+            mock_async = MagicMock()
+            mock_async.chat = AsyncMock(return_value=canned_response)
+            with patch.object(
+                type(backend), "_async_client", new_callable=PropertyMock, return_value=mock_async
+            ):
+                yield MelleaSession(backend)
     """
 
     def _make(

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -15,25 +15,10 @@ from mellea.core import CBlock, ModelOutputThunk
 from mellea.stdlib.context import SimpleContext
 
 
-def _make_backend(
-    model_options: dict | None = None, timeout: float | None = None
-) -> OllamaModelBackend:
-    """Return an OllamaModelBackend with all network calls patched."""
-    with (
-        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
-        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
-        patch("mellea.backends.ollama.ollama.Client", return_value=MagicMock()),
-        patch("mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()),
-    ):
-        return OllamaModelBackend(
-            model_id="granite3.3:8b", model_options=model_options, timeout=timeout
-        )
-
-
 @pytest.fixture
-def backend():
+def backend(mock_ollama_backend):
     """Return an OllamaModelBackend with no pre-set model options."""
-    return _make_backend()
+    return mock_ollama_backend(model_id="granite3.3:8b")
 
 
 # --- Map consistency ---
@@ -73,9 +58,11 @@ def test_simplify_and_merge_remaps_num_predict(backend):
     assert result[ModelOption.MAX_NEW_TOKENS] == 128
 
 
-def test_simplify_and_merge_per_call_overrides_backend():
+def test_simplify_and_merge_per_call_overrides_backend(mock_ollama_backend):
     # Backend sets num_predict=128; per-call value of 256 must win.
-    b = _make_backend(model_options={"num_predict": 128})
+    b = mock_ollama_backend(
+        model_id="granite3.3:8b", model_options={"num_predict": 128}
+    )
     result = b._simplify_and_merge({"num_predict": 256})
     assert result[ModelOption.MAX_NEW_TOKENS] == 256
 
@@ -189,9 +176,9 @@ def test_timeout_forwarded_to_sync_and_async_clients():
     assert async_kwargs.get("timeout") == 12.5
 
 
-def test_timeout_forwarded_to_new_async_clients_per_event_loop():
+def test_timeout_forwarded_to_new_async_clients_per_event_loop(mock_ollama_backend):
     """Newly created AsyncClients (one per event loop) must inherit the timeout."""
-    backend = _make_backend(timeout=7.0)
+    backend = mock_ollama_backend(model_id="granite3.3:8b", timeout=7.0)
     with patch(
         "mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()
     ) as mock_async_client:

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -1,51 +1,60 @@
+"""Tests for Ollama backend vision (image) support.
+
+Three tiers:
+
+1. **Construction** (unit) — pure ImageBlock logic, no backend or server required.
+2. **Structural payload** (unit, mocked) — verify mellea correctly embeds images
+   into the Ollama conversation payload. The Ollama transport is mocked so no
+   server or vision model is needed. Runs in CI unconditionally.
+3. **Dormant live e2e** (e2e, qualitative) — full round-trip against a real
+   vision-capable Ollama model. Skipped today because granite-vision-4.1 is not
+   yet in the Ollama library. Reactivates automatically once the model is pulled.
+   See #1187 for the activation checklist.
+"""
+
 import base64
+import os
 from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import numpy as np
+import ollama
 import pytest
 from PIL import Image
 
-# Mark all tests in this module as requiring Ollama with vision support
-pytestmark = [pytest.mark.ollama, pytest.mark.e2e]
-
-from mellea import MelleaSession, start_session
-from mellea.backends import ModelOption, model_ids
+from mellea import MelleaSession
+from mellea.backends import ModelOption
 from mellea.core import ImageBlock, ModelOutputThunk
 from mellea.stdlib.components import Instruction, Message
 
+# Ollama name for the target vision model; bump to the model_ids constant once
+# IBM_GRANITE_VISION_4_1_4B is added to mellea/backends/model_ids.py.
+_VISION_MODEL = "granite-vision-4.1"
+_SKIP_REASON = (
+    f"Vision model {_VISION_MODEL!r} not available in Ollama — "
+    "see https://github.com/generative-computing/mellea/issues/1187"
+)
 
-@pytest.fixture(scope="module")
-def m_session(gh_run):
-    if gh_run == 1:
-        m = start_session(model_options={ModelOption.MAX_NEW_TOKENS: 5})
-    else:
-        m = start_session(
-            "ollama",
-            model_id="granite3.2-vision",
-            model_options={ModelOption.MAX_NEW_TOKENS: 5},
-        )
-    yield m
-    del m
+
+# ── Shared image fixture ──────────────────────────────────────────────────────
 
 
 @pytest.fixture(scope="module")
 def pil_image():
-    width = 200
-    height = 150
-    random_pixel_data = np.random.randint(
-        0, 256, size=(height, width, 3), dtype=np.uint8
-    )
-    random_image = Image.fromarray(random_pixel_data, "RGB")
-    yield random_image
-    del random_image
+    rng = np.random.default_rng(seed=42)
+    data = rng.integers(0, 256, size=(150, 200, 3), dtype=np.uint8)
+    img = Image.fromarray(data, "RGB")
+    yield img
+    del img
+
+
+# ── Tier 1: Construction tests (unit, no server) ──────────────────────────────
 
 
 def test_image_block_construction(pil_image: Image.Image):
-    # create base64 PNG string from image:
     buffered = BytesIO()
     pil_image.save(buffered, format="PNG")
     img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
-
     image_block = ImageBlock(img_str)
     assert isinstance(image_block, ImageBlock)
     assert isinstance(image_block.value, str)
@@ -58,104 +67,172 @@ def test_image_block_construction_from_pil(pil_image: Image.Image):
     assert ImageBlock.is_valid_base64_png(str(image_block))
 
 
+# ── Tier 2: Structural payload tests (unit, offline mock) ────────────────────
+#
+# Verify that mellea correctly embeds ImageBlock instances into the Ollama
+# conversation payload — the images=[...] field on the outgoing message dict.
+# The Ollama transport (OllamaModelBackend._async_client.chat) is replaced with
+# an AsyncMock so post_processing runs and populates _generate_log.prompt
+# without making any network call.  No server, no vision model required.
+
+
+@pytest.fixture
+def mocked_session(mock_ollama_backend):
+    canned = ollama.ChatResponse(
+        model="granite4.1:3b",
+        created_at=None,
+        message=ollama.Message(role="assistant", content="no"),
+        done=True,
+    )
+    mock_async = MagicMock()
+    mock_async.chat = AsyncMock(return_value=canned)
+    backend = mock_ollama_backend(model_options={ModelOption.MAX_NEW_TOKENS: 5})
+    # _async_client is an event-loop-keyed property; mock it at the class level so
+    # the same mock is returned regardless of which event loop _run_async_in_thread
+    # creates in the background thread.
+    with patch.object(
+        type(backend),
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_async,
+    ):
+        yield MelleaSession(backend)
+
+
 def test_image_block_in_instruction(
-    m_session: MelleaSession, pil_image: Image.Image, gh_run: int
+    mocked_session: MelleaSession, pil_image: Image.Image
 ):
     image_block = ImageBlock.from_pil_image(pil_image)
 
-    # Set strategy=None here since we are directly comparing the object and sampling strategies tend to do a deepcopy.
-    instr = m_session.instruct(
+    instr = mocked_session.instruct(
         "Is this image mainly blue? Answer yes or no.",
         images=[image_block],
         strategy=None,
     )
     assert isinstance(instr, ModelOutputThunk)
 
-    # if not on GH
-    if not gh_run == 1:
-        assert "yes" in instr.value.lower() or "no" in instr.value.lower()  # type: ignore
-
-    # make sure you get the last action
-    turn = m_session.ctx.last_turn()
+    turn = mocked_session.ctx.last_turn()
     assert turn is not None
     last_action = turn.model_input
     assert isinstance(last_action, Instruction)
-    assert len(last_action._images) > 0  # type: ignore
+    assert last_action._images is not None  # type: ignore[union-attr]
+    assert len(last_action._images) > 0  # type: ignore[union-attr]
+    assert last_action._images[0] == image_block  # type: ignore[union-attr]
 
-    # first image in image list should be the same as the image block
-    image0 = last_action._images[0]  # type: ignore
-    assert image0 == image_block
-
-    # get prompt message
-    lp = turn.output._generate_log.prompt  # type: ignore
+    lp = turn.output._generate_log.prompt  # type: ignore[union-attr]
     assert isinstance(lp, list)
     assert len(lp) == 1
-
-    # prompt message is a dict
     prompt_msg = lp[0]
     assert isinstance(prompt_msg, dict)
 
-    # ### OLLAMA SPECIFIC TEST ####
-
-    # get content
-    image_list = prompt_msg.get("images", None)
+    # Ollama-specific: images are embedded as a top-level list on the message dict.
+    image_list = prompt_msg.get("images")
     assert isinstance(image_list, list)
     assert len(image_list) == 1
-
-    # get the image content
-    content_img = image_list[0]
-    assert isinstance(content_img, str)
-
-    # check that the image is the same
-    assert content_img == str(image_block)
+    assert image_list[0] == str(image_block)
 
 
-def test_image_block_in_chat(
-    m_session: MelleaSession, pil_image: Image.Image, gh_run: int
-):
-    ct = m_session.chat(
+def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Image):
+    ct = mocked_session.chat(
         "Is this image mainly blue? Answer yes or no.", images=[pil_image]
     )
     assert isinstance(ct, Message)
 
-    # if not on GH
-    if not gh_run == 1:
-        assert "yes" in ct.content.lower() or "no" in ct.content.lower()
-
-    # make sure you get the last action
-    turn = m_session.ctx.last_turn()
+    turn = mocked_session.ctx.last_turn()
     assert turn is not None
     last_action = turn.model_input
     assert isinstance(last_action, Message)
-    assert len(last_action.images) > 0  # type: ignore
+    assert last_action.images is not None  # type: ignore[union-attr]
+    assert len(last_action.images) > 0  # type: ignore[union-attr]
+    assert last_action.images[0] == ImageBlock.from_pil_image(pil_image).value  # type: ignore[union-attr]
 
-    # first image in image list should be the same as the image block
-    image0_str = last_action.images[0]  # type: ignore
-    assert image0_str == ImageBlock.from_pil_image(pil_image).value
-
-    # get prompt message
-    lp = turn.output._generate_log.prompt  # type: ignore
+    lp = turn.output._generate_log.prompt  # type: ignore[union-attr]
     assert isinstance(lp, list)
     assert len(lp) == 1
-
-    # prompt message is a dict
     prompt_msg = lp[0]
     assert isinstance(prompt_msg, dict)
 
-    # ### OLLAMA SPECIFIC TEST ####
-
-    # get content
-    image_list = prompt_msg.get("images", None)
+    image_list = prompt_msg.get("images")
     assert isinstance(image_list, list)
     assert len(image_list) == 1
+    assert image_list[0] == str(ImageBlock.from_pil_image(pil_image))
 
-    # get the image content
-    content_img = image_list[0]
-    assert isinstance(content_img, str)
 
-    # check that the image is the same
-    assert content_img == str(ImageBlock.from_pil_image(pil_image))
+# ── Tier 3: Dormant live e2e ──────────────────────────────────────────────────
+#
+# Full round-trip against a real vision-capable Ollama model.  Currently skipped
+# because granite-vision-4.1 is not yet in the Ollama library.
+#
+# To activate: ensure `ollama pull granite-vision-4.1` succeeds, then remove the
+# pytest.skip() call from vision_session below and add the model to the CI pull
+# step in .github/workflows/quality.yml.  See #1187 for the full checklist.
+
+
+def _ollama_vision_model_available() -> bool:
+    """Return True if _VISION_MODEL is present in the local Ollama model list."""
+    import requests
+
+    host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
+    if ":" in host:
+        host, port = host.rsplit(":", 1)
+    else:
+        port = os.environ.get("OLLAMA_PORT", "11434")
+    base_url = f"http://{host}:{port}"
+    try:
+        resp = requests.get(f"{base_url}/api/tags", timeout=5)
+        resp.raise_for_status()
+        pulled = {m.get("name", "") for m in resp.json().get("models", [])}
+        return any(_VISION_MODEL in name for name in pulled)
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def vision_session():
+    pytest.skip(_SKIP_REASON)  # remove once granite-vision-4.1 lands on Ollama (#1187)
+
+    if not _ollama_vision_model_available():
+        pytest.skip(_SKIP_REASON)
+
+    from mellea import start_session
+
+    m = start_session(
+        "ollama", model_id=_VISION_MODEL, model_options={ModelOption.MAX_NEW_TOKENS: 5}
+    )
+    yield m
+    del m
+
+
+@pytest.mark.e2e
+@pytest.mark.ollama
+@pytest.mark.qualitative
+def test_vision_instruct_live_e2e(
+    vision_session: MelleaSession, pil_image: Image.Image
+):
+    """Live vision instruct round-trip; skips until granite-vision-4.1 lands on Ollama."""
+    image_block = ImageBlock.from_pil_image(pil_image)
+    instr = vision_session.instruct(
+        "Is this image mainly blue? Answer yes or no.",
+        images=[image_block],
+        strategy=None,
+    )
+    assert isinstance(instr, ModelOutputThunk)
+    assert instr.value is not None
+    assert len(str(instr.value)) > 0
+
+
+@pytest.mark.e2e
+@pytest.mark.ollama
+@pytest.mark.qualitative
+def test_vision_chat_live_e2e(vision_session: MelleaSession, pil_image: Image.Image):
+    """Live vision chat round-trip; skips until granite-vision-4.1 lands on Ollama."""
+    ct = vision_session.chat(
+        "Is this image mainly blue? Answer yes or no.", images=[pil_image]
+    )
+    assert isinstance(ct, Message)
+    assert ct.content is not None
+    assert len(ct.content) > 0
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__, "-v"])

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -133,6 +133,7 @@ def test_image_block_in_instruction(
 
 
 def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Image):
+    image_block = ImageBlock.from_pil_image(pil_image)
     ct = mocked_session.chat(
         "Is this image mainly blue? Answer yes or no.", images=[pil_image]
     )
@@ -144,7 +145,7 @@ def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Ima
     assert isinstance(last_action, Message)
     assert last_action.images is not None  # type: ignore[union-attr]
     assert len(last_action.images) > 0  # type: ignore[union-attr]
-    assert last_action.images[0] == ImageBlock.from_pil_image(pil_image).value  # type: ignore[union-attr]
+    assert last_action.images[0] == image_block.value  # type: ignore[union-attr]
 
     lp = turn.output._generate_log.prompt  # type: ignore[union-attr]
     assert isinstance(lp, list)
@@ -155,7 +156,7 @@ def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Ima
     image_list = prompt_msg.get("images")
     assert isinstance(image_list, list)
     assert len(image_list) == 1
-    assert image_list[0] == str(ImageBlock.from_pil_image(pil_image))
+    assert image_list[0] == str(image_block)
 
 
 # ── Tier 3: Dormant live e2e ──────────────────────────────────────────────────
@@ -189,8 +190,6 @@ def _ollama_vision_model_available() -> bool:
 
 @pytest.fixture
 def vision_session():
-    pytest.skip(_SKIP_REASON)  # remove once granite-vision-4.1 lands on Ollama (#1187)
-
     if not _ollama_vision_model_available():
         pytest.skip(_SKIP_REASON)
 


### PR DESCRIPTION
<!-- PR_TEMPLATE_START -->
## Summary

Two vision tests — `test_image_block_in_instruction` and `test_image_block_in_chat` — have been silently broken in CI. The fixture used `start_session("ollama")` with no model, which defaulted to `granite4.1:3b`. Sending an image to a text-only model gets a `400 model does not support vision`, which means `post_processing` never ran and the image-embedding assertions were never reached. The tests appeared to pass (or skip gracefully) while doing nothing useful.

The deeper issue: there was no way to construct an `OllamaModelBackend` without a live server. This PR fixes that, then fixes the tests on top of it.

## What changed

**`test/backends/conftest.py`** (new) — a shared `mock_ollama_backend` fixture that patches all four server-touching points in `__init__` and returns a fully constructed backend offline. Other tests can now reuse this instead of rolling their own patch blocks.

**`test/backends/test_vision_ollama.py`** (rewrite) — three tiers:

- **Construction**: pure `ImageBlock` logic, no backend. Module-level `e2e`/`ollama` markers removed; runs as a plain unit test.
- **Structural payload**: verifies that `images=[...]` lands correctly in the Ollama message dict. Uses the offline fixture with `_async_client` patched via `PropertyMock` at the class level — required because the property is event-loop-keyed and a simple instance attribute is bypassed when `_run_async_in_thread` spins up a background thread. Runs in CI with no server, no vision model.
- **Dormant e2e**: full round-trip against `granite-vision-4.1`, skipped until the model appears in the Ollama library. The skip gate clears automatically once `ollama pull granite-vision-4.1` works. Activation checklist in #1187.

**`test/backends/test_ollama_unit.py`** (refactor) — swapped the private `_make_backend()` helper for the shared fixture. No behaviour change.

## Notes

Closes #1185. Dormant e2e tracked in #1187.

`test/backends/test_vision_openai.py` has the same structural gap (assertions hidden behind `qualitative` + `xfail`). Worth a follow-up.

## Testing

```bash
# No Ollama server running:
uv run pytest test/backends/test_vision_ollama.py -v
# 4 passed, 2 skipped (dormant e2e)

uv run pytest test/backends/test_ollama_unit.py -v
# 18 passed
```

CI: quality matrix green on 3.11, 3.12, 3.13.
<!-- PR_TEMPLATE_END -->