### PR TITLE
test: centralise HF Hub skip guard to boost CI resiliency against 429 errors

### DIFF
--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -47,6 +47,7 @@ from mellea.stdlib import functional as mfuncs
 from mellea.stdlib.components import Intrinsic, Message
 from mellea.stdlib.context import ChatContext, SimpleContext
 from mellea.stdlib.requirements import ALoraRequirement, LLMaJRequirement
+from test.conftest import hf_skip
 
 
 @pytest.fixture(scope="module")
@@ -59,15 +60,16 @@ def backend():
     against this granite-3.3 backend will fail once revision pinning is wired through
     in phase-2.2 (#1141). Other intrinsics are not affected.
     """
-    backend = LocalHFBackend(
-        model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5)
-    )
-    backend.add_adapter(
-        IntrinsicAdapter("requirement-check", base_model_name=backend.base_model_name)
-    )
-    backend.add_adapter(
-        IntrinsicAdapter("answerability", base_model_name=backend.base_model_name)
-    )
+    with hf_skip():
+        backend = LocalHFBackend(
+            model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5)
+        )
+        backend.add_adapter(
+            IntrinsicAdapter("requirement-check", base_model_name=backend.base_model_name)
+        )
+        backend.add_adapter(
+            IntrinsicAdapter("answerability", base_model_name=backend.base_model_name)
+        )
     yield backend
 
     from test.conftest import cleanup_gpu_backend

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -65,7 +65,9 @@ def backend():
             model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5)
         )
         backend.add_adapter(
-            IntrinsicAdapter("requirement-check", base_model_name=backend.base_model_name)
+            IntrinsicAdapter(
+                "requirement-check", base_model_name=backend.base_model_name
+            )
         )
         backend.add_adapter(
             IntrinsicAdapter("answerability", base_model_name=backend.base_model_name)

--- a/test/backends/test_huggingface_tools.py
+++ b/test/backends/test_huggingface_tools.py
@@ -25,14 +25,16 @@ from mellea.backends import ModelOption
 from mellea.backends.cache import SimpleLRUCache
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.stdlib.context import ChatContext
+from test.conftest import hf_skip
 
 
 @pytest.fixture(scope="module")
 def backend():
     """Shared HuggingFace backend for all tests in this module."""
-    backend = LocalHFBackend(
-        model_id=model_ids.MISTRALAI_MISTRAL_0_3_7B, cache=SimpleLRUCache(5)
-    )
+    with hf_skip():
+        backend = LocalHFBackend(
+            model_id=model_ids.MISTRALAI_MISTRAL_0_3_7B, cache=SimpleLRUCache(5)
+        )
     # add_granite_aloras(backend)
     yield backend
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import gc
 import os
 import subprocess
@@ -8,6 +9,30 @@ import pytest
 import requests
 
 from mellea.core import MelleaLogger
+
+# ============================================================================
+# HuggingFace Hub Skip Helper
+# ============================================================================
+
+
+@contextlib.contextmanager
+def hf_skip():
+    """Skip the current test/fixture when a HuggingFace Hub call fails.
+
+    Catches OSError (covers HfHubHTTPError, LocalEntryNotFoundError, and
+    transformers-wrapped Hub errors) plus requests network errors.  Use this
+    in every fixture that downloads model weights or YAML files from the Hub
+    so a 429 or transient network blip results in a clean skip rather than an
+    ERROR that masks unrelated failures.
+    """
+    try:
+        yield
+    except (OSError, requests.exceptions.RequestException) as e:
+        pytest.skip(
+            f"HuggingFace Hub not accessible: {type(e).__name__}: {e}",
+            allow_module_level=True,
+        )
+
 
 # Try to import optional dependencies for system detection
 try:

--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -21,7 +21,6 @@ import requests
 
 torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
 import yaml
-from huggingface_hub.errors import LocalEntryNotFoundError
 
 # First Party
 from mellea.formatters.granite import (
@@ -32,6 +31,7 @@ from mellea.formatters.granite import (
 )
 from mellea.formatters.granite.base import util as base_util
 from mellea.formatters.granite.intrinsics import json_util, util as intrinsics_util
+from test.conftest import hf_skip
 
 
 def _read_file(name):
@@ -147,15 +147,13 @@ class YamlJsonCombo(pydantic.BaseModel):
         object. Called at fixture creation (execution time) to prevent collection time errors.
         """
         if not self.yaml_file:
-            try:
+            with hf_skip():
                 self.yaml_file = intrinsics_util.obtain_io_yaml(
                     self.task,
                     self.base_model_id,
                     self.repo_id,
                     revision=self.revision,  # type: ignore
                 )
-            except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
-                pytest.skip(f"HuggingFace Hub not accessible: {type(e).__name__}: {e}")
         return self
 
 
@@ -537,12 +535,10 @@ def test_read_yaml():
     IntrinsicsRewriter(config_file=_INPUT_YAML_DIR / "answerability.yaml")
 
     # Read from Hugging Face hub.
-    try:
+    with hf_skip():
         local_path = intrinsics_util.obtain_io_yaml(
             "answerability", "granite-4.0-micro", _RAG_INTRINSICS_REPO_NAME
         )
-    except (LocalEntryNotFoundError, requests.exceptions.RequestException) as e:
-        pytest.skip(f"HuggingFace Hub not accessible: {type(e).__name__}: {e}")
     IntrinsicsRewriter(config_file=local_path)
 
 

--- a/test/stdlib/components/docs/test_richdocument.py
+++ b/test/stdlib/components/docs/test_richdocument.py
@@ -11,6 +11,7 @@ from docling_core.types.doc.document import DoclingDocument
 import mellea
 from mellea.core import TemplateRepresentation
 from mellea.stdlib.components.docs.richdocument import RichDocument, Table
+from test.conftest import hf_skip
 from test.predicates import require_gpu
 
 pytestmark = pytest.mark.integration
@@ -20,13 +21,9 @@ pytestmark = pytest.mark.integration
 def rd() -> RichDocument:
     # Use a specific document so we can test some of the functionality
     # related to extracting and transforming text.
-    try:
+    with hf_skip():
         return RichDocument.from_document_file(
             "https://arxiv.org/pdf/1906.04043", do_ocr=False
-        )
-    except Exception as e:
-        pytest.skip(
-            f"HuggingFace Hub or network unavailable — {e}", allow_module_level=True
         )
 
 

--- a/test/stdlib/components/docs/test_richdocument.py
+++ b/test/stdlib/components/docs/test_richdocument.py
@@ -20,9 +20,14 @@ pytestmark = pytest.mark.integration
 def rd() -> RichDocument:
     # Use a specific document so we can test some of the functionality
     # related to extracting and transforming text.
-    return RichDocument.from_document_file(
-        "https://arxiv.org/pdf/1906.04043", do_ocr=False
-    )
+    try:
+        return RichDocument.from_document_file(
+            "https://arxiv.org/pdf/1906.04043", do_ocr=False
+        )
+    except Exception as e:
+        pytest.skip(
+            f"HuggingFace Hub or network unavailable — {e}", allow_module_level=True
+        )
 
 
 def test_richdocument_basics(rd: RichDocument):

--- a/test/stdlib/components/intrinsic/test_core.py
+++ b/test/stdlib/components/intrinsic/test_core.py
@@ -17,7 +17,7 @@ from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import core
 from mellea.stdlib.components.intrinsic._util import call_intrinsic
 from mellea.stdlib.context import ChatContext
-from test.conftest import cleanup_gpu_backend
+from test.conftest import cleanup_gpu_backend, hf_skip
 from test.predicates import require_gpu
 from test.stdlib.components.intrinsic.test_rag import (
     _read_input_json as _read_rag_input_json,
@@ -48,7 +48,8 @@ def _backend():
     # Prevent thrashing if the default device is CPU
     torch.set_num_threads(4)
 
-    backend_ = LocalHFBackend(model_id=BASE_MODEL)
+    with hf_skip():
+        backend_ = LocalHFBackend(model_id=BASE_MODEL)
     yield backend_
 
     # Code after yield is cleanup code.

--- a/test/stdlib/components/intrinsic/test_guardian.py
+++ b/test/stdlib/components/intrinsic/test_guardian.py
@@ -14,7 +14,7 @@ from mellea.backends.model_ids import IBM_GRANITE_4_MICRO_3B
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import guardian
 from mellea.stdlib.context import ChatContext
-from test.conftest import cleanup_gpu_backend
+from test.conftest import cleanup_gpu_backend, hf_skip
 from test.predicates import require_gpu
 
 # Skip entire module in CI since all tests are qualitative
@@ -37,7 +37,8 @@ def _backend():
     """Backend used by the tests in this file. Module-scoped to avoid reloading the model for each test."""
     torch.set_num_threads(4)
 
-    backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_MICRO_3B.hf_model_name)  # type: ignore
+    with hf_skip():
+        backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_MICRO_3B.hf_model_name)  # type: ignore
     yield backend_
 
     cleanup_gpu_backend(backend_, "test_guardian")

