### PR TITLE
fix: inter-chunk stream timeout and download part guard (RFC)

### DIFF
--- a/docs/docs/how-to/configure-model-options.md
+++ b/docs/docs/how-to/configure-model-options.md
@@ -119,7 +119,7 @@ non-deterministic session.
 | `ModelOption.SEED` | `int` | `None` | Random seed for reproducible output. |
 | `ModelOption.SYSTEM_PROMPT` | `str` | `None` | System prompt prepended to every call on the session. |
 | `ModelOption.STREAM` | `bool` | `False` | Enable streaming output. |
-| `ModelOption.STREAM_TIMEOUT` | `float \| None` | `60.0` | Inter-chunk timeout in seconds for streaming responses. If no chunk arrives within this window the stream aborts with a `TimeoutError`. Set to `None` to disable. |
+| `ModelOption.STREAM_TIMEOUT` | `float \| None` | `60.0` | Timeout in seconds applied to every chunk, including time-to-first-token. If no chunk arrives within this window the stream aborts with a `TimeoutError`. Set to `None` to disable. Increase for slow local inference. |
 | `ModelOption.STOP_SEQUENCES` | `list[str]` | `None` | Strings that halt generation when produced by the model. |
 | `ModelOption.THINKING` | varies | `None` | Enable or configure reasoning/thinking mode (model-dependent). |
 | `ModelOption.CONTEXT_WINDOW` | `int` | backend default | Context window size override. |
@@ -145,12 +145,14 @@ value the model sees depends on the backend's own defaults.
 
 ## Streaming timeout
 
-By default Mellea waits up to 60 seconds for each individual chunk from a streaming
-response. If the backend stops sending without closing the connection — for example
-when a local Ollama server is overloaded — the stream aborts with a `TimeoutError`
-rather than hanging indefinitely.
+By default Mellea waits up to 60 seconds for each chunk, including the first
+(time-to-first-token). If the backend stops sending without closing the connection
+the stream aborts with a `TimeoutError` rather than hanging indefinitely.
 
