### PR TITLE
fix: improve repair feedback for LLM-as-a-Judge validations

### DIFF
--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -276,9 +276,19 @@ class Requirement(Component[str]):
             )
             await llm_as_a_judge_result.avalue()
 
+            # For semantic checks (binary yes/no validation), the reason should be
+            # more helpful than just "yes" or "no". Fall back to description if the
+            # reason is just a yes/no answer.
+            judge_output = llm_as_a_judge_result.value
+            reason = judge_output
+            if judge_output and judge_output.strip().lower() in ("yes", "no"):
+                # Semantic check returned binary answer; use requirement description
+                # for repair feedback instead
+                reason = self.description
+
             return ValidationResult(
                 result=self.output_to_bool(llm_as_a_judge_result),
-                reason=llm_as_a_judge_result.value,
+                reason=reason,
                 thunk=llm_as_a_judge_result,
                 context=val_ctx,
             )

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -276,15 +276,17 @@ class Requirement(Component[str]):
             )
             await llm_as_a_judge_result.avalue()
 
-            # For semantic checks (binary yes/no validation), the reason should be
-            # more helpful than just "yes" or "no". Fall back to description if the
-            # reason is just a yes/no answer.
+            # LLM-as-a-Judge validation often returns only "yes"/"no" because the
+            # prompt asks for binary classification. However, repair strategies
+            # display the reason to guide the model during repair iterations.
+            # A bare "no" is unhelpful; the requirement description is more
+            # actionable (e.g., "The email should have a salutation" vs "no").
             judge_output = llm_as_a_judge_result.value
             reason = judge_output
-            if judge_output and judge_output.strip().lower() in ("yes", "no"):
-                # Semantic check returned binary answer; use requirement description
-                # for repair feedback instead
-                reason = self.description
+            if judge_output:
+                judge_output_str = str(judge_output).strip().lower()
+                if judge_output_str in ("yes", "no"):
+                    reason = self.description
 
             return ValidationResult(
                 result=self.output_to_bool(llm_as_a_judge_result),

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -93,8 +93,8 @@ def test_plain_string_yes():
 # @pytest: unit
 
 
-async def _reason_for(backend, judge_value: str, description: str) -> str | None:
-    """Helper to get the reason from Requirement.validate with a mocked backend."""
+async def _validate_result(backend, judge_value: str, description: str):
+    """Helper to get the full validation result from Requirement.validate with a mocked backend."""
     from unittest.mock import AsyncMock, patch
 
     from mellea.core import ModelOutputThunk, Requirement
@@ -112,7 +112,7 @@ async def _reason_for(backend, judge_value: str, description: str) -> str | None
     ):
         result = await req.validate(backend, ctx)
 
-    return result.reason
+    return result
 
 
 @pytest.fixture
@@ -125,54 +125,64 @@ def mock_backend():
 
 @pytest.mark.unit
 async def test_validate_binary_no_uses_description(mock_backend):
-    """Binary 'no' should use requirement description as reason."""
-    reason = await _reason_for(mock_backend, "no", "The email should have a salutation")
-    assert reason == "The email should have a salutation"
+    """Binary 'no' should fail with requirement description as reason."""
+    result = await _validate_result(
+        mock_backend, "no", "The email should have a salutation"
+    )
+    assert result.as_bool() is False
+    assert result.reason == "The email should have a salutation"
 
 
 @pytest.mark.unit
 async def test_validate_binary_yes_uses_description(mock_backend):
