### PR TITLE
test(formatters): skip combo fixtures gracefully when Hub returns 429

### DIFF
--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -537,9 +537,12 @@ def test_read_yaml():
     IntrinsicsRewriter(config_file=_INPUT_YAML_DIR / "answerability.yaml")
 
     # Read from Hugging Face hub.
-    local_path = intrinsics_util.obtain_io_yaml(
-        "answerability", "granite-4.0-micro", _RAG_INTRINSICS_REPO_NAME
-    )
+    try:
+        local_path = intrinsics_util.obtain_io_yaml(
+            "answerability", "granite-4.0-micro", _RAG_INTRINSICS_REPO_NAME
+        )
+    except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
+        pytest.skip(f"HuggingFace Hub not accessible: {e}")
     IntrinsicsRewriter(config_file=local_path)
 
 

--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -155,7 +155,7 @@ class YamlJsonCombo(pydantic.BaseModel):
                     revision=self.revision,  # type: ignore
                 )
             except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
-                pytest.skip(f"HuggingFace Hub not accessible: {e}")
+                pytest.skip(f"HuggingFace Hub not accessible: {type(e).__name__}: {e}")
         return self
 
 
@@ -542,7 +542,7 @@ def test_read_yaml():
             "answerability", "granite-4.0-micro", _RAG_INTRINSICS_REPO_NAME
         )
     except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
-        pytest.skip(f"HuggingFace Hub not accessible: {e}")
+        pytest.skip(f"HuggingFace Hub not accessible: {type(e).__name__}: {e}")
     IntrinsicsRewriter(config_file=local_path)
 
 

--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -18,6 +18,7 @@ import openai
 import pydantic
 import pytest
 import requests
+from huggingface_hub.errors import LocalEntryNotFoundError
 
 torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
 import yaml
@@ -146,12 +147,15 @@ class YamlJsonCombo(pydantic.BaseModel):
         object. Called at fixture creation (execution time) to prevent collection time errors.
         """
         if not self.yaml_file:
-            self.yaml_file = intrinsics_util.obtain_io_yaml(
-                self.task,
-                self.base_model_id,
-                self.repo_id,
-                revision=self.revision,  # type: ignore
-            )
+            try:
+                self.yaml_file = intrinsics_util.obtain_io_yaml(
+                    self.task,
+                    self.base_model_id,
+                    self.repo_id,
+                    revision=self.revision,  # type: ignore
+                )
+            except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
+                pytest.skip(f"HuggingFace Hub not accessible: {e}")
         return self
 
 

--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -18,10 +18,10 @@ import openai
 import pydantic
 import pytest
 import requests
-from huggingface_hub.errors import LocalEntryNotFoundError
 
 torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
 import yaml
+from huggingface_hub.errors import LocalEntryNotFoundError
 
 # First Party
 from mellea.formatters.granite import (


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1193

## Description

When `obtain_io_yaml(..., revision="main")` is called, `huggingface_hub` first hits the Hub ref-resolution endpoint (`/api/models/{repo}/revision/main`) to resolve the branch tip to a commit SHA. Under load, this endpoint returns 429. With no local snapshot cached for the failed revision, the library raises `LocalEntryNotFoundError` — and because this happens inside pytest fixture setup (`_resolve_yaml()`), a single 429 produces ERROR entries for every test that depends on that fixture (~66 on a bad Hub day). That swamps CI output and masks real failures.

Two changes:

1. **`_resolve_yaml()`** — wrap `obtain_io_yaml` in a `try/except (LocalEntryNotFoundError, requests.exceptions.RequestException)` and call `pytest.skip()`. Each fixture that needs Hub will skip cleanly when Hub is unavailable instead of hard-erroring and cascading.

2. **`test_read_yaml`** — apply the same guard to its direct `obtain_io_yaml` call, so a Hub outage produces a skip rather than a CI-breaking FAIL.

Together these mean: Hub unavailability → skips, never failures. CI only fails on real test breakage. Matches the pattern already used by `test_adapter_versions_unchanged`, which "silently tolerates network/auth failures so this test doesn't false-fail when run offline".

Skip messages include the exception class name for easier triage, e.g.:

    SKIPPED - HuggingFace Hub not accessible: LocalEntryNotFoundError: An error happened while trying to locate the files on the Hub...

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
