### PR TITLE
fix(backends): route ModelOption.THINKING=bool to chat_template_kwargs for vLLM

### DIFF
--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -45,6 +45,21 @@ class ModelOption:
     TEMPERATURE = "temperature"
     CONTEXT_WINDOW = "@@@context_window@@@"
     THINKING = "@@@thinking@@@"
+    """Enable or configure reasoning/thinking mode.
+
+    Accepted values:
+
+    * ``True`` — sets ``chat_template_kwargs.enable_thinking=True`` (vLLM,
+      Ollama OpenAI-compat) **and** ``reasoning_effort="medium"`` (OpenAI
+      o-series, DeepSeek). Use this to engage reasoning on vLLM-served models
+      such as Qwen3, Gemma 4, and GLM-4.5 — ``"medium"`` alone is silently
+      ignored by those servers.
+    * ``False`` — sets ``chat_template_kwargs.enable_thinking=False`` to
+      suppress the think block. ``reasoning_effort`` is not sent (passing
+      ``False`` would be an invalid value for OpenAI).
+    * ``"low"`` / ``"medium"`` / ``"high"`` — passed directly as
+      ``reasoning_effort`` (OpenAI/DeepSeek only; no-op on vLLM).
+    """
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"
     STOP_SEQUENCES = "@@@stop_sequences@@@"

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -942,8 +942,17 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         )
         user_extra_body = backend_specific.pop("extra_body", None)
         if user_extra_body:
-            eb = extra_params.get("extra_body") or {}
+            user_extra_body = dict(
+                user_extra_body
+            )  # shallow copy so .pop() below doesn't mutate the caller's dict
+            eb = dict(extra_params.get("extra_body") or {})
+            user_ctk = user_extra_body.pop("chat_template_kwargs", None)
             eb.update(user_extra_body)
+            if user_ctk is not None:
+                eb["chat_template_kwargs"] = {
+                    **eb.get("chat_template_kwargs", {}),
+                    **user_ctk,
+                }
             extra_params["extra_body"] = eb
 
         chat_response: Coroutine[

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -684,8 +684,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         # - chat_template_kwargs.enable_thinking: vLLM/Qwen3 (bool toggle)
         # - reasoning_effort: OpenAI/DeepSeek (string level, or True → "medium")
         # Both are set for True so the right server picks up whichever it understands.
-        thinking = model_options.get(ModelOption.THINKING, None)
-        if thinking is not None:
+        thinking = model_options.get(ModelOption.THINKING)
+        if thinking is not None:  # False is a valid value — cannot use `if thinking`
             if type(thinking) is bool:
                 ctk = extra_body.get("chat_template_kwargs", {}) or {}
                 ctk["enable_thinking"] = thinking
@@ -914,9 +914,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         # - chat_template_kwargs.enable_thinking: vLLM/Qwen3 (bool toggle)
         # - reasoning_effort: OpenAI/DeepSeek (string level, or True → "medium")
         # NOTE: don't pass reasoning_effort to non-reasoning models (e.g. gpt-4o).
-        thinking = model_opts.get(ModelOption.THINKING, None)
+        thinking = model_opts.get(ModelOption.THINKING)
         reasoning_params: dict[str, Any] = {}
-        if thinking is not None:
+        if thinking is not None:  # False is a valid value — cannot use `if thinking`
             if type(thinking) is bool:
                 ctk_body: dict[str, Any] = extra_params.get("extra_body", {}) or {}
                 ctk = ctk_body.get("chat_template_kwargs", {}) or {}

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -947,7 +947,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             )  # shallow copy so .pop() below doesn't mutate the caller's dict
             eb = dict(extra_params.get("extra_body") or {})
             user_ctk = user_extra_body.pop("chat_template_kwargs", None)