-    """Binary 'yes' should use requirement description as reason."""
-    reason = await _reason_for(
+    """Binary 'yes' should pass with requirement description as reason."""
+    result = await _validate_result(
         mock_backend, "yes", "The email should have a salutation"
     )
-    assert reason == "The email should have a salutation"
+    assert result.as_bool() is True
+    assert result.reason == "The email should have a salutation"
 
 
 @pytest.mark.unit
 async def test_validate_detailed_answer_preserves_output(mock_backend):
     """Detailed judge output (not binary) should preserve the actual answer."""
-    reason = await _reason_for(
+    result = await _validate_result(
         mock_backend,
-        "The email contains a proper greeting",
+        "Yes, the email contains a proper greeting",
         "The email should have a salutation",
     )
-    assert reason == "The email contains a proper greeting"
+    assert result.as_bool() is True
+    assert result.reason == "Yes, the email contains a proper greeting"
 
 
 @pytest.mark.unit
 async def test_validate_binary_detection_whitespace_and_case(mock_backend):
     """Binary detection should handle whitespace and case variation."""
-    reason = await _reason_for(mock_backend, "  NO  ", "Check requirement")
-    assert reason == "Check requirement"
+    result = await _validate_result(mock_backend, "  NO  ", "Check requirement")
+    assert result.as_bool() is False
+    assert result.reason == "Check requirement"
 
 
 @pytest.mark.unit
 async def test_validate_empty_string_preserves_output(mock_backend):
     """Empty string should not trigger fallback."""
-    reason = await _reason_for(mock_backend, "", "The email should have a salutation")
-    assert reason == ""
+    result = await _validate_result(
+        mock_backend, "", "The email should have a salutation"
+    )
+    assert result.as_bool() is False
+    assert result.reason == ""
 
 
 @pytest.mark.unit
 async def test_validate_yes_in_sentence_preserves_output(mock_backend):
     """'Yes' as part of sentence should preserve judge output."""
-    reason = await _reason_for(
+    result = await _validate_result(
         mock_backend,
         "Yes, the email has a salutation",
         "The email should have a salutation",
     )
-    assert reason == "Yes, the email has a salutation"
+    assert result.as_bool() is True
+    assert result.reason == "Yes, the email has a salutation"
 
 
 if __name__ == "__main__":

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -87,5 +87,98 @@ def test_plain_string_yes():
     assert default_output_to_bool("YES") is True  # type: ignore
 
 
+# --- Binary detection for repair feedback (PR #1248) ---
+
+
+def test_repair_feedback_binary_detection_yes():
+    """Binary 'yes' should trigger description fallback."""
+    judge_output = "yes"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is True
+
+
+def test_repair_feedback_binary_detection_no():
+    """Binary 'no' should trigger description fallback."""
+    judge_output = "no"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is True
+
+
+def test_repair_feedback_binary_detection_yes_uppercase():
+    """Binary 'YES' (uppercase) should trigger description fallback."""
+    judge_output = "YES"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is True
+
+
+def test_repair_feedback_binary_detection_no_mixed_case():
+    """Binary 'No' (mixed case) should trigger description fallback."""
+    judge_output = "No"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is True
+
+
+def test_repair_feedback_binary_detection_whitespace():
+    """Binary answer with whitespace should trigger description fallback."""
+    judge_output = "  yes  "
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is True
+
+
+def test_repair_feedback_binary_detection_detailed_answer():
+    """Detailed answer (not binary) should preserve judge output."""
+    judge_output = "The requirement is met"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is False
+
+
+def test_repair_feedback_binary_detection_yes_in_sentence():
+    """'Yes' as part of sentence should preserve judge output."""
+    judge_output = "Yes, the email has a salutation"
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert should_use_description is False
+
+
+def test_repair_feedback_binary_detection_empty_string():
+    """Empty string should preserve (not trigger fallback)."""
+    judge_output = ""
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert not should_use_description
+
+
+def test_repair_feedback_binary_detection_none():
+    """None value should not crash and should not trigger fallback."""
+    judge_output = None
+    should_use_description = judge_output and judge_output.strip().lower() in (
+        "yes",
+        "no",
+    )
+    assert not should_use_description
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -88,93 +88,91 @@ def test_plain_string_yes():
 
 
 # --- Binary detection for repair feedback (PR #1248) ---
-# These tests validate the binary detection logic from requirement.py:284-289
-# which is used in Requirement.validate() to replace bare "yes"/"no" responses
-# with the requirement description for more actionable repair feedback.
+# Tests for Requirement.validate() binary detection: bare "yes"/"no" responses
+# are replaced with the requirement description for more actionable repair feedback.
+# @pytest: unit
 
 
-def test_validate_reason_binary_no_uses_description():
-    """Binary 'no' should use requirement description as reason (validates production logic)."""
-    description = "The email should have a salutation"
-    judge_output = "no"
+async def _reason_for(backend, judge_value: str, description: str) -> str | None:
+    """Helper to get the reason from Requirement.validate with a mocked backend."""
+    from unittest.mock import AsyncMock, patch
 
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
+    from mellea.core import ModelOutputThunk, Requirement
+    from mellea.stdlib.context import ChatContext
 
-    assert reason == description
+    req = Requirement(description)
+    ctx = ChatContext().add(ModelOutputThunk("some output"))
+    judge_thunk = ModelOutputThunk(value=judge_value)
+    val_ctx = ctx.add(judge_thunk)
+
+    with patch.object(
+        backend,
+        "generate_from_context",
+        new=AsyncMock(return_value=(judge_thunk, val_ctx)),
+    ):
+        result = await req.validate(backend, ctx)
+
+    return result.reason
 
 
-def test_validate_reason_binary_yes_uses_description():
+@pytest.fixture
+def mock_backend():
+    """Mock backend for testing Requirement.validate."""
+    from unittest.mock import MagicMock
+
+    return MagicMock()
+
+
+@pytest.mark.unit
+async def test_validate_binary_no_uses_description(mock_backend):
+    """Binary 'no' should use requirement description as reason."""
+    reason = await _reason_for(mock_backend, "no", "The email should have a salutation")
+    assert reason == "The email should have a salutation"
+
+
+@pytest.mark.unit
+async def test_validate_binary_yes_uses_description(mock_backend):
     """Binary 'yes' should use requirement description as reason."""
-    description = "The email should have a salutation"
-    judge_output = "yes"
-
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
-
-    assert reason == description
+    reason = await _reason_for(
+        mock_backend, "yes", "The email should have a salutation"
+    )
+    assert reason == "The email should have a salutation"
 
 
-def test_validate_reason_detailed_answer_preserves_output():
+@pytest.mark.unit
+async def test_validate_detailed_answer_preserves_output(mock_backend):
     """Detailed judge output (not binary) should preserve the actual answer."""
-    description = "The email should have a salutation"
-    judge_output = "The email contains a proper greeting"
-
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
-
-    assert reason == judge_output
+    reason = await _reason_for(
+        mock_backend,
+        "The email contains a proper greeting",
+        "The email should have a salutation",
+    )
+    assert reason == "The email contains a proper greeting"
 
 
-def test_validate_reason_binary_detection_whitespace_and_case():
+@pytest.mark.unit
+async def test_validate_binary_detection_whitespace_and_case(mock_backend):
     """Binary detection should handle whitespace and case variation."""
-    description = "Check requirement"
-    judge_output = "  NO  "
-
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
-
-    assert reason == description
+    reason = await _reason_for(mock_backend, "  NO  ", "Check requirement")
+    assert reason == "Check requirement"
 
 
-def test_validate_reason_empty_string_preserves_output():
+@pytest.mark.unit
+async def test_validate_empty_string_preserves_output(mock_backend):
     """Empty string should not trigger fallback."""
-    description = "The email should have a salutation"
-    judge_output = ""
-
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
-
+    reason = await _reason_for(mock_backend, "", "The email should have a salutation")
     assert reason == ""
 
 
-def test_validate_reason_yes_in_sentence_preserves_output():
+@pytest.mark.unit
+async def test_validate_yes_in_sentence_preserves_output(mock_backend):
     """'Yes' as part of sentence should preserve judge output."""
-    description = "The email should have a salutation"
-    judge_output = "Yes, the email has a salutation"
-
-    reason = judge_output
-    if judge_output:
-        judge_output_str = str(judge_output).strip().lower()
-        if judge_output_str in ("yes", "no"):
-            reason = description
-
-    assert reason == judge_output
+    reason = await _reason_for(
+        mock_backend,
+        "Yes, the email has a salutation",
+        "The email should have a salutation",
+    )
+    assert reason == "Yes, the email has a salutation"
 
 
 if __name__ == "__main__":

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -88,96 +88,93 @@ def test_plain_string_yes():
 
 
 # --- Binary detection for repair feedback (PR #1248) ---
+# These tests validate the binary detection logic from requirement.py:284-289
+# which is used in Requirement.validate() to replace bare "yes"/"no" responses
+# with the requirement description for more actionable repair feedback.
 
 
-def test_repair_feedback_binary_detection_yes():
-    """Binary 'yes' should trigger description fallback."""
-    judge_output = "yes"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is True
-
-
-def test_repair_feedback_binary_detection_no():
-    """Binary 'no' should trigger description fallback."""
+def test_validate_reason_binary_no_uses_description():
+    """Binary 'no' should use requirement description as reason (validates production logic)."""
+    description = "The email should have a salutation"
     judge_output = "no"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is True
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == description
 
 
-def test_repair_feedback_binary_detection_yes_uppercase():
-    """Binary 'YES' (uppercase) should trigger description fallback."""
-    judge_output = "YES"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is True
+def test_validate_reason_binary_yes_uses_description():
+    """Binary 'yes' should use requirement description as reason."""
+    description = "The email should have a salutation"
+    judge_output = "yes"
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == description
 
 
-def test_repair_feedback_binary_detection_no_mixed_case():
-    """Binary 'No' (mixed case) should trigger description fallback."""
-    judge_output = "No"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is True
+def test_validate_reason_detailed_answer_preserves_output():
+    """Detailed judge output (not binary) should preserve the actual answer."""
+    description = "The email should have a salutation"
+    judge_output = "The email contains a proper greeting"
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == judge_output
 
 
-def test_repair_feedback_binary_detection_whitespace():
-    """Binary answer with whitespace should trigger description fallback."""
-    judge_output = "  yes  "
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is True
+def test_validate_reason_binary_detection_whitespace_and_case():
+    """Binary detection should handle whitespace and case variation."""
+    description = "Check requirement"
+    judge_output = "  NO  "
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == description
 
 
-def test_repair_feedback_binary_detection_detailed_answer():
-    """Detailed answer (not binary) should preserve judge output."""
-    judge_output = "The requirement is met"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is False
-
-
-def test_repair_feedback_binary_detection_yes_in_sentence():
-    """'Yes' as part of sentence should preserve judge output."""
-    judge_output = "Yes, the email has a salutation"
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert should_use_description is False
-
-
-def test_repair_feedback_binary_detection_empty_string():
-    """Empty string should preserve (not trigger fallback)."""
+def test_validate_reason_empty_string_preserves_output():
+    """Empty string should not trigger fallback."""
+    description = "The email should have a salutation"
     judge_output = ""
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert not should_use_description
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == ""
 
 
-def test_repair_feedback_binary_detection_none():
-    """None value should not crash and should not trigger fallback."""
-    judge_output = None
-    should_use_description = judge_output and judge_output.strip().lower() in (
-        "yes",
-        "no",
-    )
-    assert not should_use_description
+def test_validate_reason_yes_in_sentence_preserves_output():
+    """'Yes' as part of sentence should preserve judge output."""
+    description = "The email should have a salutation"
+    judge_output = "Yes, the email has a salutation"
+
+    reason = judge_output
+    if judge_output:
+        judge_output_str = str(judge_output).strip().lower()
+        if judge_output_str in ("yes", "no"):
+            reason = description
+
+    assert reason == judge_output
 
 
 if __name__ == "__main__":

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -1,9 +1,12 @@
 """Unit tests for core/requirement.py pure helpers — ValidationResult, default_output_to_bool."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from mellea.core import CBlock, ModelOutputThunk
+from mellea.core import CBlock, ModelOutputThunk, Requirement
 from mellea.core.requirement import ValidationResult, default_output_to_bool
+from mellea.stdlib.context import ChatContext
 
 # --- ValidationResult ---
 
@@ -90,16 +93,10 @@ def test_plain_string_yes():
 # --- Binary detection for repair feedback (PR #1248) ---
 # Tests for Requirement.validate() binary detection: bare "yes"/"no" responses
 # are replaced with the requirement description for more actionable repair feedback.
-# @pytest: unit
 
 
 async def _validate_result(backend, judge_value: str, description: str):
     """Helper to get the full validation result from Requirement.validate with a mocked backend."""
-    from unittest.mock import AsyncMock, patch
-
-    from mellea.core import ModelOutputThunk, Requirement
-    from mellea.stdlib.context import ChatContext
-
     req = Requirement(description)
     ctx = ChatContext().add(ModelOutputThunk("some output"))
     judge_thunk = ModelOutputThunk(value=judge_value)
@@ -118,12 +115,9 @@ async def _validate_result(backend, judge_value: str, description: str):
 @pytest.fixture
 def mock_backend():
     """Mock backend for testing Requirement.validate."""
-    from unittest.mock import MagicMock
-
     return MagicMock()
 
 
-@pytest.mark.unit
 async def test_validate_binary_no_uses_description(mock_backend):
     """Binary 'no' should fail with requirement description as reason."""
     result = await _validate_result(
@@ -133,7 +127,6 @@ async def test_validate_binary_no_uses_description(mock_backend):
     assert result.reason == "The email should have a salutation"
 
 
-@pytest.mark.unit
 async def test_validate_binary_yes_uses_description(mock_backend):
     """Binary 'yes' should pass with requirement description as reason."""
     result = await _validate_result(
@@ -143,7 +136,6 @@ async def test_validate_binary_yes_uses_description(mock_backend):
     assert result.reason == "The email should have a salutation"
 
 
-@pytest.mark.unit
 async def test_validate_detailed_answer_preserves_output(mock_backend):
     """Detailed judge output (not binary) should preserve the actual answer."""
     result = await _validate_result(
@@ -155,7 +147,6 @@ async def test_validate_detailed_answer_preserves_output(mock_backend):
     assert result.reason == "Yes, the email contains a proper greeting"
 
 
-@pytest.mark.unit
 async def test_validate_binary_detection_whitespace_and_case(mock_backend):
     """Binary detection should handle whitespace and case variation."""
     result = await _validate_result(mock_backend, "  NO  ", "Check requirement")
@@ -163,7 +154,6 @@ async def test_validate_binary_detection_whitespace_and_case(mock_backend):
     assert result.reason == "Check requirement"
 
 
-@pytest.mark.unit
 async def test_validate_empty_string_preserves_output(mock_backend):
     """Empty string should not trigger fallback."""
     result = await _validate_result(
@@ -173,7 +163,6 @@ async def test_validate_empty_string_preserves_output(mock_backend):
     assert result.reason == ""
 
 
-@pytest.mark.unit
 async def test_validate_yes_in_sentence_preserves_output(mock_backend):
     """'Yes' as part of sentence should preserve judge output."""
     result = await _validate_result(


### PR DESCRIPTION
# Pull Request

## Issue
Fix: #1247 

## Description
   When LLM-as-a-Judge validation returns binary yes/no answers, use the requirement
   description as the repair reason instead of just 'yes' or 'no'. This applies to all
   semantic validations (check(), req() without validation_fn, etc.) regardless of
   check_only setting.

   Previously, repair feedback would show:
```
     The following requirements failed before:
     * no
```
   Now it shows:
``` 
     The following requirements failed before:
     * The email should have a salutation
```

   This makes repair feedback more actionable and helps models understand what needs
   to be fixed during repair iterations in RepairTemplateStrategy and MultiTurnStrategy.


### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used: claudecode

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
