### PR TITLE
fix: demote format= warning to INFO and fix grammar

### DIFF
--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -862,8 +862,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     },
                 }
             else:
-                MelleaLogger.get_logger().warning(
-                    "Mellea assumes you are NOT using the OpenAI platform, and that other model providers have less strict requirements on support JSON schemas passed into `format=`. If you encounter a server-side error following this message, then you found an exception to this assumption. Please open an issue at github.com/generative_computing/mellea with this stack trace and your inference engine / model provider."
+                MelleaLogger.get_logger().info(
+                    "Mellea assumes you are NOT using the OpenAI platform, and that other model providers have less strict requirements on supporting JSON schemas passed into `format=`. If you encounter a server-side error following this message, then you found an exception to this assumption. Please open an issue at github.com/generative_computing/mellea with this stack trace and your inference engine / model provider."
                 )
                 extra_params["response_format"] = {
                     "type": "json_schema",


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1092

## Description
Demotes the noisy log message emitted when a non-OpenAI backend is used
with `format=` from `WARNING` to `INFO` level, and fixes a grammar error
in the message text (`"on support JSON schemas"` → `"on supporting JSON schemas"`).

The message is already only emitted in the `else` branch of the
`if self._server_type == _ServerType.OPENAI` check, so it is inherently
scoped to non-OpenAI backends — satisfying the "make analysis more precise"
option from the issue without any structural changes.

### Testing
- [x] Tests added to the respective file if code was changed — no new tests needed; this is a log-level/grammar-only change with no behavioural impact
- [x] New code has 100% coverage if code was added — N/A (no new code paths)
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used — Assisted-by: IBM Bob