### PR TITLE
fix(streaming): use public mot.cancelled property in as_thunk

### DIFF
--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -434,7 +434,7 @@ class StreamChunkingResult:
                 "as_thunk accessed before acomplete() — await acomplete() first"
             )
         thunk = ModelOutputThunk(value=self.full_text)
-        thunk._cancelled = self._mot._cancelled
+        thunk._cancelled = self._mot.cancelled
         thunk.generation = copy(self._mot.generation)
         thunk.parsed_repr = thunk.value  # type: ignore[assignment]
         return thunk


### PR DESCRIPTION
## Summary

`mellea/stdlib/streaming.py:437` was reading the private `self._mot._cancelled` attribute inside `StreamChunkingResult.as_thunk`, bypassing the public `cancelled` property on `ModelOutputThunk` that #942 added. This is a one-line encapsulation hygiene fix.

## Changes

- `mellea/stdlib/streaming.py:437`: `thunk._cancelled = self._mot._cancelled` → `thunk._cancelled = self._mot.cancelled`

The write side (`thunk._cancelled = ...`) is intentionally left as a direct attribute write, because the public `cancelled` property on `ModelOutputThunk` is read-only — backends still need write access to the underlying attribute to flip the flag during cancellation. Only the right-hand side changes.

## Behavior

No behavioral change. The `cancelled` property simply returns the underlying `_cancelled` attribute, so the propagated value is identical.

## Verification

- `uv run ruff check mellea/stdlib/streaming.py` — clean
- `uv run mypy mellea/stdlib/streaming.py` — clean
- `uv run pytest test/stdlib/test_streaming.py -v -m "not qualitative"` — 40/40 passed, including the key tests:
  - `test_as_thunk_correctness`
  - `test_cancelled_flag_reflects_cancellation_state`
  - `test_cancelled_flag_propagates_through_copy_methods`

## Fixes

Fixes #1219