--- a/test/stdlib/components/intrinsic/test_rag.py
+++ b/test/stdlib/components/intrinsic/test_rag.py
@@ -15,6 +15,7 @@ from mellea.core import ModelOutputThunk
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.intrinsic import rag
 from mellea.stdlib.context import ChatContext
+from test.conftest import hf_skip
 from test.predicates import require_gpu
 
 # Skip entire module in CI since all 7 tests are qualitative
@@ -42,7 +43,8 @@ def _backend():
     torch.set_num_threads(4)
 
     # No adapters for hybrid version.
-    backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_1_3B.hf_model_name)
+    with hf_skip():
+        backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_1_3B.hf_model_name)
     yield backend_
 
     from test.conftest import cleanup_gpu_backend
@@ -57,7 +59,8 @@ def _backend_4_0():
     torch.set_num_threads(4)
 
     # No adapters for hybrid version.
-    backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_MICRO_3B.hf_model_name)
+    with hf_skip():
+        backend_ = LocalHFBackend(model_id=IBM_GRANITE_4_MICRO_3B.hf_model_name)
     yield backend_
 
     from test.conftest import cleanup_gpu_backend

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -15,7 +15,10 @@ from test.predicates import require_gpu
 @pytest.fixture
 def backend():
     """Provide HuggingFace backend for tests."""
