### PR TITLE
docs: clarify MelleaSession vs functional.act() layering; add start_session() pin example

### DIFF
--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -55,20 +55,19 @@ Three lines: create a session, instruct, print. The `instruct()` call returns a
 
 > **Full example:** [`docs/examples/tutorial/simple_email.py`](https://github.com/generative-computing/mellea/blob/main/docs/examples/tutorial/simple_email.py)
 
-To pin a specific backend and model — useful when you need reproducible
-behaviour across environments — use the explicit form:
+To pin a specific backend and model — ensuring the same model runs across all
+environments — use the explicit form:
 
 ```python
 import mellea
-from mellea.backends.model_ids import IBM_GRANITE_4_1_3B
 
-with mellea.start_session("ollama", IBM_GRANITE_4_1_3B) as m:
+with mellea.start_session("ollama", mellea.model_ids.IBM_GRANITE_4_1_3B) as m:
     email = m.instruct("Write an email inviting interns to an office party at 3:30pm.")
     print(str(email))
 ```
 
-The `with` block closes the session automatically — use this form in long-running
-scripts to avoid resource leaks.
+The `with` block closes the session cleanly on exit, flushing telemetry and
+deregistering any scoped plugins.
 
 ## User variables
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -50,6 +50,11 @@ Best Regards,
 
 > **Note:** LLM output is non-deterministic. Your exact results will vary by model and temperature, but you should see a well-formed email in a similar format.
 
+Three lines: create a session, instruct, print. The `instruct()` call returns a
+[`ModelOutputThunk`](../reference/glossary#modeloutputthunk); call `str()` on it (or access `.value`) to get the string.
+
+> **Full example:** [`docs/examples/tutorial/simple_email.py`](https://github.com/generative-computing/mellea/blob/main/docs/examples/tutorial/simple_email.py)
+
 To pin a specific backend and model — useful when you need reproducible
 behaviour across environments — use the explicit form:
 
@@ -62,11 +67,6 @@ with start_session("ollama", IBM_GRANITE_4_1_3B) as m:
     email = m.instruct("Write an email inviting interns to an office party at 3:30pm.")
     print(str(email))
 ```
-
-Three lines: create a session, instruct, print. The `instruct()` call returns a
-[`ModelOutputThunk`](../reference/glossary#modeloutputthunk); call `str()` on it (or access `.value`) to get the string.
-
-> **Full example:** [`docs/examples/tutorial/simple_email.py`](https://github.com/generative-computing/mellea/blob/main/docs/examples/tutorial/simple_email.py)
 
 ## User variables
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -66,8 +66,8 @@ with mellea.start_session("ollama", mellea.model_ids.IBM_GRANITE_4_1_3B) as m:
     print(str(email))
 ```
 
-The `with` block closes the session cleanly on exit, flushing telemetry and
-deregistering any scoped plugins.
+The `with` block closes the session cleanly on exit, ending any open telemetry
+spans and deregistering any scoped plugins.
 
 ## User variables
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -50,6 +50,19 @@ Best Regards,
 
 > **Note:** LLM output is non-deterministic. Your exact results will vary by model and temperature, but you should see a well-formed email in a similar format.
 
+To pin a specific backend and model — useful when you need reproducible
+behaviour across environments — use the explicit form:
+
+```python
+from mellea import start_session
+from mellea.backends.model_ids import IBM_GRANITE_4_1_3B
+
+# Explicit form — same as default, but pinned for reproducibility:
+with start_session("ollama", IBM_GRANITE_4_1_3B) as m:
+    email = m.instruct("Write an email inviting interns to an office party at 3:30pm.")
+    print(str(email))
+```
+
 Three lines: create a session, instruct, print. The `instruct()` call returns a
 [`ModelOutputThunk`](../reference/glossary#modeloutputthunk); call `str()` on it (or access `.value`) to get the string.
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -59,14 +59,16 @@ To pin a specific backend and model — useful when you need reproducible
 behaviour across environments — use the explicit form:
 
 ```python
-from mellea import start_session
+import mellea
 from mellea.backends.model_ids import IBM_GRANITE_4_1_3B
 
-# Explicit form — same as default, but pinned for reproducibility:
-with start_session("ollama", IBM_GRANITE_4_1_3B) as m:
+with mellea.start_session("ollama", IBM_GRANITE_4_1_3B) as m:
     email = m.instruct("Write an email inviting interns to an office party at 3:30pm.")
     print(str(email))
 ```
+
+The `with` block closes the session automatically — use this form in long-running
+scripts to avoid resource leaks.
 
 ## User variables
 

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -1,4 +1,10 @@
-"""Functions for Mellea operations like Instruct, Chat, etc..."""
+"""Low-level primitives for Mellea operations: Instruct, Chat, and friends.
+
+For scripts and applications, prefer :class:`mellea.MelleaSession`
+(via :func:`mellea.start_session`), which manages context and backend for
+you. Reach for these functions only when implementing a custom session or
+sampling strategy.
+"""
 
 from __future__ import annotations
 

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -1,9 +1,8 @@
 """Low-level primitives for Mellea operations: Instruct, Chat, and friends.
 
-For scripts and applications, prefer :class:`mellea.MelleaSession`
-(via :func:`mellea.start_session`), which manages context and backend for
-you. Reach for these functions only when implementing a custom session or
-sampling strategy.
+For scripts and applications, prefer `MelleaSession` (via `start_session()`),
+which manages context and backend for you. Reach for these functions only when
+implementing a custom session or sampling strategy.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Doc-only. Two gaps that required source-diving to resolve.

**`functional.py` module docstring** — the old one-liner gave no guidance on when to reach for `functional.act()` vs `session.act()`. The new docstring calls it a low-level primitive and points to `MelleaSession` / `start_session()` for the common case.

**Quickstart pinning example** — `start_session()` with no args appears in several places but the explicit `mellea.start_session("ollama", IBM_GRANITE_4_1_3B)` form didn't appear anywhere users land first. Added one snippet to the quickstart showing the import path, the pinning pattern, and a note that the `with` form closes the session automatically.

**Compatibility**: no concerns. `MelleaSession.__enter__`/`__exit__` are implemented (session.py:276, 305), so the context manager form in the snippet is already supported. The argument order (`backend_name` then `model_id`) matches the signature. `IBM_GRANITE_4_1_3B` is also the default `model_id`, so the pinned example produces the same result as the no-args call.

Fixes #1276.