### PR TITLE
feat: re-export serve types from public mellea.* namespace

### DIFF
--- a/cli/serve/models.py
+++ b/cli/serve/models.py
@@ -2,99 +2,13 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, RootModel, model_validator
 
-from mellea.core import ImageBlock
 from mellea.helpers.openai_compatible_helpers import CompletionUsage
-
-
-class TextContent(BaseModel):
-    """Text content in a multimodal message."""
-
-    type: Literal["text"]
-    text: str
-
-
-class ImageUrlContent(BaseModel):
-    """Image URL content in a multimodal message.
-
-    Supports both data URIs (base64-encoded images) and HTTP(S) URLs.
-    """
-
-    type: Literal["image_url"]
-    image_url: dict[str, str]
-    """Image URL object containing 'url' key and optional 'detail' key."""
-
-
-# Union type for all content types
-MessageContent = TextContent | ImageUrlContent
-
-
-class ChatMessage(BaseModel):
-    """Chat message with support for text-only or multimodal content.
-
-    The content field can be:
-    - A string (text-only, backward compatible)
-    - None (for messages without content)
-    - A list of content objects (multimodal: text, images)
-    """
-
-    role: Literal["system", "user", "assistant", "tool", "function"]
-    content: str | list[MessageContent] | None = None
-    name: str | None = None
-    tool_call_id: str | None = None
-    function_call: dict[str, Any] | None = None  # For function/tool messages
-
-    def get_text_content(self) -> str:
-        """Extract text content from message, handling both string and multimodal formats.
-
-        Returns:
-            Concatenated text from all TextContent items, or empty string if no text.
-            Images are ignored (handled separately via extraction utilities).
-        """
-        if isinstance(self.content, str):
-            return self.content
-        elif isinstance(self.content, list):
-            return " ".join(
-                item.text for item in self.content if isinstance(item, TextContent)
-            )
-        return ""
-
-    def get_image_urls(self) -> list[str]:
-        """Extract image URLs from message content.
-
-        Returns:
-            List of image URL strings from all ImageUrlContent items.
-            Empty list if content is a string or contains no images.
-        """
-        if not isinstance(self.content, list):
-            return []
-        urls = []
-        for item in self.content:
-            if isinstance(item, ImageUrlContent):
-                url = item.image_url.get("url")
-                if url:
-                    urls.append(url)
-        return urls
-
-    def get_image_blocks(self) -> list[ImageBlock]:
-        """Extract ImageBlocks from message content.
-
-        Returns:
-            List of ImageBlocks from all ImageUrlContent items.
-            Empty list if content is a string or contains no images.
-        """
-        image_urls = self.get_image_urls()
-        image_blocks: list[ImageBlock] = []
-        for url in image_urls:
-            try:
-                image_blocks.append(ImageBlock(url))
-            except AssertionError as e:
-                # Raise ValueError for invalid URLs so the client gets a clear 400 error
-                # rather than silently processing a request without the expected images
-                raise ValueError(
-                    f"Invalid image URL: {url[:100]}{'...' if len(url) > 100 else ''}. "
-                    f"Error: {e}"
-                ) from e
-        return image_blocks
+from mellea.serve.models import (
+    ChatMessage,
+    ImageUrlContent,
+    MessageContent,
+    TextContent,
+)
 
 
 class FunctionParameters(RootModel[dict[str, Any]]):

--- a/docs/docs/integrations/m-serve.md
+++ b/docs/docs/integrations/m-serve.md
@@ -16,8 +16,8 @@ it were a model.
 Your program must define a `serve()` function with this signature:
 
 ```python
-from cli.serve.models import ChatMessage
 from mellea.core import ModelOutputThunk, SamplingResult
+from mellea.serve import ChatMessage
 
 def serve(
     input: list[ChatMessage],
@@ -35,8 +35,8 @@ def serve(
 
 ```python
 import mellea
-from cli.serve.models import ChatMessage
 from mellea.core import ModelOutputThunk, Requirement, SamplingResult
+from mellea.serve import ChatMessage
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import simple_validate
 from mellea.stdlib.sampling import RejectionSamplingStrategy

--- a/docs/examples/m_serve/m_serve_example_multimodal_image.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_image.py
@@ -18,9 +18,9 @@ Then test with:
 
 from typing import Any, cast
 
-from cli.serve.models import ChatMessage
 from mellea import start_session
 from mellea.core import ModelOutputThunk
+from mellea.serve import ChatMessage
 
 MODEL_ID = "granite3.2-vision"
 session = start_session(model_id=MODEL_ID)

