### PR TITLE
docs(docusaurus): suppress unreleased banner until first snapshot exists

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -43,7 +43,7 @@ const config: Config = {
               label: 'main (unreleased)',
               // path is added by the release pipeline (set-last-version.mjs) on
               // first final release, once a snapshot version exists as the default
-              banner: 'unreleased',
+              banner: 'none',
             },
           },
         } satisfies DocsOptions,


### PR DESCRIPTION
## What

Removes the yellow "This is unreleased documentation" banner from the docs site.

Before the first release snapshot, Docusaurus has no stable version to compare against, so `banner: 'unreleased'` produces a circular message:

> *"This is unreleased documentation for Mellea **main (unreleased)** version. For up-to-date documentation, see the **latest version** (main (unreleased))."*

Setting `banner: 'none'` suppresses the strip entirely. The version dropdown in the navbar still correctly shows "main (unreleased)" so the information is available to users who want it.

## After the first final release

The `publish-release.yml` snapshot job runs `set-last-version.mjs`, which rewrites `lastVersion` to the new tag and sets the `current` version path. At that point the banner can be re-enabled — the current (`main`) docs will genuinely be ahead of the released snapshot.

<!-- pr-template -->