### PR TITLE
fix: add request timeouts and mask API key in repr

### DIFF
--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -235,11 +235,12 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
     def __repr__(self) -> str:
         """Mask the API key to prevent accidental exposure in logs."""
+        key_repr = "'***'" if self._api_key is not None else "None"
         return (
             f"{self.__class__.__name__}("
             f"model_id={self._model_id!r}, "
             f"base_url={self._base_url!r}, "
-            f"_api_key='***')"
+            f"_api_key={key_repr})"
         )
 
     def __str__(self) -> str:

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -233,6 +233,19 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         if load_embedded_adapters:
             self.register_embedded_adapter_model(self._adapter_source or self._model_id)
 
+    def __repr__(self) -> str:
+        """Mask the API key to prevent accidental exposure in logs."""
+        return (
+            f"{self.__class__.__name__}("
+            f"model_id={self._model_id!r}, "
+            f"base_url={self._base_url!r}, "
+            f"_api_key='***')"
+        )
+
+    def __str__(self) -> str:
+        """Mask the API key to prevent accidental exposure in logs."""
+        return repr(self)
+
     # ------------------------------------------------------------------
     # AdapterMixin implementation
     # ------------------------------------------------------------------

--- a/mellea/core/utils.py
+++ b/mellea/core/utils.py
@@ -272,6 +272,7 @@ class RESTHandler(logging.Handler):
                 self.api_url,
                 headers=self.headers,
                 data=json.dumps([log_dict]),
+                timeout=2,
             )
             response.raise_for_status()
         except requests.exceptions.RequestException:

--- a/mellea/helpers/server_type.py
+++ b/mellea/helpers/server_type.py
@@ -70,7 +70,7 @@ def is_vllm_server_with_structured_output(
             base_url.removesuffix("/v1").removesuffix("/v1/") + "/version"
         )
 
-        version_response = requests.get(version_endpoint, headers=headers)
+        version_response = requests.get(version_endpoint, headers=headers, timeout=10)
         if not version_response.ok:
             return False
 

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -29,6 +29,33 @@ def backend():
     return _make_backend()
 
 
+# --- __repr__ / __str__ ---
+
+
+def test_repr_masks_api_key():
+    backend = _make_backend()
+    r = repr(backend)
+    assert "fake-key" not in r
+    assert "***" in r
+
+
+def test_repr_no_key_shows_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    backend = OpenAIBackend(
+        model_id="gpt-4o", api_key=None, base_url="http://localhost:9999/v1"
+    )
+    r = repr(backend)
+    assert "env-key" not in r
+    assert "***" not in r
+    assert "_api_key=None" in r
+
+
+def test_str_masks_api_key():
+    backend = _make_backend()
+    assert "fake-key" not in str(backend)
+    assert "***" in str(backend)
+
+
 # --- filter_openai_client_kwargs ---
 
 

--- a/test/core/test_utils_logging.py
+++ b/test/core/test_utils_logging.py
@@ -1003,6 +1003,7 @@ class TestWebhookHandler:
             handler.emit(record)
 
         assert mock_req.call_count == 1
+        assert mock_req.call_args.kwargs["timeout"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/test/helpers/test_server_type.py
+++ b/test/helpers/test_server_type.py
@@ -44,7 +44,9 @@ def _mock_version_response(version_string, status_code=200):
 def test_version_above_threshold(mock_get):
     mock_get.return_value = _mock_version_response("0.16.0")
     assert is_vllm_server_with_structured_output(BASE_URL, HEADERS) is True
-    mock_get.assert_called_once_with("http://localhost:8000/version", headers=HEADERS)
+    mock_get.assert_called_once_with(
+        "http://localhost:8000/version", headers=HEADERS, timeout=10
+    )
 
 
 @patch("mellea.helpers.server_type.requests.get")
@@ -141,21 +143,27 @@ def test_timeout_error(mock_get):
 def test_url_strips_v1_suffix(mock_get):
     mock_get.return_value = _mock_version_response("0.14.0")
     is_vllm_server_with_structured_output("http://myserver:9000/v1", HEADERS)
-    mock_get.assert_called_once_with("http://myserver:9000/version", headers=HEADERS)
+    mock_get.assert_called_once_with(
+        "http://myserver:9000/version", headers=HEADERS, timeout=10
+    )
 
 
 @patch("mellea.helpers.server_type.requests.get")
 def test_url_strips_v1_slash_suffix(mock_get):
     mock_get.return_value = _mock_version_response("0.14.0")
     is_vllm_server_with_structured_output("http://myserver:9000/v1/", HEADERS)
-    mock_get.assert_called_once_with("http://myserver:9000/version", headers=HEADERS)
+    mock_get.assert_called_once_with(
+        "http://myserver:9000/version", headers=HEADERS, timeout=10
+    )
 
 
 @patch("mellea.helpers.server_type.requests.get")
 def test_url_without_v1(mock_get):
     mock_get.return_value = _mock_version_response("0.14.0")
     is_vllm_server_with_structured_output("http://myserver:9000", HEADERS)
-    mock_get.assert_called_once_with("http://myserver:9000/version", headers=HEADERS)
+    mock_get.assert_called_once_with(
+        "http://myserver:9000/version", headers=HEADERS, timeout=10
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add explicit timeouts to two previously unbounded `requests` calls, and
mask the API key in `OpenAIBackend.__repr__` / `__str__`.

**Timeouts**

`RESTHandler.emit()` uses `timeout=2`: this handler fires synchronously
on every log event, so a slow or unreachable webhook endpoint would block
the calling thread on every log write. 2 s is enough to confirm liveness;
beyond that the record should be dropped.

`is_vllm_server_with_structured_output()` uses `timeout=10`: this probe
runs once at `OpenAIBackend.__init__()` time, not on every request, so a
longer timeout costs nothing in throughput. vLLM's `/version` endpoint is
trivial (no GPU path), but cloud or VPN round-trips can be slow; 10 s covers
realistic slow-network cases while still failing fast on a dead server. A
false timeout here silently degrades structured output behaviour, so erring
toward patience is correct.

**API key masking**

`__repr__` and `__str__` previously fell back to Python's default object repr — safe, but not very useful. Both now return a structured repr showing `model_id` and `base_url`, with the API key replaced by `***`. The masking is defensive: if the repr is later extended, the key is already guarded.

Identified in the 2026-05-12 security audit. Ref #1246. Follow-up to cover other backends: #1317.