--- a/docs/examples/m_serve/m_serve_example_response_format.py
+++ b/docs/examples/m_serve/m_serve_example_response_format.py
@@ -18,8 +18,8 @@ Test with the client:
 from typing import Any
 
 import mellea
-from cli.serve.models import ChatMessage
 from mellea.core import ModelOutputThunk
+from mellea.serve import ChatMessage
 from mellea.stdlib.context import ChatContext
 
 session = mellea.start_session(ctx=ChatContext())

--- a/docs/examples/m_serve/m_serve_example_simple.py
+++ b/docs/examples/m_serve/m_serve_example_simple.py
@@ -5,8 +5,8 @@
 from typing import Any
 
 import mellea
-from cli.serve.models import ChatMessage
 from mellea.core import ModelOutputThunk, Requirement, SamplingResult
+from mellea.serve import ChatMessage
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import simple_validate
 from mellea.stdlib.sampling import RejectionSamplingStrategy

--- a/docs/examples/m_serve/m_serve_example_streaming.py
+++ b/docs/examples/m_serve/m_serve_example_streaming.py
@@ -5,9 +5,9 @@
 from typing import Any
 
 import mellea
-from cli.serve.models import ChatMessage
 from mellea.backends.model_options import ModelOption
 from mellea.core import ComputedModelOutputThunk, ModelOutputThunk
+from mellea.serve import ChatMessage
 from mellea.stdlib.context import SimpleContext
 
 session = mellea.start_session(ctx=SimpleContext())

--- a/docs/examples/m_serve/m_serve_example_tool_calling.py
+++ b/docs/examples/m_serve/m_serve_example_tool_calling.py
@@ -17,7 +17,6 @@ should use ``MelleaTool`` objects directly.
 import os
 from typing import Any
 
-from cli.serve.models import ChatMessage
 from mellea.backends import ModelOption
 from mellea.backends.model_ids import IBM_GRANITE_4_HYBRID_MICRO
 from mellea.backends.openai import OpenAIBackend
@@ -25,6 +24,7 @@ from mellea.backends.tools import MelleaTool
 from mellea.core import ModelOutputThunk, Requirement
 from mellea.core.base import AbstractMelleaTool
 from mellea.formatters import TemplateFormatter
+from mellea.serve import ChatMessage
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.session import MelleaSession
 

--- a/docs/examples/m_serve/pii_serve.py
+++ b/docs/examples/m_serve/pii_serve.py
@@ -4,9 +4,9 @@
 import spacy
 
 import mellea
-from cli.serve.models import ChatMessage
 from mellea.backends.model_ids import IBM_GRANITE_4_1_3B
 from mellea.core import ModelOutputThunk, SamplingResult
+from mellea.serve import ChatMessage
 from mellea.stdlib.requirements import req, simple_validate
 from mellea.stdlib.sampling import RejectionSamplingStrategy
 

--- a/mellea/__init__.py
+++ b/mellea/__init__.py
@@ -1,8 +1,16 @@
 """Mellea."""
 
+from . import serve
 from .backends import model_ids
 from .stdlib.components.genstub import generative
 from .stdlib.session import MelleaSession, start_session
 from .stdlib.start_backend import start_backend
 
-__all__ = ["MelleaSession", "generative", "model_ids", "start_backend", "start_session"]
+__all__ = [
+    "MelleaSession",
+    "generative",
+    "model_ids",
+    "serve",
+    "start_backend",
+    "start_session",
+]