-    return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
+    try:
+        return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
+    except Exception as e:
+        pytest.skip(f"HuggingFace Hub or network unavailable — {e}")
 
 
 @pytest.fixture

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -9,16 +9,15 @@ from mellea.core.base import ModelOutputThunk
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements.rag import GroundednessRequirement
+from test.conftest import hf_skip
 from test.predicates import require_gpu
 
 
 @pytest.fixture
 def backend():
     """Provide HuggingFace backend for tests."""
-    try:
+    with hf_skip():
         return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
-    except Exception as e:
-        pytest.skip(f"HuggingFace Hub or network unavailable — {e}")
 
 
 @pytest.fixture

--- a/test/stdlib/requirements/test_groundedness_requirement_e2e.py
+++ b/test/stdlib/requirements/test_groundedness_requirement_e2e.py
@@ -6,13 +6,15 @@ from mellea.backends.huggingface import LocalHFBackend
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements.rag import GroundednessRequirement
+from test.conftest import hf_skip
 from test.predicates import require_gpu
 
 
 @pytest.fixture(scope="session")
 def backend():
     """Provide HuggingFace backend for tests (session-scoped to avoid OOM)."""
-    return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
+    with hf_skip():
+        return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
 
 
 @pytest.fixture

--- a/test/stdlib/test_spans.py
+++ b/test/stdlib/test_spans.py
@@ -10,6 +10,7 @@ from mellea.backends.model_ids import IBM_GRANITE_4_1_3B
 from mellea.core import CBlock
 from mellea.stdlib.components import SimpleComponent
 from mellea.stdlib.session import MelleaSession, start_session
+from test.conftest import hf_skip
 from test.predicates import require_gpu
 
 # Module-level markers for all tests using Granite 4.1 3B model
