### PR TITLE
docs: clarify sampling raises

### DIFF
--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -225,8 +225,13 @@ class BaseSamplingStrategy(SamplingStrategy):
             SamplingResult[S]: A result object indicating the success or failure of the sampling process.
 
         Raises:
-            AssertionError: Asserts that all required components (repair, select_from_failure, validate, and generate) are provided before proceeding with the sampling.
+            AssertionError: If `select_from_failure` returns an index outside
+                the generated samples, or if the selected result has no
+                generation log to mark as final.
             ValueError: If a `SAMPLING_LOOP_START` hook returns a non-positive `loop_budget`.
+            Exception: Re-raised from a concurrent subsample if all subsamples
+                fail without producing a result, for example due to a backend
+                error.
         """
         validation_ctx = validation_ctx if validation_ctx is not None else context
 

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -225,13 +225,13 @@ class BaseSamplingStrategy(SamplingStrategy):
             SamplingResult[S]: A result object indicating the success or failure of the sampling process.
 
         Raises:
-            AssertionError: If `select_from_failure` returns an index outside
-                the generated samples, or if the selected result has no
-                generation log to mark as final.
+            AssertionError: If `select_from_failure` returns an out-of-range index
+                into `sample_generations`, or if the selected result's
+                `_generate_log` is `None`.
             ValueError: If a `SAMPLING_LOOP_START` hook returns a non-positive `loop_budget`.
-            Exception: Re-raised from a concurrent subsample if all subsamples
-                fail without producing a result, for example due to a backend
-                error.
+            Exception: If all subsamples raise without producing a result,
+                the first non-cancellation exception is re-raised (e.g. a
+                backend error).
         """
         validation_ctx = validation_ctx if validation_ctx is not None else context
 


### PR DESCRIPTION
## Summary
- clarify the `AssertionError` entry for `BaseSamplingStrategy.sample()` so it matches the current `select_from_failure` and generation-log assertions
- document the concurrent subsample exception re-raise path when no subsample produces a result

Fixes #1213.

## Checks
- `uv run ruff format --check mellea/stdlib/sampling/base.py`
- `uv run ruff check mellea/stdlib/sampling/base.py`
- `uv run pytest test/stdlib/sampling/test_sampling_base_unit.py -q`
- `git diff --check`