-            eb.update(user_extra_body)
+            eb.update(
+                user_extra_body
+            )  # shallow merge is safe: chat_template_kwargs is the only nested dict key the rewriter writes, and it is deep-merged separately below
             if user_ctk is not None:
                 eb["chat_template_kwargs"] = {
                     **eb.get("chat_template_kwargs", {}),

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -673,11 +673,6 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         formatted_tools = convert_tools_to_json(tools)
         use_tools = len(formatted_tools) > 0
 
-        # Handle thinking/reasoning.
-        thinking = model_options.get(ModelOption.THINKING, None)
-        if type(thinking) is bool and thinking:
-            thinking = "medium"
-
         # Remap and filter remaining model options, then overlay onto api_params
         # so user values override rewriter/io.yaml defaults.
         user_api_params = self._make_backend_specific_and_remove(
@@ -685,10 +680,22 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         )
         api_params.update(user_api_params)
 
-        # Add reasoning_effort last so it overrides any io.yaml default and
-        # avoids duplicate kwargs in the API call.
+        # Map THINKING to the correct backend parameter(s). Two mechanisms:
+        # - chat_template_kwargs.enable_thinking: vLLM/Qwen3 (bool toggle)
+        # - reasoning_effort: OpenAI/DeepSeek (string level, or True → "medium")
+        # Both are set for True so the right server picks up whichever it understands.
+        thinking = model_options.get(ModelOption.THINKING, None)
         if thinking is not None:
-            api_params["reasoning_effort"] = thinking
+            if type(thinking) is bool:
+                ctk = extra_body.get("chat_template_kwargs", {}) or {}
+                ctk["enable_thinking"] = thinking
+                extra_body["chat_template_kwargs"] = ctk
+                if thinking:
+                    api_params["reasoning_effort"] = "medium"
+                # False: don't send reasoning_effort — OpenAI disables reasoning by
+                # default when the param is absent; passing False would be invalid.
+            else:
+                api_params["reasoning_effort"] = thinking
 
         # --- call the OpenAI-compatible API --------------------------------
         # The rewriter may add instruction messages where 'role' is a default
@@ -900,19 +907,28 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 add_tools_from_context_actions(tools, [action])
             MelleaLogger.get_logger().info(f"Tools for call: {tools.keys()}")
 
-        thinking = model_opts.get(ModelOption.THINKING, None)
-        if type(thinking) is bool and thinking:
-            # OpenAI uses strings for its reasoning levels.
-            thinking = "medium"
-
         formatted_tools = convert_tools_to_json(tools)
         use_tools = len(formatted_tools) > 0
 
-        # Build optional reasoning parameters
-        # NOTE: the openai SDK doesn't like it if you pass `reasoning_effort` param to a non-reasoning model e.g. gpt4o
-        reasoning_params = {}
+        # Map THINKING to the correct backend parameter(s). Two mechanisms:
+        # - chat_template_kwargs.enable_thinking: vLLM/Qwen3 (bool toggle)
+        # - reasoning_effort: OpenAI/DeepSeek (string level, or True → "medium")
+        # NOTE: don't pass reasoning_effort to non-reasoning models (e.g. gpt-4o).
+        thinking = model_opts.get(ModelOption.THINKING, None)
+        reasoning_params: dict[str, Any] = {}
         if thinking is not None:
-            reasoning_params["reasoning_effort"] = thinking
+            if type(thinking) is bool:
+                ctk_body: dict[str, Any] = extra_params.get("extra_body", {}) or {}
+                ctk = ctk_body.get("chat_template_kwargs", {}) or {}
+                ctk["enable_thinking"] = thinking
+                ctk_body["chat_template_kwargs"] = ctk
+                extra_params["extra_body"] = ctk_body
+                if thinking:
+                    reasoning_params["reasoning_effort"] = "medium"
+                # False: don't send reasoning_effort — OpenAI disables reasoning by
+                # default when the param is absent; passing False would be invalid.
+            else:
+                reasoning_params["reasoning_effort"] = thinking
 
         # Request usage information in streaming responses
         if model_opts.get(ModelOption.STREAM, False):

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -941,15 +941,14 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             model_opts, is_chat_context=ctx.is_chat_context
         )
         user_extra_body = backend_specific.pop("extra_body", None)
-        if user_extra_body:
-            user_extra_body = dict(
-                user_extra_body
-            )  # shallow copy so .pop() below doesn't mutate the caller's dict
+        if user_extra_body is not None:
+            # shallow copy so .pop() below doesn't mutate the caller's dict
+            user_extra_body = dict(user_extra_body)
             eb = dict(extra_params.get("extra_body") or {})
             user_ctk = user_extra_body.pop("chat_template_kwargs", None)
