### PR TITLE
test(formatters): remove Hub download from test_read_yaml

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -532,12 +532,6 @@ def test_read_yaml():
     # Read from local disk
     IntrinsicsRewriter(config_file=_INPUT_YAML_DIR / "answerability.yaml")
 
-    # Read from Hugging Face hub.
-    local_path = intrinsics_util.obtain_io_yaml(
-        "answerability", "granite-4.0-micro", _RAG_INTRINSICS_REPO_NAME
-    )
-    IntrinsicsRewriter(config_file=local_path)
-
 
 def test_name_field_accepted_by_make_config_dict():
     """make_config_dict accepts 'name' as an optional field without error."""


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1193

## Description

The Hub call at the end of `test_read_yaml` was out of scope for a test whose docstring says "verify that reading a model's YAML file from disk works". It made the test dependent on HuggingFace Hub availability and caused intermittent CI failures when the Hub ref-resolution API returned 429 — the Hub client couldn't fall back to a local cache because CI has no cached snapshot for the default `revision="main"` resolution.

Removing those lines makes the test purely disk-based, matching its stated purpose. The Hub download path is already exercised by the `test_canned_input` combo fixtures when Hub is accessible.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool