### PR TITLE
chore: add PEP 484 return-type annotations to mellea.stdlib public me…

### DIFF
--- a/mellea/stdlib/components/docs/richdocument.py
+++ b/mellea/stdlib/components/docs/richdocument.py
@@ -80,7 +80,7 @@ class RichDocument(Component[str]):
         """
         return self._doc
 
-    def to_markdown(self):
+    def to_markdown(self) -> str:
         """Get the full text of the document as markdown."""
         return self._doc.export_to_markdown()
 
@@ -282,7 +282,7 @@ class Table(MObject):
         else:
             return None
 
-    def parts(self):
+    def parts(self) -> list[Component | CBlock]:
         """Return the constituent parts of this table component.
 
         The current implementation always returns an empty list because the

--- a/mellea/stdlib/components/instruction.py
+++ b/mellea/stdlib/components/instruction.py
@@ -142,8 +142,15 @@ class Instruction(Component[str]):
         self._images = images
         self._repair_string: str | None = None
 
-    def parts(self):
-        """Returns all of the constituent parts of an Instruction."""
+    def parts(self) -> list[Component | CBlock]:
+        """Returns all of the constituent parts of an Instruction.
+
+        Returns:
+            list[Component | CBlock]: All non-None constituent blocks and
+            components making up this instruction, including description,
+            prefix, grounding context, requirements, and in-context-learning
+            examples.
+        """
         # Add all of the optionally defined CBlocks/Components then filter Nones at the end.
         cs = [self._description, self._prefix, self._output_prefix]
         match self._grounding_context:

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -355,7 +355,7 @@ class MelleaSession:
         """
         return copy(self)
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the context state to a fresh, empty context of the same type.
 
         Fires the `SESSION_RESET` plugin hook if any plugins are registered, then
@@ -1132,7 +1132,7 @@ class MelleaSession:
         return result
 
     @classmethod
-    def powerup(cls, powerup_cls: type):
+    def powerup(cls, powerup_cls: type) -> None:
         """Appends methods in a class object `powerup_cls` to MelleaSession.
 
         Iterates over all functions defined on `powerup_cls` and attaches each


### PR DESCRIPTION
Partial fix for #1177 — adds return-type annotations to the 5 griffe warnings on the mellea.stdlib public surface.
Changes

mellea/stdlib/session.py: MelleaSession.reset → -> None, MelleaSession.powerup → -> None
mellea/stdlib/components/instruction.py: Instruction.parts → -> list[Component | CBlock]
mellea/stdlib/components/docs/richdocument.py: RichDocument.to_markdown → -> str, Table.parts → -> list[Component | CBlock]

No logic changes — purely additive metadata. Backend protocol methods (processing, post_processing) and the broader __all__ question are left for a follow-up once the public surface is decided.
Generated and verified by [Symbiote](https://callmedai.com/) — autonomous Python annotation engine.