### PR TITLE
fix(litellm): pass api_base and set enable_thinking for bool THINKING

### DIFF
--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -341,16 +341,50 @@ class LiteLLMBackend(FormatterBackend):
         if model_opts.get(ModelOption.STREAM, False):
             extra_params["stream_options"] = {"include_usage": True}
 
+        # Map THINKING to the correct backend parameter(s). Two mechanisms:
+        # - chat_template_kwargs.enable_thinking: vLLM/Qwen3/Gemma4 (bool toggle)
+        # - reasoning_effort: LiteLLM/OpenAI-compatible (string level, or True → "medium")
+        # Both are set for True so each server picks up whichever it understands.
+        # NOTE: don't pass reasoning_effort=False — it is invalid; absence disables reasoning.
         thinking = model_opts.get(ModelOption.THINKING, None)
-        if type(thinking) is bool and thinking:
-            # OpenAI uses strings for its reasoning levels.
-            thinking = "medium"
+        original_thinking = thinking  # preserve raw caller value for the generate log
+        reasoning_params: dict[str, Any] = {}
+        if thinking is not None:
+            if type(thinking) is bool:
+                ctk_body: dict[str, Any] = extra_params.get("extra_body", {}) or {}
+                ctk: dict[str, Any] = ctk_body.get("chat_template_kwargs", {}) or {}
+                ctk["enable_thinking"] = thinking
+                ctk_body["chat_template_kwargs"] = ctk
+                extra_params["extra_body"] = ctk_body
+                if thinking:
+                    reasoning_params["reasoning_effort"] = "medium"
+                # False: do not send reasoning_effort — absent param disables reasoning;
+                # passing False would be invalid.
+            else:
+                reasoning_params["reasoning_effort"] = thinking
 
         # Append tool call information if applicable.
         tools = self._extract_tools(action, _format, model_opts, tool_calls, ctx)
         formatted_tools = convert_tools_to_json(tools) if len(tools) > 0 else None
 
         model_specific_options = self._make_backend_specific_and_remove(model_opts)
+
+        # Merge any user-supplied extra_body from model_specific_options so there is
+        # a single extra_body source in extra_params (two spread dicts with the same
+        # key would raise TypeError at call time).
+        # Deep-merge chat_template_kwargs so enable_thinking (set above) and any
+        # user-supplied chat_template_kwargs keys both survive.
+        user_extra_body = model_specific_options.pop("extra_body", None)
+        if user_extra_body:
+            eb = extra_params.get("extra_body") or {}
+            user_ctk = user_extra_body.pop("chat_template_kwargs", None)
+            eb.update(user_extra_body)
+            if user_ctk:
+                eb["chat_template_kwargs"] = {
+                    **eb.get("chat_template_kwargs", {}),
+                    **user_ctk,
+                }
+            extra_params["extra_body"] = eb
 
         if self._has_potential_event_loop_errors():
             MelleaLogger.get_logger().warning(
@@ -363,9 +397,10 @@ class LiteLLMBackend(FormatterBackend):
             model=self._model_id,
             messages=conversation,
             tools=formatted_tools,
-            reasoning_effort=thinking,  # type: ignore
+            api_base=self._base_url,
             drop_params=True,  # See note in `_make_backend_specific_and_remove`.
             **extra_params,
+            **reasoning_params,  # type: ignore
             **model_specific_options,
         )
 
@@ -382,7 +417,7 @@ class LiteLLMBackend(FormatterBackend):
             self.post_processing,
             conversation=conversation,
             tools=tools,
-            thinking=thinking,
+            thinking=original_thinking,
             _format=_format,
         )
 
@@ -682,7 +717,10 @@ class LiteLLMBackend(FormatterBackend):
             prompts = [self.formatter.print(action) for action in actions]
 
             completion_response = await litellm.atext_completion(
-                model=self._model_id, prompt=prompts, **model_specific_options
+                model=self._model_id,
+                prompt=prompts,
+                api_base=self._base_url,
+                **model_specific_options,
             )
 
         # Necessary for type checker.

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -374,17 +374,26 @@ class LiteLLMBackend(FormatterBackend):
         # key would raise TypeError at call time).
         # Deep-merge chat_template_kwargs so enable_thinking (set above) and any
         # user-supplied chat_template_kwargs keys both survive.
+        # Copy before mutating — model_specific_options holds references into the
+        # caller's dict; popping from the originals would silently corrupt reused
+        # model_options on the next call.
         user_extra_body = model_specific_options.pop("extra_body", None)
         if user_extra_body:
-            eb = extra_params.get("extra_body") or {}
+            user_extra_body = dict(user_extra_body)
+            eb = dict(extra_params.get("extra_body") or {})
             user_ctk = user_extra_body.pop("chat_template_kwargs", None)
             eb.update(user_extra_body)
-            if user_ctk:
+            if user_ctk is not None:
                 eb["chat_template_kwargs"] = {
                     **eb.get("chat_template_kwargs", {}),
                     **user_ctk,
                 }
             extra_params["extra_body"] = eb
+
+        # Pop api_base from model_specific_options before the call so an explicit
+        # user-supplied value doesn't collide with the positional api_base kwarg;
+        # let the user's value take precedence over the backend default.
+        user_api_base = model_specific_options.pop("api_base", None)
 
         if self._has_potential_event_loop_errors():
             MelleaLogger.get_logger().warning(
@@ -397,7 +406,7 @@ class LiteLLMBackend(FormatterBackend):
             model=self._model_id,
             messages=conversation,
             tools=formatted_tools,
-            api_base=self._base_url,
+            api_base=user_api_base or self._base_url,
             drop_params=True,  # See note in `_make_backend_specific_and_remove`.
             **extra_params,
             **reasoning_params,  # type: ignore
@@ -716,10 +725,11 @@ class LiteLLMBackend(FormatterBackend):
 
             prompts = [self.formatter.print(action) for action in actions]
 
+            user_api_base_raw = model_specific_options.pop("api_base", None)
             completion_response = await litellm.atext_completion(
                 model=self._model_id,
                 prompt=prompts,
-                api_base=self._base_url,
+                api_base=user_api_base_raw or self._base_url,
                 **model_specific_options,
             )
 

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -66,8 +66,12 @@ class LiteLLMBackend(FormatterBackend):
             `"<provider>/<model_creator>/<model_name>"`.
         formatter (ChatFormatter | None): Formatter for rendering components.
             Defaults to `TemplateFormatter`.
-        base_url (str | None): Base URL for the LLM API endpoint; defaults to
-            the Ollama local endpoint.
+        base_url (str | None): Base URL for the LLM API endpoint. When set,
+            forwarded as ``api_base`` to LiteLLM. When ``None`` (default),
+            LiteLLM infers the endpoint from the model prefix (e.g.
+            ``ollama_chat/`` → localhost:11434, ``anthropic/`` → Anthropic API).
+            Use ``None`` for cloud providers; set explicitly for local servers
+            such as vLLM or a non-default Ollama port.
         model_options (dict | None): Default model options for generation requests.
 
     Attributes:
@@ -81,7 +85,7 @@ class LiteLLMBackend(FormatterBackend):
         self,
         model_id: str = "ollama_chat/" + str(model_ids.IBM_GRANITE_4_1_3B.ollama_name),
         formatter: ChatFormatter | None = None,
-        base_url: str | None = "http://localhost:11434",
+        base_url: str | None = None,
         model_options: dict | None = None,
     ):
         """Initialize a LiteLLM-compatible backend for the given model ID and endpoint."""
@@ -98,10 +102,13 @@ class LiteLLMBackend(FormatterBackend):
         assert isinstance(model_id, str), "Model ID must be a string."
         self._model_id = model_id
 
-        if base_url is None:
-            self._base_url = "http://localhost:11434/v1"  # ollama
-        else:
-            self._base_url = base_url
+        # _explicit_base_url tracks whether the caller provided a base_url.
+        # api_base is only forwarded to litellm when explicit — otherwise litellm
+        # infers the endpoint from the model prefix (correct for cloud providers).
+        self._explicit_base_url = base_url is not None
+        self._base_url = (
+            base_url if base_url is not None else "http://localhost:11434/v1"
+        )
 
         # A mapping of common options for this backend mapped to their Mellea ModelOptions equivalent.
         # These are usually values that must be extracted before hand or that are common among backend providers.
@@ -394,6 +401,12 @@ class LiteLLMBackend(FormatterBackend):
         # user-supplied value doesn't collide with the positional api_base kwarg;
         # let the user's value take precedence over the backend default.
         user_api_base = model_specific_options.pop("api_base", None)
