### PR TITLE
chore(backends): drop deprecated torch_dtype argument in LocalHFBackend

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -331,7 +331,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 )
                 # Get the model and tokenizer.
                 self._model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-                    self._hf_model_id, device_map=str(self._device), torch_dtype="auto"
+                    self._hf_model_id, device_map=str(self._device)
                 )
                 self._tokenizer: PreTrainedTokenizerBase = (
                     AutoTokenizer.from_pretrained(self._hf_model_id)

--- a/test/cli/test_alora_train_integration.py
+++ b/test/cli/test_alora_train_integration.py
@@ -204,7 +204,7 @@ def test_alora_training_integration():
         from transformers import AutoModelForCausalLM
 
         base_model = AutoModelForCausalLM.from_pretrained(
-            "ibm-granite/granite-4.1-3b", device_map="auto", torch_dtype=torch.bfloat16
+            "ibm-granite/granite-4.1-3b", device_map="auto", dtype=torch.bfloat16
         )
 
         # Load the trained adapter


### PR DESCRIPTION
Closes #1230

## Summary

One-line cleanup: drop the deprecated `torch_dtype="auto"` argument from
`AutoModelForCausalLM.from_pretrained()` in `LocalHFBackend`.

Transformers v5 deprecated `torch_dtype` in favour of `dtype`
(BC-preserved, emits a runtime warning). The argument is also now
redundant — v5 defaults model dtype to `auto` (respects the dtype in
which the checkpoint was saved), so the explicit `torch_dtype="auto"`
had no effect anyway.

## Change

`mellea/backends/huggingface.py:334` — delete the `torch_dtype="auto"`
kwarg. No behaviour change; silences the deprecation warning.

## Test plan

- [ ] Existing `test/backends/test_huggingface.py` tests pass unchanged
- [ ] No new tests required (argument deletion, no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)