-            eb.update(
-                user_extra_body
-            )  # shallow merge is safe: chat_template_kwargs is the only nested dict key the rewriter writes, and it is deep-merged separately below
+            # shallow merge is safe: chat_template_kwargs is the only nested dict
+            # key Mellea writes into extra_body; it is deep-merged separately below
+            eb.update(user_extra_body)
             if user_ctk is not None:
                 eb["chat_template_kwargs"] = {
                     **eb.get("chat_template_kwargs", {}),

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -934,6 +934,18 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         if model_opts.get(ModelOption.STREAM, False):
             extra_params["stream_options"] = {"include_usage": True}
 
+        # Build the final backend-specific params and merge any user-supplied
+        # extra_body into extra_params so there is a single extra_body source.
+        # Two spreads each containing extra_body raises TypeError at call time.
+        backend_specific = self._make_backend_specific_and_remove(
+            model_opts, is_chat_context=ctx.is_chat_context
+        )
+        user_extra_body = backend_specific.pop("extra_body", None)
+        if user_extra_body:
+            eb = extra_params.get("extra_body") or {}
+            eb.update(user_extra_body)
+            extra_params["extra_body"] = eb
+
         chat_response: Coroutine[
             Any, Any, ChatCompletion | openai.AsyncStream[ChatCompletionChunk]
         ] = self._async_client.chat.completions.create(
@@ -943,9 +955,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # parallel_tool_calls=False, # We only support calling one tool per turn. But we do the choosing on our side so we leave this False.
             **extra_params,
             **reasoning_params,  # type: ignore
-            **self._make_backend_specific_and_remove(
-                model_opts, is_chat_context=ctx.is_chat_context
-            ),
+            **backend_specific,
         )  # type: ignore
 
         output = ModelOutputThunk(None)
@@ -1070,8 +1080,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             tools (dict[str, AbstractMelleaTool]): Available tools, keyed by name.
             conversation (list[dict]): The chat conversation sent to the model,
                 used for logging.
-            thinking: The reasoning effort level passed to the model, or `None`
-                if reasoning mode was not enabled.
+            thinking: The reasoning value passed to the model: a string level
+                (``"low"``, ``"medium"``, ``"high"``) for explicit effort strings,
+                ``True``/``False`` for the bool toggle, or ``None`` if reasoning
+                was not enabled.
             seed: The random seed used during generation, or `None`.
             _format: The structured output format class used during generation, if any.
         """

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -445,7 +445,7 @@ async def test_reasoning_effort_from_io_yaml_only():
 
 
 async def test_reasoning_effort_bool_true():
-    """THINKING: True is normalized to reasoning_effort='medium'."""
+    """THINKING: True sets reasoning_effort='medium' and chat_template_kwargs.enable_thinking=True."""
     backend = _make_backend_with_adapter(_SIMPLE_CONFIG)
     ctx = _make_context()
     mock_create = AsyncMock(return_value=_simple_chat_completion())
@@ -470,6 +470,40 @@ async def test_reasoning_effort_bool_true():
 
     call_kwargs = mock_create.call_args
     assert call_kwargs.kwargs.get("reasoning_effort") == "medium"
+    extra_body = call_kwargs.kwargs.get("extra_body", {})
+    assert extra_body.get("chat_template_kwargs", {}).get("enable_thinking") is True
+
+
+async def test_reasoning_effort_bool_false():
+    """THINKING: False sets chat_template_kwargs.enable_thinking=False; no reasoning_effort."""
+    backend = _make_backend_with_adapter(_SIMPLE_CONFIG)
+    ctx = _make_context()
+    mock_create = AsyncMock(return_value=_simple_chat_completion())
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with patch.object(
+        OpenAIBackend,
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_client,
+    ):
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"),
+            ctx,
+            backend,
+            strategy=None,
+            model_options={ModelOption.THINKING: False},
+        )
+        await mot.avalue()
+
+    call_kwargs = mock_create.call_args
+    assert "reasoning_effort" not in call_kwargs.kwargs, (
+        "reasoning_effort must not be sent for THINKING=False (invalid for OpenAI)"
+    )
+    extra_body = call_kwargs.kwargs.get("extra_body", {})
+    assert extra_body.get("chat_template_kwargs", {}).get("enable_thinking") is False
 
 
 async def test_tools_passed_to_api():

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -472,6 +472,11 @@ async def test_reasoning_effort_bool_true():
     assert call_kwargs.kwargs.get("reasoning_effort") == "medium"
     extra_body = call_kwargs.kwargs.get("extra_body", {})
     assert extra_body.get("chat_template_kwargs", {}).get("enable_thinking") is True
+    # adapter_name must survive the merge — the THINKING block must not clobber it.
+    assert (
+        extra_body.get("chat_template_kwargs", {}).get("adapter_name")
+        == "answerability"
+    )
 
 
 async def test_reasoning_effort_bool_false():
@@ -504,6 +509,11 @@ async def test_reasoning_effort_bool_false():
     )
     extra_body = call_kwargs.kwargs.get("extra_body", {})
     assert extra_body.get("chat_template_kwargs", {}).get("enable_thinking") is False
+    # adapter_name must survive the merge — the THINKING block must not clobber it.
+    assert (
+        extra_body.get("chat_template_kwargs", {}).get("adapter_name")
+        == "answerability"
+    )
 
 
 async def test_tools_passed_to_api():

--- a/test/backends/test_openai_ollama.py
+++ b/test/backends/test_openai_ollama.py
@@ -263,7 +263,7 @@ async def test_reasoning_effort_conditional_passing(backend) -> None:
             "reasoning_effort should not be passed when not specified"
         )
 
-    # Test 2: reasoning_effort SHOULD be passed when specified
+    # Test 2: reasoning_effort SHOULD be passed when specified (string)
     with patch.object(
         backend._async_client.chat.completions, "create", new_callable=AsyncMock
     ) as mock_create:
@@ -274,6 +274,42 @@ async def test_reasoning_effort_conditional_passing(backend) -> None:
         call_kwargs = mock_create.call_args.kwargs
         assert call_kwargs.get("reasoning_effort") == "medium", (
             "reasoning_effort should be passed with correct value when specified"
+        )
+
+    # Test 3: THINKING=True sets both reasoning_effort and chat_template_kwargs
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_response
+        await backend.generate_from_chat_context(
+            CBlock(value="Hi"), ctx, model_options={ModelOption.THINKING: True}
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs.get("reasoning_effort") == "medium"
+        assert (
+            call_kwargs.get("extra_body", {})
+            .get("chat_template_kwargs", {})
+            .get("enable_thinking")
+            is True
+        )
+
+    # Test 4: THINKING=False sets chat_template_kwargs but NOT reasoning_effort
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_response
+        await backend.generate_from_chat_context(
+            CBlock(value="Hi"), ctx, model_options={ModelOption.THINKING: False}
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        assert "reasoning_effort" not in call_kwargs, (
+            "reasoning_effort must not be sent for THINKING=False (invalid for OpenAI)"
+        )
+        assert (
+            call_kwargs.get("extra_body", {})
+            .get("chat_template_kwargs", {})
+            .get("enable_thinking")
+            is False
         )
 
 

--- a/test/backends/test_openai_ollama.py
+++ b/test/backends/test_openai_ollama.py
@@ -312,6 +312,29 @@ async def test_reasoning_effort_conditional_passing(backend) -> None:
             is False
         )
 
+    # Test 5: THINKING=True + user-supplied extra_body merges without TypeError
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_response
+        await backend.generate_from_chat_context(
+            CBlock(value="Hi"),
+            ctx,
+            model_options={
+                ModelOption.THINKING: True,
+                "extra_body": {"guided_json": {"type": "string"}},
+            },
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        eb = call_kwargs.get("extra_body", {})
+        assert eb.get("chat_template_kwargs", {}).get("enable_thinking") is True, (
+            "enable_thinking must survive the merge"
+        )
+        assert eb.get("guided_json") == {"type": "string"}, (
+            "user-supplied extra_body keys must be preserved alongside enable_thinking"
+        )
+        assert call_kwargs.get("reasoning_effort") == "medium"
+
 
 def test_api_key_and_base_url_from_parameters() -> None:
     """Test that API key and base URL can be set via parameters."""

--- a/test/backends/test_openai_ollama.py
+++ b/test/backends/test_openai_ollama.py
@@ -335,6 +335,29 @@ async def test_reasoning_effort_conditional_passing(backend) -> None:
         )
         assert call_kwargs.get("reasoning_effort") == "medium"
 
+    # Test 6: THINKING=True + user extra_body containing chat_template_kwargs must
+    # deep-merge — not clobber the backend-set enable_thinking.
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_response
+        await backend.generate_from_chat_context(
+            CBlock(value="Hi"),
+            ctx,
+            model_options={
+                ModelOption.THINKING: True,
+                "extra_body": {"chat_template_kwargs": {"adapter_name": "foo"}},
+            },
+        )
+        call_kwargs = mock_create.call_args.kwargs
+        ctk = call_kwargs.get("extra_body", {}).get("chat_template_kwargs", {})
+        assert ctk.get("enable_thinking") is True, (
+            "backend-set enable_thinking must survive a user chat_template_kwargs merge"
+        )
+        assert ctk.get("adapter_name") == "foo", (
+            "user chat_template_kwargs keys must be preserved alongside enable_thinking"
+        )
+
 
 def test_api_key_and_base_url_from_parameters() -> None:
     """Test that API key and base URL can be set via parameters."""


### PR DESCRIPTION
<!-- PR_BODY_START -->

`ModelOption.THINKING=True` did nothing for vLLM-served models. `THINKING=False` caused an API error. This PR fixes both.

**Before:** thinking-model users on vLLM had to resort to raw `extra_body` workarounds, and setting `THINKING=False` to suppress reasoning would raise a `TypeError` from the OpenAI SDK.
**After:** `THINKING=True/False` works correctly out of the box against vLLM (Qwen3, Gemma 4, GLM-4.5, and any model using `--reasoning-parser`), and against Ollama's OpenAI-compatible endpoint.

| `ModelOption.THINKING` | Before | After |
|---|---|---|
| `True` | `reasoning_effort="medium"` only — vLLM ignores it | `reasoning_effort="medium"` + `enable_thinking=True` |
| `False` | `reasoning_effort=False` — SDK TypeError | `enable_thinking=False`; no `reasoning_effort` sent |
| `"medium"/"high"` | unchanged | unchanged |

**Scope:** `OpenAIBackend` only (`mellea/backends/openai.py`). `OllamaBackend` (native SDK) was already correct. `LiteLLMBackend` is handled in sibling PR #1207.

Closes #1093. Part of #1201.

## Test plan

- [ ] `test_reasoning_effort_conditional_passing` — Tests 3+4 cover `THINKING=True/False` streaming; Test 5 verifies user `extra_body` merges correctly
- [ ] `test_reasoning_effort_bool_true` — asserts both `reasoning_effort="medium"` and `enable_thinking=True`; `adapter_name` survives
- [ ] `test_reasoning_effort_bool_false` — `enable_thinking=False`, no `reasoning_effort`, `adapter_name` survives
- [ ] Live: Qwen3.6-27B on vLLM — `THINKING=False` suppresses `<think>` ✅
- [ ] Live: Gemma-4-31B-it on vLLM — `THINKING=True` enables reasoning, `THINKING=False` suppresses, merge works ✅
- [ ] Live: qwen3.6:35b on Ollama 0.30.4 (OpenAI-compat) — `THINKING=True` populates `mot._thinking`, `THINKING=False` clean ✅

<details>
<summary>Why <code>enable_thinking</code> in <code>extra_body</code> — technical detail</summary>

`chat_template_kwargs` cannot be a direct kwarg to the OpenAI SDK's `create()` — the SDK raises `TypeError` on unknown parameters. `extra_body` is the SDK escape hatch: its contents are merged into the top-level HTTP request JSON body before the call. vLLM then reads `chat_template_kwargs` from the body and injects them into the Jinja chat template at render time.

`enable_thinking` is the vLLM-standardised toggle (Qwen3, Gemma 4, GLM-4.5, MiniMax-M2, and most models added since early 2026). When `reasoning_effort` is sent, vLLM v0.22.0+ auto-injects `enable_thinking` for recognised reasoning parsers — so the dual-set (`reasoning_effort` + `enable_thinking`) is consistent with that direction and ensures correctness even for servers that haven't yet updated. See the [vLLM reasoning outputs docs](https://docs.vllm.ai/en/v0.22.0/features/reasoning_outputs/).

**Out of scope:** IBM Granite 3.2 and DeepSeek-V3.1 use `thinking=True` (not `enable_thinking`) in their chat templates. The bool branch sends `enable_thinking`, which those models won't act on — this is a pre-existing gap, not a regression introduced here.

</details>

<details>
<summary>Regression safety</summary>

Sending `chat_template_kwargs` in `extra_body` to servers that don't understand it (OpenAI proper, DeepSeek, etc.) is safe — unknown `extra_body` fields are silently ignored.

If a caller passes `THINKING=True` and their own `extra_body` in `model_options`, we merge them rather than spreading two dicts (which would raise `TypeError`). Tested.

For the intrinsic path, `chat_template_kwargs.adapter_name` is written before the THINKING block. The new code merges `enable_thinking` into the existing dict rather than replacing it; tests assert `adapter_name` survives.

Minor: `generate_log.extra["thinking"]` now records the raw caller value (`True`/`False`) rather than the normalised `"medium"` string. Nothing reads this field functionally.

</details>

<!-- PR_BODY_END -->