--- a/mellea/plugins/policies.py
+++ b/mellea/plugins/policies.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    from cpex.framework.hooks.policies import (
-        HookPayloadPolicy,  # type: ignore[import-not-found]
+    from cpex.framework.hooks.policies import (  # type: ignore[import-not-found]
+        HookPayloadPolicy,
     )
 
     _HAS_PLUGIN_FRAMEWORK = True

--- a/mellea/plugins/policies.py
+++ b/mellea/plugins/policies.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    from cpex.framework.hooks.policies import (  # type: ignore[import-not-found]
-        HookPayloadPolicy,
+    from cpex.framework.hooks.policies import (
+        HookPayloadPolicy,  # type: ignore[import-not-found]
     )
 
     _HAS_PLUGIN_FRAMEWORK = True

--- a/mellea/serve/__init__.py
+++ b/mellea/serve/__init__.py
@@ -1,0 +1,9 @@
+"""Public API for m serve types.
+
+This module provides the types that users need when writing serve() functions
+for use with the `m serve` command.
+"""
+
+from .models import ChatMessage, ImageUrlContent, MessageContent, TextContent
+
+__all__ = ["ChatMessage", "ImageUrlContent", "MessageContent", "TextContent"]

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -86,6 +86,9 @@ class ChatMessage(BaseModel):
         Returns:
             List of ImageBlocks from all ImageUrlContent items.
             Empty list if content is a string or contains no images.
+
+        Raises:
+            ValueError: If an image URL is invalid or cannot be processed.
         """
         image_urls = self.get_image_urls()
         image_blocks: list[ImageBlock] = []

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -1,8 +1,4 @@
-"""User-facing types for m serve.
-
-This module contains the types that users need when writing serve() functions
-for use with the `m serve` command.
-"""
+"""User-facing types for `m serve`."""
 
 from typing import Any, Literal
 

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -1,0 +1,102 @@
+"""User-facing types for m serve.
+
+This module contains the types that users need when writing serve() functions
+for use with the `m serve` command.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from mellea.core import ImageBlock
+
+
+class TextContent(BaseModel):
+    """Text content in a multimodal message."""
+
+    type: Literal["text"]
+    text: str
+
+
+class ImageUrlContent(BaseModel):
+    """Image URL content in a multimodal message.
+
+    Supports both data URIs (base64-encoded images) and HTTP(S) URLs.
+    """
+
+    type: Literal["image_url"]
+    image_url: dict[str, str]
+    """Image URL object containing 'url' key and optional 'detail' key."""
+
+
+# Union type for all content types
+MessageContent = TextContent | ImageUrlContent
+
+
+class ChatMessage(BaseModel):
+    """Chat message with support for text-only or multimodal content.
+
+    The content field can be:
+    - A string (text-only, backward compatible)
+    - None (for messages without content)
+    - A list of content objects (multimodal: text, images)
+    """
+
+    role: Literal["system", "user", "assistant", "tool", "function"]
+    content: str | list[MessageContent] | None = None
+    name: str | None = None
+    tool_call_id: str | None = None
+    function_call: dict[str, Any] | None = None  # For function/tool messages
+
+    def get_text_content(self) -> str:
+        """Extract text content from message, handling both string and multimodal formats.
+
+        Returns:
+            Concatenated text from all TextContent items, or empty string if no text.
+            Images are ignored (handled separately via extraction utilities).
+        """
+        if isinstance(self.content, str):
+            return self.content
+        elif isinstance(self.content, list):
+            return " ".join(
+                item.text for item in self.content if isinstance(item, TextContent)
+            )
+        return ""
+
+    def get_image_urls(self) -> list[str]:
+        """Extract image URLs from message content.
+
+        Returns:
+            List of image URL strings from all ImageUrlContent items.
+            Empty list if content is a string or contains no images.
+        """
+        if not isinstance(self.content, list):
+            return []
+        urls = []
+        for item in self.content:
+            if isinstance(item, ImageUrlContent):
+                url = item.image_url.get("url")
+                if url:
+                    urls.append(url)
+        return urls
+
+    def get_image_blocks(self) -> list[ImageBlock]:
+        """Extract ImageBlocks from message content.
+
+        Returns:
+            List of ImageBlocks from all ImageUrlContent items.
+            Empty list if content is a string or contains no images.
+        """
+        image_urls = self.get_image_urls()
+        image_blocks: list[ImageBlock] = []
+        for url in image_urls:
+            try:
+                image_blocks.append(ImageBlock(url))
+            except AssertionError as e:
+                # Raise ValueError for invalid URLs so the client gets a clear 400 error
+                # rather than silently processing a request without the expected images
+                raise ValueError(
+                    f"Invalid image URL: {url[:100]}{'...' if len(url) > 100 else ''}. "
+                    f"Error: {e}"
+                ) from e
+        return image_blocks

--- a/test/serve/test_models_multimodal.py
+++ b/test/serve/test_models_multimodal.py
@@ -5,8 +5,8 @@ import base64
 import pytest
 from pydantic import ValidationError
 
-from cli.serve.models import ChatMessage, ImageUrlContent, TextContent
 from mellea.core import ImageBlock
+from mellea.serve.models import ChatMessage, ImageUrlContent, TextContent
 
 
 class TestTextContent:


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #873 

## Description
<!-- What does this PR do and why? -->
Creates a stable public API for m serve types by moving user-facing types from cli/serve/models to mellea/serve/models. Users can now import ChatMessage and related types via:

  from mellea.serve import ChatMessage

Changes:
- Add mellea/serve/ module with ChatMessage, TextContent, ImageUrlContent, and MessageContent
- Update cli/serve/models.py to re-export from mellea.serve
- Update m serve examples to use new import path
- Update m-serve.md documentation
- Maintain backward compatibility (cli.serve.models still works)

The new public API provides clear separation
between user-facing types (mellea.serve) and internal CLI implementation (cli/serve).

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