-Adjust the timeout per call or for the whole session:
+> **Note for slow or local backends:** The 60 s default covers time-to-first-token.
+> Large models on CPU, long prompts, or heavily loaded servers can take longer than
+> this before producing the first token. Use a higher value or `None` for those
+> deployments.
 
 ```python
 from mellea.backends import ModelOption
@@ -161,7 +163,13 @@ mot = await m.ainstruct(
     model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 10},
 )
 
-# Disable entirely for a slow local model where chunks may be far apart
+# Larger value for slow local inference (e.g. large model on CPU)
+mot = await m.ainstruct(
+    "Write a long analysis.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 300},
+)
+
+# Disable entirely — original unbounded behaviour
 mot = await m.ainstruct(
     "Write a long analysis.",
     model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: None},

--- a/docs/docs/how-to/configure-model-options.md
+++ b/docs/docs/how-to/configure-model-options.md
@@ -119,7 +119,7 @@ non-deterministic session.
 | `ModelOption.SEED` | `int` | `None` | Random seed for reproducible output. |
 | `ModelOption.SYSTEM_PROMPT` | `str` | `None` | System prompt prepended to every call on the session. |
 | `ModelOption.STREAM` | `bool` | `False` | Enable streaming output. |
-| `ModelOption.STREAM_TIMEOUT` | `float \| None` | `60.0` | Timeout in seconds applied to every chunk, including time-to-first-token. If no chunk arrives within this window the stream aborts with a `TimeoutError`. Set to `None` to disable. Increase for slow local inference. |
+| `ModelOption.STREAM_TIMEOUT` | `float \| None` | `120.0` | Timeout in seconds applied to every chunk, including time-to-first-token. Only applies to streaming responses; non-streaming calls are unaffected. If no chunk arrives within this window the stream aborts with a `TimeoutError`. Set to `None` to disable. Increase for slow local inference. |
 | `ModelOption.STOP_SEQUENCES` | `list[str]` | `None` | Strings that halt generation when produced by the model. |
 | `ModelOption.THINKING` | varies | `None` | Enable or configure reasoning/thinking mode (model-dependent). |
 | `ModelOption.CONTEXT_WINDOW` | `int` | backend default | Context window size override. |
@@ -145,11 +145,12 @@ value the model sees depends on the backend's own defaults.
 
 ## Streaming timeout
 
-By default Mellea waits up to 60 seconds for each chunk, including the first
+By default Mellea waits up to 120 seconds for each chunk, including the first
 (time-to-first-token). If the backend stops sending without closing the connection
-the stream aborts with a `TimeoutError` rather than hanging indefinitely.
+the stream aborts with a `TimeoutError` rather than hanging indefinitely. This
+timeout only applies to streaming responses; non-streaming calls are unaffected.
 
-> **Note for slow or local backends:** The 60 s default covers time-to-first-token.
+> **Note for slow or local backends:** The 120 s default covers time-to-first-token.
 > Large models on CPU, long prompts, or heavily loaded servers can take longer than
 > this before producing the first token. Use a higher value or `None` for those
 > deployments.

--- a/docs/docs/how-to/configure-model-options.md
+++ b/docs/docs/how-to/configure-model-options.md
@@ -115,7 +115,7 @@ non-deterministic session.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `ModelOption.TEMPERATURE` | `float` | backend default | Sampling temperature. |
-| `ModelOption.MAX_NEW_TOKENS` | `int` | backend default | Maximum tokens to generate. |
+| `ModelOption.MAX_NEW_TOKENS` | `int` | backend default ⚠️ | Maximum tokens to generate. Backend defaults vary widely — set this explicitly in production code. |
 | `ModelOption.SEED` | `int` | `None` | Random seed for reproducible output. |
 | `ModelOption.SYSTEM_PROMPT` | `str` | `None` | System prompt prepended to every call on the session. |
 | `ModelOption.STREAM` | `bool` | `False` | Enable streaming output. |
@@ -128,6 +128,20 @@ non-deterministic session.
 
 Keys marked with a backend default are forwarded to the underlying API unchanged; the
 value the model sees depends on the backend's own defaults.
+
+> **Warning:** `MAX_NEW_TOKENS` backend defaults vary widely and some are very low — for
+> example vLLM defaults to 16 tokens, which will silently truncate most real responses.
+> Always set `ModelOption.MAX_NEW_TOKENS` explicitly in production code:
+>
+> ```python
+> m.instruct(
+>     "Summarise this document.",
+>     model_options={ModelOption.MAX_NEW_TOKENS: 1024},
+> )
+> ```
+>
+> A value of 512–2048 covers most chat and instruction use cases. For code generation
+> or long-form output, set a higher value to match your expected output length.
 
 ## Streaming timeout
 

--- a/docs/docs/how-to/configure-model-options.md
+++ b/docs/docs/how-to/configure-model-options.md
@@ -110,6 +110,50 @@ result3 = m.instruct("Write a short poem.")
 This is useful when you need deterministic output for a batch of calls within a larger,
 non-deterministic session.
 
+## Reference: all ModelOption keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ModelOption.TEMPERATURE` | `float` | backend default | Sampling temperature. |
+| `ModelOption.MAX_NEW_TOKENS` | `int` | backend default | Maximum tokens to generate. |
+| `ModelOption.SEED` | `int` | `None` | Random seed for reproducible output. |
+| `ModelOption.SYSTEM_PROMPT` | `str` | `None` | System prompt prepended to every call on the session. |
+| `ModelOption.STREAM` | `bool` | `False` | Enable streaming output. |
+| `ModelOption.STREAM_TIMEOUT` | `float \| None` | `60.0` | Inter-chunk timeout in seconds for streaming responses. If no chunk arrives within this window the stream aborts with a `TimeoutError`. Set to `None` to disable. |
+| `ModelOption.STOP_SEQUENCES` | `list[str]` | `None` | Strings that halt generation when produced by the model. |
+| `ModelOption.THINKING` | varies | `None` | Enable or configure reasoning/thinking mode (model-dependent). |
+| `ModelOption.CONTEXT_WINDOW` | `int` | backend default | Context window size override. |
+| `ModelOption.TOOLS` | `list[MelleaTool]` | `None` | Tools exposed to the model for tool calling. |
+| `ModelOption.TOOL_CHOICE` | `str` | `"auto"` | Tool selection strategy (`"none"`, `"auto"`, or a specific tool name). |
+
+Keys marked with a backend default are forwarded to the underlying API unchanged; the
+value the model sees depends on the backend's own defaults.
+
+## Streaming timeout
+
+By default Mellea waits up to 60 seconds for each individual chunk from a streaming
+response. If the backend stops sending without closing the connection — for example
+when a local Ollama server is overloaded — the stream aborts with a `TimeoutError`
+rather than hanging indefinitely.
+
+Adjust the timeout per call or for the whole session:
+
+```python
+from mellea.backends import ModelOption
+
+# Tighter bound for a known-fast remote endpoint
+mot = await m.ainstruct(
+    "Summarise this document.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 10},
+)
+
+# Disable entirely for a slow local model where chunks may be far apart
+mot = await m.ainstruct(
+    "Write a long analysis.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: None},
+)
+```
+
 ## System prompts
 
 Set a system prompt with `ModelOption.SYSTEM_PROMPT`. At session level it applies to all

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -145,9 +145,11 @@ How `astream()` behaves:
 
 ### Streaming timeout
 