@@ -19,11 +20,12 @@ pytestmark = [pytest.mark.huggingface, require_gpu(min_vram_gb=12), pytest.mark.
 # We edit the context type in the async tests below. Don't change the scope here.
 @pytest.fixture(scope="function")
 def m_session(gh_run):
-    m = start_session(
-        "hf",
-        model_id=IBM_GRANITE_4_1_3B,
-        model_options={ModelOption.MAX_NEW_TOKENS: 64},
-    )
+    with hf_skip():
+        m = start_session(
+            "hf",
+            model_id=IBM_GRANITE_4_1_3B,
+            model_options={ModelOption.MAX_NEW_TOKENS: 64},
+        )
     yield m
 
     from test.conftest import cleanup_gpu_backend

--- a/test/telemetry/test_metrics_backend.py
+++ b/test/telemetry/test_metrics_backend.py
@@ -16,6 +16,7 @@ from mellea.plugins.manager import (
 )
 from mellea.stdlib.components import Message
 from mellea.stdlib.context import SimpleContext
+from test.conftest import hf_skip
 from test.predicates import require_api_key, require_gpu
 
 # Check if OpenTelemetry is available
@@ -72,10 +73,11 @@ def hf_metrics_backend(gh_run):
     from mellea.backends.cache import SimpleLRUCache
     from mellea.backends.huggingface import LocalHFBackend
 
-    backend = LocalHFBackend(
-        model_id=IBM_GRANITE_4_1_3B.hf_model_name,  # type: ignore
-        cache=SimpleLRUCache(5),
-    )
+    with hf_skip():
+        backend = LocalHFBackend(
+            model_id=IBM_GRANITE_4_1_3B.hf_model_name,  # type: ignore
+            cache=SimpleLRUCache(5),
+        )
 
     yield backend
 


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary

CI was failing intermittently when HuggingFace Hub returned HTTP 429 (rate limit) or was temporarily unreachable: fixtures that called `LocalHFBackend()`, `start_session("hf", ...)`, `RichDocument.from_document_file()`, or `obtain_io_yaml()` without a guard would raise an unhandled `OSError` or `HfHubHTTPError`, erroring every dependent test in the module rather than skipping them cleanly. This masked unrelated failures and made CI noise harder to diagnose.

This PR adds a single `hf_skip()` context manager to `test/conftest.py` that catches `(OSError, requests.exceptions.RequestException)` — the two exception families that cover every Hub failure mode (direct `HfHubHTTPError`, `LocalEntryNotFoundError`, and transformers-internal wrappers that re-raise as `OSError`) — and converts them into a clean `pytest.skip`. It then applies this guard to all 11 fixtures across the test suite that were previously unprotected, and retrofits the two hand-rolled guards already in `test_intrinsics_formatters.py` to use the same helper, removing the now-redundant `LocalEntryNotFoundError` import.

**This PR does not address the underlying cause of 429 responses** — it makes no changes to production code, adds no retry logic, and provides no mitigation such as an authenticated Hub token. It purely ensures that Hub unavailability produces clean SKIPPED outcomes rather than ERROR noise.

## Changed files (test-only)

| File | Change |
|------|--------|
| `test/conftest.py` | Added `hf_skip()` context manager |
| `test/stdlib/components/docs/test_richdocument.py` | Apply `hf_skip()` |
| `test/stdlib/requirements/test_groundedness_requirement.py` | Apply `hf_skip()` |
| `test/stdlib/requirements/test_groundedness_requirement_e2e.py` | Apply `hf_skip()` |
| `test/stdlib/components/intrinsic/test_core.py` | Apply `hf_skip()` |
| `test/stdlib/components/intrinsic/test_guardian.py` | Apply `hf_skip()` |
| `test/stdlib/components/intrinsic/test_rag.py` | Apply `hf_skip()` (2 fixtures) |
| `test/backends/test_huggingface.py` | Apply `hf_skip()` (covers `add_adapter` Hub calls too) |
| `test/backends/test_huggingface_tools.py` | Apply `hf_skip()` |
| `test/telemetry/test_metrics_backend.py` | Apply `hf_skip()` alongside existing CI guard |
| `test/stdlib/test_spans.py` | Apply `hf_skip()` |
| `test/formatters/granite/test_intrinsics_formatters.py` | Retrofit to `hf_skip()`, remove `LocalEntryNotFoundError` import |

## Testing

- [ ] CI green on this branch (run when HF is reachable; tests pass normally)
- [ ] When HF is unavailable, affected fixtures show as SKIPPED rather than ERROR in pytest output

Closes #1198
<!-- PR_BODY_END -->