### PR TITLE
feat(thunk): add .parsed property to ComputedModelOutputThunk for structured output

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1513,6 +1513,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             generate_log.action = action
 
             result._generate_log = generate_log
+            result._format = format
             results.append(result)
 
         usage: dict[str, Any] | None = (

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1378,6 +1378,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         generate_log.result = mot
 
         mot._generate_log = generate_log
+        mot._format = _format
 
     async def _generate_from_raw(
         self,

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -596,6 +596,7 @@ class LiteLLMBackend(FormatterBackend):
         generate_log.action = mot._action
         generate_log.result = mot
         mot._generate_log = generate_log
+        mot._format = _format
 
         # Extract token usage from full response dict or streaming usage
         full_response = mot._meta.get("litellm_full_response")

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -613,6 +613,7 @@ class OllamaModelBackend(FormatterBackend):
                 generate_log.extra["error"] = error
                 generate_log.extra["empty_response"] = response.model_dump()
             result._generate_log = generate_log
+            result._format = format
 
             results.append(result)
 
@@ -742,6 +743,7 @@ class OllamaModelBackend(FormatterBackend):
         generate_log.result = mot
 
         mot._generate_log = generate_log
+        mot._format = _format
         mot._generate = None
 
         # Extract token counts from response

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1127,6 +1127,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         generate_log.action = mot._action
         generate_log.result = mot
         mot._generate_log = generate_log
+        mot._format = _format
 
         # Extract token usage from response or streaming usage
         response = mot._meta["oai_chat_response"]

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -614,6 +614,7 @@ class WatsonxAIBackend(FormatterBackend):
         generate_log.result = mot
         generate_log.action = mot._action
         mot._generate_log = generate_log
+        mot._format = _format
 
     async def _generate_from_raw(
         self,

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -885,7 +885,12 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
 
     @property
     def value(self) -> str:
-        """Gets the value of the block."""
+        """Gets the raw string value of the block.
+
+        When ``format=`` is set on the originating ``act()``/``instruct()`` call, the
+        model returns a JSON string and ``.value`` contains that raw JSON — not a
+        Pydantic instance.  Use ``.parsed`` to get the validated model object.
+        """
         return self._underlying_value  # type: ignore
 
     @value.setter
@@ -897,15 +902,17 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     def parsed(self) -> S | None:
         """Returns the result as a validated Pydantic instance when ``format=`` was set.
 
-        The return type tracks the format type supplied at the originating call
-        site: ``m.act(action, format=MyModel)`` yields a
-        ``ComputedModelOutputThunk[MyModel]`` whose ``.parsed`` is typed
-        ``MyModel | None`` — no ``cast()`` required. Returns ``None`` when no
-        ``format=`` type was provided.  Use this instead of casting ``.value``
-        manually::
+        The return type is ``S | None``, where ``S`` is the thunk's type parameter.
+        The ``format=`` overloads do not yet bind ``S`` to the format model, so
+        callers must parameterize the thunk explicitly to get a narrowed type::
 
-            result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # typed MyModel | None, no model_validate_json needed
+            thunk = cast(ComputedModelOutputThunk[MyModel], result)
+            obj = thunk.parsed  # typed MyModel | None, no model_validate_json needed
+
+        Returns ``None`` when no ``format=`` type was provided.  Unlike
+        ``parsed_repr`` (which holds the action-specific parse result),
+        ``.parsed`` always re-validates the raw JSON string against ``_format``
+        via ``model_validate_json``.
 
         Note:
             This property relies on the originating backend storing the format

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -32,6 +32,7 @@ from typing import (
     runtime_checkable,
 )
 
+import pydantic
 import typing_extensions
 from PIL import Image as PILImage
 
@@ -401,6 +402,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
+        self._format: type[pydantic.BaseModel] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -542,6 +544,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._thinking = other._thinking
         self.generation = other.generation
         self._generate_log = other._generate_log
+        self._format = other._format
         self._cancelled = other._cancelled
         # _cancel_hook is deliberately not copied: _copy_from swaps output state,
         # not backend-thread plumbing, which is tied to the original computation.
@@ -557,7 +560,13 @@ class ModelOutputThunk(CBlock, Generic[S]):
 
     @property
     def value(self) -> str | None:
-        """Gets the value of the block."""
+        """Gets the raw string value of the block.
+
+        When ``format=`` is set on the originating ``act()``/``instruct()`` call, the
+        model returns a JSON string and ``.value`` contains that raw JSON — not a
+        Pydantic instance.  Use ``.parsed`` on a ``ComputedModelOutputThunk`` to get
+        the validated model object.
+        """
         if not self._computed:
             return None
         return self._underlying_value
@@ -880,6 +889,25 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     def value(self, v: str):
         """Sets the value of the block."""
         self._underlying_value = v
+
+    @property
+    def parsed(self) -> pydantic.BaseModel | None:
+        """Returns the result as a validated Pydantic instance when ``format=`` was set.
+
+        Returns ``None`` when no ``format=`` type was provided to the originating
+        ``act()`` / ``instruct()`` call.  Use this instead of casting ``.value``
+        manually::
+
+            result = m.act(Instruction("Say yes or no"), format=MyModel)
+            obj = result.parsed  # MyModel instance, no cast needed
+
+        Returns:
+            A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
+            or ``None`` if no format type was set.
+        """
+        if self._format is None:
+            return None
+        return self._format.model_validate_json(self.value)
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -901,7 +901,7 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         manually::
 
             result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # MyModel instance, no cast needed
+            obj = result.parsed  # no manual model_validate_json needed
 
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -903,6 +903,13 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
             result = m.act(Instruction("Say yes or no"), format=MyModel)
             obj = result.parsed  # no manual model_validate_json needed
 
+        Note:
+            This property relies on the originating backend storing the format
+            type on the thunk. Custom backend authors must set ``mot._format``
+            in their ``post_processing`` method (mirroring the built-in
+            backends); otherwise ``.parsed`` always returns ``None`` even when
+            ``format=`` was supplied.
+
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
             or ``None`` if no format type was set.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -403,7 +403,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
-        self._format: type[S] | None = None
+        self._format: type[pydantic.BaseModel] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -924,11 +924,10 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         """
         if self._format is None:
             return None
-        # `_format` is a pydantic model type in every code path that sets it (the
-        # `format=` overloads bind `S` to that model), but `S` itself is unbounded,
-        # so we narrow to call `model_validate_json` and re-assert the result as `S`.
-        fmt = cast("type[pydantic.BaseModel]", self._format)
-        return cast("S", fmt.model_validate_json(self.value))
+        # `_format` is always a pydantic model type; `model_validate_json` returns
+        # `pydantic.BaseModel` statically, but the caller's type parameter `S` is
+        # the concrete model when `format=` was used, so we cast the result to `S`.
+        return cast(S, self._format.model_validate_json(self.value))
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -785,6 +785,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         copied._action = self._action
         copied._context = self._context
         copied._generate_log = self._generate_log
+        copied._format = self._format
         copied._model_options = self._model_options
         copied.generation = copy(self.generation)
         return copied
@@ -819,6 +820,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
             self._context
         )  # The items in a context should be immutable.
         deepcopied._generate_log = copy(self._generate_log)
+        deepcopied._format = self._format
         deepcopied._model_options = copy(self._model_options)
         deepcopied.generation = deepcopy(self.generation)
         return deepcopied
@@ -904,6 +906,10 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
             or ``None`` if no format type was set.
+
+        Raises:
+            pydantic.ValidationError: If the raw JSON value does not conform to
+                the format model (e.g. the model returned malformed structured output).
         """
         if self._format is None:
             return None

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -29,6 +29,7 @@ from typing import (
     ParamSpec,
     Protocol,
     TypeVar,
+    cast,
     runtime_checkable,
 )
 
@@ -402,7 +403,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
-        self._format: type[pydantic.BaseModel] | None = None
+        self._format: type[S] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -893,15 +894,18 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         self._underlying_value = v
 
     @property
-    def parsed(self) -> pydantic.BaseModel | None:
+    def parsed(self) -> S | None:
         """Returns the result as a validated Pydantic instance when ``format=`` was set.
 
-        Returns ``None`` when no ``format=`` type was provided to the originating
-        ``act()`` / ``instruct()`` call.  Use this instead of casting ``.value``
+        The return type tracks the format type supplied at the originating call
+        site: ``m.act(action, format=MyModel)`` yields a
+        ``ComputedModelOutputThunk[MyModel]`` whose ``.parsed`` is typed
+        ``MyModel | None`` — no ``cast()`` required. Returns ``None`` when no
+        ``format=`` type was provided.  Use this instead of casting ``.value``
         manually::
 
             result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # no manual model_validate_json needed
+            obj = result.parsed  # typed MyModel | None, no model_validate_json needed
 
         Note:
             This property relies on the originating backend storing the format
@@ -911,8 +915,8 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
             ``format=`` was supplied.
 
         Returns:
-            A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
-            or ``None`` if no format type was set.
+            An instance of the format type (``S``) produced by
+            ``model_validate_json``, or ``None`` if no format type was set.
 
         Raises:
             pydantic.ValidationError: If the raw JSON value does not conform to
@@ -920,7 +924,11 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         """
         if self._format is None:
             return None
-        return self._format.model_validate_json(self.value)
+        # `_format` is a pydantic model type in every code path that sets it (the
+        # `format=` overloads bind `S` to that model), but `S` itself is unbounded,
+        # so we narrow to call `model_validate_json` and re-assert the result as `S`.
+        fmt = cast("type[pydantic.BaseModel]", self._format)
+        return cast("S", fmt.model_validate_json(self.value))
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -434,7 +434,9 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: if set, the BaseModel to use for constrained decoding.
+            format: if set, the BaseModel to use for constrained decoding.  When
+                provided, ``.value`` on the returned thunk is always a raw JSON string —
+                use ``.parsed`` to obtain the validated Pydantic model instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
 

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -253,6 +253,24 @@ def test_format(session) -> None:
 
 
 @pytest.mark.qualitative
+def test_parsed_returns_pydantic_instance(session) -> None:
+    class Sentiment(pydantic.BaseModel):
+        label: str
+
+    output = session.instruct(
+        "Classify the sentiment of 'I love this!' as the single word "
+        "positive, negative, or neutral. Respond with a label field.",
+        format=Sentiment,
+        model_options={ModelOption.MAX_NEW_TOKENS: 2**8},
+    )
+
+    parsed = output.parsed
+    assert isinstance(parsed, Sentiment)
+    assert isinstance(parsed.label, str) and parsed.label
+    assert parsed == Sentiment.model_validate_json(output.value)
+
+
+@pytest.mark.qualitative
 async def test_generate_from_raw(session) -> None:
     prompts = [
         "what is 1+1?",

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -128,6 +128,24 @@ def test_format(session) -> None:
 
 
 @pytest.mark.qualitative
+def test_parsed_returns_pydantic_instance(session) -> None:
+    class Sentiment(pydantic.BaseModel):
+        label: str
+
+    output = session.instruct(
+        "Classify the sentiment of 'I love this!' as the single word "
+        "positive, negative, or neutral. Respond with a label field.",
+        format=Sentiment,
+        model_options={ModelOption.MAX_NEW_TOKENS: 2**8},
+    )
+
+    parsed = output.parsed
+    assert isinstance(parsed, Sentiment)
+    assert isinstance(parsed.label, str) and parsed.label
+    assert parsed == Sentiment.model_validate_json(output.value)
+
+
+@pytest.mark.qualitative
 @pytest.mark.timeout(150)
 async def test_generate_from_raw(session) -> None:
     prompts = ["What is 1+1?", "What is 2+2?", "What is 3+3?", "What is 4+4?"]

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -371,6 +371,8 @@ def test_format_preserved_by_copy() -> None:
     result = _make_computed('{"label": "yes"}', _Label)
     shallow = _copy.copy(result)
     assert shallow._format is _Label
+    # __copy__ returns ModelOutputThunk (loses ComputedModelOutputThunk subclass due to
+    # zero-copy __class__ reassignment), so we validate manually rather than via .parsed.
     assert shallow._format.model_validate_json(shallow.value).label == "yes"  # type: ignore[union-attr]
 
 
@@ -380,4 +382,5 @@ def test_format_preserved_by_deepcopy() -> None:
     result = _make_computed('{"label": "yes"}', _Label)
     deep = _copy.deepcopy(result)
     assert deep._format is _Label
+    # Same subclass-loss caveat as test_format_preserved_by_copy.
     assert deep._format.model_validate_json(deep.value).label == "yes"  # type: ignore[union-attr]

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -3,10 +3,17 @@ import copy
 import io
 from typing import Any
 
+import pydantic
 import pytest
 from PIL import Image as PILImage
 
-from mellea.core import CBlock, Component, ImageBlock, ModelOutputThunk
+from mellea.core import (
+    CBlock,
+    Component,
+    ComputedModelOutputThunk,
+    ImageBlock,
+    ModelOutputThunk,
+)
 from mellea.stdlib.components import Message
 
 
@@ -317,3 +324,42 @@ async def test_cancel_generation_propagates_outer_cancellation() -> None:
         await asyncio.wait_for(mot._generate, timeout=1.0)  # type: ignore[attr-defined]
     except (TimeoutError, asyncio.CancelledError):
         pass
+
+
+# --- ComputedModelOutputThunk.parsed ---
+
+
+class _Label(pydantic.BaseModel):
+    label: str
+
+
+def _make_computed(
+    json_str: str, fmt: type[pydantic.BaseModel] | None
+) -> ComputedModelOutputThunk:
+    thunk = ModelOutputThunk(value=json_str)
+    thunk._format = fmt
+    return ComputedModelOutputThunk(thunk)
+
+
+def test_parsed_returns_model_instance() -> None:
+    result = _make_computed('{"label": "yes"}', _Label)
+    obj = result.parsed
+    assert isinstance(obj, _Label)
+    assert obj.label == "yes"
+
+
+def test_parsed_returns_none_when_no_format() -> None:
+    result = _make_computed('{"label": "yes"}', None)
+    assert result.parsed is None
+
+
+def test_parsed_raises_on_invalid_json() -> None:
+    result = _make_computed("not json", _Label)
+    with pytest.raises(pydantic.ValidationError):
+        _ = result.parsed
+
+
+def test_value_unaffected_by_format() -> None:
+    raw = '{"label": "ok"}'
+    result = _make_computed(raw, _Label)
+    assert result.value == raw

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -363,3 +363,21 @@ def test_value_unaffected_by_format() -> None:
     raw = '{"label": "ok"}'
     result = _make_computed(raw, _Label)
     assert result.value == raw
+
+
+def test_format_preserved_by_copy() -> None:
+    import copy as _copy
+
+    result = _make_computed('{"label": "yes"}', _Label)
+    shallow = _copy.copy(result)
+    assert shallow._format is _Label
+    assert shallow._format.model_validate_json(shallow.value).label == "yes"  # type: ignore[union-attr]
+
+
+def test_format_preserved_by_deepcopy() -> None:
+    import copy as _copy
+
+    result = _make_computed('{"label": "yes"}', _Label)
+    deep = _copy.deepcopy(result)
+    assert deep._format is _Label
+    assert deep._format.model_validate_json(deep.value).label == "yes"  # type: ignore[union-attr]

--- a/test/typing/check_parsed.py
+++ b/test/typing/check_parsed.py
@@ -1,10 +1,14 @@
-"""Mypy checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
+"""Mypy / pyright checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
 
 `.parsed` is typed `S | None`, so a thunk parameterized with a Pydantic model
 (`ComputedModelOutputThunk[MyModel]`) exposes `.parsed` as `MyModel | None` —
 callers need no `cast()`. The `format=` overloads in `session.py` /
 `functional.py` bind `S` to the format model (companion issue #1274), at which
 point these checks hold end-to-end from the call site.
+
+The `cast(X, cast(object, None))` idiom creates a typed stub value without
+triggering basedpyright's ``reportInvalidCast`` rule (direct ``cast(X, None)``
+raises that diagnostic because ``None`` and ``X`` share no overlap).
 """
 
 from typing import assert_type, cast
@@ -19,10 +23,10 @@ class _Person(pydantic.BaseModel):
 
 
 def check_parsed_tracks_format_model() -> None:
-    thunk = cast(ComputedModelOutputThunk[_Person], None)
-    assert_type(thunk.parsed, _Person | None)
+    thunk = cast(ComputedModelOutputThunk[_Person], cast(object, None))
+    _ = assert_type(thunk.parsed, _Person | None)
 
 
 def check_parsed_is_str_for_str_thunk() -> None:
-    thunk = cast(ComputedModelOutputThunk[str], None)
-    assert_type(thunk.parsed, str | None)
+    thunk = cast(ComputedModelOutputThunk[str], cast(object, None))
+    _ = assert_type(thunk.parsed, str | None)

--- a/test/typing/check_parsed.py
+++ b/test/typing/check_parsed.py
@@ -1,0 +1,28 @@
+"""Mypy checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
+
+`.parsed` is typed `S | None`, so a thunk parameterized with a Pydantic model
+(`ComputedModelOutputThunk[MyModel]`) exposes `.parsed` as `MyModel | None` —
+callers need no `cast()`. The `format=` overloads in `session.py` /
+`functional.py` bind `S` to the format model (companion issue #1274), at which
+point these checks hold end-to-end from the call site.
+"""
+
+from typing import assert_type, cast
+
+import pydantic
+
+from mellea.core import ComputedModelOutputThunk
+
+
+class _Person(pydantic.BaseModel):
+    name: str
+
+
+def check_parsed_tracks_format_model() -> None:
+    thunk = cast(ComputedModelOutputThunk[_Person], None)
+    assert_type(thunk.parsed, _Person | None)
+
+
+def check_parsed_is_str_for_str_thunk() -> None:
+    thunk = cast(ComputedModelOutputThunk[str], None)
+    assert_type(thunk.parsed, str | None)


### PR DESCRIPTION
Fixes #1273.

## Why

When `format=` is passed to `act()`, the model returns JSON and `.value` holds the raw string — not a Pydantic instance. The natural workaround is `cast(MyModel, result.value)`, which satisfies the type checker but raises `AttributeError` at runtime. Because that error is often swallowed by a broad `except` handler, callers fall back silently on every invocation rather than surfacing a clear failure.

`@generative` avoids this, but it requires a fixed function signature. Dynamically-built prompts in a loop — a common pattern for batch classification — cannot use it.

## Summary

- Adds `ComputedModelOutputThunk.parsed` — validates the raw JSON string via `model_validate_json` and returns the Pydantic instance typed as `S | None`. Returns `None` when no `format=` type was passed.
- All five built-in backends store the format type on the thunk so `parsed` can use it.
- Docstring notes on `value` and `act()` point callers at `.parsed`.
- Unit tests covering the happy path, `None` fallback, invalid JSON, value unchanged, copy/deepcopy `_format` preservation, and end-to-end through Ollama and HuggingFace backends.

## Before / After

```python
# Before
result = m.act(Instruction("Say yes or no"), format=Result)
classification = cast(Result, result.value)
print(classification.label)  # AttributeError: 'str' object has no attribute 'label'

# After
result = m.act(Instruction("Say yes or no"), format=Result)
print(result.parsed.label)   # works
```

## Compatibility

- `.value` is unchanged — existing callers are unaffected.
- `.parsed` is a new property; nothing relies on it today.
- Custom backends that subclass `Backend` without setting `mot._format` will return `None` from `.parsed` even when `format=` is passed. The `.parsed` docstring has a `Note:` calling this out explicitly for backend authors. The built-in backends are all updated.

## What is not in this PR

`.parsed` is now typed `S | None`, so a `ComputedModelOutputThunk[MyModel]` exposes `.parsed` as `MyModel | None` with no cast at the call site. The remaining gap is that `m.act(format=MyModel)` does not yet infer `ComputedModelOutputThunk[MyModel]` — the call site still resolves to `ComputedModelOutputThunk[Any]`. That binding is tracked in #1274.

## Test plan

- [ ] `uv run pytest test/core/test_base.py -k parsed`
- [ ] `uv run pytest test/core/ -m "not qualitative"`
- [ ] `uv run pytest test/backends/test_ollama.py -k parsed -m qualitative` (requires Ollama)
- [ ] `uv run pytest test/backends/test_huggingface.py -k parsed -m qualitative` (requires GPU)