### PR TITLE
refactor(adapters): decouple KNOWN_CAPABILITIES from catalog entry names (#1186)

### DIFF
--- a/mellea/backends/adapters/capabilities.py
+++ b/mellea/backends/adapters/capabilities.py
@@ -7,16 +7,12 @@ intrinsics are not blocked.
 
 Deriving from the catalog (rather than hand-copying) keeps the two registries in
 sync automatically — adding a new entry to ``catalog.py`` automatically registers
-it as a known capability.
-
-.. note::
-    Capabilities are currently derived from catalog entry *names*. Decoupling the
-    capability vocabulary from entry names (an explicit ``capability`` field on
-    ``CatalogEntry``) is tracked as a follow-up under Epic #929.
+its :attr:`~mellea.backends.adapters.catalog.IntriniscsCatalogEntry.effective_capability`
+as a known capability.
 """
 
 from .catalog import _INTRINSICS_CATALOG_ENTRIES
 
 KNOWN_CAPABILITIES: frozenset[str] = frozenset(
-    e.name for e in _INTRINSICS_CATALOG_ENTRIES
+    e.effective_capability for e in _INTRINSICS_CATALOG_ENTRIES
 )

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -99,6 +99,13 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         description="Adapter types that are known to be available for this intrinsic.",
     )
 
+    @pydantic.field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name must be a non-empty string")
+        return v
+
     @pydantic.field_validator("capability")
     @classmethod
     def _check_capability(cls, v: str | None) -> str | None:

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -99,6 +99,15 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
         description="Adapter types that are known to be available for this intrinsic.",
     )
 
+    @pydantic.field_validator("capability")
+    @classmethod
+    def _check_capability(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError(
+                "capability must be a non-empty string when set; use None to fall back to name"
+            )
+        return v
+
     @pydantic.field_validator("revision")
     @classmethod
     def _check_revision(cls, v: str) -> str:
@@ -195,6 +204,14 @@ _INTRINSICS_CATALOG = {e.name: e for e in _INTRINSICS_CATALOG_ENTRIES}
 """Catalog of intrinsics that Mellea knows about.
 
 Mellea code should access this catalog via :func:`fetch_intrinsic_metadata()`"""
+
+_effective_caps = [e.effective_capability for e in _INTRINSICS_CATALOG_ENTRIES]
+if len(_effective_caps) != len(set(_effective_caps)):
+    _dupes = {c for c in _effective_caps if _effective_caps.count(c) > 1}
+    raise ValueError(
+        f"Duplicate effective_capability values in intrinsics catalog: {_dupes}"
+    )
+del _effective_caps
 
 
 def known_intrinsic_names() -> list[str]:

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -26,10 +26,13 @@ def validate_revision(revision: str) -> str:
         str: The validated revision unchanged.
 
     Raises:
-        ValueError: If `revision` is empty or whitespace-only.
+        ValueError: If `revision` is empty, whitespace-only, or has leading
+            or trailing whitespace.
     """
     if not revision.strip():
         raise ValueError("revision must be a non-empty string")
+    if revision != revision.strip():
+        raise ValueError("revision must not have leading or trailing whitespace")
     return revision
 
 
@@ -53,10 +56,12 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
     Attributes:
         name (str): User-visible name of the intrinsic. May contain hyphens when
             that matches the upstream adapter name; prefer ``effective_capability``
-            to form the stable capability token.
+            to form the stable capability token. Must be non-empty with no leading
+            or trailing whitespace.
         capability (str | None): Stable Mellea-level capability token, independent
             of the upstream adapter name. Uses underscores. When ``None``,
-            :attr:`effective_capability` falls back to ``name``.
+            :attr:`effective_capability` falls back to ``name``. When set, must be
+            non-empty with no leading or trailing whitespace.
         internal_name (str | None): Internal name used for adapter loading, or
             ``None`` if the same as ``name``.
         repo_id (str): HuggingFace repository where adapters for the intrinsic
@@ -72,13 +77,15 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
             ``(AdapterType.LORA, AdapterType.ALORA)``.
     """
 
-    name: str = pydantic.Field(description="User-visible name of the intrinsic.")
+    name: str = pydantic.Field(
+        description="User-visible name of the intrinsic. Non-empty, no leading/trailing whitespace."
+    )
     capability: str | None = pydantic.Field(
         default=None,
         description=(
             "Stable capability token, independent of the upstream adapter name. "
-            "Uses underscores. When ``None``, ``effective_capability`` falls back "
-            "to ``name``."
+            "Uses underscores; no leading/trailing whitespace. When ``None``, "
+            "``effective_capability`` falls back to ``name``."
         ),
     )
     internal_name: str | None = pydantic.Field(
@@ -104,15 +111,21 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
     def _check_name(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("name must be a non-empty string")
+        if v != v.strip():
+            raise ValueError("name must not have leading or trailing whitespace")
         return v
 
     @pydantic.field_validator("capability")
     @classmethod
     def _check_capability(cls, v: str | None) -> str | None:
-        if v is not None and not v.strip():
+        if v is None:
+            return v
+        if not v.strip():
             raise ValueError(
                 "capability must be a non-empty string when set; use None to fall back to name"
             )
+        if v != v.strip():
+            raise ValueError("capability must not have leading or trailing whitespace")
         return v
 
     @pydantic.field_validator("revision")

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -51,7 +51,12 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
     We use Pydantic for this dataclass because the rest of Mellea also uses Pydantic.
 
     Attributes:
-        name (str): User-visible name of the intrinsic.
+        name (str): User-visible name of the intrinsic. May contain hyphens when
+            that matches the upstream adapter name; prefer ``effective_capability``
+            to form the stable capability token.
+        capability (str | None): Stable Mellea-level capability token, independent
+            of the upstream adapter name. Uses underscores. When ``None``,
+            :attr:`effective_capability` falls back to ``name``.
         internal_name (str | None): Internal name used for adapter loading, or
             ``None`` if the same as ``name``.
         repo_id (str): HuggingFace repository where adapters for the intrinsic
@@ -68,6 +73,14 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
     """
 
     name: str = pydantic.Field(description="User-visible name of the intrinsic.")
+    capability: str | None = pydantic.Field(
+        default=None,
+        description=(
+            "Stable capability token, independent of the upstream adapter name. "
+            "Uses underscores. When ``None``, ``effective_capability`` falls back "
+            "to ``name``."
+        ),
+    )
     internal_name: str | None = pydantic.Field(
         default=None,
         description="Internal name used for adapter loading, or None if the name used "
@@ -91,6 +104,20 @@ class IntriniscsCatalogEntry(pydantic.BaseModel):
     def _check_revision(cls, v: str) -> str:
         return validate_revision(v)
 
+    @property
+    def effective_capability(self) -> str:
+        """Return the stable capability token for this intrinsic.
+
+        Returns ``capability`` when explicitly set; falls back to ``name``
+        otherwise. Use this property — not ``name`` — whenever building the
+        capability vocabulary or resolving an
+        :class:`~mellea.backends.adapters.Identity` capability.
+
+        Returns:
+            str: Capability token, guaranteed non-empty.
+        """
+        return self.capability if self.capability is not None else self.name
+
 
 _RAG_REPO = "ibm-granite/granitelib-rag-r1.0"
 _CORE_R1_REPO = "ibm-granite/granitelib-core-r1.0"
@@ -106,10 +133,16 @@ _INTRINSICS_CATALOG_ENTRIES = [
     # Core Intrinsics
     ############################################
     IntriniscsCatalogEntry(
-        name="context-attribution", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+        name="context-attribution",
+        capability="context_attribution",
+        repo_id=_CORE_R1_REPO,
+        revision=_CORE_R1_SHA,
     ),
     IntriniscsCatalogEntry(
-        name="requirement-check", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
+        name="requirement-check",
+        capability="requirement_check",
+        repo_id=_CORE_R1_REPO,
+        revision=_CORE_R1_SHA,
     ),
     IntriniscsCatalogEntry(
         name="uncertainty", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
@@ -133,16 +166,28 @@ _INTRINSICS_CATALOG_ENTRIES = [
     # Guardian Intrinsics
     ############################################
     IntriniscsCatalogEntry(
-        name="policy-guardrails", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+        name="policy-guardrails",
+        capability="policy_guardrails",
+        repo_id=_GUARDIAN_REPO,
+        revision=_GUARDIAN_SHA,
     ),
     IntriniscsCatalogEntry(
-        name="guardian-core", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+        name="guardian-core",
+        capability="guardian_core",
+        repo_id=_GUARDIAN_REPO,
+        revision=_GUARDIAN_SHA,
     ),
     IntriniscsCatalogEntry(
-        name="factuality-detection", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+        name="factuality-detection",
+        capability="factuality_detection",
+        repo_id=_GUARDIAN_REPO,
+        revision=_GUARDIAN_SHA,
     ),
     IntriniscsCatalogEntry(
-        name="factuality-correction", repo_id=_GUARDIAN_REPO, revision=_GUARDIAN_SHA
+        name="factuality-correction",
+        capability="factuality_correction",
+        repo_id=_GUARDIAN_REPO,
+        revision=_GUARDIAN_SHA,
     ),
 ]
 

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -144,3 +144,12 @@ def test_capability_none_means_effective_capability_equals_name():
     )
     assert entry.capability is None
     assert entry.effective_capability == "plain_name"
+
+
+def test_all_catalog_effective_capabilities_are_nonempty():
+    from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
+
+    for entry in _INTRINSICS_CATALOG_ENTRIES:
+        assert entry.effective_capability, (
+            f"Entry {entry.name!r} has an empty effective_capability"
+        )

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -165,6 +165,11 @@ def test_name_whitespace_only_rejected():
         IntriniscsCatalogEntry(name="   ", repo_id="org/repo", revision="abc123")
 
 
+def test_name_leading_trailing_whitespace_rejected():
+    with pytest.raises(ValueError, match="leading or trailing whitespace"):
+        IntriniscsCatalogEntry(name="  foo  ", repo_id="org/repo", revision="abc123")
+
+
 def test_capability_empty_string_rejected():
     with pytest.raises(ValueError, match="non-empty"):
         IntriniscsCatalogEntry(
@@ -176,4 +181,11 @@ def test_capability_whitespace_only_rejected():
     with pytest.raises(ValueError, match="non-empty"):
         IntriniscsCatalogEntry(
             name="x", capability="   ", repo_id="org/repo", revision="abc123"
+        )
+
+
+def test_capability_leading_trailing_whitespace_rejected():
+    with pytest.raises(ValueError, match="leading or trailing whitespace"):
+        IntriniscsCatalogEntry(
+            name="x", capability="  foo  ", repo_id="org/repo", revision="abc123"
         )

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -155,6 +155,16 @@ def test_all_catalog_effective_capabilities_are_nonempty():
         )
 
 
+def test_name_empty_string_rejected():
+    with pytest.raises(ValueError, match="non-empty"):
+        IntriniscsCatalogEntry(name="", repo_id="org/repo", revision="abc123")
+
+
+def test_name_whitespace_only_rejected():
+    with pytest.raises(ValueError, match="non-empty"):
+        IntriniscsCatalogEntry(name="   ", repo_id="org/repo", revision="abc123")
+
+
 def test_capability_empty_string_rejected():
     with pytest.raises(ValueError, match="non-empty"):
         IntriniscsCatalogEntry(

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -3,6 +3,7 @@
 import pytest
 
 from mellea.backends.adapters.catalog import (
+    _INTRINSICS_CATALOG_ENTRIES,
     AdapterType,
     IntriniscsCatalogEntry,
     fetch_intrinsic_metadata,
@@ -147,8 +148,6 @@ def test_capability_none_means_effective_capability_equals_name():
 
 
 def test_all_catalog_effective_capabilities_are_nonempty():
-    from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
-
     for entry in _INTRINSICS_CATALOG_ENTRIES:
         assert entry.effective_capability, (
             f"Entry {entry.name!r} has an empty effective_capability"

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -153,3 +153,17 @@ def test_all_catalog_effective_capabilities_are_nonempty():
         assert entry.effective_capability, (
             f"Entry {entry.name!r} has an empty effective_capability"
         )
+
+
+def test_capability_empty_string_rejected():
+    with pytest.raises(ValueError, match="non-empty"):
+        IntriniscsCatalogEntry(
+            name="x", capability="", repo_id="org/repo", revision="abc123"
+        )
+
+
+def test_capability_whitespace_only_rejected():
+    with pytest.raises(ValueError, match="non-empty"):
+        IntriniscsCatalogEntry(
+            name="x", capability="   ", repo_id="org/repo", revision="abc123"
+        )

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -4,6 +4,7 @@ import pytest
 
 from mellea.backends.adapters.catalog import (
     AdapterType,
+    IntriniscsCatalogEntry,
     fetch_intrinsic_metadata,
     known_intrinsic_names,
 )
@@ -68,3 +69,78 @@ def test_lora_only_entry(monkeypatch):
     )
     entry = fetch_intrinsic_metadata("query_clarification")
     assert entry.adapter_types == (AdapterType.LORA,)
+
+
+# --- capability / effective_capability ---
+
+
+def test_effective_capability_defaults_to_name():
+    entry = fetch_intrinsic_metadata("answerability")
+    assert entry.capability is None
+    assert entry.effective_capability == "answerability"
+
+
+def test_effective_capability_returns_explicit_capability():
+    entry = fetch_intrinsic_metadata("requirement-check")
+    assert entry.effective_capability == "requirement_check"
+
+
+@pytest.mark.parametrize(
+    "name,expected_capability",
+    [
+        ("context-attribution", "context_attribution"),
+        ("requirement-check", "requirement_check"),
+        ("policy-guardrails", "policy_guardrails"),
+        ("guardian-core", "guardian_core"),
+        ("factuality-detection", "factuality_detection"),
+        ("factuality-correction", "factuality_correction"),
+    ],
+)
+def test_hyphenated_entries_have_underscore_capabilities(name, expected_capability):
+    entry = fetch_intrinsic_metadata(name)
+    assert entry.capability == expected_capability
+    assert entry.effective_capability == expected_capability
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "answerability",
+        "citations",
+        "context_relevance",
+        "hallucination_detection",
+        "query_clarification",
+        "query_rewrite",
+        "uncertainty",
+    ],
+)
+def test_clean_named_entries_have_no_explicit_capability(name):
+    entry = fetch_intrinsic_metadata(name)
+    assert entry.capability is None
+    assert entry.effective_capability == name
+
+
+def test_effective_capability_not_in_model_dump():
+    entry = fetch_intrinsic_metadata("requirement-check")
+    dumped = entry.model_dump()
+    assert "effective_capability" not in dumped
+    assert "capability" in dumped
+    assert dumped["capability"] == "requirement_check"
+
+
+def test_capability_field_used_when_constructing_directly():
+    entry = IntriniscsCatalogEntry(
+        name="my-custom-adapter",
+        capability="my_custom_adapter",
+        repo_id="org/repo",
+        revision="abc123def456",
+    )
+    assert entry.effective_capability == "my_custom_adapter"
+
+
+def test_capability_none_means_effective_capability_equals_name():
+    entry = IntriniscsCatalogEntry(
+        name="plain_name", repo_id="org/repo", revision="abc123def456"
+    )
+    assert entry.capability is None
+    assert entry.effective_capability == "plain_name"

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -30,6 +30,11 @@ def test_revision_validation_rejects_whitespace():
         validate_revision("   ")
 
 
+def test_revision_validation_rejects_leading_trailing_whitespace():
+    with pytest.raises(ValueError, match="leading or trailing whitespace"):
+        validate_revision("  main  ")
+
+
 def test_revision_validation_accepts_sha():
     assert validate_revision(_VALID_SHA) == _VALID_SHA
 

--- a/test/backends/test_adapters/test_core_types.py
+++ b/test/backends/test_adapters/test_core_types.py
@@ -17,6 +17,7 @@ from mellea.backends.adapters import (
     ServerMediatedBinding,
     WeightsBinding,
 )
+from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
 from mellea.core import Component
 
 
@@ -212,6 +213,4 @@ def test_known_capabilities_contains_no_hyphens():
 def test_known_capabilities_count_matches_catalog():
     # Every catalog entry must contribute exactly one distinct effective_capability.
     # If two entries resolve to the same token, the frozenset shrinks and this fails.
-    from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
-
     assert len(KNOWN_CAPABILITIES) == len(_INTRINSICS_CATALOG_ENTRIES)

--- a/test/backends/test_adapters/test_core_types.py
+++ b/test/backends/test_adapters/test_core_types.py
@@ -158,6 +158,10 @@ def test_adapter_schema_mismatch_error_pickles():
 def test_known_capabilities_importable():
     assert isinstance(KNOWN_CAPABILITIES, frozenset)
     assert "answerability" in KNOWN_CAPABILITIES
+    # Hyphenated upstream names must NOT be in the capability vocabulary;
+    # only the stable underscore forms derived from effective_capability are.
+    assert "requirement-check" not in KNOWN_CAPABILITIES
+    assert "requirement_check" in KNOWN_CAPABILITIES
 
 
 def test_identity_known_capability_no_warning():
@@ -177,3 +181,21 @@ def test_identity_known_capability_no_warning():
 def test_identity_unknown_capability_warns():
     with pytest.warns(UserWarning, match="not in the KNOWN_CAPABILITIES"):
         Identity(name="a", adapter_type="lora", capability="unknown-capability")
+
+
+def test_identity_requirement_check_underscore_no_warning():
+    """requirement_check (underscore) must be a known capability after #1186."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Identity(
+            name="requirement-check",
+            adapter_type="lora",
+            capability="requirement_check",
+        )
+    capability_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning)
+        and "KNOWN_CAPABILITIES" in str(w.message)
+    ]
+    assert capability_warnings == []

--- a/test/backends/test_adapters/test_core_types.py
+++ b/test/backends/test_adapters/test_core_types.py
@@ -199,3 +199,19 @@ def test_identity_requirement_check_underscore_no_warning():
         and "KNOWN_CAPABILITIES" in str(w.message)
     ]
     assert capability_warnings == []
+
+
+def test_known_capabilities_contains_no_hyphens():
+    # No hyphenated name should leak into KNOWN_CAPABILITIES.  If a future
+    # catalog entry uses hyphens in `name` without setting `capability`, this
+    # catches it immediately.
+    hyphenated = [cap for cap in KNOWN_CAPABILITIES if "-" in cap]
+    assert hyphenated == [], f"Hyphenated capabilities found: {hyphenated}"
+
+
+def test_known_capabilities_count_matches_catalog():
+    # Every catalog entry must contribute exactly one distinct effective_capability.
+    # If two entries resolve to the same token, the frozenset shrinks and this fails.
+    from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
+
+    assert len(KNOWN_CAPABILITIES) == len(_INTRINSICS_CATALOG_ENTRIES)


### PR DESCRIPTION
Fixes #1186. Part of Epic #929 Phase 0 (adapter lifecycle refactor).

## Background

Epic #929 is a multi-phase refactor of how Mellea loads and identifies adapters (LoRA/aLoRA fine-tuned modules). Phase 0 (`#1134`, `#1135`, this PR) lays the scaffolding; later phases wire it into the live loading paths.

This PR fixes a coupling introduced in `#1134`: `KNOWN_CAPABILITIES` was built directly from catalog entry `name` fields, so the capability vocabulary was tied to the names HuggingFace uses for their adapters. When an upstream adapter gets renamed, Mellea capability strings break too. The `requirement-check` / `requirement_check` mismatch (hyphens vs underscores) had already forced several edits.

## Change

**Before** — capability vocabulary = upstream adapter names:

```python
# capabilities.py
KNOWN_CAPABILITIES = frozenset(e.name for e in _INTRINSICS_CATALOG_ENTRIES)
# → {"requirement-check", "context-attribution", "policy-guardrails", ...}

# catalog.py
IntriniscsCatalogEntry(name="requirement-check", repo_id=..., revision=...)
```

**After** — capability vocabulary is declared independently:

```python
# capabilities.py
KNOWN_CAPABILITIES = frozenset(e.effective_capability for e in _INTRINSICS_CATALOG_ENTRIES)
# → {"requirement_check", "context_attribution", "policy_guardrails", ...}

# catalog.py
IntriniscsCatalogEntry(
    name="requirement-check",       # upstream HF adapter name — may change
    capability="requirement_check", # stable Mellea token — must not change without deprecation
    repo_id=...,
    revision=...,
)
```

`effective_capability` returns `capability` when set, falling back to `name` — so entries whose name is already a clean identifier (`answerability`, `citations`, etc.) need no explicit `capability` field.

The six hyphenated catalog entries (Core + Guardian groups) get explicit underscore capabilities. The seven underscore-named RAG entries are unchanged.

The issue also called out updating call sites that hardcode adapter names as capabilities. There are none: `Identity` is Phase 0 scaffolding not yet wired into production adapter loading — nothing in production code constructs `Identity` objects today. That migration is Phase 1/2 work.

## Validation hardening

As part of ensuring `effective_capability` genuinely guarantees a non-empty, clean token, this PR extends validation consistently across all three string token fields on `IntriniscsCatalogEntry`:

- `name`, `capability`, and `revision` all now reject empty strings, whitespace-only strings, and strings with leading or trailing whitespace
- Validators raise; they do not silently strip — consistent with the existing codebase convention throughout `mellea/`
- `validate_revision` (pre-existing, exported) updated to match

## Relationship to #1256

Independent of #1256 (terminology sweep) — can merge in either order. Both touch `catalog.py` and `capabilities.py` but in different lines. Whoever merges second needs a one-line docstring rebase.

## Test plan

```
uv run pytest test/backends/test_adapters/test_catalog.py \
               test/backends/test_adapters/test_catalog_revision.py \
               test/backends/test_adapters/test_core_types.py -v
```

60 tests pass. Key assertions:
- `"requirement_check" in KNOWN_CAPABILITIES`, `"requirement-check" not in KNOWN_CAPABILITIES`
- All six hyphenated entries carry explicit underscore capabilities
- No hyphenated string can leak into `KNOWN_CAPABILITIES` (regression guard)
- `len(KNOWN_CAPABILITIES) == len(_INTRINSICS_CATALOG_ENTRIES)` (no duplicates)
- `name`, `capability`, `revision` all reject empty, whitespace-only, and leading/trailing whitespace