### PR TITLE
fix(streaming): use public cancellation property

### DIFF
--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -434,7 +434,7 @@ class StreamChunkingResult:
                 "as_thunk accessed before acomplete() — await acomplete() first"
             )
         thunk = ModelOutputThunk(value=self.full_text)
-        thunk._cancelled = self._mot._cancelled
+        thunk._cancelled = self._mot.cancelled
         thunk.generation = copy(self._mot.generation)
         thunk.parsed_repr = thunk.value  # type: ignore[assignment]
         return thunk


### PR DESCRIPTION
Closes #1219.

This updates `StreamChunkingResult.as_thunk` to read the public `ModelOutputThunk.cancelled` property from the source MOT instead of reaching into `self._mot._cancelled`. The destination still writes `thunk._cancelled` because that side is constructing a new thunk and the public property is read-only.

Checks run:

- `uv run ruff format --check mellea/stdlib/streaming.py`
- `uv run ruff check mellea/stdlib/streaming.py`
- `uv run mypy mellea/stdlib/streaming.py`
- `uv run pytest test/stdlib/test_streaming.py -k cancelled_flag -q`
- `uv run pytest test/stdlib/test_streaming.py -q`
- `CICD=1 uv run pytest test/stdlib/test_streaming.py -q`

I also attempted `uv run pre-commit run --all-files` after `uv sync --all-extras --all-groups`. Ruff, uv-lock, codespell, markdownlint, and generated-docs validation passed; the MyPy hook still fails outside this change on `mellea/plugins/policies.py` because `cpex.framework.hooks.policies` is not importable in the synced environment.

I attempted the broader `CICD=1 uv run pytest test -q` gate as well, but collection entered `test/stdlib/requirements/test_reqlib_python.py` and tried to pull `ghcr.io/vndee/sandbox-python-311-bullseye` through Docker. After several minutes with the run sitting in that image pull, I interrupted it and kept the focused streaming suite as the relevant verification for this one-line streaming fix.