### PR TITLE
fix: use public cancelled property in streaming thunk

### DIFF
--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -434,7 +434,7 @@ class StreamChunkingResult:
                 "as_thunk accessed before acomplete() — await acomplete() first"
             )
         thunk = ModelOutputThunk(value=self.full_text)
-        thunk._cancelled = self._mot._cancelled
+        thunk._cancelled = self._mot.cancelled
         thunk.generation = copy(self._mot.generation)
         thunk.parsed_repr = thunk.value  # type: ignore[assignment]
         return thunk


### PR DESCRIPTION
## Summary
Use the public `ModelOutputThunk.cancelled` property when copying cancellation state into a streaming result thunk.

## Root Cause
`StreamChunkingResult.as_thunk` read `self._mot._cancelled` directly. That reaches into a private implementation detail even though the public `cancelled` property already exposes the intended read-only state.

## Fix
Change the right-hand side to `self._mot.cancelled` while keeping the write to `thunk._cancelled`, since the generated thunk still needs its internal state populated.

## Impact
No behavior change is intended. This keeps the streaming thunk wrapper aligned with the public `ModelOutputThunk` API and avoids depending on a private field.

## Tests
- `uv run pytest -q test/stdlib/test_streaming.py -k 'as_thunk or cancelled_flag'`
- `uv run ruff check mellea/stdlib/streaming.py`
- `uv run pytest -q test/stdlib/test_streaming.py`

Fixes #1219