+        # Only forward api_base when the caller explicitly set a base_url (or model_options
+        # contains one). Sending the default localhost URL to a cloud provider (Anthropic,
+        # Watsonx, etc.) would override LiteLLM's provider-default endpoint inference.
+        resolved_api_base = user_api_base or (
+            self._base_url if self._explicit_base_url else None
+        )
 
         if self._has_potential_event_loop_errors():
             MelleaLogger.get_logger().warning(
@@ -406,7 +419,7 @@ class LiteLLMBackend(FormatterBackend):
             model=self._model_id,
             messages=conversation,
             tools=formatted_tools,
-            api_base=user_api_base or self._base_url,
+            api_base=resolved_api_base,
             drop_params=True,  # See note in `_make_backend_specific_and_remove`.
             **extra_params,
             **reasoning_params,  # type: ignore
@@ -729,7 +742,8 @@ class LiteLLMBackend(FormatterBackend):
             completion_response = await litellm.atext_completion(
                 model=self._model_id,
                 prompt=prompts,
-                api_base=user_api_base_raw or self._base_url,
+                api_base=user_api_base_raw
+                or (self._base_url if self._explicit_base_url else None),
                 **model_specific_options,
             )
 

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -221,3 +221,174 @@ async def test_processing_streaming_empty_reasoning_content_does_not_fall_back(
     )
     await backend.processing(mot, stream_chunk)
     assert mot._thinking == ""
+
+
+# ---------------------------------------------------------------------------
+# Parameter-passing tests (mock litellm.acompletion — no server required)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response() -> ModelResponse:
+    """Minimal non-streaming ModelResponse that survives processing() and post_processing()."""
+    msg = Message(content="ok", role="assistant")
+    choice = Choices(finish_reason="stop", index=0, message=msg)
+    return ModelResponse(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="hosted_vllm/qwen3",
+        object="chat.completion",
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.fixture()
+def chat_backend() -> LiteLLMBackend:
+    return LiteLLMBackend(
+        model_id="hosted_vllm/qwen3", base_url="http://localhost:9997"
+    )
+
+
+async def _call_and_capture(backend: LiteLLMBackend, model_options: dict) -> dict:
+    """Call _generate_from_chat_context_standard with mocked litellm.acompletion.
+
+    Returns the kwargs dict that litellm.acompletion was called with.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from mellea.core import CBlock
+    from mellea.stdlib.components import Message as MelleaMessage
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(MelleaMessage("user", "Hello"))
+    action = CBlock(value="Test")
+    mock_response = _make_mock_response()
+
+    with patch("litellm.acompletion", new_callable=AsyncMock) as mock_acomplete:
+        mock_acomplete.return_value = mock_response
+        mot = await backend._generate_from_chat_context_standard(
+            action, ctx, model_options=model_options
+        )
+        await mot.avalue()
+
+    assert mock_acomplete.called, "litellm.acompletion was never called"
+    return mock_acomplete.call_args.kwargs
+
+
+async def test_thinking_true_sets_reasoning_effort_and_enable_thinking(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """THINKING=True sets reasoning_effort='medium' AND extra_body.chat_template_kwargs.enable_thinking=True."""
+    from mellea.backends import ModelOption
+
+    kwargs = await _call_and_capture(chat_backend, {ModelOption.THINKING: True})
+
+    assert kwargs.get("reasoning_effort") == "medium", (
+        "reasoning_effort should be 'medium' for THINKING=True"
+    )
+    assert (
+        kwargs.get("extra_body", {})
+        .get("chat_template_kwargs", {})
+        .get("enable_thinking")
+        is True
+    ), "extra_body.chat_template_kwargs.enable_thinking should be True"
+
+
+async def test_thinking_false_omits_reasoning_effort_and_sets_disable(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """THINKING=False: reasoning_effort absent, extra_body.chat_template_kwargs.enable_thinking=False."""
+    from mellea.backends import ModelOption
+
+    kwargs = await _call_and_capture(chat_backend, {ModelOption.THINKING: False})
+
+    assert "reasoning_effort" not in kwargs, (
+        "reasoning_effort must not be sent for THINKING=False (invalid value)"
+    )
+    assert (
+        kwargs.get("extra_body", {})
+        .get("chat_template_kwargs", {})
+        .get("enable_thinking")
+        is False
+    ), "extra_body.chat_template_kwargs.enable_thinking should be False"
+
+
+async def test_thinking_string_sets_only_reasoning_effort(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """THINKING='high' sets reasoning_effort='high' but does NOT set extra_body.enable_thinking."""
+    from mellea.backends import ModelOption
+
+    kwargs = await _call_and_capture(chat_backend, {ModelOption.THINKING: "high"})
+
+    assert kwargs.get("reasoning_effort") == "high", (
+        "reasoning_effort should be 'high' for THINKING='high'"
+    )
+    assert "enable_thinking" not in kwargs.get("extra_body", {}).get(
+        "chat_template_kwargs", {}
+    ), "enable_thinking must not be set for string THINKING values"
+
+
+async def test_thinking_unset_sends_neither(chat_backend: LiteLLMBackend) -> None:
+    """No THINKING option: neither reasoning_effort nor extra_body.enable_thinking is sent."""
+    kwargs = await _call_and_capture(chat_backend, {})
+
+    assert "reasoning_effort" not in kwargs, (
+        "reasoning_effort should not be present when THINKING is not set"
+    )
+    assert "enable_thinking" not in kwargs.get("extra_body", {}).get(
+        "chat_template_kwargs", {}
+    ), "enable_thinking should not be present when THINKING is not set"
+
+
+async def test_api_base_passed_to_litellm(chat_backend: LiteLLMBackend) -> None:
+    """api_base is forwarded to litellm.acompletion matching the backend's base_url."""
+    kwargs = await _call_and_capture(chat_backend, {})
+
+    assert kwargs.get("api_base") == "http://localhost:9997", (
+        "api_base must equal the backend base_url"
+    )
+
+
+async def test_thinking_true_with_user_extra_body_merged(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """THINKING=True + user extra_body: enable_thinking and user keys both survive in extra_body."""
+    from mellea.backends import ModelOption
+
+    kwargs = await _call_and_capture(
+        chat_backend,
+        {ModelOption.THINKING: True, "extra_body": {"guided_json": {"type": "string"}}},
+    )
+
+    eb = kwargs.get("extra_body", {})
+    assert eb.get("chat_template_kwargs", {}).get("enable_thinking") is True, (
+        "enable_thinking must survive the merge with user-supplied extra_body"
+    )
+    assert eb.get("guided_json") == {"type": "string"}, (
+        "user-supplied extra_body keys must be preserved alongside enable_thinking"
+    )
+    assert kwargs.get("reasoning_effort") == "medium"
+
+
+async def test_thinking_true_with_user_chat_template_kwargs_deep_merged(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """THINKING=True + user extra_body.chat_template_kwargs: both enable_thinking and user CTK keys survive."""
+    from mellea.backends import ModelOption
+
+    kwargs = await _call_and_capture(
+        chat_backend,
+        {
+            ModelOption.THINKING: True,
+            "extra_body": {"chat_template_kwargs": {"adapter_name": "my-adapter"}},
+        },
+    )
+
+    ctk = kwargs.get("extra_body", {}).get("chat_template_kwargs", {})
+    assert ctk.get("enable_thinking") is True, (
+        "enable_thinking must survive when user also supplies chat_template_kwargs"
+    )
+    assert ctk.get("adapter_name") == "my-adapter", (
+        "user-supplied chat_template_kwargs keys must be preserved"
+    )

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -272,7 +272,7 @@ async def _call_and_capture(backend: LiteLLMBackend, model_options: dict) -> dic
         await mot.avalue()
 
     assert mock_acomplete.called, "litellm.acompletion was never called"
-    return mock_acomplete.call_args.kwargs
+    return dict(mock_acomplete.call_args.kwargs)
 
 
 async def test_thinking_true_sets_reasoning_effort_and_enable_thinking(

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -397,13 +397,24 @@ async def test_thinking_true_with_user_chat_template_kwargs_deep_merged(
 async def test_user_api_base_in_model_options_takes_precedence(
     chat_backend: LiteLLMBackend,
 ) -> None:
-    """api_base in model_options must win over backend default and not cause a TypeError."""
+    """api_base in model_options must win over backend base_url and not cause a TypeError."""
     kwargs = await _call_and_capture(
         chat_backend, {"api_base": "http://custom:1234/v1"}
     )
 
     assert kwargs.get("api_base") == "http://custom:1234/v1", (
         "user-supplied api_base in model_options must take precedence over backend base_url"
+    )
+
+
+async def test_no_api_base_forwarded_when_base_url_not_set() -> None:
+    """Backend constructed without base_url must not forward api_base (cloud-provider safety)."""
+    backend = LiteLLMBackend(model_id="anthropic/claude-3-5-sonnet-20241022")
+    kwargs = await _call_and_capture(backend, {})
+
+    assert kwargs.get("api_base") is None, (
+        "api_base must not be forwarded for cloud providers with default base_url — "
+        "LiteLLM must infer the endpoint from the model prefix"
     )
 
 

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -392,3 +392,40 @@ async def test_thinking_true_with_user_chat_template_kwargs_deep_merged(
     assert ctk.get("adapter_name") == "my-adapter", (
         "user-supplied chat_template_kwargs keys must be preserved"
     )
+
+
+async def test_user_api_base_in_model_options_takes_precedence(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """api_base in model_options must win over backend default and not cause a TypeError."""
+    kwargs = await _call_and_capture(
+        chat_backend, {"api_base": "http://custom:1234/v1"}
+    )
+
+    assert kwargs.get("api_base") == "http://custom:1234/v1", (
+        "user-supplied api_base in model_options must take precedence over backend base_url"
+    )
+
+
+async def test_extra_body_mutation_does_not_corrupt_caller_dict(
+    chat_backend: LiteLLMBackend,
+) -> None:
+    """Reusing a model_options dict across two calls must not lose chat_template_kwargs."""
+    from mellea.backends import ModelOption
+
+    model_opts = {
+        ModelOption.THINKING: True,
+        "extra_body": {"chat_template_kwargs": {"adapter_name": "persistent"}},
+    }
+
+    kwargs1 = await _call_and_capture(chat_backend, model_opts)
+    kwargs2 = await _call_and_capture(chat_backend, model_opts)
+
+    for call_n, kwargs in enumerate((kwargs1, kwargs2), start=1):
+        ctk = kwargs.get("extra_body", {}).get("chat_template_kwargs", {})
+        assert ctk.get("adapter_name") == "persistent", (
+            f"call {call_n}: adapter_name silently lost — caller dict was mutated"
+        )
+        assert ctk.get("enable_thinking") is True, (
+            f"call {call_n}: enable_thinking missing"
+        )


### PR DESCRIPTION
<!-- PR_BODY_START -->

`LiteLLMBackend` silently ignored custom endpoints and `THINKING` had no effect. This PR fixes both.

Any backend constructed with a `base_url` (e.g. pointing at a vLLM server) was broken: `_base_url` was stored but never forwarded to `litellm.acompletion()`, so all requests routed to LiteLLM's default provider inference instead. Separately, `THINKING=True/False` never set `chat_template_kwargs.enable_thinking`, so vLLM models requiring an explicit opt-in (e.g. Gemma 4) never got thinking. `THINKING=False` also incorrectly sent `reasoning_effort=False`, which is an invalid value.

| Issue | Before | After |
|---|---|---|
| Custom `base_url` | Stored, never used — requests misrouted | Forwarded as `api_base` to both call sites |
| `THINKING=True` | `reasoning_effort="medium"` only — Gemma 4 ignored it | `reasoning_effort="medium"` + `enable_thinking=True` |
| `THINKING=False` | `reasoning_effort=False` — invalid value | `enable_thinking=False` only; no `reasoning_effort` |
| User `extra_body` + THINKING | `TypeError` on merge | Deep-merged correctly |

**Scope:** `LiteLLMBackend` only (`mellea/backends/litellm.py`). Sibling PR #1204 covers `OpenAIBackend`. Both are part of #1201.

Closes #1206. Relates to #1201, #1204.

## Test plan

- [ ] `uv run pytest test/backends/test_litellm_thinking.py -v` — all 17 tests pass
- [ ] `uv run pytest -m "not qualitative"` — full fast suite passes
- [ ] Live via `scratchpad/smoke_litellm_vllm.py` and `scratchpad/smoke_litellm_ollama.py`:
  - Qwen3.6-27B (vLLM): `reasoning_effort='medium'` → thinking engaged ✅
  - Gemma-4-31B-it (vLLM): `reasoning_effort='medium'` alone → no thinking ❌; with `enable_thinking=True` → thinking ✅
  - LiteLLM → Ollama (`qwen3.6:35b`): `THINKING=True` → `mot._thinking` populated ✅; `THINKING=False` → clean ✅

<details>
<summary>Technical detail — why two mechanisms</summary>

vLLM models control thinking via `chat_template_kwargs.enable_thinking` (a Jinja template variable). LiteLLM-compatible providers (Ollama, cloud) use `reasoning_effort`. Sending both means each server picks up whichever it understands. `THINKING=True` sets `reasoning_effort="medium"` (for LiteLLM's translation layer, e.g. Ollama → `think=True`) and `enable_thinking=True` (for vLLM). `THINKING=False` sends only `enable_thinking=False` — omitting `reasoning_effort` rather than sending an invalid `False`.

String values (`"low"`, `"medium"`, `"high"`) still route to `reasoning_effort` only; they are OpenAI-compatible values and don't set `enable_thinking`. For vLLM users wanting string-level control, `True`/`False` is the correct API.

</details>

<!-- PR_BODY_END -->