### PR TITLE
fix(streaming): use public mot.cancelled property in streaming.py:437

### DIFF
--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -434,7 +434,7 @@ class StreamChunkingResult:
                 "as_thunk accessed before acomplete() — await acomplete() first"
             )
         thunk = ModelOutputThunk(value=self.full_text)
-        thunk._cancelled = self._mot._cancelled
+        thunk._cancelled = self._mot.cancelled
         thunk.generation = copy(self._mot.generation)
         thunk.parsed_repr = thunk.value  # type: ignore[assignment]
         return thunk


### PR DESCRIPTION
Closes #1219

Updates the RHS on line 437 in `mellea/stdlib/streaming.py` from `self._mot._cancelled` to `self._mot.cancelled` to use the public property added in #942. The LHS write to `thunk._cancelled` is intentionally preserved because the public `cancelled` property on `ModelOutputThunk` is read-only.\n\n## Verification\n- `uv run pytest test/stdlib/test_streaming.py -v` — 40/40 passed\n- `uv run ruff check mellea/stdlib/streaming.py` — clean\n- `uv run mypy mellea/stdlib/streaming.py` — clean\n\nAssisted-by: Kimi