### PR TITLE
fix(streaming): use public mot.cancelled property in as_thunk

### DIFF
--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -434,7 +434,7 @@ class StreamChunkingResult:
                 "as_thunk accessed before acomplete() — await acomplete() first"
             )
         thunk = ModelOutputThunk(value=self.full_text)
-        thunk._cancelled = self._mot._cancelled
+        thunk._cancelled = self._mot.cancelled
         thunk.generation = copy(self._mot.generation)
         thunk.parsed_repr = thunk.value  # type: ignore[assignment]
         return thunk


### PR DESCRIPTION
## Summary

Fixes #1219.

`mellea/stdlib/streaming.py:437` read the private `self._mot._cancelled` attribute when projecting the cancellation flag onto the thunk returned by `StreamChunkingResult.as_thunk`. PR #942 introduced a public, read-only `ModelOutputThunk.cancelled` property for exactly this consumer use case; this PR switches the read to the public surface.

## Change

The right-hand side of the assignment in `as_thunk` is updated:

```python
thunk._cancelled = self._mot.cancelled   # was: self._mot._cancelled
```

The write side (`thunk._cancelled = ...`) is intentionally left as a direct attribute write — the public property is read-only and backends / `__init__` / `__copy__` / `__deepcopy__` / `_copy_from` all seed the underlying attribute directly.

## Verification

- `uv run pytest test/stdlib/test_streaming.py -q` → 40 passed
- `uv run pytest test/core/test_base.py -q` → 22 passed
- `uv run ruff format` / `uv run ruff check` → clean
- `uv run mypy mellea/stdlib/streaming.py` → no issues

The existing `test_cancelled_flag_reflects_cancellation_state` already covers both paths (early-exit → `cancelled is True`, normal completion → `cancelled is False`), so no new test was added for this one-line passthrough.

## Risk

Very low. `cancelled` is a one-line passthrough to the same underlying attribute, so the change is behaviorally inert.

## Related

Discovered during the #1197 audit (Appendix A item 2). Independent of #909.

Assisted-by: Claude Code