### PR TITLE
feat(intrinsics): shim old adapters onto Adapter dataclass; call_intrinsic rewritten (Epic #929 Phase 1)

### DIFF
--- a/docs/dev/requirement_aLoRA_rerouting.md
+++ b/docs/dev/requirement_aLoRA_rerouting.md
@@ -81,12 +81,7 @@ adapter, replacing the old `isinstance` + `AdapterType` check:
 adapter = get_adapter_for_intrinsic("requirement-check", [AdapterType.ALORA], self._added_adapters)
 
 # After (Phase 1)
-adapter = next(
-    (a for a in self._added_adapters.values()
-     if isinstance(a, Adapter) and a.identity.capability == "requirement-check"
-     and a.identity.adapter_type == "alora"),
-    None,
-)
+adapter = self._find_adapter("requirement-check", {"alora"})
 ```
 
 The logical rule (three exceptions above) is unchanged. The change is purely

--- a/docs/dev/requirement_aLoRA_rerouting.md
+++ b/docs/dev/requirement_aLoRA_rerouting.md
@@ -81,7 +81,7 @@ adapter, replacing the old `isinstance` + `AdapterType` check:
 adapter = get_adapter_for_intrinsic("requirement-check", [AdapterType.ALORA], self._added_adapters)
 
 # After (Phase 1)
-adapter = self._find_adapter("requirement-check", {"alora"})
+adapter = self._find_adapter("requirement-check", ("alora",))
 ```
 
 The logical rule (three exceptions above) is unchanged. The change is purely

--- a/docs/dev/requirement_aLoRA_rerouting.md
+++ b/docs/dev/requirement_aLoRA_rerouting.md
@@ -70,3 +70,26 @@ All backends that implement the aLoRA mixin need to implement this semantics.
  * This might be a blessing in disguise. It's actually not clear that ALora context construction can be done WLOG outside of the specific backend.
  * That code is written rarely in any case.
  * Depending on the truth of the first bullet point's conjecture, we can mitigate by implementing this routing in `m.validate` so that even if a backend contributor gets this wrong the proper behavior is still usually observed by most users.
+
+## Phase 1 change (Epic #929, issue #1136)
+
+Backends now use a **capability-based lookup** to find the `requirement-check`
+adapter, replacing the old `isinstance` + `AdapterType` check:
+
+```python
+# Before (Phase 0)
+adapter = get_adapter_for_intrinsic("requirement-check", [AdapterType.ALORA], self._added_adapters)
+
+# After (Phase 1)
+adapter = next(
+    (a for a in self._added_adapters.values()
+     if isinstance(a, Adapter) and a.identity.capability == "requirement-check"
+     and a.identity.adapter_type == "alora"),
+    None,
+)
+```
+
+The logical rule (three exceptions above) is unchanged. The change is purely
+in how the matching adapter is located: capability name and adapter type are
+now read from `adapter.identity` (the new `Identity` dataclass introduced in
+Phase 0, issue #1134) rather than derived from the adapter's class hierarchy.

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -137,9 +137,13 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
         base_model_name (str | None): Base model name provided at construction, if any.
         adapter_type (AdapterType): The adapter type (``LORA`` or ``ALORA``).
         config (dict): Parsed I/O transformation configuration for the adapter function.
-        identity (Identity): Composable identity from the new Adapter design.
-        io_contract (IOContract): Phase 1 stub; replaced in Phase 2.
-        weights (WeightsBinding): Phase 1 stub; replaced in Phase 2.
+
+    .. note::
+        ``identity``, ``io_contract``, and ``weights`` are Phase 1 internal scaffolding
+        populated in ``__init__`` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
+        protocol.  They are not meaningful consumer-facing attributes; ``io_contract`` and
+        ``weights`` raise :exc:`NotImplementedError` and will be replaced in Phase 2
+        (issues #1137, #1138).
     """
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -384,14 +388,9 @@ class AdapterMixin(Backend, abc.ABC):
             ValueError: If the backend has no model ID.
             KeyError: If the adapter cannot be found after registration.
         """
-        added: dict = getattr(self, "_added_adapters", {})
-
-        for adapter in added.values():
-            if (
-                isinstance(adapter, _AdapterCore)
-                and adapter.identity.capability == name
-            ):
-                return adapter
+        found = self._find_adapter(name)
+        if found is not None:
+            return found
 
         base = self.base_model_name
         if base is None:
@@ -420,13 +419,9 @@ class AdapterMixin(Backend, abc.ABC):
                     )
                 )
 
-        added = getattr(self, "_added_adapters", {})
-        for adapter in added.values():
-            if (
-                isinstance(adapter, _AdapterCore)
-                and adapter.identity.capability == name
-            ):
-                return adapter
+        found = self._find_adapter(name)
+        if found is not None:
+            return found
 
         raise KeyError(f"Adapter {name!r} not found after registration")
 
@@ -441,6 +436,28 @@ class AdapterMixin(Backend, abc.ABC):
             adapter: The adapter to activate, or ``None`` (no-op in Phase 1).
         """
         yield
+
+    def _find_adapter(
+        self, capability: str, adapter_types: set[str] | None = None
+    ) -> "_AdapterCore | None":
+        """Return the first registered adapter matching capability and (optionally) type.
+
+        Args:
+            capability (str): Capability name (e.g. ``"answerability"``).
+            adapter_types (set[str] | None): Allowed adapter type strings
+                (e.g. ``{"alora"}``). ``None`` matches any type.
+
+        Returns:
+            _AdapterCore | None: Matching adapter, or ``None`` if not found.
+        """
+        for a in getattr(self, "_added_adapters", {}).values():
+            if (
+                isinstance(a, _AdapterCore)
+                and a.identity.capability == capability
+                and (adapter_types is None or a.identity.adapter_type in adapter_types)
+            ):
+                return a
+        return None
 
 
 class EmbeddedIntrinsicAdapter(_AdapterCore):
@@ -469,9 +486,13 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
         intrinsic_name (str): Name of the adapter function this adapter implements.
         config (dict): Parsed I/O transformation configuration.
         technology (str): ``"lora"`` or ``"alora"``.
-        identity (Identity): Composable identity from the new Adapter design.
-        io_contract (IOContract): Phase 1 stub; replaced in Phase 2.
-        weights (WeightsBinding): Phase 1 stub; replaced in Phase 2.
+
+    .. note::
+        ``identity``, ``io_contract``, and ``weights`` are Phase 1 internal scaffolding
+        populated in ``__init__`` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
+        protocol.  They are not meaningful consumer-facing attributes; ``io_contract`` and
+        ``weights`` raise :exc:`NotImplementedError` and will be replaced in Phase 2
+        (issues #1137, #1138).
     """
 
     def __setattr__(self, name: str, value: object) -> None:

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -9,15 +9,17 @@ loading and unloading.
 """
 
 import abc
+import contextlib
 import pathlib
 import re
-from typing import TypeVar
+import warnings
+from typing import Literal, TypeVar, cast
 
 import yaml
 
 from ...core import Backend
 from ...formatters.granite import intrinsics as intrinsics
-from ...helpers import _ServerType
+from ._core import Adapter as _AdapterCore, Identity, IOContract, WeightsBinding
 from .catalog import AdapterType, fetch_intrinsic_metadata
 
 
@@ -76,8 +78,36 @@ class LocalHFAdapter(Adapter):
         ...
 
 
-class IntrinsicAdapter(LocalHFAdapter):
-    """Base class for adapters that implement adapter functions.
+class _ShimIOContract(IOContract):
+    """Phase 1 placeholder; Phase 2 (issue #1137) implements real I/O."""
+
+    def build_prompt(self, **kwargs: object):  # type: ignore[override]
+        raise NotImplementedError(
+            "Phase 2 (issue #1137) — IOContract not yet implemented"
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        raise NotImplementedError(
+            "Phase 2 (issue #1137) — IOContract not yet implemented"
+        )
+
+
+class _ShimWeightsBinding(WeightsBinding):
+    """Phase 1 placeholder; Phase 2 (issue #1138) wires in real lifecycle."""
+
+    def prepare(self) -> None: ...
+    def activate(self) -> None: ...
+    def deactivate(self) -> None: ...
+    def release(self) -> None: ...
+
+
+class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
+    """Deprecated shim for adapters that implement adapter functions.
+
+    .. deprecated::
+        Use :class:`~mellea.backends.adapters.Adapter` directly.
+        ``IntrinsicAdapter`` will be removed in a future release (Epic #929,
+        issue #1144).
 
     Subtype of :class:`Adapter` for models that:
 
@@ -107,7 +137,18 @@ class IntrinsicAdapter(LocalHFAdapter):
         base_model_name (str | None): Base model name provided at construction, if any.
         adapter_type (AdapterType): The adapter type (``LORA`` or ``ALORA``).
         config (dict): Parsed I/O transformation configuration for the adapter function.
+        identity (Identity): Composable identity from the new Adapter design.
+        io_contract (IOContract): Phase 1 stub; replaced in Phase 2.
+        weights (WeightsBinding): Phase 1 stub; replaced in Phase 2.
     """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Allow mutation; bypasses the frozen restriction on _AdapterCore."""
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        """Allow deletion; bypasses the frozen restriction on _AdapterCore."""
+        object.__delattr__(self, name)
 
     def __init__(
         self,
@@ -118,6 +159,11 @@ class IntrinsicAdapter(LocalHFAdapter):
         base_model_name: str | None = None,
     ):
         """Initialize IntrinsicAdapter for the named adapter function, loading its I/O configuration."""
+        warnings.warn(
+            "IntrinsicAdapter is deprecated; use Adapter directly (Epic #929, issue #1144).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(intrinsic_name, adapter_type)
 
         self.intrinsic_name = intrinsic_name
@@ -173,6 +219,20 @@ class IntrinsicAdapter(LocalHFAdapter):
         assert config_dict is not None  # Code above should initialize this variable
         self.config: dict = config_dict
 
+        # Populate the new Adapter triple so isinstance(self, _AdapterCore) holds.
+        _AdapterCore.__init__(
+            self,
+            identity=Identity(
+                name=intrinsic_name,
+                adapter_type="alora"
+                if self.adapter_type == AdapterType.ALORA
+                else "lora",
+                capability=intrinsic_name,
+            ),
+            io_contract=_ShimIOContract(),
+            weights=_ShimWeightsBinding(),
+        )
+
     def get_local_hf_path(self, base_model_name: str) -> str:
         """Return the local filesystem path from which adapter weights should be loaded.
 
@@ -188,7 +248,7 @@ class IntrinsicAdapter(LocalHFAdapter):
         return self.download_and_get_path(base_model_name)
 
     def download_and_get_path(self, base_model_name: str) -> str:
-        """Downloads the required RAG adapter function files if necessary and returns the path to them.
+        """Download the required adapter function files if necessary and return the path to them.
 
         Args:
             base_model_name: the base model; typically the last part of the huggingface
@@ -307,9 +367,89 @@ class AdapterMixin(Backend, abc.ABC):
             f"Backend type {type(self)} does not implement list_adapters() API call."
         )
 
+    def resolve_adapter(self, name: str) -> _AdapterCore:
+        """Find or lazily register an adapter by capability name.
 
-class EmbeddedIntrinsicAdapter(Adapter):
-    """Adapter for adapter functions embedded in a Granite Switch model.
+        Default implementation preserves Phase 0 behaviour, using the internal
+        ``_added_adapters`` dict that concrete backends maintain.  Override in
+        Phase 2 (issue #1138) to implement proper lifecycle management.
+
+        Args:
+            name (str): Capability name (e.g. ``"answerability"``).
+
+        Returns:
+            Adapter: The registered adapter with the given capability.
+
+        Raises:
+            ValueError: If the backend has no model ID.
+            KeyError: If the adapter cannot be found after registration.
+        """
+        added: dict = getattr(self, "_added_adapters", {})
+
+        for adapter in added.values():
+            if (
+                isinstance(adapter, _AdapterCore)
+                and adapter.identity.capability == name
+            ):
+                return adapter
+
+        base = self.base_model_name
+        if base is None:
+            raise ValueError(
+                f"Backend has no model ID; cannot resolve adapter {name!r}"
+            )
+
+        # Suppress DeprecationWarning: the shim constructors warn user-facing code,
+        # not internal registration paths.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            if getattr(self, "_uses_embedded_adapters", False):
+                repo_id = (
+                    getattr(self, "_adapter_source", None)
+                    or getattr(self, "_model_id", None)
+                    or base
+                )
+                for a in EmbeddedIntrinsicAdapter.from_source(
+                    repo_id, intrinsic_name=name
+                ):
+                    self.add_adapter(a)
+            else:
+                self.add_adapter(
+                    IntrinsicAdapter(
+                        name, adapter_type=AdapterType.LORA, base_model_name=base
+                    )
+                )
+
+        added = getattr(self, "_added_adapters", {})
+        for adapter in added.values():
+            if (
+                isinstance(adapter, _AdapterCore)
+                and adapter.identity.capability == name
+            ):
+                return adapter
+
+        raise KeyError(f"Adapter {name!r} not found after registration")
+
+    @contextlib.contextmanager
+    def adapter_scope(self, adapter: "_AdapterCore | None"):  # type: ignore[type-arg]
+        """Context manager wrapping adapter activation and deactivation.
+
+        Phase 1 stub — yields immediately (no-op). Phase 2 (issue #1138) wires
+        in ``adapter.weights.activate()`` and ``adapter.weights.deactivate()``.
+
+        Args:
+            adapter: The adapter to activate, or ``None`` (no-op in Phase 1).
+        """
+        yield
+
+
+class EmbeddedIntrinsicAdapter(_AdapterCore):
+    """Deprecated shim for adapter functions embedded in a Granite Switch model.
+
+    .. deprecated::
+        Use :class:`~mellea.backends.adapters.Adapter` directly.
+        ``EmbeddedIntrinsicAdapter`` will be removed in a future release
+        (Epic #929, issue #1144).
 
     Unlike PEFT-based adapters that are loaded into the model at runtime,
     embedded adapters are already baked into the model weights and activated
@@ -329,19 +469,56 @@ class EmbeddedIntrinsicAdapter(Adapter):
         intrinsic_name (str): Name of the adapter function this adapter implements.
         config (dict): Parsed I/O transformation configuration.
         technology (str): ``"lora"`` or ``"alora"``.
+        identity (Identity): Composable identity from the new Adapter design.
+        io_contract (IOContract): Phase 1 stub; replaced in Phase 2.
+        weights (WeightsBinding): Phase 1 stub; replaced in Phase 2.
     """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Allow mutation; bypasses the frozen restriction on _AdapterCore."""
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        """Allow deletion; bypasses the frozen restriction on _AdapterCore."""
+        object.__delattr__(self, name)
 
     def __init__(self, intrinsic_name: str, config: dict, technology: str = "lora"):
         """Initialize an embedded adapter function with its I/O config."""
+        warnings.warn(
+            "EmbeddedIntrinsicAdapter is deprecated; use Adapter directly (Epic #929, issue #1144).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if technology not in ("lora", "alora"):
             raise ValueError(
                 f"technology must be 'lora' or 'alora', got '{technology}'"
             )
         adapter_type = AdapterType.ALORA if technology == "alora" else AdapterType.LORA
-        super().__init__(intrinsic_name, adapter_type)
+
+        # Old-style Adapter fields — set manually since we no longer inherit from the
+        # legacy Adapter ABC.  Preserved for backward compatibility until Phase 4.
+        self.name = intrinsic_name
+        self.adapter_type = adapter_type
+        self.qualified_name = intrinsic_name + "_" + adapter_type.value
+        self.backend: Backend | None = None
+        self.path: str | None = None
+
         self.intrinsic_name = intrinsic_name
         self.config = config
         self.technology = technology
+
+        # Populate the new Adapter triple so isinstance(self, _AdapterCore) holds.
+        # technology is validated above; cast to the Literal type mypy expects.
+        _AdapterCore.__init__(
+            self,
+            identity=Identity(
+                name=intrinsic_name,
+                adapter_type=cast(Literal["lora", "alora"], technology),
+                capability=intrinsic_name,
+            ),
+            io_contract=_ShimIOContract(),
+            weights=_ShimWeightsBinding(),
+        )
 
     @staticmethod
     def from_model_directory(
@@ -505,16 +682,16 @@ class EmbeddedIntrinsicAdapter(Adapter):
 
 
 class CustomIntrinsicAdapter(IntrinsicAdapter):
-    """Special class for users to subclass when creating custom adapter functions.
+    """Deprecated shim for user-defined custom adapter functions.
 
-    The documentation says that any developer who creates an adapter function should create
-    a subclass of this class. Creating a subclass of this class appears to be a cosmetic
-    boilerplate development task that isn't actually necessary for any existing use case.
+    .. deprecated::
+        Use :class:`~mellea.backends.adapters.Adapter` directly.
+        ``CustomIntrinsicAdapter`` will be removed in a future release
+        (Epic #929, issue #1144).
 
-    This class has the same functionality as ``IntrinsicAdapter``, except that its
-    constructor monkey-patches Mellea global variables to enable the backend to load
-    the user's adapter. The code that performs this monkey-patching is marked as a
-    temporary hack.
+    This class has the same functionality as ``IntrinsicAdapter``, except that
+    its constructor monkey-patches Mellea global variables to enable the backend
+    to load the user's adapter.
 
     Args:
         model_id (str): The Hugging Face model ID used for downloading model weights;
@@ -528,6 +705,11 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
         self, *, model_id: str, intrinsic_name: str | None = None, base_model_name: str
     ):
         """Initialize CustomIntrinsicAdapter and patch the global adapter function catalog if needed."""
+        warnings.warn(
+            "CustomIntrinsicAdapter is deprecated; use Adapter directly (Epic #929, issue #1144).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         assert re.match(".*/.*", model_id), (
             "expected a huggingface model id with format <user-id>/<repo-name>"
         )
@@ -548,4 +730,10 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
                 e.name: e for e in catalog._INTRINSICS_CATALOG_ENTRIES
             }
 
-        super().__init__(intrinsic_name=intrinsic_name, base_model_name=base_model_name)
+        # Suppress DeprecationWarning from the IntrinsicAdapter shim: the warning we
+        # emitted above is already correctly attributed to the caller's frame.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            IntrinsicAdapter.__init__(
+                self, intrinsic_name=intrinsic_name, base_model_name=base_model_name
+            )

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -438,33 +438,34 @@ class AdapterMixin(Backend, abc.ABC):
         yield
 
     def _find_adapter(
-        self, capability: str, adapter_types: set[str] | None = None
+        self, capability: str, adapter_types: tuple[str, ...] | None = None
     ) -> "_AdapterCore | None":
         """Return the first registered adapter matching capability and (optionally) type.
 
         Args:
             capability (str): Capability name (e.g. ``"answerability"``).
-            adapter_types (set[str] | None): Allowed adapter type strings
-                (e.g. ``{"alora"}``). ``None`` matches any type.
+            adapter_types (tuple[str, ...] | None): Adapter type strings in
+                preference order (e.g. ``("alora", "lora")``).  When provided,
+                aLoRA is returned before LoRA if both are registered for the same
+                capability.  ``None`` matches any type (insertion order wins).
 
         Returns:
             _AdapterCore | None: Matching adapter, or ``None`` if not found.
-
-        Note:
-            Returns the first dict hit in ``_added_adapters`` insertion order.
-            If both a ``lora`` and ``alora`` entry exist for the same capability,
-            pass ``adapter_types`` to constrain the result.  Phase 0's
-            ``get_adapter_for_intrinsic`` accepted an ordered list and preferred
-            the first matching type; that preference ordering is not preserved
-            here.  Phase 2 (issue #1138) will revisit if needed.
         """
-        for a in getattr(self, "_added_adapters", {}).values():
-            if (
-                isinstance(a, _AdapterCore)
-                and a.identity.capability == capability
-                and (adapter_types is None or a.identity.adapter_type in adapter_types)
-            ):
-                return a
+        adapters = getattr(self, "_added_adapters", {})
+        if adapter_types is None:
+            for a in adapters.values():
+                if isinstance(a, _AdapterCore) and a.identity.capability == capability:
+                    return a
+            return None
+        for preferred_type in adapter_types:
+            for a in adapters.values():
+                if (
+                    isinstance(a, _AdapterCore)
+                    and a.identity.capability == capability
+                    and a.identity.adapter_type == preferred_type
+                ):
+                    return a
         return None
 
 

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -95,10 +95,17 @@ class _ShimIOContract(IOContract):
 class _ShimWeightsBinding(WeightsBinding):
     """Phase 1 placeholder; Phase 2 (issue #1138) wires in real lifecycle."""
 
-    def prepare(self) -> None: ...
-    def activate(self) -> None: ...
-    def deactivate(self) -> None: ...
-    def release(self) -> None: ...
+    def prepare(self) -> None:
+        raise NotImplementedError("WeightsBinding not yet implemented")
+
+    def activate(self) -> None:
+        raise NotImplementedError("WeightsBinding not yet implemented")
+
+    def deactivate(self) -> None:
+        raise NotImplementedError("WeightsBinding not yet implemented")
+
+    def release(self) -> None:
+        raise NotImplementedError("WeightsBinding not yet implemented")
 
 
 class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
@@ -398,6 +405,10 @@ class AdapterMixin(Backend, abc.ABC):
                 f"Backend has no model ID; cannot resolve adapter {name!r}"
             )
 
+        # warnings.catch_warnings() modifies the process-global filter state and is not
+        # async/thread-safe.  Concurrent first-time resolves race on filter restoration;
+        # add_adapter is idempotent so the double-registration hazard is benign, but the
+        # filter race is a known Phase-1 gap.  Phase 2 (#1138) introduces a proper lock.
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
         with warnings.catch_warnings():
@@ -411,8 +422,15 @@ class AdapterMixin(Backend, abc.ABC):
                 for a in EmbeddedIntrinsicAdapter.from_source(
                     repo_id, intrinsic_name=name
                 ):
+                    # EmbeddedIntrinsicAdapter is only valid for backends whose
+                    # add_adapter accepts the full Adapter type (e.g. OpenAIBackend).
+                    # LocalHFBackend.add_adapter expects LocalHFAdapter; HF backends
+                    # never set _uses_embedded_adapters=True.
                     self.add_adapter(a)
             else:
+                # AdapterType.LORA is the pre-Phase-1 default (mirrors old _util.py).
+                # Every current catalog entry supports LORA.  Phase 2 (#1138) will
+                # select the type from catalog availability instead of hardcoding.
                 self.add_adapter(
                     IntrinsicAdapter(
                         name, adapter_type=AdapterType.LORA, base_model_name=base

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -1,11 +1,14 @@
 """Adapter classes for adding fine-tuned modules to inference backends.
 
-Defines the abstract ``Adapter`` base class and its concrete subclasses
-``LocalHFAdapter`` (for locally loaded Hugging Face models) and ``IntrinsicAdapter``
-(for adapters whose metadata is stored in Mellea's adapter function catalog). Also
-provides ``get_adapter_for_intrinsic`` for resolving the right adapter class given an
-adapter function name, and ``AdapterMixin`` for backends that support runtime adapter
-loading and unloading.
+The primary public surface is :func:`AdapterMixin.resolve_adapter` (find or lazily
+register an adapter by capability name) and :meth:`AdapterMixin._find_adapter`
+(look up a registered adapter).  :class:`AdapterMixin` is mixed into backends that
+support runtime adapter loading and unloading.
+
+``LocalHFAdapter``, ``IntrinsicAdapter``, and ``EmbeddedIntrinsicAdapter`` are
+**deprecation shims** retained for backwards compatibility.  They satisfy
+``isinstance(x, _core.Adapter)`` but delegate all behaviour to the new dataclass.
+``get_adapter_for_intrinsic`` is similarly deprecated; prefer ``resolve_adapter``.
 """
 
 import abc
@@ -96,16 +99,24 @@ class _ShimWeightsBinding(WeightsBinding):
     """Phase 1 placeholder; Phase 2 (issue #1138) wires in real lifecycle."""
 
     def prepare(self) -> None:
-        raise NotImplementedError("WeightsBinding not yet implemented")
+        raise NotImplementedError(
+            "Phase 2 (issue #1138) — WeightsBinding not yet implemented"
+        )
 
     def activate(self) -> None:
-        raise NotImplementedError("WeightsBinding not yet implemented")
+        raise NotImplementedError(
+            "Phase 2 (issue #1138) — WeightsBinding not yet implemented"
+        )
 
     def deactivate(self) -> None:
-        raise NotImplementedError("WeightsBinding not yet implemented")
+        raise NotImplementedError(
+            "Phase 2 (issue #1138) — WeightsBinding not yet implemented"
+        )
 
     def release(self) -> None:
-        raise NotImplementedError("WeightsBinding not yet implemented")
+        raise NotImplementedError(
+            "Phase 2 (issue #1138) — WeightsBinding not yet implemented"
+        )
 
 
 class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
@@ -408,7 +419,9 @@ class AdapterMixin(Backend, abc.ABC):
         # warnings.catch_warnings() modifies the process-global filter state and is not
         # async/thread-safe.  Concurrent first-time resolves race on filter restoration;
         # add_adapter is idempotent so the double-registration hazard is benign, but the
-        # filter race is a known Phase-1 gap.  Phase 2 (#1138) introduces a proper lock.
+        # filter race is a known Phase-1 gap: two concurrent first-time call_intrinsic
+        # calls can interleave their catch_warnings contexts, causing a DeprecationWarning
+        # to surface in user code during lazy-registration.  Phase 2 (#1138) adds a lock.
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
         with warnings.catch_warnings():

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -449,6 +449,14 @@ class AdapterMixin(Backend, abc.ABC):
 
         Returns:
             _AdapterCore | None: Matching adapter, or ``None`` if not found.
+
+        Note:
+            Returns the first dict hit in ``_added_adapters`` insertion order.
+            If both a ``lora`` and ``alora`` entry exist for the same capability,
+            pass ``adapter_types`` to constrain the result.  Phase 0's
+            ``get_adapter_for_intrinsic`` accepted an ordered list and preferred
+            the first matching type; that preference ordering is not preserved
+            here.  Phase 2 (issue #1138) will revisit if needed.
         """
         for a in getattr(self, "_added_adapters", {}).values():
             if (
@@ -505,15 +513,15 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
 
     def __init__(self, intrinsic_name: str, config: dict, technology: str = "lora"):
         """Initialize an embedded adapter function with its I/O config."""
+        if technology not in ("lora", "alora"):
+            raise ValueError(
+                f"technology must be 'lora' or 'alora', got '{technology}'"
+            )
         warnings.warn(
             "EmbeddedIntrinsicAdapter is deprecated; use Adapter directly (Epic #929, issue #1144).",
             DeprecationWarning,
             stacklevel=2,
         )
-        if technology not in ("lora", "alora"):
-            raise ValueError(
-                f"technology must be 'lora' or 'alora', got '{technology}'"
-            )
         adapter_type = AdapterType.ALORA if technology == "alora" else AdapterType.LORA
 
         # Old-style Adapter fields — set manually since we no longer inherit from the

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -378,7 +378,7 @@ class AdapterMixin(Backend, abc.ABC):
             name (str): Capability name (e.g. ``"answerability"``).
 
         Returns:
-            Adapter: The registered adapter with the given capability.
+            _AdapterCore: The registered adapter with the given capability.
 
         Raises:
             ValueError: If the backend has no model ID.

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -60,13 +60,8 @@ from ..helpers import message_to_openai_message, messages_to_docs, send_to_queue
 from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import ALoraRequirement, LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
-from .adapters import (
-    AdapterMixin,
-    AdapterType,
-    IntrinsicAdapter,
-    LocalHFAdapter,
-    get_adapter_for_intrinsic,
-)
+from .adapters import AdapterMixin, IntrinsicAdapter, LocalHFAdapter
+from .adapters._core import Adapter
 from .backend import FormatterBackend
 from .cache import Cache, SimpleLRUCache
 from .model_ids import ModelIdentifier
@@ -442,8 +437,16 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
                 # Check if a requirement-check (or AloraRequirement specified) adapter
                 # exists.
-                alora_req_adapter = get_adapter_for_intrinsic(
-                    adapter_name, [AdapterType.ALORA], self._added_adapters
+                # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
+                alora_req_adapter = next(
+                    (
+                        a
+                        for a in self._added_adapters.values()
+                        if isinstance(a, Adapter)
+                        and a.identity.capability == adapter_name
+                        and a.identity.adapter_type == "alora"
+                    ),
+                    None,
                 )
                 if alora_req_adapter is None:
                     # Log a warning if using an AloraRequirement but no adapter fit.
@@ -583,8 +586,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         docs = messages_to_docs(ctx_as_message_list)
 
-        adapter = get_adapter_for_intrinsic(
-            action.intrinsic_name, action.adapter_types, self._added_adapters
+        # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
+        allowed_types = {at.value for at in action.adapter_types}
+        adapter = next(
+            (
+                a
+                for a in self._added_adapters.values()
+                if isinstance(a, Adapter)
+                and a.identity.capability == action.intrinsic_name
+                and a.identity.adapter_type in allowed_types
+            ),
+            None,
         )
         if adapter is None:
             raise ValueError(

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -61,7 +61,6 @@ from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import ALoraRequirement, LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
 from .adapters import AdapterMixin, IntrinsicAdapter, LocalHFAdapter
-from .adapters._core import Adapter
 from .backend import FormatterBackend
 from .cache import Cache, SimpleLRUCache
 from .model_ids import ModelIdentifier
@@ -437,17 +436,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
                 # Check if a requirement-check (or AloraRequirement specified) adapter
                 # exists.
-                # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
-                alora_req_adapter = next(
-                    (
-                        a
-                        for a in self._added_adapters.values()
-                        if isinstance(a, Adapter)
-                        and a.identity.capability == adapter_name
-                        and a.identity.adapter_type == "alora"
-                    ),
-                    None,
-                )
+                alora_req_adapter = self._find_adapter(adapter_name, {"alora"})
                 if alora_req_adapter is None:
                     # Log a warning if using an AloraRequirement but no adapter fit.
                     if reroute_to_alora and isinstance(action, ALoraRequirement):
@@ -586,18 +575,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         docs = messages_to_docs(ctx_as_message_list)
 
-        # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
         allowed_types = {at.value for at in action.adapter_types}
-        adapter = next(
-            (
-                a
-                for a in self._added_adapters.values()
-                if isinstance(a, Adapter)
-                and a.identity.capability == action.intrinsic_name
-                and a.identity.adapter_type in allowed_types
-            ),
-            None,
-        )
+        adapter = self._find_adapter(action.intrinsic_name, allowed_types)
         if adapter is None:
             raise ValueError(
                 f"backend ({self}) has no adapter for processing intrinsic: {action.intrinsic_name}"

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -436,7 +436,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
                 # Check if a requirement-check (or AloraRequirement specified) adapter
                 # exists.
-                alora_req_adapter = self._find_adapter(adapter_name, {"alora"})
+                alora_req_adapter = self._find_adapter(adapter_name, ("alora",))
                 if alora_req_adapter is None:
                     # Log a warning if using an AloraRequirement but no adapter fit.
                     if reroute_to_alora and isinstance(action, ALoraRequirement):
@@ -575,7 +575,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         docs = messages_to_docs(ctx_as_message_list)
 
-        allowed_types = {at.value for at in action.adapter_types}
+        allowed_types = tuple(at.value for at in action.adapter_types)
         adapter = self._find_adapter(action.intrinsic_name, allowed_types)
         if adapter is None:
             raise ValueError(

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -483,7 +483,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     )
                     alora_action = ALoraRequirement(action.description, adapter_name)
 
-                alora_req_adapter = self._find_adapter(adapter_name, {"alora"})
+                alora_req_adapter = self._find_adapter(adapter_name, ("alora",))
                 if alora_req_adapter is None:
                     if reroute_to_alora and isinstance(action, ALoraRequirement):
                         MelleaLogger.get_logger().warning(
@@ -567,7 +567,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             )
 
         # --- adapter lookup ------------------------------------------------
-        allowed_types = {at.value for at in action.adapter_types}
+        allowed_types = tuple(at.value for at in action.adapter_types)
         adapter = self._find_adapter(action.intrinsic_name, allowed_types)
         if adapter is None:
             raise ValueError(

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -484,8 +484,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     alora_action = ALoraRequirement(action.description, adapter_name)
 
                 # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
-                # No isinstance guard needed: add_adapter (line 250) enforces that
-                # only EmbeddedIntrinsicAdapter (which IS-AN Adapter) can be registered.
+                # No isinstance guard needed: add_adapter enforces that only
+                # EmbeddedIntrinsicAdapter (which IS-AN Adapter) can be registered.
                 alora_req_adapter = next(
                     (
                         a

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -483,18 +483,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     )
                     alora_action = ALoraRequirement(action.description, adapter_name)
 
-                # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
-                # No isinstance guard needed: add_adapter enforces that only
-                # EmbeddedIntrinsicAdapter (which IS-AN Adapter) can be registered.
-                alora_req_adapter = next(
-                    (
-                        a
-                        for a in self._added_adapters.values()
-                        if a.identity.capability == adapter_name
-                        and a.identity.adapter_type == "alora"
-                    ),
-                    None,
-                )
+                alora_req_adapter = self._find_adapter(adapter_name, {"alora"})
                 if alora_req_adapter is None:
                     if reroute_to_alora and isinstance(action, ALoraRequirement):
                         MelleaLogger.get_logger().warning(
@@ -578,17 +567,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             )
 
         # --- adapter lookup ------------------------------------------------
-        # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
         allowed_types = {at.value for at in action.adapter_types}
-        adapter = next(
-            (
-                a
-                for a in self._added_adapters.values()
-                if a.identity.capability == action.intrinsic_name
-                and a.identity.adapter_type in allowed_types
-            ),
-            None,
-        )
+        adapter = self._find_adapter(action.intrinsic_name, allowed_types)
         if adapter is None:
             raise ValueError(
                 f"backend ({self}) has no adapter for processing adapter function: "

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -45,13 +45,8 @@ from ..helpers import (
 from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
-from .adapters.adapter import (
-    Adapter,
-    AdapterMixin,
-    EmbeddedIntrinsicAdapter,
-    get_adapter_for_intrinsic,
-)
-from .adapters.catalog import AdapterType
+from .adapters._core import Adapter
+from .adapters.adapter import AdapterMixin, EmbeddedIntrinsicAdapter
 from .backend import FormatterBackend
 from .model_options import ModelOption
 from .tools import (
@@ -488,8 +483,15 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     )
                     alora_action = ALoraRequirement(action.description, adapter_name)
 
-                alora_req_adapter = get_adapter_for_intrinsic(
-                    adapter_name, [AdapterType.ALORA], self._added_adapters
+                # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
+                alora_req_adapter = next(
+                    (
+                        a
+                        for a in self._added_adapters.values()
+                        if a.identity.capability == adapter_name
+                        and a.identity.adapter_type == "alora"
+                    ),
+                    None,
                 )
                 if alora_req_adapter is None:
                     if reroute_to_alora and isinstance(action, ALoraRequirement):
@@ -574,8 +576,16 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             )
 
         # --- adapter lookup ------------------------------------------------
-        adapter = get_adapter_for_intrinsic(
-            action.intrinsic_name, action.adapter_types, self._added_adapters
+        # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
+        allowed_types = {at.value for at in action.adapter_types}
+        adapter = next(
+            (
+                a
+                for a in self._added_adapters.values()
+                if a.identity.capability == action.intrinsic_name
+                and a.identity.adapter_type in allowed_types
+            ),
+            None,
         )
         if adapter is None:
             raise ValueError(

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -484,6 +484,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     alora_action = ALoraRequirement(action.description, adapter_name)
 
                 # Capability-based lookup (Epic #929 Phase 1 — issue #1136).
+                # No isinstance guard needed: add_adapter (line 250) enforces that
+                # only EmbeddedIntrinsicAdapter (which IS-AN Adapter) can be registered.
                 alora_req_adapter = next(
                     (
                         a

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -113,28 +113,31 @@ def call_intrinsic(
     # Ensure the adapter is registered; resolve_adapter creates it if absent.
     backend.resolve_adapter(intrinsic_name)
 
-    with backend.adapter_scope(None):  # Phase 1 stub — no-op; Phase 2 activates weights
-        intrinsic = Intrinsic(
-            intrinsic_name,
-            intrinsic_kwargs=kwargs,
-            adapter_types=(AdapterType.ALORA, AdapterType.LORA),
-        )
+    # Adapter activation is the backend's responsibility — the HF backend acquires
+    # its generation lock and sets the active adapter inside _generate_with_adapter_lock,
+    # immediately before generation.  Activating here (outside that lock) would race
+    # with concurrent async requests.
+    intrinsic = Intrinsic(
+        intrinsic_name,
+        intrinsic_kwargs=kwargs,
+        adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+    )
 
-        default_opts: dict = {ModelOption.TEMPERATURE: 0.0}
-        if model_options is not None:
-            default_opts.update(model_options)
+    default_opts: dict = {ModelOption.TEMPERATURE: 0.0}
+    if model_options is not None:
+        default_opts.update(model_options)
 
-        model_output_thunk, _ = mfuncs.act(
-            intrinsic,
-            context,
-            backend,
-            model_options=default_opts,
-            tool_calls=True,
-            strategy=None,
-        )
+    model_output_thunk, _ = mfuncs.act(
+        intrinsic,
+        context,
+        backend,
+        model_options=default_opts,
+        tool_calls=True,
+        strategy=None,
+    )
 
-        assert model_output_thunk.is_computed()
-        result_str = model_output_thunk.value
-        if result_str is None:
-            raise ValueError("Model output is None.")
-        return json.loads(result_str)
+    assert model_output_thunk.is_computed()
+    result_str = model_output_thunk.value
+    if result_str is None:
+        raise ValueError("Model output is None.")
+    return json.loads(result_str)

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -3,12 +3,7 @@
 import json
 
 from ....backends import ModelOption
-from ....backends.adapters import (
-    AdapterMixin,
-    AdapterType,
-    EmbeddedIntrinsicAdapter,
-    IntrinsicAdapter,
-)
+from ....backends.adapters import AdapterMixin, AdapterType
 from ....core import Backend
 from ....stdlib import functional as mfuncs
 from ...components import Document
@@ -98,81 +93,48 @@ def call_intrinsic(
     kwargs: dict | None = None,
     model_options: dict | None = None,
 ):
-    """Shared code for invoking intrinsics.
+    """Invoke an adapter function via the backend, returning parsed JSON output.
+
+    Uses :meth:`~mellea.backends.adapters.AdapterMixin.resolve_adapter` to find
+    or lazily register the adapter, then executes via ``mfuncs.act``.
+
+    Args:
+        intrinsic_name (str): Capability name of the adapter function
+            (e.g. ``"answerability"``).
+        context (ChatContext): The current conversation context.
+        backend (AdapterMixin): A backend that supports adapter functions.
+        kwargs (dict | None): Extra keyword arguments forwarded to the
+            adapter function's input template.
+        model_options (dict | None): Model options that override defaults.
 
     Returns:
-        dict: Result of the call as a parsed JSON object.
+        dict: Parsed JSON output from the adapter function.
     """
-    # Adapter needs to be present in the backend before it can be invoked.
-    # We must create the Adapter object in order to determine whether we need to create
-    # the Adapter object.
-    base_model_name = backend.base_model_name
-    if base_model_name is None:
-        raise ValueError("Backend has no model ID")
+    # Ensure the adapter is registered; resolve_adapter creates it if absent.
+    backend.resolve_adapter(intrinsic_name)
 
-    # Check if the backend already has the adapter.
-    has_adapter = any(
-        qualified_name.startswith(f"{intrinsic_name}_")
-        for qualified_name in backend.list_adapters()
-    )
+    with backend.adapter_scope(None):  # Phase 1 stub — no-op; Phase 2 activates weights
+        intrinsic = Intrinsic(
+            intrinsic_name,
+            intrinsic_kwargs=kwargs,
+            adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+        )
 
-    # TODO: We should improve this logic. For now, we know that there are two cases of
-    # adapter loading: 1. regular adapters, and 2. embedded adapters.
-    if not has_adapter:
-        # EmbeddedAdapters get grabbed directly from the hf repo.
-        if getattr(backend, "_uses_embedded_adapters", False):
-            repo_id: str = (
-                getattr(backend, "_adapter_source", None)
-                or getattr(backend, "_model_id", None)
-                or base_model_name
-            )
-            adapters = EmbeddedIntrinsicAdapter.from_source(
-                repo_id, intrinsic_name=intrinsic_name
-            )
-            # Only one adapter should be returned, but we add any returned here in case.
-            for adapter in adapters:
-                backend.add_adapter(adapter)
-        else:
-            # Regular IntrinsicAdapters utilize a catalog to download during their instantiation.
-            intrinsic_adapter = IntrinsicAdapter(
-                intrinsic_name,
-                adapter_type=AdapterType.LORA,
-                base_model_name=base_model_name,
-            )
-            backend.add_adapter(intrinsic_adapter)
+        default_opts: dict = {ModelOption.TEMPERATURE: 0.0}
+        if model_options is not None:
+            default_opts.update(model_options)
 
-    # Create the AST node for the action we wish to perform.
-    intrinsic = Intrinsic(
-        intrinsic_name,
-        intrinsic_kwargs=kwargs,
-        adapter_types=(
-            AdapterType.ALORA,
-            AdapterType.LORA,
-        ),  # Forcibly allow either type of adapter. The intrinsic itself doesn't care as long as an adapter exists.
-    )
+        model_output_thunk, _ = mfuncs.act(
+            intrinsic,
+            context,
+            backend,
+            model_options=default_opts,
+            tool_calls=True,
+            strategy=None,
+        )
 
-    # Execute the AST node.
-    default_opts: dict = {ModelOption.TEMPERATURE: 0.0}
-    if model_options is not None:
-        default_opts.update(model_options)
-
-    model_output_thunk, _ = mfuncs.act(
-        intrinsic,
-        context,
-        backend,
-        model_options=default_opts,
-        tool_calls=True,
-        # No rejection sampling, please
-        strategy=None,
-    )
-
-    # act() can return a future. Don't know how to handle one from non-async code.
-    assert model_output_thunk.is_computed()
-
-    # Output of an Intrinsic action is the string representation of the output of the
-    # intrinsic. Parse the string.
-    result_str = model_output_thunk.value
-    if result_str is None:
-        raise ValueError("Model output is None.")
-    result_json = json.loads(result_str)
-    return result_json
+        assert model_output_thunk.is_computed()
+        result_str = model_output_thunk.value
+        if result_str is None:
+            raise ValueError("Model output is None.")
+        return json.loads(result_str)

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -240,6 +240,26 @@ def test_resolve_adapter_returns_existing_by_capability():
     mock_backend.add_adapter.assert_not_called()
 
 
+def test_find_adapter_honours_type_preference_order():
+    """_find_adapter must return the highest-priority type, not the insertion-order winner."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        lora = EmbeddedIntrinsicAdapter("answerability", config={}, technology="lora")
+        alora = EmbeddedIntrinsicAdapter("answerability", config={}, technology="alora")
+
+    mock_backend = MagicMock(spec=AdapterMixin)
+    # Register lora first so insertion order would return it without preference logic.
+    mock_backend._added_adapters = {
+        lora.qualified_name: lora,
+        alora.qualified_name: alora,
+    }
+
+    result = AdapterMixin._find_adapter(
+        mock_backend, "answerability", ("alora", "lora")
+    )
+    assert result is alora, "alora must win over lora regardless of insertion order"
+
+
 def test_resolve_adapter_raises_without_base_model():
     """resolve_adapter must raise ValueError when the backend has no model ID."""
     mock_backend = MagicMock(spec=AdapterMixin)

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -269,3 +269,42 @@ def test_resolve_adapter_raises_without_base_model():
     mock_backend._find_adapter.return_value = None
     with pytest.raises(ValueError, match="no model ID"):
         AdapterMixin.resolve_adapter(mock_backend, "answerability")
+
+
+def test_resolve_adapter_lazy_creates_and_returns():
+    """resolve_adapter must create an IntrinsicAdapter when none is registered."""
+    mock_catalog_entry = IntriniscsCatalogEntry(
+        name="answerability",
+        repo_id="ibm-granite/granitelib-rag-r1.0",
+        revision="abc123",
+        adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+    )
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+
+    created_adapters: list = []
+
+    def fake_add_adapter(a):
+        created_adapters.append(a)
+        mock_backend._added_adapters[a.qualified_name] = a
+
+    mock_backend._added_adapters = {}
+    mock_backend.add_adapter.side_effect = fake_add_adapter
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    with patch(
+        "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+        return_value=mock_catalog_entry,
+    ):
+        result = AdapterMixin.resolve_adapter(mock_backend, "answerability")
+
+    assert mock_backend.add_adapter.called, (
+        "add_adapter must be called for a new capability"
+    )
+    assert len(created_adapters) == 1
+    assert isinstance(created_adapters[0], IntrinsicAdapter)
+    assert created_adapters[0].adapter_type == AdapterType.LORA
+    assert result is created_adapters[0]

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -1,0 +1,223 @@
+"""Unit tests for adapter shim classes (Epic #929 Phase 1, issue #1136).
+
+Verifies that IntrinsicAdapter, EmbeddedIntrinsicAdapter, and CustomIntrinsicAdapter:
+  - emit DeprecationWarning on construction
+  - are instances of both their own class and the new Adapter dataclass
+  - expose a well-formed Identity (name, adapter_type, capability)
+  - leave AdapterMixin.resolve_adapter and AdapterMixin.adapter_scope callable
+"""
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mellea.backends.adapters import Adapter, EmbeddedIntrinsicAdapter, IntrinsicAdapter
+from mellea.backends.adapters._core import Identity
+from mellea.backends.adapters.adapter import AdapterMixin
+from mellea.backends.adapters.catalog import AdapterType, IntriniscsCatalogEntry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MOCK_CATALOG_ENTRY = IntriniscsCatalogEntry(
+    name="answerability",
+    repo_id="ibm-granite/granitelib-rag-r1.0",
+    revision="abc123deadbeef",
+    adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+)
+
+
+def _make_intrinsic_adapter(intrinsic_name: str = "answerability") -> IntrinsicAdapter:
+    """Construct IntrinsicAdapter with mocked catalog + config (no HF downloads)."""
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=IntriniscsCatalogEntry(
+                name=intrinsic_name,
+                repo_id="ibm-granite/granitelib-rag-r1.0",
+                revision="abc123",
+                adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+            ),
+        ),
+        warnings.catch_warnings(),
+    ):
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return IntrinsicAdapter(
+            intrinsic_name,
+            adapter_type=AdapterType.ALORA,
+            config_dict={"dummy": "config"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# EmbeddedIntrinsicAdapter shim tests (no mock needed — no catalog access)
+# ---------------------------------------------------------------------------
+
+
+def test_embedded_emits_deprecation_warning():
+    with pytest.warns(
+        DeprecationWarning, match="EmbeddedIntrinsicAdapter is deprecated"
+    ):
+        EmbeddedIntrinsicAdapter("answerability", config={}, technology="alora")
+
+
+def test_embedded_is_instance_of_new_adapter():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = EmbeddedIntrinsicAdapter(
+            "answerability", config={}, technology="alora"
+        )
+    assert isinstance(adapter, Adapter), (
+        "shim must be instance of new Adapter dataclass"
+    )
+    assert isinstance(adapter, EmbeddedIntrinsicAdapter), (
+        "shim must remain its own type"
+    )
+
+
+def test_embedded_identity_populated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = EmbeddedIntrinsicAdapter(
+            "answerability", config={}, technology="alora"
+        )
+    assert isinstance(adapter.identity, Identity)
+    assert adapter.identity.name == "answerability"
+    assert adapter.identity.capability == "answerability"
+    assert adapter.identity.adapter_type == "alora"
+
+
+def test_embedded_identity_lora_technology():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = EmbeddedIntrinsicAdapter(
+            "answerability", config={}, technology="lora"
+        )
+    assert adapter.identity.adapter_type == "lora"
+
+
+def test_embedded_legacy_attributes_preserved():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = EmbeddedIntrinsicAdapter(
+            "answerability", config={"k": 1}, technology="alora"
+        )
+    assert adapter.intrinsic_name == "answerability"
+    assert adapter.config == {"k": 1}
+    assert adapter.technology == "alora"
+    assert adapter.qualified_name == "answerability_alora"
+    assert adapter.backend is None
+
+
+def test_embedded_backend_mutable():
+    """Shim must allow setting backend after construction (frozen bypass)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = EmbeddedIntrinsicAdapter(
+            "answerability", config={}, technology="alora"
+        )
+    sentinel = object()
+    adapter.backend = sentinel  # type: ignore[assignment]
+    assert adapter.backend is sentinel
+
+
+def test_embedded_invalid_technology():
+    with pytest.raises(ValueError, match="technology must be"):
+        EmbeddedIntrinsicAdapter("answerability", config={}, technology="qlora")
+
+
+# ---------------------------------------------------------------------------
+# IntrinsicAdapter shim tests (uses patch to avoid catalog / HF access)
+# ---------------------------------------------------------------------------
+
+
+def test_intrinsic_emits_deprecation_warning():
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=_MOCK_CATALOG_ENTRY,
+        ),
+        pytest.warns(DeprecationWarning, match="IntrinsicAdapter is deprecated"),
+    ):
+        IntrinsicAdapter(
+            "answerability",
+            adapter_type=AdapterType.ALORA,
+            config_dict={"dummy": "config"},
+        )
+
+
+def test_intrinsic_is_instance_of_new_adapter():
+    adapter = _make_intrinsic_adapter("answerability")
+    assert isinstance(adapter, Adapter), (
+        "shim must be instance of new Adapter dataclass"
+    )
+    assert isinstance(adapter, IntrinsicAdapter), "shim must remain its own type"
+
+
+def test_intrinsic_identity_populated():
+    adapter = _make_intrinsic_adapter("answerability")
+    assert isinstance(adapter.identity, Identity)
+    assert adapter.identity.name == "answerability"
+    assert adapter.identity.capability == "answerability"
+    assert adapter.identity.adapter_type == "alora"
+
+
+def test_intrinsic_identity_lora_adapter_type():
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=IntriniscsCatalogEntry(
+                name="answerability",
+                repo_id="ibm-granite/granitelib-rag-r1.0",
+                revision="abc123",
+                adapter_types=(AdapterType.LORA,),
+            ),
+        ),
+        warnings.catch_warnings(),
+    ):
+        warnings.simplefilter("ignore", DeprecationWarning)
+        adapter = IntrinsicAdapter(
+            "answerability",
+            adapter_type=AdapterType.LORA,
+            config_dict={"dummy": "config"},
+        )
+    assert adapter.identity.adapter_type == "lora"
+
+
+def test_intrinsic_legacy_attributes_preserved():
+    adapter = _make_intrinsic_adapter("answerability")
+    assert adapter.intrinsic_name == "answerability"
+    assert adapter.config == {"dummy": "config"}
+    assert adapter.qualified_name == "answerability_alora"
+    assert adapter.backend is None
+
+
+def test_intrinsic_backend_mutable():
+    """Shim must allow setting backend after construction (frozen bypass)."""
+    adapter = _make_intrinsic_adapter()
+    sentinel = object()
+    adapter.backend = sentinel  # type: ignore[assignment]
+    assert adapter.backend is sentinel
+
+
+# ---------------------------------------------------------------------------
+# AdapterMixin stub methods
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_mixin_has_resolve_adapter():
+    assert callable(getattr(AdapterMixin, "resolve_adapter", None))
+
+
+def test_adapter_mixin_has_adapter_scope():
+    assert callable(getattr(AdapterMixin, "adapter_scope", None))
+
+
+def test_adapter_scope_is_noop():
+    """adapter_scope must work as a no-op context manager via the mixin default."""
+    mock_backend = MagicMock(spec=AdapterMixin)
+    # Call the real implementation via the class (bypasses mock's own spec)
+    with AdapterMixin.adapter_scope(mock_backend, None):
+        pass  # must not raise

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -228,6 +228,10 @@ def test_resolve_adapter_returns_existing_by_capability():
     existing = _make_intrinsic_adapter("answerability")
     mock_backend = MagicMock(spec=AdapterMixin)
     mock_backend._added_adapters = {existing.qualified_name: existing}
+    # Route _find_adapter through the real implementation so the _added_adapters search runs.
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
     result = AdapterMixin.resolve_adapter(mock_backend, "answerability")
     assert result is existing
     mock_backend.add_adapter.assert_not_called()
@@ -238,5 +242,7 @@ def test_resolve_adapter_raises_without_base_model():
     mock_backend = MagicMock(spec=AdapterMixin)
     mock_backend._added_adapters = {}
     mock_backend.base_model_name = None
+    # _find_adapter returns None so resolve_adapter proceeds to the base-model check.
+    mock_backend._find_adapter.return_value = None
     with pytest.raises(ValueError, match="no model ID"):
         AdapterMixin.resolve_adapter(mock_backend, "answerability")

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -8,7 +8,7 @@ Verifies that IntrinsicAdapter, EmbeddedIntrinsicAdapter, and CustomIntrinsicAda
 """
 
 import warnings
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -295,9 +295,16 @@ def test_resolve_adapter_lazy_creates_and_returns():
         AdapterMixin._find_adapter(mock_backend, cap, types)
     )
 
-    with patch(
-        "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
-        return_value=mock_catalog_entry,
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=mock_catalog_entry,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
     ):
         result = AdapterMixin.resolve_adapter(mock_backend, "answerability")
 

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -221,3 +221,22 @@ def test_adapter_scope_is_noop():
     # Call the real implementation via the class (bypasses mock's own spec)
     with AdapterMixin.adapter_scope(mock_backend, None):
         pass  # must not raise
+
+
+def test_resolve_adapter_returns_existing_by_capability():
+    """resolve_adapter must return an already-registered adapter without creating a new one."""
+    existing = _make_intrinsic_adapter("answerability")
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend._added_adapters = {existing.qualified_name: existing}
+    result = AdapterMixin.resolve_adapter(mock_backend, "answerability")
+    assert result is existing
+    mock_backend.add_adapter.assert_not_called()
+
+
+def test_resolve_adapter_raises_without_base_model():
+    """resolve_adapter must raise ValueError when the backend has no model ID."""
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend._added_adapters = {}
+    mock_backend.base_model_name = None
+    with pytest.raises(ValueError, match="no model ID"):
+        AdapterMixin.resolve_adapter(mock_backend, "answerability")

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -124,8 +124,11 @@ def test_embedded_backend_mutable():
 
 
 def test_embedded_invalid_technology():
-    with pytest.raises(ValueError, match="technology must be"):
-        EmbeddedIntrinsicAdapter("answerability", config={}, technology="qlora")
+    # Validation runs before the deprecation warning, so no DeprecationWarning fires.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(ValueError, match="technology must be"):
+            EmbeddedIntrinsicAdapter("answerability", config={}, technology="qlora")
 
 
 # ---------------------------------------------------------------------------

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -16,7 +16,7 @@ pytest.importorskip(
 from transformers.generation.utils import GenerateDecoderOnlyOutput
 
 from mellea.backends import ModelOption
-from mellea.backends.adapters import IntrinsicAdapter
+from mellea.backends.adapters import AdapterMixin, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
@@ -144,7 +144,7 @@ def _make_intrinsic_adapter_stub():
     adapter.qualified_name = "answerability_alora"
     adapter.config = {}
     # Required for the capability-based lookup introduced in Epic #929 Phase 1.
-    # Use object.__setattr__ because IntrinsicAdapter inherits from a frozen dataclass.
+    # __new__ bypasses __init__; use object.__setattr__ to set frozen-dataclass fields.
     object.__setattr__(
         adapter,
         "identity",
@@ -171,6 +171,9 @@ def _make_intrinsic_backend_stub(stub_backend):
     stub_backend.post_processing = lambda *args, **kwargs: None
     stub_backend._generate_with_adapter_lock = (
         lambda adapter_name, generate_func, *args: generate_func(*args)
+    )
+    stub_backend._find_adapter = lambda cap, types=None: AdapterMixin._find_adapter(
+        stub_backend, cap, types
     )
     return stub_backend
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -17,6 +17,7 @@ from transformers.generation.utils import GenerateDecoderOnlyOutput
 
 from mellea.backends import ModelOption
 from mellea.backends.adapters import IntrinsicAdapter
+from mellea.backends.adapters._core import Identity
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
 from mellea.stdlib.components import Intrinsic, Message
@@ -142,6 +143,15 @@ def _make_intrinsic_adapter_stub():
     adapter.name = "answerability"
     adapter.qualified_name = "answerability_alora"
     adapter.config = {}
+    # Required for the capability-based lookup introduced in Epic #929 Phase 1.
+    # Use object.__setattr__ because IntrinsicAdapter inherits from a frozen dataclass.
+    object.__setattr__(
+        adapter,
+        "identity",
+        Identity(
+            name="answerability", adapter_type="alora", capability="answerability"
+        ),
+    )
     return adapter
 
 
@@ -222,11 +232,10 @@ async def test_intrinsic_seed_with_zero_temperature_keeps_greedy(stub_backend):
     def fake_generate_with_transformers(tokenizer, model, generate_input, other_input):
         return object()
 
+    # Pre-populate the adapter so the capability-based lookup finds it.
+    backend._added_adapters = {adapter.qualified_name: adapter}
+
     with (
-        patch(
-            "mellea.backends.huggingface.get_adapter_for_intrinsic",
-            return_value=adapter,
-        ),
         patch(
             "mellea.backends.huggingface.granite_formatters.IntrinsicsRewriter",
             _FakeRewriter,


### PR DESCRIPTION
<!-- mellea-pr-edited-marker: do not remove this marker -->

## Why

**If you use `IntrinsicAdapter`, `EmbeddedIntrinsicAdapter`, or `CustomIntrinsicAdapter` directly, you will start seeing `DeprecationWarning` after this PR merges.** These classes are being retired as part of Epic #929 — the new `Adapter` dataclass (introduced in Phase 0, PR #1158) is the replacement. Phase 1 (this PR) bridges the gap: the old classes still work exactly as before, but each one now inherits from `Adapter` and warns on construction so you know to migrate.

Most users reach adapter functions through the high-level wrappers in `mellea.stdlib.components.intrinsic` (e.g. `check_certainty`, `check_answerability`). Those callers are unaffected — they go through `call_intrinsic`, which was rewritten to use the new `AdapterMixin.resolve_adapter` API and no longer touches the deprecated classes directly.

## What changed

**(a) Legacy adapter classes become deprecation shims** — `IntrinsicAdapter`, `EmbeddedIntrinsicAdapter`, and `CustomIntrinsicAdapter` now:
- emit `DeprecationWarning(stacklevel=2)` on construction (pointing to the caller's frame, not library internals)
- inherit from the new `Adapter` dataclass, so `isinstance(x, Adapter)` returns `True`
- preserve all existing attributes and behaviour — this is a warning only, not a breaking change

Private `_ShimIOContract` and `_ShimWeightsBinding` stubs satisfy the new `Adapter` protocol in Phase 1; the real implementations come in Phase 2 (issues #1137, #1138).

**(b) Internal callers switch to the new API** — `call_intrinsic` is rewritten to use `backend.resolve_adapter(name)` (no-op stub in Phase 1), removing ~50 lines of manual adapter-loading logic. `AdapterMixin` gains three new methods: `resolve_adapter`, `adapter_scope` (context manager), and `_find_adapter` (private helper that centralises the capability-based lookup previously duplicated inline across `LocalHFBackend` and `OpenAIBackend`). Adapter activation remains inside the backend's generation lock, not at the `call_intrinsic` level — this avoids a race condition when Phase 2 implements real activation.

## User impact

| Who | Impact |
|-----|--------|
| Uses `check_answerability`, `check_certainty`, etc. | ✅ None — high-level wrappers are unchanged |
| Constructs `IntrinsicAdapter` directly | ⚠️ `DeprecationWarning` on construction — code still works |
| Constructs `EmbeddedIntrinsicAdapter` directly | ⚠️ `DeprecationWarning` on construction — code still works |
| Subclasses `CustomIntrinsicAdapter` | ⚠️ `DeprecationWarning` on construction — code still works |
| Uses `isinstance(x, IntrinsicAdapter)` / `isinstance(x, EmbeddedIntrinsicAdapter)` | ✅ Still works |
| Depends on adapter-type preference ordering (aLoRA before LoRA) | ✅ Fixed — `_find_adapter` now accepts `tuple[str, ...]` and iterates preferred types first; the HF and OpenAI backends pass `tuple` (not `set`) so aLoRA is always preferred over LoRA when both are registered |

To silence the warnings now, filter `DeprecationWarning` from `mellea.backends.adapters`. Migration guide to the new `Adapter` dataclass will land with Phase 4 (issue #1144).

## Where this fits in Epic #929

| Phase | PR | Status |
|-------|-----|--------|
| 0 — Scaffolding | #1158 | ✅ merged |
| 0 — Catalogue revision pinning | #1157 | ✅ merged |
| **1 — Shims + call_intrinsic** | **this PR** | 🔄 review |
| 3 — RAG migration | #1137 | ⏳ blocked on this |
| 3 — requirement_check | #1138 | ⏳ blocked on this |
| 3 — Guardian | #1139 | ⏳ blocked on this |
| 2.1 — Backend verb rename | #1140 | ⏳ blocked on this |

⚠️ **This PR is a blocking dependency for Phase 3** — issues #1137–#1140 cannot start until this merges.

## What changed (files)

| File | Change |
|------|--------|
| `mellea/backends/adapters/adapter.py` | Shim classes; `_ShimIOContract`/`_ShimWeightsBinding`; `AdapterMixin.resolve_adapter`, `adapter_scope`, `_find_adapter` |
| `mellea/stdlib/components/intrinsic/_util.py` | `call_intrinsic` rewritten; `adapter_scope` removed (activation is backend's responsibility) |
| `mellea/backends/openai.py` | Capability-based rerouting via `_find_adapter`; `tuple` call sites |
| `mellea/backends/huggingface.py` | Capability-based rerouting via `_find_adapter`; `tuple` call sites |
| `docs/dev/requirement_aLoRA_rerouting.md` | Phase 1 change note |
| `test/backends/test_adapters/test_shims.py` | New: 18 unit tests for shim behaviour + `_find_adapter` ordering test |
| `test/backends/test_adapters/test_embedded_adapter.py` | Update one error-message assertion |

## Testing

```bash
uv run pytest test/backends/test_adapters/ -v          # 18 new + existing adapter tests — all pass
uv run pytest test/ -m "not qualitative"               # full suite — pre-existing optional-dep collection errors only
uv run ruff format . && uv run ruff check .            # clean
uv run mypy . --ignore-missing-imports                 # 109 pre-existing optional-dep errors only
```

### GPU test campaign

216 unit/integration intrinsic tests pass. Five GPU-only tests were investigated with a 10-run campaign on the same GPU cluster, comparing `upstream/main` (`317d5d9`) against this branch (`f6fb2e7`):

| Test | main (10 runs) | this branch (10 runs) |
|------|:--------------:|:---------------------:|
| `test_run_transformers[context_relevance_alora]` | 0/10 | 0/10 |
| `test_run_transformers[uncertainty_alora]` | 0/10 | 0/10 |
| `test_run_transformers[requirement_check_alora]` | 1/10 | 1/10 |
| `test_run_transformers[context-attribution]` | 1/10 | 5/10 |
| `test_groundedness_e2e_string_documents` | 2/10 | 4/10 |

No regressions from this PR. The pass-rate improvements for `context-attribution` and `groundedness` are a side-effect of the `_find_adapter` ordering fix — aLoRA is now selected consistently, producing better citation quality when it works.

The low pass rates on both branches are pre-existing issues, tracked and fixed in **#1292**:
- `context_relevance_alora` / `uncertainty_alora` (0/10): peft aLoRA offsets disabled due to `inputs=` vs `input_ids=` call — see #1286
- `requirement_check_alora` / `context-attribution` / `groundedness_e2e`: score non-determinism and parser bug — see #1291

### Attribution

- [x] AI coding assistants used: Claude Code

Fixes #1136