-Mellea waits up to 60 seconds for each individual chunk by default. If the backend
-stops sending without closing the connection the stream aborts with a `TimeoutError`
-rather than hanging indefinitely. Adjust with `ModelOption.STREAM_TIMEOUT`:
+Mellea waits up to 60 seconds for each chunk by default, including the first
+(time-to-first-token). If the backend stops sending without closing the connection
+the stream aborts with a `TimeoutError` rather than hanging indefinitely.
+
+For slow local inference or large models on CPU, increase the timeout or disable it:
 
 ```python
 # Shorter timeout for a fast remote endpoint
@@ -156,7 +158,13 @@ mot = await m.ainstruct(
     model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 10},
 )
 
-# Disable for a slow local model where chunks may arrive far apart
+# Larger value for slow local inference
+mot = await m.ainstruct(
+    "Write a long analysis.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 300},
+)
+
+# Disable entirely — original unbounded behaviour
 mot = await m.ainstruct(
     "Write a long analysis.",
     model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: None},

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -143,6 +143,29 @@ How `astream()` behaves:
 > **Warning:** Do not call `astream()` from multiple coroutines simultaneously on
 > the same thunk. Each thunk should have a single reader.
 
+### Streaming timeout
+
+Mellea waits up to 60 seconds for each individual chunk by default. If the backend
+stops sending without closing the connection the stream aborts with a `TimeoutError`
+rather than hanging indefinitely. Adjust with `ModelOption.STREAM_TIMEOUT`:
+
+```python
+# Shorter timeout for a fast remote endpoint
+mot = await m.ainstruct(
+    "Summarise this document.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 10},
+)
+
+# Disable for a slow local model where chunks may arrive far apart
+mot = await m.ainstruct(
+    "Write a long analysis.",
+    model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: None},
+)
+```
+
+See [Configure model options — Streaming timeout](../how-to/configure-model-options#streaming-timeout)
+for the full reference.
+
 ## Async and context
 
 Use `SimpleContext` (the default) with concurrent async requests. Using `ChatContext`

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -145,7 +145,7 @@ How `astream()` behaves:
 
 ### Streaming timeout
 
-Mellea waits up to 60 seconds for each chunk by default, including the first
+Mellea waits up to 120 seconds for each chunk by default, including the first
 (time-to-first-token). If the backend stops sending without closing the connection
 the stream aborts with a `TimeoutError` rather than hanging indefinitely.
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -733,7 +733,13 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)  # type: ignore
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )  # type: ignore
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:
@@ -1017,7 +1023,13 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 # This function should always be called from a running event loop so we don't have to worry about
                 # scheduling the task to a specific event loop here.
                 output._generate = asyncio.create_task(
-                    send_to_queue(response, output._async_queue)  # type: ignore
+                    send_to_queue(
+                        response,
+                        output._async_queue,
+                        chunk_timeout=(model_options or {}).get(
+                            ModelOption.STREAM_TIMEOUT, 60.0
+                        ),
+                    )  # type: ignore
                 )
                 output._generate_type = GenerateType.ASYNC
             except RuntimeError as e:
@@ -1185,7 +1197,13 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 # This function should always be called from a running event loop so we don't have to worry about
                 # scheduling the task to a specific event loop here.
                 output._generate = asyncio.create_task(
-                    send_to_queue(response, output._async_queue)  # type: ignore
+                    send_to_queue(
+                        response,
+                        output._async_queue,
+                        chunk_timeout=(model_options or {}).get(
+                            ModelOption.STREAM_TIMEOUT, 60.0
+                        ),
+                    )  # type: ignore
                 )
                 output._generate_type = GenerateType.ASYNC
             except RuntimeError as e:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -56,7 +56,12 @@ from ..core import (
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter, granite as granite_formatters
 from ..formatters.granite.base.util import _GuidanceLogitsProcessor
-from ..helpers import message_to_openai_message, messages_to_docs, send_to_queue
+from ..helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
+    message_to_openai_message,
+    messages_to_docs,
+    send_to_queue,
+)
 from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import ALoraRequirement, LLMaJRequirement
 from ..telemetry.backend_instrumentation import (
@@ -737,7 +742,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )  # type: ignore
             )
@@ -1027,7 +1032,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                         response,
                         output._async_queue,
                         chunk_timeout=(model_options or {}).get(
-                            ModelOption.STREAM_TIMEOUT, 60.0
+                            ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore
                 )
@@ -1201,7 +1206,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                         response,
                         output._async_queue,
                         chunk_timeout=(model_options or {}).get(
-                            ModelOption.STREAM_TIMEOUT, 60.0
+                            ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore
                 )

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -741,7 +741,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_options.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )  # type: ignore
@@ -988,6 +988,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             # Arm the cancel hook before creating tasks so a cancel racing
             # task creation still finds the hook set.
             if stream:
+                # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
+                # through stream_with_chunking; direct avalue()/astream() callers do not,
+                # so the worker thread leaks on STREAM_TIMEOUT for those paths.
                 output._cancel_hook = _cancel_event.set
             output._start = datetime.datetime.now()
             output._context = ctx.view_for_generation()
@@ -1031,7 +1034,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     send_to_queue(
                         response,
                         output._async_queue,
-                        chunk_timeout=(model_options or {}).get(
+                        chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore
@@ -1162,6 +1165,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             # Arm the cancel hook before creating tasks so a cancel racing
             # task creation still finds the hook set.
             if stream:
+                # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
+                # through stream_with_chunking; direct avalue()/astream() callers do not,
+                # so the worker thread leaks on STREAM_TIMEOUT for those paths.
                 output._cancel_hook = _cancel_event.set
             output._start = datetime.datetime.now()
             output._context = ctx.view_for_generation()
@@ -1205,7 +1211,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     send_to_queue(
                         response,
                         output._async_queue,
-                        chunk_timeout=(model_options or {}).get(
+                        chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -33,6 +33,7 @@ from ..core import (
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter
 from ..helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
     chat_completion_delta_merge,
     extract_model_tool_requests,
     get_current_event_loop,
@@ -458,7 +459,7 @@ class LiteLLMBackend(FormatterBackend):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -458,7 +458,7 @@ class LiteLLMBackend(FormatterBackend):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -454,7 +454,13 @@ class LiteLLMBackend(FormatterBackend):
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -30,7 +30,8 @@ class ModelOption:
         THINKING (str): Sentinel key for enabling/configuring reasoning/thinking mode.
         SEED (str): Sentinel key for the random seed for reproducible generation.
         STREAM (str): Sentinel key for enabling streaming responses.
-        STREAM_TIMEOUT (str): Sentinel key for the inter-chunk streaming timeout in seconds.
+        STREAM_TIMEOUT (str): Sentinel key for the per-chunk streaming timeout in seconds
+            (applied to every chunk, including time-to-first-token).
             ``None`` disables the timeout. Defaults to ``60.0`` when not set.
         STOP_SEQUENCES (str): Sentinel key for a `list[str]` of strings that, when
             encountered in the model output, cause generation to halt.
@@ -50,9 +51,9 @@ class ModelOption:
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"
     STREAM_TIMEOUT = "@@@stream_timeout@@@"
-    """Inter-chunk timeout in seconds for streaming responses. If no chunk arrives within
-    this window the stream is aborted with ``TimeoutError``. ``None`` disables the timeout.
-    Defaults to ``60.0`` seconds when not set."""
+    """Per-chunk timeout in seconds (applied to every chunk, including time-to-first-token).
+    If no chunk arrives within this window the stream is aborted with ``TimeoutError``.
+    ``None`` disables the timeout. Defaults to ``60.0`` seconds when not set."""
     STOP_SEQUENCES = "@@@stop_sequences@@@"
     """Must be a `list[str]`. Generation halts when the model emits any of these strings.
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -30,6 +30,8 @@ class ModelOption:
         THINKING (str): Sentinel key for enabling/configuring reasoning/thinking mode.
         SEED (str): Sentinel key for the random seed for reproducible generation.
         STREAM (str): Sentinel key for enabling streaming responses.
+        STREAM_TIMEOUT (str): Sentinel key for the inter-chunk streaming timeout in seconds.
+            ``None`` disables the timeout. Defaults to ``60.0`` when not set.
         STOP_SEQUENCES (str): Sentinel key for a `list[str]` of strings that, when
             encountered in the model output, cause generation to halt.
     """
@@ -47,6 +49,10 @@ class ModelOption:
     THINKING = "@@@thinking@@@"
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"
+    STREAM_TIMEOUT = "@@@stream_timeout@@@"
+    """Inter-chunk timeout in seconds for streaming responses. If no chunk arrives within
+    this window the stream is aborted with ``TimeoutError``. ``None`` disables the timeout.
+    Defaults to ``60.0`` seconds when not set."""
     STOP_SEQUENCES = "@@@stop_sequences@@@"
     """Must be a `list[str]`. Generation halts when the model emits any of these strings.
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -32,7 +32,7 @@ class ModelOption:
         STREAM (str): Sentinel key for enabling streaming responses.
         STREAM_TIMEOUT (str): Sentinel key for the per-chunk streaming timeout in seconds
             (applied to every chunk, including time-to-first-token).
-            ``None`` disables the timeout. Defaults to ``60.0`` when not set.
+            ``None`` disables the timeout. Defaults to ``120.0`` when not set.
         STOP_SEQUENCES (str): Sentinel key for a `list[str]` of strings that, when
             encountered in the model output, cause generation to halt.
     """
@@ -53,7 +53,7 @@ class ModelOption:
     STREAM_TIMEOUT = "@@@stream_timeout@@@"
     """Per-chunk timeout in seconds (applied to every chunk, including time-to-first-token).
     If no chunk arrives within this window the stream is aborted with ``TimeoutError``.
-    ``None`` disables the timeout. Defaults to ``60.0`` seconds when not set."""
+    ``None`` disables the timeout. Defaults to ``120.0`` seconds when not set."""
     STOP_SEQUENCES = "@@@stop_sequences@@@"
     """Must be a `list[str]`. Generation halts when the model emits any of these strings.
 

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -472,7 +472,13 @@ class OllamaModelBackend(FormatterBackend):
 
             # Use `create_task` so that we don't have to specifically await this task before it starts executing.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -24,7 +24,12 @@ from ..core import (
 )
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter
-from ..helpers import ClientCache, get_current_event_loop, send_to_queue
+from ..helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
+    ClientCache,
+    get_current_event_loop,
+    send_to_queue,
+)
 from ..stdlib.components import Message
 from ..stdlib.requirements import ALoraRequirement
 from ..telemetry.backend_instrumentation import (
@@ -476,7 +481,7 @@ class OllamaModelBackend(FormatterBackend):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -480,7 +480,7 @@ class OllamaModelBackend(FormatterBackend):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -770,7 +770,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_options.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -968,7 +968,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -31,6 +31,7 @@ from ..core import (
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter, granite as granite_formatters
 from ..helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
     ClientCache,
     _server_type,
     _ServerType,
@@ -770,7 +771,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
@@ -968,7 +969,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -766,7 +766,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # we don't have to worry about scheduling the task to a specific
             # event loop here.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:
@@ -958,7 +964,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -36,6 +36,7 @@ from ..core import (
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter
 from ..helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
     ClientCache,
     chat_completion_delta_merge,
     extract_model_tool_requests,
@@ -481,7 +482,7 @@ class WatsonxAIBackend(FormatterBackend):
                     chat_response,
                     output._async_queue,
                     chunk_timeout=(model_options or {}).get(
-                        ModelOption.STREAM_TIMEOUT, 60.0
+                        ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -481,7 +481,7 @@ class WatsonxAIBackend(FormatterBackend):
                 send_to_queue(
                     chat_response,
                     output._async_queue,
-                    chunk_timeout=(model_options or {}).get(
+                    chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -477,7 +477,13 @@ class WatsonxAIBackend(FormatterBackend):
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
             output._generate = asyncio.create_task(
-                send_to_queue(chat_response, output._async_queue)
+                send_to_queue(
+                    chat_response,
+                    output._async_queue,
+                    chunk_timeout=(model_options or {}).get(
+                        ModelOption.STREAM_TIMEOUT, 60.0
+                    ),
+                )
             )
             output._generate_type = GenerateType.ASYNC
         except RuntimeError as e:

--- a/mellea/formatters/granite/retrievers/util.py
+++ b/mellea/formatters/granite/retrievers/util.py
@@ -130,8 +130,12 @@ def download_mtrag_embeddings(
 
     part_num = 1
     repo_root = "https://github.com/frreiss/mt-rag-embeddings"
-    _MAX_PARTS = 50  # the largest corpus currently has 20 parts; 50 gives headroom
-    while part_num <= _MAX_PARTS:
+    _MAX_PARTS = (
+        50  # the largest corpus currently has 20 parts; 50 gives headroom for growth
+    )
+    while (
+        part_num <= _MAX_PARTS + 1
+    ):  # +1 so a corpus of exactly _MAX_PARTS parts can fetch the terminating 404
         # Download part_001.parquet, part_002.parquet, etc. until a download fails.
         parquet_file_name = f"part_{part_num:03d}.parquet"
         source_url = (

--- a/mellea/formatters/granite/retrievers/util.py
+++ b/mellea/formatters/granite/retrievers/util.py
@@ -50,6 +50,7 @@ def download_mtrag_corpus(target_dir: str, corpus_name: str) -> pathlib.Path:
 
 
 MB = 1048576  # 1MB in bytes
+_MAX_PARTS = 50  # largest corpus currently has 20 parts; 50 gives headroom for growth
 
 
 def read_mtrag_corpus(corpus_file: str | pathlib.Path) -> pa.Table:
@@ -130,9 +131,6 @@ def download_mtrag_embeddings(
 
     part_num = 1
     repo_root = "https://github.com/frreiss/mt-rag-embeddings"
-    _MAX_PARTS = (
-        50  # the largest corpus currently has 20 parts; 50 gives headroom for growth
-    )
     while (
         part_num <= _MAX_PARTS + 1
     ):  # +1 so a corpus of exactly _MAX_PARTS parts can fetch the terminating 404

--- a/mellea/formatters/granite/retrievers/util.py
+++ b/mellea/formatters/granite/retrievers/util.py
@@ -130,7 +130,7 @@ def download_mtrag_embeddings(
 
     part_num = 1
     repo_root = "https://github.com/frreiss/mt-rag-embeddings"
-    _MAX_PARTS = 1000  # sanity guard against a malformed or unexpectedly large dataset
+    _MAX_PARTS = 50  # the largest corpus currently has 20 parts; 50 gives headroom
     while part_num <= _MAX_PARTS:
         # Download part_001.parquet, part_002.parquet, etc. until a download fails.
         parquet_file_name = f"part_{part_num:03d}.parquet"
@@ -149,7 +149,8 @@ def download_mtrag_embeddings(
             raise  # 429/5xx propagate rather than silently truncating
     else:
         raise RuntimeError(
-            f"Corpus download exceeded {_MAX_PARTS} parts — possible dataset corruption."
+            f"Corpus download exceeded {_MAX_PARTS} parts — the dataset may have grown "
+            "beyond what this guard expects. Raise _MAX_PARTS if the corpus is legitimately larger."
         )
 
     if part_num == 1:

--- a/mellea/formatters/granite/retrievers/util.py
+++ b/mellea/formatters/granite/retrievers/util.py
@@ -130,7 +130,8 @@ def download_mtrag_embeddings(
 
     part_num = 1
     repo_root = "https://github.com/frreiss/mt-rag-embeddings"
-    while True:
+    _MAX_PARTS = 1000  # sanity guard against a malformed or unexpectedly large dataset
+    while part_num <= _MAX_PARTS:
         # Download part_001.parquet, part_002.parquet, etc. until a download fails.
         parquet_file_name = f"part_{part_num:03d}.parquet"
         source_url = (
@@ -146,6 +147,10 @@ def download_mtrag_embeddings(
                 # Found all the parts; flow through
                 break
             raise  # 429/5xx propagate rather than silently truncating
+    else:
+        raise RuntimeError(
+            f"Corpus download exceeded {_MAX_PARTS} parts — possible dataset corruption."
+        )
 
     if part_num == 1:
         raise ValueError(

--- a/mellea/helpers/__init__.py
+++ b/mellea/helpers/__init__.py
@@ -10,6 +10,7 @@ this package directly — it is consumed internally by the backend layer.
 """
 
 from .async_helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
     ClientCache,
     get_current_event_loop,
     send_to_queue,
@@ -29,6 +30,7 @@ from .server_type import (
 )
 
 __all__ = [
+    "DEFAULT_CHUNK_TIMEOUT",
     "ClientCache",
     "_ServerType",
     "_run_async_in_thread",

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -54,6 +54,11 @@ async def send_to_queue(
             the queue and the stream is aborted. ``None`` disables the timeout.
             Defaults to ``DEFAULT_CHUNK_TIMEOUT`` (120 s). Note that ``0`` sets the
             deadline to "now" and aborts immediately — use ``None`` to disable.
+
+    Raises:
+        TimeoutError: Re-raised verbatim when the backend itself raises ``TimeoutError``
+            (i.e. the timeout did not originate from *this* function's per-chunk guard).
+            Stream-guard timeouts are forwarded into *aqueue* rather than raised.
     """
     try:
         if isinstance(co, Coroutine):

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from collections.abc import AsyncGenerator, AsyncIterator, Coroutine
+from collections.abc import AsyncIterator, Coroutine
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -72,11 +72,18 @@ async def send_to_queue(
                             "Set ModelOption.STREAM_TIMEOUT to a larger value or None to disable."
                         )
                     )
-                    if isinstance(ait, AsyncGenerator):
+                    close = getattr(ait, "aclose", None) or getattr(ait, "close", None)
+                    if close is not None:
+                        from ..core import MelleaLogger
+
                         try:
-                            await ait.aclose()
-                        except Exception:
-                            pass
+                            result = close()
+                            if asyncio.iscoroutine(result):
+                                await result
+                        except Exception as e:
+                            MelleaLogger.get_logger().debug(
+                                f"Failed to close stalled stream iterator: {e}"
+                            )
                     return
                 await aqueue.put(item)
         else:

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -19,19 +19,24 @@ if TYPE_CHECKING:
     from ..core import ModelOutputThunk
 
 
-DEFAULT_CHUNK_TIMEOUT: float = 60.0
+DEFAULT_CHUNK_TIMEOUT: float = 120.0
 """Default per-chunk timeout for streaming responses, in seconds.
 
 This value applies to every chunk including the first (time-to-first-token).
 Slow local inference (large models on CPU, heavily queued servers) can take
 well over 60 s before producing the first token — set ``ModelOption.STREAM_TIMEOUT``
 to a higher value or ``None`` for those deployments.
+
+This timeout only activates when the backend returns an ``AsyncIterator`` (i.e.
+streaming responses). Non-streaming coroutines that resolve to a plain response
+object bypass the per-chunk loop entirely and are unaffected by this value.
 """
 
 
 async def send_to_queue(
     co: Coroutine[Any, Any, AsyncIterator | Any] | AsyncIterator,
     aqueue: asyncio.Queue,
+    *,
     chunk_timeout: float | None = DEFAULT_CHUNK_TIMEOUT,
 ) -> None:
     """Processes the output of an async chat request by sending the output to an async queue.
@@ -43,10 +48,12 @@ async def send_to_queue(
             appended on error. A timeout does **not** append a trailing sentinel — the
             exception item is the stream terminator.
         chunk_timeout: Maximum seconds to wait for each chunk from the backend iterator,
-            including the first (time-to-first-token). If no chunk arrives within this
-            window a ``TimeoutError`` is forwarded to the queue and the stream is aborted.
-            ``None`` disables the timeout (original behaviour).
-            Defaults to ``DEFAULT_CHUNK_TIMEOUT`` (60 s).
+            including the first (time-to-first-token). Only applies when the backend
+            response is an ``AsyncIterator``; non-streaming coroutines are unaffected.
+            If no chunk arrives within this window a ``TimeoutError`` is forwarded to
+            the queue and the stream is aborted. ``None`` disables the timeout.
+            Defaults to ``DEFAULT_CHUNK_TIMEOUT`` (120 s). Note that ``0`` sets the
+            deadline to "now" and aborts immediately — use ``None`` to disable.
     """
     try:
         if isinstance(co, Coroutine):
@@ -59,12 +66,15 @@ async def send_to_queue(
         if isinstance(aresponse, AsyncIterator):
             ait = aiter(aresponse)
             while True:
+                cm: asyncio.Timeout | None = None
                 try:
-                    async with asyncio.timeout(chunk_timeout):
+                    async with asyncio.timeout(chunk_timeout) as cm:
                         item = await anext(ait)
                 except StopAsyncIteration:
                     break
                 except TimeoutError:
+                    if cm is None or not cm.expired():
+                        raise  # backend's own TimeoutError — forward verbatim
                     await aqueue.put(
                         TimeoutError(
                             f"Stream timed out after {chunk_timeout}s without a chunk "

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -19,15 +19,24 @@ if TYPE_CHECKING:
     from ..core import ModelOutputThunk
 
 
+_DEFAULT_CHUNK_TIMEOUT: float = 60.0
+
+
 async def send_to_queue(
-    co: Coroutine[Any, Any, AsyncIterator | Any] | AsyncIterator, aqueue: asyncio.Queue
+    co: Coroutine[Any, Any, AsyncIterator | Any] | AsyncIterator,
+    aqueue: asyncio.Queue,
+    chunk_timeout: float | None = _DEFAULT_CHUNK_TIMEOUT,
 ) -> None:
     """Processes the output of an async chat request by sending the output to an async queue.
 
     Args:
         co: A coroutine or async iterator producing the backend response.
-        aqueue: The async queue to send results to. A sentinel `None` is appended on
+        aqueue: The async queue to send results to. A sentinel ``None`` is appended on
             completion; an exception instance is appended on error.
+        chunk_timeout: Maximum seconds to wait for each individual chunk from the backend
+            iterator. If a chunk does not arrive within this window a ``TimeoutError`` is
+            forwarded to the queue and the stream is aborted. ``None`` disables the timeout
+            (original behaviour). Defaults to ``_DEFAULT_CHUNK_TIMEOUT`` (60 s).
     """
     try:
         if isinstance(co, Coroutine):
@@ -38,7 +47,21 @@ async def send_to_queue(
             aresponse = co
 
         if isinstance(aresponse, AsyncIterator):
-            async for item in aresponse:
+            aiter = aresponse.__aiter__()
+            while True:
+                try:
+                    async with asyncio.timeout(chunk_timeout):
+                        item = await aiter.__anext__()
+                except StopAsyncIteration:
+                    break
+                except TimeoutError:
+                    await aqueue.put(
+                        TimeoutError(
+                            f"Stream timed out waiting for next chunk after {chunk_timeout}s. "
+                            "Set ModelOption.STREAM_TIMEOUT to a larger value or None to disable."
+                        )
+                    )
+                    return
                 await aqueue.put(item)
         else:
             await aqueue.put(aresponse)

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -12,31 +12,41 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Coroutine
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..core import ModelOutputThunk
 
 
-_DEFAULT_CHUNK_TIMEOUT: float = 60.0
+DEFAULT_CHUNK_TIMEOUT: float = 60.0
+"""Default per-chunk timeout for streaming responses, in seconds.
+
+This value applies to every chunk including the first (time-to-first-token).
+Slow local inference (large models on CPU, heavily queued servers) can take
+well over 60 s before producing the first token — set ``ModelOption.STREAM_TIMEOUT``
+to a higher value or ``None`` for those deployments.
+"""
 
 
 async def send_to_queue(
     co: Coroutine[Any, Any, AsyncIterator | Any] | AsyncIterator,
     aqueue: asyncio.Queue,
-    chunk_timeout: float | None = _DEFAULT_CHUNK_TIMEOUT,
+    chunk_timeout: float | None = DEFAULT_CHUNK_TIMEOUT,
 ) -> None:
     """Processes the output of an async chat request by sending the output to an async queue.
 
     Args:
         co: A coroutine or async iterator producing the backend response.
         aqueue: The async queue to send results to. A sentinel ``None`` is appended on
-            completion; an exception instance is appended on error.
-        chunk_timeout: Maximum seconds to wait for each individual chunk from the backend
-            iterator. If a chunk does not arrive within this window a ``TimeoutError`` is
-            forwarded to the queue and the stream is aborted. ``None`` disables the timeout
-            (original behaviour). Defaults to ``_DEFAULT_CHUNK_TIMEOUT`` (60 s).
+            normal completion; an exception instance (including ``TimeoutError``) is
+            appended on error. A timeout does **not** append a trailing sentinel — the
+            exception item is the stream terminator.
+        chunk_timeout: Maximum seconds to wait for each chunk from the backend iterator,
+            including the first (time-to-first-token). If no chunk arrives within this
+            window a ``TimeoutError`` is forwarded to the queue and the stream is aborted.
+            ``None`` disables the timeout (original behaviour).
+            Defaults to ``DEFAULT_CHUNK_TIMEOUT`` (60 s).
     """
     try:
         if isinstance(co, Coroutine):
@@ -47,20 +57,26 @@ async def send_to_queue(
             aresponse = co
 
         if isinstance(aresponse, AsyncIterator):
-            aiter = aresponse.__aiter__()
+            ait = aiter(aresponse)
             while True:
                 try:
                     async with asyncio.timeout(chunk_timeout):
-                        item = await aiter.__anext__()
+                        item = await anext(ait)
                 except StopAsyncIteration:
                     break
                 except TimeoutError:
                     await aqueue.put(
                         TimeoutError(
-                            f"Stream timed out waiting for next chunk after {chunk_timeout}s. "
+                            f"Stream timed out after {chunk_timeout}s without a chunk "
+                            "(covers time-to-first-token and inter-chunk gaps). "
                             "Set ModelOption.STREAM_TIMEOUT to a larger value or None to disable."
                         )
                     )
+                    if isinstance(ait, AsyncGenerator):
+                        try:
+                            await ait.aclose()
+                        except Exception:
+                            pass
                     return
                 await aqueue.put(item)
         else:

--- a/test/formatters/granite/test_retrievers_util.py
+++ b/test/formatters/granite/test_retrievers_util.py
@@ -97,3 +97,17 @@ def test_embeddings_propagates_non_404_errors(tmp_path, code):
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             download_mtrag_embeddings("model", "cloud", str(tmp_path))
     assert exc_info.value.code == code
+
+
+def test_embeddings_raises_if_corpus_exceeds_max_parts(tmp_path):
+    """If the loop exhausts _MAX_PARTS+1 attempts without a 404, RuntimeError is raised."""
+
+    def always_succeed(_url, dest):
+        open(dest, "wb").close()
+
+    with (
+        patch("mellea.formatters.granite.retrievers.util._MAX_PARTS", 2),
+        patch("urllib.request.urlretrieve", side_effect=always_succeed),
+    ):
+        with pytest.raises(RuntimeError, match="Corpus download exceeded"):
+            download_mtrag_embeddings("model", "cloud", str(tmp_path))

--- a/test/helpers/test_async_helpers.py
+++ b/test/helpers/test_async_helpers.py
@@ -85,11 +85,11 @@ class TestSendToQueue:
 
         async def _stalling_gen():
             yield "first"
-            await asyncio.sleep(10)  # longer than chunk_timeout
+            await asyncio.sleep(1)  # longer than chunk_timeout
             yield "never"  # pragma: no cover
 
         q: asyncio.Queue = asyncio.Queue()
-        await send_to_queue(_stalling_gen(), q, chunk_timeout=0.5)
+        await send_to_queue(_stalling_gen(), q, chunk_timeout=0.05)
 
         assert await q.get() == "first"
         item = await q.get()
@@ -113,8 +113,8 @@ class TestSendToQueue:
         assert await q.get() is None  # sentinel present on clean completion
 
     def test_default_chunk_timeout_value(self):
-        """DEFAULT_CHUNK_TIMEOUT is 60 seconds."""
-        assert DEFAULT_CHUNK_TIMEOUT == 60.0
+        """DEFAULT_CHUNK_TIMEOUT is 120 seconds."""
+        assert DEFAULT_CHUNK_TIMEOUT == 120.0
 
 
 # --- get_current_event_loop ---

--- a/test/helpers/test_async_helpers.py
+++ b/test/helpers/test_async_helpers.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from mellea.helpers.async_helpers import (
+    DEFAULT_CHUNK_TIMEOUT,
     ClientCache,
     get_current_event_loop,
     send_to_queue,
@@ -78,6 +79,42 @@ class TestSendToQueue:
         assert await q.get() == "ok"
         item = await q.get()
         assert isinstance(item, RuntimeError)
+
+    async def test_chunk_timeout_fires(self):
+        """A stalling iterator puts TimeoutError in the queue; no sentinel follows."""
+
+        async def _stalling_gen():
+            yield "first"
+            await asyncio.sleep(10)  # longer than chunk_timeout
+            yield "never"  # pragma: no cover
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(_stalling_gen(), q, chunk_timeout=0.05)
+
+        assert await q.get() == "first"
+        item = await q.get()
+        assert isinstance(item, TimeoutError)
+        assert "STREAM_TIMEOUT" in str(item)
+        assert q.empty()  # no trailing sentinel after a timeout
+
+    async def test_chunk_timeout_none_disables_timeout(self):
+        """chunk_timeout=None allows a slow-but-completing iterator to finish normally."""
+
+        async def _slow_gen():
+            yield "a"
+            await asyncio.sleep(0.05)
+            yield "b"
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(_slow_gen(), q, chunk_timeout=None)
+
+        assert await q.get() == "a"
+        assert await q.get() == "b"
+        assert await q.get() is None  # sentinel present on clean completion
+
+    def test_default_chunk_timeout_value(self):
+        """DEFAULT_CHUNK_TIMEOUT is 60 seconds."""
+        assert DEFAULT_CHUNK_TIMEOUT == 60.0
 
 
 # --- get_current_event_loop ---

--- a/test/helpers/test_async_helpers.py
+++ b/test/helpers/test_async_helpers.py
@@ -89,7 +89,7 @@ class TestSendToQueue:
             yield "never"  # pragma: no cover
 
         q: asyncio.Queue = asyncio.Queue()
-        await send_to_queue(_stalling_gen(), q, chunk_timeout=0.05)
+        await send_to_queue(_stalling_gen(), q, chunk_timeout=0.5)
 
         assert await q.get() == "first"
         item = await q.get()


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

Closes #650. Addresses all three concerns in #1235.

Fixes #650
Fixes #1235

## What changed

**Streaming hang fix (`helpers/async_helpers.py`)**

A stalled backend iterator previously blocked the process forever. `send_to_queue` had no per-chunk timeout, so its iteration loop waited indefinitely and no sentinel ever reached the queue. Every downstream consumer blocked with it.

This wraps each `anext()` call in `asyncio.timeout()`. A stalled stream now surfaces as a `TimeoutError` through the queue. On timeout, the underlying iterator's close method is called via duck-typing (`getattr(ait, "aclose", None) or getattr(ait, "close", None)`) to release HTTP connections cleanly — this covers both `async def`-style `AsyncGenerator` and class-based iterators such as OpenAI's `AsyncStream` and HF's `AsyncTextIteratorStreamer`.

The timeout context manager is captured (`async with asyncio.timeout(...) as cm`) and `cm.expired()` is checked before rewriting the error — so a `TimeoutError` raised by the backend iterator itself (e.g. an httpx read timeout) is forwarded verbatim rather than being misreported as a misconfigured `STREAM_TIMEOUT`.

`DEFAULT_CHUNK_TIMEOUT = 120.0` is a public constant exported from `helpers/`. All eight backend call sites import and use it — no hardcoded values. The new `ModelOption.STREAM_TIMEOUT` key lets callers override per-call or at the backend/session level. `chunk_timeout` is keyword-only in the `send_to_queue` signature.

The 120 s default covers time-to-first-token as well as inter-chunk gaps. Slow local inference (large models on CPU, long prompts) can legitimately exceed this before the first token. Use a higher value or `None` for those deployments. Note: this timeout only applies to streaming responses; non-streaming coroutines bypass the per-chunk loop entirely and are unaffected.

**Retriever download guard (`formatters/granite/retrievers/util.py`)**

The parquet download loop now stops at `_MAX_PARTS + 1` attempts. The extra iteration allows a corpus of exactly `_MAX_PARTS` parts to receive the terminating 404 rather than raising spuriously. The largest corpus currently has 20 parts; 50 gives headroom. `_MAX_PARTS` is a module-level constant (patchable in tests).

**Documentation (`docs/`)**

`ModelOption` reference table updated: `STREAM_TIMEOUT` description notes it covers TTFT and that non-streaming calls are unaffected. `MAX_NEW_TOKENS` row flags that backend defaults vary widely (vLLM defaults to 16). Both streaming how-to pages show three examples: tight timeout, slow-model value (300 s), and `None` to disable.

**Tests**

Four new cases in `test/helpers/test_async_helpers.py`: timeout fires and puts `TimeoutError` with no trailing sentinel; `None` disables the timeout and clean completion still gets a sentinel; `DEFAULT_CHUNK_TIMEOUT` is 120.0. One new case in `test/formatters/granite/test_retrievers_util.py`: `_MAX_PARTS` exhaustion raises `RuntimeError`.

## Follow-up

#1242 tracks the cancel hook not firing for direct `avalue()`/`astream()` callers on HF `STREAM_TIMEOUT` — the worker thread keeps generating until natural completion on those paths. Marked with `TODO(#1242)` at the two `_cancel_hook` arming sites. The `stream_with_chunking` path already calls `cancel_generation()` and is not affected.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)