### PR TITLE
feat(thunk+types): add .parsed property and wire format= overloads for cast-free structured output

### DIFF
--- a/docs/examples/m_serve/m_serve_example_response_format.py
+++ b/docs/examples/m_serve/m_serve_example_response_format.py
@@ -44,18 +44,18 @@ def serve(
     """
     message = input[-1].get_text_content() or "No message provided"
 
-    # When format is provided (from json_schema response_format),
-    # pass it to instruct() to get structured output
-    # `format` arrives as a dynamic `type | None` from the response_format request, so it
-    # matches no single narrow instruct() overload (those key off format=None vs a concrete
-    # type). A serving wrapper that wanted cast-free typing would branch on `format is None`
-    # and call instruct() in each branch; here the passthrough ignore keeps the example
-    # focused on the serving flow.
-    result = session.instruct(
-        description=message,
-        requirements=requirements,  # type: ignore
-        model_options=model_options,
-        format=format,  # type: ignore[arg-type]  # dynamic format from caller
-    )
+    if format is None:
+        result = session.instruct(
+            description=message,
+            requirements=requirements,  # type: ignore
+            model_options=model_options,
+        )
+    else:
+        result = session.instruct(
+            description=message,
+            requirements=requirements,  # type: ignore
+            model_options=model_options,
+            format=format,
+        )
 
     return result

--- a/docs/examples/m_serve/m_serve_example_response_format.py
+++ b/docs/examples/m_serve/m_serve_example_response_format.py
@@ -46,6 +46,11 @@ def serve(
 
     # When format is provided (from json_schema response_format),
     # pass it to instruct() to get structured output
+    # `format` arrives as a dynamic `type | None` from the response_format request, so it
+    # matches no single narrow instruct() overload (those key off format=None vs a concrete
+    # type). A serving wrapper that wanted cast-free typing would branch on `format is None`
+    # and call instruct() in each branch; here the passthrough ignore keeps the example
+    # focused on the serving flow.
     result = session.instruct(
         description=message,
         requirements=requirements,  # type: ignore

--- a/docs/examples/m_serve/m_serve_example_response_format.py
+++ b/docs/examples/m_serve/m_serve_example_response_format.py
@@ -50,7 +50,7 @@ def serve(
         description=message,
         requirements=requirements,  # type: ignore
         model_options=model_options,
-        format=format,  # This enables structured output validation
+        format=format,  # type: ignore[arg-type]  # dynamic format from caller
     )
 
     return result

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1513,6 +1513,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             generate_log.action = action
 
             result._generate_log = generate_log
+            result._format = format
             results.append(result)
 
         usage: dict[str, Any] | None = (

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1378,6 +1378,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         generate_log.result = mot
 
         mot._generate_log = generate_log
+        mot._format = _format
 
     async def _generate_from_raw(
         self,

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -596,6 +596,7 @@ class LiteLLMBackend(FormatterBackend):
         generate_log.action = mot._action
         generate_log.result = mot
         mot._generate_log = generate_log
+        mot._format = _format
 
         # Extract token usage from full response dict or streaming usage
         full_response = mot._meta.get("litellm_full_response")

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -613,6 +613,7 @@ class OllamaModelBackend(FormatterBackend):
                 generate_log.extra["error"] = error
                 generate_log.extra["empty_response"] = response.model_dump()
             result._generate_log = generate_log
+            result._format = format
 
             results.append(result)
 
@@ -742,6 +743,7 @@ class OllamaModelBackend(FormatterBackend):
         generate_log.result = mot
 
         mot._generate_log = generate_log
+        mot._format = _format
         mot._generate = None
 
         # Extract token counts from response

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1127,6 +1127,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         generate_log.action = mot._action
         generate_log.result = mot
         mot._generate_log = generate_log
+        mot._format = _format
 
         # Extract token usage from response or streaming usage
         response = mot._meta["oai_chat_response"]

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -614,6 +614,7 @@ class WatsonxAIBackend(FormatterBackend):
         generate_log.result = mot
         generate_log.action = mot._action
         mot._generate_log = generate_log
+        mot._format = _format
 
     async def _generate_from_raw(
         self,

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -885,7 +885,12 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
 
     @property
     def value(self) -> str:
-        """Gets the value of the block."""
+        """Gets the raw string value of the block.
+
+        When ``format=`` is set on the originating ``act()``/``instruct()`` call, the
+        model returns a JSON string and ``.value`` contains that raw JSON — not a
+        Pydantic instance.  Use ``.parsed`` to get the validated model object.
+        """
         return self._underlying_value  # type: ignore
 
     @value.setter
@@ -897,15 +902,17 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     def parsed(self) -> S | None:
         """Returns the result as a validated Pydantic instance when ``format=`` was set.
 
-        The return type tracks the format type supplied at the originating call
-        site: ``m.act(action, format=MyModel)`` yields a
-        ``ComputedModelOutputThunk[MyModel]`` whose ``.parsed`` is typed
-        ``MyModel | None`` — no ``cast()`` required. Returns ``None`` when no
-        ``format=`` type was provided.  Use this instead of casting ``.value``
-        manually::
+        The return type is ``S | None``, where ``S`` is the thunk's type parameter.
+        The ``format=`` overloads do not yet bind ``S`` to the format model, so
+        callers must parameterize the thunk explicitly to get a narrowed type::
 
-            result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # typed MyModel | None, no model_validate_json needed
+            thunk = cast(ComputedModelOutputThunk[MyModel], result)
+            obj = thunk.parsed  # typed MyModel | None, no model_validate_json needed
+
+        Returns ``None`` when no ``format=`` type was provided.  Unlike
+        ``parsed_repr`` (which holds the action-specific parse result),
+        ``.parsed`` always re-validates the raw JSON string against ``_format``
+        via ``model_validate_json``.
 
         Note:
             This property relies on the originating backend storing the format

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -32,6 +32,7 @@ from typing import (
     runtime_checkable,
 )
 
+import pydantic
 import typing_extensions
 from PIL import Image as PILImage
 
@@ -401,6 +402,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
+        self._format: type[pydantic.BaseModel] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -542,6 +544,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._thinking = other._thinking
         self.generation = other.generation
         self._generate_log = other._generate_log
+        self._format = other._format
         self._cancelled = other._cancelled
         # _cancel_hook is deliberately not copied: _copy_from swaps output state,
         # not backend-thread plumbing, which is tied to the original computation.
@@ -557,7 +560,13 @@ class ModelOutputThunk(CBlock, Generic[S]):
 
     @property
     def value(self) -> str | None:
-        """Gets the value of the block."""
+        """Gets the raw string value of the block.
+
+        When ``format=`` is set on the originating ``act()``/``instruct()`` call, the
+        model returns a JSON string and ``.value`` contains that raw JSON — not a
+        Pydantic instance.  Use ``.parsed`` on a ``ComputedModelOutputThunk`` to get
+        the validated model object.
+        """
         if not self._computed:
             return None
         return self._underlying_value
@@ -880,6 +889,25 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     def value(self, v: str):
         """Sets the value of the block."""
         self._underlying_value = v
+
+    @property
+    def parsed(self) -> pydantic.BaseModel | None:
+        """Returns the result as a validated Pydantic instance when ``format=`` was set.
+
+        Returns ``None`` when no ``format=`` type was provided to the originating
+        ``act()`` / ``instruct()`` call.  Use this instead of casting ``.value``
+        manually::
+
+            result = m.act(Instruction("Say yes or no"), format=MyModel)
+            obj = result.parsed  # MyModel instance, no cast needed
+
+        Returns:
+            A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
+            or ``None`` if no format type was set.
+        """
+        if self._format is None:
+            return None
+        return self._format.model_validate_json(self.value)
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -901,7 +901,7 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         manually::
 
             result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # MyModel instance, no cast needed
+            obj = result.parsed  # no manual model_validate_json needed
 
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -903,6 +903,13 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
             result = m.act(Instruction("Say yes or no"), format=MyModel)
             obj = result.parsed  # no manual model_validate_json needed
 
+        Note:
+            This property relies on the originating backend storing the format
+            type on the thunk. Custom backend authors must set ``mot._format``
+            in their ``post_processing`` method (mirroring the built-in
+            backends); otherwise ``.parsed`` always returns ``None`` even when
+            ``format=`` was supplied.
+
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
             or ``None`` if no format type was set.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -403,7 +403,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
-        self._format: type[S] | None = None
+        self._format: type[pydantic.BaseModel] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -924,11 +924,10 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         """
         if self._format is None:
             return None
-        # `_format` is a pydantic model type in every code path that sets it (the
-        # `format=` overloads bind `S` to that model), but `S` itself is unbounded,
-        # so we narrow to call `model_validate_json` and re-assert the result as `S`.
-        fmt = cast("type[pydantic.BaseModel]", self._format)
-        return cast("S", fmt.model_validate_json(self.value))
+        # `_format` is always a pydantic model type; `model_validate_json` returns
+        # `pydantic.BaseModel` statically, but the caller's type parameter `S` is
+        # the concrete model when `format=` was used, so we cast the result to `S`.
+        return cast(S, self._format.model_validate_json(self.value))
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -785,6 +785,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         copied._action = self._action
         copied._context = self._context
         copied._generate_log = self._generate_log
+        copied._format = self._format
         copied._model_options = self._model_options
         copied.generation = copy(self.generation)
         return copied
@@ -819,6 +820,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
             self._context
         )  # The items in a context should be immutable.
         deepcopied._generate_log = copy(self._generate_log)
+        deepcopied._format = self._format
         deepcopied._model_options = copy(self._model_options)
         deepcopied.generation = deepcopy(self.generation)
         return deepcopied
@@ -904,6 +906,10 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         Returns:
             A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
             or ``None`` if no format type was set.
+
+        Raises:
+            pydantic.ValidationError: If the raw JSON value does not conform to
+                the format model (e.g. the model returned malformed structured output).
         """
         if self._format is None:
             return None

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -29,6 +29,7 @@ from typing import (
     ParamSpec,
     Protocol,
     TypeVar,
+    cast,
     runtime_checkable,
 )
 
@@ -402,7 +403,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
-        self._format: type[pydantic.BaseModel] | None = None
+        self._format: type[S] | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
@@ -893,15 +894,18 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         self._underlying_value = v
 
     @property
-    def parsed(self) -> pydantic.BaseModel | None:
+    def parsed(self) -> S | None:
         """Returns the result as a validated Pydantic instance when ``format=`` was set.
 
-        Returns ``None`` when no ``format=`` type was provided to the originating
-        ``act()`` / ``instruct()`` call.  Use this instead of casting ``.value``
+        The return type tracks the format type supplied at the originating call
+        site: ``m.act(action, format=MyModel)`` yields a
+        ``ComputedModelOutputThunk[MyModel]`` whose ``.parsed`` is typed
+        ``MyModel | None`` — no ``cast()`` required. Returns ``None`` when no
+        ``format=`` type was provided.  Use this instead of casting ``.value``
         manually::
 
             result = m.act(Instruction("Say yes or no"), format=MyModel)
-            obj = result.parsed  # no manual model_validate_json needed
+            obj = result.parsed  # typed MyModel | None, no model_validate_json needed
 
         Note:
             This property relies on the originating backend storing the format
@@ -911,8 +915,8 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
             ``format=`` was supplied.
 
         Returns:
-            A ``pydantic.BaseModel`` instance produced by ``model_validate_json``,
-            or ``None`` if no format type was set.
+            An instance of the format type (``S``) produced by
+            ``model_validate_json``, or ``None`` if no format type was set.
 
         Raises:
             pydantic.ValidationError: If the raw JSON value does not conform to
@@ -920,7 +924,11 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         """
         if self._format is None:
             return None
-        return self._format.model_validate_json(self.value)
+        # `_format` is a pydantic model type in every code path that sets it (the
+        # `format=` overloads bind `S` to that model), but `S` itself is unbounded,
+        # so we narrow to call `model_validate_json` and re-assert the result as `S`.
+        fmt = cast("type[pydantic.BaseModel]", self._format)
+        return cast("S", fmt.model_validate_json(self.value))
 
     def is_computed(self) -> Literal[True]:
         """Returns `True` since thunk is always computed.

--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -654,9 +654,9 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
 
         assert response.parsed_repr is not None
         if context is None:
-            return response.parsed_repr  # type: ignore[return-value]
+            return response.parsed_repr  # type: ignore[return-value]  # genstub unwraps R from FunctionResponse[R]; format overloads can't re-bind R here
         else:
-            return response.parsed_repr, context  # type: ignore[return-value]
+            return response.parsed_repr, context  # type: ignore[return-value]  # same
 
 
 class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
@@ -797,9 +797,9 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
             )
             assert response.parsed_repr is not None
             if context is None:
-                return response.parsed_repr  # type: ignore[return-value]
+                return response.parsed_repr  # type: ignore[return-value]  # genstub unwraps R from FunctionResponse[R]; format overloads can't re-bind R here
             else:
-                return response.parsed_repr, context  # type: ignore[return-value]
+                return response.parsed_repr, context  # type: ignore[return-value]  # same
 
         return __async_call__()
 

--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -6,7 +6,16 @@ import inspect
 from collections.abc import Awaitable, Callable, Coroutine
 from copy import deepcopy
 from dataclasses import dataclass, fields
-from typing import Any, Generic, ParamSpec, TypedDict, TypeVar, get_type_hints, overload
+from typing import (
+    Any,
+    Generic,
+    ParamSpec,
+    TypedDict,
+    TypeVar,
+    cast,
+    get_type_hints,
+    overload,
+)
 
 from pydantic import BaseModel, Field, create_model
 
@@ -653,19 +662,15 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
             )
 
         assert response.parsed_repr is not None
-        # The format= overloads on act/aact narrow the *thunk's* element type, but a
-        # genstub must return the inner value R (the unwrapped FunctionResponse[R]
-        # payload), not the thunk. `parsed_repr` is typed `S | None` at the call
-        # site and cannot be re-bound to R here, so the ignore bridges the gap.
-        #
-        # TODO: the clean shape is for act/aact to deliver a ComputedModelOutputThunk[R]
-        # whose value is R, with the FunctionResponse[R] unwrap happening inside a typed
-        # parse step rather than at the genstub boundary. That requires coordinating the
-        # thunk-generics redesign (see the .parsed work) and is outside this PR's scope.
+        # GenerativeStub._parse calls model_validate_json and returns the unwrapped R,
+        # so parsed_repr is R at runtime. The thunk types it as S | None (where
+        # S = FunctionResponse[R]) because the overloads narrow S to the format type,
+        # not to R. cast makes the coercion explicit rather than suppressing it.
+        parsed = cast("R", response.parsed_repr)
         if context is None:
-            return response.parsed_repr  # type: ignore[return-value]
+            return parsed
         else:
-            return response.parsed_repr, context  # type: ignore[return-value]
+            return parsed, context
 
 
 class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
@@ -805,16 +810,13 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
                 "unexpectedly received uncomputed model output thunk in async generative stub"
             )
             assert response.parsed_repr is not None
-            # See the SyncGenerativeStub.__call__ comment above: the format= overloads
-            # narrow the thunk's element type, but a genstub returns the unwrapped inner
-            # value R, not the thunk. `parsed_repr` is `S | None` and can't be re-bound to
-            # R here. The clean fix (ComputedModelOutputThunk[R] with the FunctionResponse[R]
-            # unwrap in a typed parse step) needs the thunk-generics redesign and is out of
-            # scope for this PR.
+            # Same as SyncGenerativeStub: _parse returns the unwrapped R at runtime;
+            # cast makes the S → R coercion explicit.
+            parsed = cast("R", response.parsed_repr)
             if context is None:
-                return response.parsed_repr  # type: ignore[return-value]
+                return parsed
             else:
-                return response.parsed_repr, context  # type: ignore[return-value]
+                return parsed, context
 
         return __async_call__()
 

--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -653,10 +653,19 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
             )
 
         assert response.parsed_repr is not None
+        # The format= overloads on act/aact narrow the *thunk's* element type, but a
+        # genstub must return the inner value R (the unwrapped FunctionResponse[R]
+        # payload), not the thunk. `parsed_repr` is typed `S | None` at the call
+        # site and cannot be re-bound to R here, so the ignore bridges the gap.
+        #
+        # TODO: the clean shape is for act/aact to deliver a ComputedModelOutputThunk[R]
+        # whose value is R, with the FunctionResponse[R] unwrap happening inside a typed
+        # parse step rather than at the genstub boundary. That requires coordinating the
+        # thunk-generics redesign (see the .parsed work) and is outside this PR's scope.
         if context is None:
-            return response.parsed_repr  # type: ignore[return-value]  # genstub unwraps R from FunctionResponse[R]; format overloads can't re-bind R here
+            return response.parsed_repr  # type: ignore[return-value]
         else:
-            return response.parsed_repr, context  # type: ignore[return-value]  # same
+            return response.parsed_repr, context  # type: ignore[return-value]
 
 
 class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
@@ -796,10 +805,16 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
                 "unexpectedly received uncomputed model output thunk in async generative stub"
             )
             assert response.parsed_repr is not None
+            # See the SyncGenerativeStub.__call__ comment above: the format= overloads
+            # narrow the thunk's element type, but a genstub returns the unwrapped inner
+            # value R, not the thunk. `parsed_repr` is `S | None` and can't be re-bound to
+            # R here. The clean fix (ComputedModelOutputThunk[R] with the FunctionResponse[R]
+            # unwrap in a typed parse step) needs the thunk-generics redesign and is out of
+            # scope for this PR.
             if context is None:
-                return response.parsed_repr  # type: ignore[return-value]  # genstub unwraps R from FunctionResponse[R]; format overloads can't re-bind R here
+                return response.parsed_repr  # type: ignore[return-value]
             else:
-                return response.parsed_repr, context  # type: ignore[return-value]  # same
+                return response.parsed_repr, context  # type: ignore[return-value]
 
         return __async_call__()
 

--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -654,9 +654,9 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
 
         assert response.parsed_repr is not None
         if context is None:
-            return response.parsed_repr
+            return response.parsed_repr  # type: ignore[return-value]
         else:
-            return response.parsed_repr, context
+            return response.parsed_repr, context  # type: ignore[return-value]
 
 
 class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
@@ -797,9 +797,9 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
             )
             assert response.parsed_repr is not None
             if context is None:
-                return response.parsed_repr
+                return response.parsed_repr  # type: ignore[return-value]
             else:
-                return response.parsed_repr, context
+                return response.parsed_repr, context  # type: ignore[return-value]
 
         return __async_call__()
 

--- a/mellea/stdlib/frameworks/react.py
+++ b/mellea/stdlib/frameworks/react.py
@@ -111,7 +111,7 @@ async def react(
             assert len(tool_responses) == 1, "multiple tools were called with 'final'"
 
             if format is not None:
-                step, next_context = await mfuncs.aact(  # type: ignore[assignment]
+                step, next_context = await mfuncs.aact(  # type: ignore[assignment]  # dynamic format from caller
                     action=ReactThought(),
                     context=context,
                     backend=backend,

--- a/mellea/stdlib/frameworks/react.py
+++ b/mellea/stdlib/frameworks/react.py
@@ -111,7 +111,7 @@ async def react(
             assert len(tool_responses) == 1, "multiple tools were called with 'final'"
 
             if format is not None:
-                step, next_context = await mfuncs.aact(
+                step, next_context = await mfuncs.aact(  # type: ignore[assignment]
                     action=ReactThought(),
                     context=context,
                     backend=backend,

--- a/mellea/stdlib/frameworks/react.py
+++ b/mellea/stdlib/frameworks/react.py
@@ -111,6 +111,15 @@ async def react(
             assert len(tool_responses) == 1, "multiple tools were called with 'final'"
 
             if format is not None:
+                # `format` is a dynamic `type[BaseModelSubclass] | None` forwarded from
+                # the caller, which matches no single narrow aact() overload (those key
+                # off `format=None` vs `format=<type>` as distinct literals). We are
+                # already inside `if format is not None`, so the value is known non-None
+                # here, but mypy does not propagate that narrowing into the overload pick.
+                # The clean fix is for the caller to branch on `format is None` and call
+                # aact in each branch so each call matches a narrow overload; that is
+                # not worth the duplication for this single internal call site, so we
+                # accept the ignore.
                 step, next_context = await mfuncs.aact(  # type: ignore[assignment]  # dynamic format from caller
                     action=ReactThought(),
                     context=context,

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -228,7 +228,8 @@ def instruct(
     output_prefix: str | CBlock | None = None,
     strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
     return_sampling_results: bool = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[Any]
+    | None = None,  # widened: TypeVar only needed in @overload signatures
     model_options: dict | None = None,
     tool_calls: bool = False,
 ) -> tuple[ComputedModelOutputThunk[Any], Context] | SamplingResult[Any]:
@@ -1022,7 +1023,8 @@ async def ainstruct(
     output_prefix: str | CBlock | None = None,
     strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
     return_sampling_results: bool = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[Any]
+    | None = None,  # widened: TypeVar only needed in @overload signatures
     model_options: dict | None = None,
     tool_calls: bool = False,
     await_result: bool = False,

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -101,6 +101,11 @@ def act(
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
+    # Implementation return type intentionally widened to `Any`: the @overload signatures
+    # above own the precise S propagation (action's S -> thunk's S, plus the
+    # format= -> BaseModelSubclass narrowing). Tightening the body to the bare `[S]` case
+    # would conflict with the format= and sampling overloads, so it is left untyped on
+    # purpose. Callers always resolve against an overload, never this implementation body.
 ) -> tuple[ComputedModelOutputThunk[Any], Context] | SamplingResult[Any]:
     """Runs a generic action, and adds both the action and the result to the context.
 

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -47,6 +47,21 @@ from .sampling import RejectionSamplingStrategy
 
 @overload
 def act(
+    action: Component[Any],
+    context: Context,
+    backend: Backend,
+    *,
+    requirements: list[Requirement] | None = None,
+    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    return_sampling_results: Literal[False] = False,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+def act(
     action: Component[S],
     context: Context,
     backend: Backend,
@@ -54,7 +69,7 @@ def act(
     requirements: list[Requirement] | None = None,
     strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
 ) -> tuple[ComputedModelOutputThunk[S], Context]: ...
@@ -86,7 +101,7 @@ def act(
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
-) -> tuple[ComputedModelOutputThunk[S], Context] | SamplingResult[S]:
+) -> tuple[ComputedModelOutputThunk[Any], Context] | SamplingResult[Any]:
     """Runs a generic action, and adds both the action and the result to the context.
 
     Args:
@@ -146,7 +161,28 @@ def instruct(
     output_prefix: str | CBlock | None = None,
     strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+def instruct(
+    description: str,
+    context: Context,
+    backend: Backend,
+    *,
+    images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    requirements: list[Requirement | str] | None = None,
+    icl_examples: list[str | CBlock] | None = None,
+    grounding_context: dict[str, str | CBlock | Component] | None = None,
+    user_variables: dict[str, str] | None = None,
+    prefix: str | CBlock | None = None,
+    output_prefix: str | CBlock | None = None,
+    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    return_sampling_results: Literal[False] = False,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
 ) -> tuple[ComputedModelOutputThunk[str], Context]: ...
@@ -190,7 +226,7 @@ def instruct(
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
-) -> tuple[ComputedModelOutputThunk[str], Context] | SamplingResult[str]:
+) -> tuple[ComputedModelOutputThunk[Any], Context] | SamplingResult[Any]:
     """Generates from an instruction.
 
     Args:
@@ -476,6 +512,23 @@ def transform(
 
 @overload
 async def aact(
+    action: Component[Any],
+    context: Context,
+    backend: Backend,
+    *,
+    requirements: list[Requirement] | None = None,
+    strategy: None = None,
+    return_sampling_results: Literal[False] = False,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    silence_context_type_warning: bool = False,
+    await_result: Literal[True],
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+async def aact(
     action: Component[S],
     context: Context,
     backend: Backend,
@@ -483,12 +536,29 @@ async def aact(
     requirements: list[Requirement] | None = None,
     strategy: None = None,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     silence_context_type_warning: bool = False,
     await_result: Literal[True],
 ) -> tuple[ComputedModelOutputThunk[S], Context]: ...
+
+
+@overload
+async def aact(
+    action: Component[Any],
+    context: Context,
+    backend: Backend,
+    *,
+    requirements: list[Requirement] | None = None,
+    strategy: SamplingStrategy,
+    return_sampling_results: Literal[False] = False,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    silence_context_type_warning: bool = False,
+    await_result: bool = False,
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
 
 
 @overload
@@ -500,12 +570,29 @@ async def aact(
     requirements: list[Requirement] | None = None,
     strategy: SamplingStrategy,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     silence_context_type_warning: bool = False,
     await_result: bool = False,
 ) -> tuple[ComputedModelOutputThunk[S], Context]: ...
+
+
+@overload
+async def aact(
+    action: Component[Any],
+    context: Context,
+    backend: Backend,
+    *,
+    requirements: list[Requirement] | None = None,
+    strategy: None = None,
+    return_sampling_results: Literal[False] = False,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    silence_context_type_warning: bool = False,
+    await_result: Literal[False] = False,
+) -> tuple[ModelOutputThunk[BaseModelSubclass], Context]: ...
 
 
 @overload
@@ -517,7 +604,7 @@ async def aact(
     requirements: list[Requirement] | None = None,
     strategy: None = None,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     silence_context_type_warning: bool = False,
@@ -555,7 +642,7 @@ async def aact(
     tool_calls: bool = False,
     silence_context_type_warning: bool = False,
     await_result: bool = False,
-) -> tuple[ModelOutputThunk[S], Context] | SamplingResult:
+) -> tuple[ModelOutputThunk[Any], Context] | SamplingResult[Any]:
     """Asynchronous version of .act; runs a generic action, and adds both the action and the result to the context.
 
     Args:
@@ -777,7 +864,29 @@ async def ainstruct(
     output_prefix: str | CBlock | None = None,
     strategy: None = None,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    await_result: Literal[True],
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+async def ainstruct(
+    description: str,
+    context: Context,
+    backend: Backend,
+    *,
+    images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    requirements: list[Requirement | str] | None = None,
+    icl_examples: list[str | CBlock] | None = None,
+    grounding_context: dict[str, str | CBlock | Component] | None = None,
+    user_variables: dict[str, str] | None = None,
+    prefix: str | CBlock | None = None,
+    output_prefix: str | CBlock | None = None,
+    strategy: None = None,
+    return_sampling_results: Literal[False] = False,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     await_result: Literal[True],
@@ -799,7 +908,29 @@ async def ainstruct(
     output_prefix: str | CBlock | None = None,
     strategy: SamplingStrategy,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    await_result: bool = False,
+) -> tuple[ComputedModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+async def ainstruct(
+    description: str,
+    context: Context,
+    backend: Backend,
+    *,
+    images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    requirements: list[Requirement | str] | None = None,
+    icl_examples: list[str | CBlock] | None = None,
+    grounding_context: dict[str, str | CBlock | Component] | None = None,
+    user_variables: dict[str, str] | None = None,
+    prefix: str | CBlock | None = None,
+    output_prefix: str | CBlock | None = None,
+    strategy: SamplingStrategy,
+    return_sampling_results: Literal[False] = False,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     await_result: bool = False,
@@ -821,7 +952,29 @@ async def ainstruct(
     output_prefix: str | CBlock | None = None,
     strategy: None = None,
     return_sampling_results: Literal[False] = False,
-    format: type[BaseModelSubclass] | None = None,
+    format: type[BaseModelSubclass],
+    model_options: dict | None = None,
+    tool_calls: bool = False,
+    await_result: Literal[False] = False,
+) -> tuple[ModelOutputThunk[BaseModelSubclass], Context]: ...
+
+
+@overload
+async def ainstruct(
+    description: str,
+    context: Context,
+    backend: Backend,
+    *,
+    images: list[ImageBlock] | list[PILImage.Image] | None = None,
+    requirements: list[Requirement | str] | None = None,
+    icl_examples: list[str | CBlock] | None = None,
+    grounding_context: dict[str, str | CBlock | Component] | None = None,
+    user_variables: dict[str, str] | None = None,
+    prefix: str | CBlock | None = None,
+    output_prefix: str | CBlock | None = None,
+    strategy: None = None,
+    return_sampling_results: Literal[False] = False,
+    format: None = None,
     model_options: dict | None = None,
     tool_calls: bool = False,
     await_result: Literal[False] = False,
@@ -868,7 +1021,7 @@ async def ainstruct(
     model_options: dict | None = None,
     tool_calls: bool = False,
     await_result: bool = False,
-) -> tuple[ModelOutputThunk[str], Context] | SamplingResult:
+) -> tuple[ModelOutputThunk[Any], Context] | SamplingResult[Any]:
     """Generates from an instruction.
 
     Args:

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -393,12 +393,25 @@ class MelleaSession:
     @overload
     def act(
         self,
+        action: Component[Any],
+        *,
+        requirements: list[Requirement] | None = None,
+        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    def act(
+        self,
         action: Component[S],
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
     ) -> ComputedModelOutputThunk[S]: ...
@@ -418,7 +431,7 @@ class MelleaSession:
 
     def act(
         self,
-        action: Component[S],
+        action: Component[Any],
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
@@ -426,7 +439,7 @@ class MelleaSession:
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
-    ) -> ModelOutputThunk[S] | SamplingResult:
+    ) -> ModelOutputThunk[Any] | SamplingResult[Any]:
         """Runs a generic action, and adds both the action and the result to the context.
 
         Args:
@@ -475,7 +488,26 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    def instruct(
+        self,
+        description: str,
+        *,
+        images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        return_sampling_results: Literal[False] = False,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
     ) -> ComputedModelOutputThunk[str]: ...
@@ -515,7 +547,7 @@ class MelleaSession:
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
-    ) -> ModelOutputThunk[str] | SamplingResult:
+    ) -> ModelOutputThunk[Any] | SamplingResult[Any]:
         """Generates from an instruction.
 
         Args:
@@ -710,16 +742,44 @@ class MelleaSession:
     @overload
     async def aact(
         self,
+        action: Component[Any],
+        *,
+        requirements: list[Requirement] | None = None,
+        strategy: None = None,
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: Literal[True],
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    async def aact(
+        self,
         action: Component[S],
         *,
         requirements: list[Requirement] | None = None,
         strategy: None = None,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: Literal[True],
     ) -> ComputedModelOutputThunk[S]: ...
+
+    @overload
+    async def aact(
+        self,
+        action: Component[Any],
+        *,
+        requirements: list[Requirement] | None = None,
+        strategy: SamplingStrategy,
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: bool = False,
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
 
     @overload
     async def aact(
@@ -729,11 +789,25 @@ class MelleaSession:
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: bool = False,
     ) -> ComputedModelOutputThunk[S]: ...
+
+    @overload
+    async def aact(
+        self,
+        action: Component[Any],
+        *,
+        requirements: list[Requirement] | None = None,
+        strategy: None = None,
+        return_sampling_results: Literal[False] = False,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: Literal[False] = False,
+    ) -> ModelOutputThunk[BaseModelSubclass]: ...
 
     @overload
     async def aact(
@@ -743,7 +817,7 @@ class MelleaSession:
         requirements: list[Requirement] | None = None,
         strategy: None = None,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: Literal[False] = False,
@@ -765,7 +839,7 @@ class MelleaSession:
 
     async def aact(
         self,
-        action: Component[S],
+        action: Component[Any],
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
@@ -774,7 +848,7 @@ class MelleaSession:
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: bool = False,
-    ) -> ModelOutputThunk[S] | SamplingResult:
+    ) -> ModelOutputThunk[Any] | SamplingResult[Any]:
         """Runs a generic action, and adds both the action and the result to the context.
 
         Args:
@@ -826,7 +900,27 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: None = None,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: Literal[True],
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    async def ainstruct(
+        self,
+        description: str,
+        *,
+        images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: None = None,
+        return_sampling_results: Literal[False] = False,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: Literal[True],
@@ -846,7 +940,27 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: SamplingStrategy,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: bool = False,
+    ) -> ComputedModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    async def ainstruct(
+        self,
+        description: str,
+        *,
+        images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: SamplingStrategy,
+        return_sampling_results: Literal[False] = False,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: bool = False,
@@ -866,7 +980,27 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: None = None,
         return_sampling_results: Literal[False] = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[BaseModelSubclass],
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+        await_result: Literal[False] = False,
+    ) -> ModelOutputThunk[BaseModelSubclass]: ...
+
+    @overload
+    async def ainstruct(
+        self,
+        description: str,
+        *,
+        images: list[ImageBlock] | list[PILImage.Image] | None = None,
+        requirements: list[Requirement | str] | None = None,
+        icl_examples: list[str | CBlock] | None = None,
+        grounding_context: dict[str, str | CBlock | Component] | None = None,
+        user_variables: dict[str, str] | None = None,
+        prefix: str | CBlock | None = None,
+        output_prefix: str | CBlock | None = None,
+        strategy: None = None,
+        return_sampling_results: Literal[False] = False,
+        format: None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: Literal[False] = False,
@@ -909,7 +1043,7 @@ class MelleaSession:
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: bool = False,
-    ) -> ModelOutputThunk[str] | SamplingResult[str]:
+    ) -> ModelOutputThunk[Any] | SamplingResult[Any]:
         """Generates from an instruction.
 
         Args:

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -434,7 +434,9 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: if set, the BaseModel to use for constrained decoding.
+            format: if set, the BaseModel to use for constrained decoding.  When
+                provided, ``.value`` on the returned thunk is always a raw JSON string —
+                use ``.parsed`` to obtain the validated Pydantic model instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
 

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -390,6 +390,14 @@ class MelleaSession:
 
             deregister_session_plugins(self.id)
 
+    # The format= overloads below narrow the thunk's generic element type. That narrowing
+    # is observable on `parsed_repr: S | None`, NOT on `.value` — ComputedModelOutputThunk.value
+    # is typed `-> str` unconditionally (mellea/core/base.py). There is also a runtime gap:
+    # parsed_repr currently goes through Instruction._parse, which returns a plain str, so
+    # `result.parsed_repr.some_field` type-checks but raises AttributeError at runtime.
+    # TODO: a coherent end state has the thunk's `.parsed` generic over S backed by a runtime
+    # path that delivers S. That is a coordinated change tracked by PR #1282 and is out of
+    # scope here; these overloads only land the static format= narrowing where they can.
     @overload
     def act(
         self,

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -552,7 +552,8 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
         return_sampling_results: bool = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[Any]
+        | None = None,  # widened: TypeVar only needed in @overload signatures
         model_options: dict | None = None,
         tool_calls: bool = False,
     ) -> ModelOutputThunk[Any] | SamplingResult[Any]:
@@ -1047,7 +1048,8 @@ class MelleaSession:
         output_prefix: str | CBlock | None = None,
         strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
         return_sampling_results: bool = False,
-        format: type[BaseModelSubclass] | None = None,
+        format: type[Any]
+        | None = None,  # widened: TypeVar only needed in @overload signatures
         model_options: dict | None = None,
         tool_calls: bool = False,
         await_result: bool = False,

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -253,6 +253,24 @@ def test_format(session) -> None:
 
 
 @pytest.mark.qualitative
+def test_parsed_returns_pydantic_instance(session) -> None:
+    class Sentiment(pydantic.BaseModel):
+        label: str
+
+    output = session.instruct(
+        "Classify the sentiment of 'I love this!' as the single word "
+        "positive, negative, or neutral. Respond with a label field.",
+        format=Sentiment,
+        model_options={ModelOption.MAX_NEW_TOKENS: 2**8},
+    )
+
+    parsed = output.parsed
+    assert isinstance(parsed, Sentiment)
+    assert isinstance(parsed.label, str) and parsed.label
+    assert parsed == Sentiment.model_validate_json(output.value)
+
+
+@pytest.mark.qualitative
 async def test_generate_from_raw(session) -> None:
     prompts = [
         "what is 1+1?",

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -128,6 +128,24 @@ def test_format(session) -> None:
 
 
 @pytest.mark.qualitative
+def test_parsed_returns_pydantic_instance(session) -> None:
+    class Sentiment(pydantic.BaseModel):
+        label: str
+
+    output = session.instruct(
+        "Classify the sentiment of 'I love this!' as the single word "
+        "positive, negative, or neutral. Respond with a label field.",
+        format=Sentiment,
+        model_options={ModelOption.MAX_NEW_TOKENS: 2**8},
+    )
+
+    parsed = output.parsed
+    assert isinstance(parsed, Sentiment)
+    assert isinstance(parsed.label, str) and parsed.label
+    assert parsed == Sentiment.model_validate_json(output.value)
+
+
+@pytest.mark.qualitative
 @pytest.mark.timeout(150)
 async def test_generate_from_raw(session) -> None:
     prompts = ["What is 1+1?", "What is 2+2?", "What is 3+3?", "What is 4+4?"]

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -371,6 +371,8 @@ def test_format_preserved_by_copy() -> None:
     result = _make_computed('{"label": "yes"}', _Label)
     shallow = _copy.copy(result)
     assert shallow._format is _Label
+    # __copy__ returns ModelOutputThunk (loses ComputedModelOutputThunk subclass due to
+    # zero-copy __class__ reassignment), so we validate manually rather than via .parsed.
     assert shallow._format.model_validate_json(shallow.value).label == "yes"  # type: ignore[union-attr]
 
 
@@ -380,4 +382,5 @@ def test_format_preserved_by_deepcopy() -> None:
     result = _make_computed('{"label": "yes"}', _Label)
     deep = _copy.deepcopy(result)
     assert deep._format is _Label
+    # Same subclass-loss caveat as test_format_preserved_by_copy.
     assert deep._format.model_validate_json(deep.value).label == "yes"  # type: ignore[union-attr]

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -3,10 +3,17 @@ import copy
 import io
 from typing import Any
 
+import pydantic
 import pytest
 from PIL import Image as PILImage
 
-from mellea.core import CBlock, Component, ImageBlock, ModelOutputThunk
+from mellea.core import (
+    CBlock,
+    Component,
+    ComputedModelOutputThunk,
+    ImageBlock,
+    ModelOutputThunk,
+)
 from mellea.stdlib.components import Message
 
 
@@ -317,3 +324,42 @@ async def test_cancel_generation_propagates_outer_cancellation() -> None:
         await asyncio.wait_for(mot._generate, timeout=1.0)  # type: ignore[attr-defined]
     except (TimeoutError, asyncio.CancelledError):
         pass
+
+
+# --- ComputedModelOutputThunk.parsed ---
+
+
+class _Label(pydantic.BaseModel):
+    label: str
+
+
+def _make_computed(
+    json_str: str, fmt: type[pydantic.BaseModel] | None
+) -> ComputedModelOutputThunk:
+    thunk = ModelOutputThunk(value=json_str)
+    thunk._format = fmt
+    return ComputedModelOutputThunk(thunk)
+
+
+def test_parsed_returns_model_instance() -> None:
+    result = _make_computed('{"label": "yes"}', _Label)
+    obj = result.parsed
+    assert isinstance(obj, _Label)
+    assert obj.label == "yes"
+
+
+def test_parsed_returns_none_when_no_format() -> None:
+    result = _make_computed('{"label": "yes"}', None)
+    assert result.parsed is None
+
+
+def test_parsed_raises_on_invalid_json() -> None:
+    result = _make_computed("not json", _Label)
+    with pytest.raises(pydantic.ValidationError):
+        _ = result.parsed
+
+
+def test_value_unaffected_by_format() -> None:
+    raw = '{"label": "ok"}'
+    result = _make_computed(raw, _Label)
+    assert result.value == raw

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -363,3 +363,21 @@ def test_value_unaffected_by_format() -> None:
     raw = '{"label": "ok"}'
     result = _make_computed(raw, _Label)
     assert result.value == raw
+
+
+def test_format_preserved_by_copy() -> None:
+    import copy as _copy
+
+    result = _make_computed('{"label": "yes"}', _Label)
+    shallow = _copy.copy(result)
+    assert shallow._format is _Label
+    assert shallow._format.model_validate_json(shallow.value).label == "yes"  # type: ignore[union-attr]
+
+
+def test_format_preserved_by_deepcopy() -> None:
+    import copy as _copy
+
+    result = _make_computed('{"label": "yes"}', _Label)
+    deep = _copy.deepcopy(result)
+    assert deep._format is _Label
+    assert deep._format.model_validate_json(deep.value).label == "yes"  # type: ignore[union-attr]

--- a/test/typing/check_functional_aact.py
+++ b/test/typing/check_functional_aact.py
@@ -2,6 +2,8 @@
 
 from typing import assert_type, cast
 
+from pydantic import BaseModel
+
 from mellea.core import (
     Backend,
     ComputedModelOutputThunk,
@@ -16,6 +18,10 @@ from mellea.stdlib.sampling import RejectionSamplingStrategy
 ctx = cast(Context, None)
 backend = cast(Backend, None)
 action: Instruction = cast(Instruction, None)
+
+
+class _M(BaseModel):
+    value: str
 
 
 async def check_computed_await() -> None:
@@ -37,3 +43,19 @@ async def check_uncomputed() -> None:
 async def check_sampling() -> None:
     r = await aact(action, ctx, backend, return_sampling_results=True)
     assert_type(r, SamplingResult[str])
+
+
+async def check_format_computed_await() -> None:
+    r = await aact(action, ctx, backend, strategy=None, await_result=True, format=_M)
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])
+
+
+async def check_format_computed_strategy() -> None:
+    strat = RejectionSamplingStrategy(loop_budget=2)
+    r = await aact(action, ctx, backend, strategy=strat, format=_M)
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])
+
+
+async def check_format_uncomputed() -> None:
+    r = await aact(action, ctx, backend, strategy=None, format=_M)
+    assert_type(r, tuple[ModelOutputThunk[_M], Context])

--- a/test/typing/check_functional_ainstruct.py
+++ b/test/typing/check_functional_ainstruct.py
@@ -2,6 +2,8 @@
 
 from typing import assert_type, cast
 
+from pydantic import BaseModel
+
 from mellea.core import (
     Backend,
     ComputedModelOutputThunk,
@@ -10,9 +12,14 @@ from mellea.core import (
     SamplingResult,
 )
 from mellea.stdlib.functional import ainstruct
+from mellea.stdlib.sampling import RejectionSamplingStrategy
 
 ctx = cast(Context, None)
 backend = cast(Backend, None)
+
+
+class _M(BaseModel):
+    value: str
 
 
 async def check_computed() -> None:
@@ -28,3 +35,21 @@ async def check_uncomputed() -> None:
 async def check_sampling() -> None:
     r = await ainstruct("test", ctx, backend, return_sampling_results=True)
     assert_type(r, SamplingResult[str])
+
+
+async def check_format_computed_await() -> None:
+    r = await ainstruct(
+        "test", ctx, backend, strategy=None, await_result=True, format=_M
+    )
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])
+
+
+async def check_format_computed_strategy() -> None:
+    strat = RejectionSamplingStrategy(loop_budget=2)
+    r = await ainstruct("test", ctx, backend, strategy=strat, format=_M)
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])
+
+
+async def check_format_uncomputed() -> None:
+    r = await ainstruct("test", ctx, backend, strategy=None, format=_M)
+    assert_type(r, tuple[ModelOutputThunk[_M], Context])

--- a/test/typing/check_functional_sync.py
+++ b/test/typing/check_functional_sync.py
@@ -2,6 +2,8 @@
 
 from typing import assert_type, cast
 
+from pydantic import BaseModel
+
 from mellea.core import Backend, ComputedModelOutputThunk, Context
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.functional import act, instruct
@@ -11,6 +13,10 @@ ctx = cast(Context, None)
 backend = cast(Backend, None)
 action: Instruction = cast(Instruction, None)
 s = cast(MelleaSession, None)
+
+
+class _M(BaseModel):
+    value: str
 
 
 def check_act_sync() -> None:
@@ -31,3 +37,13 @@ def check_session_act_sync() -> None:
 def check_session_instruct_sync() -> None:
     r = s.instruct("test")
     assert_type(r, ComputedModelOutputThunk[str])
+
+
+def check_act_format() -> None:
+    r = act(action, ctx, backend, format=_M)
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])
+
+
+def check_instruct_format() -> None:
+    r = instruct("test", ctx, backend, format=_M)
+    assert_type(r, tuple[ComputedModelOutputThunk[_M], Context])

--- a/test/typing/check_parsed.py
+++ b/test/typing/check_parsed.py
@@ -1,10 +1,14 @@
-"""Mypy checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
+"""Mypy / pyright checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
 
 `.parsed` is typed `S | None`, so a thunk parameterized with a Pydantic model
 (`ComputedModelOutputThunk[MyModel]`) exposes `.parsed` as `MyModel | None` —
 callers need no `cast()`. The `format=` overloads in `session.py` /
 `functional.py` bind `S` to the format model (companion issue #1274), at which
 point these checks hold end-to-end from the call site.
+
+The `cast(X, cast(object, None))` idiom creates a typed stub value without
+triggering basedpyright's ``reportInvalidCast`` rule (direct ``cast(X, None)``
+raises that diagnostic because ``None`` and ``X`` share no overlap).
 """
 
 from typing import assert_type, cast
@@ -19,10 +23,10 @@ class _Person(pydantic.BaseModel):
 
 
 def check_parsed_tracks_format_model() -> None:
-    thunk = cast(ComputedModelOutputThunk[_Person], None)
-    assert_type(thunk.parsed, _Person | None)
+    thunk = cast(ComputedModelOutputThunk[_Person], cast(object, None))
+    _ = assert_type(thunk.parsed, _Person | None)
 
 
 def check_parsed_is_str_for_str_thunk() -> None:
-    thunk = cast(ComputedModelOutputThunk[str], None)
-    assert_type(thunk.parsed, str | None)
+    thunk = cast(ComputedModelOutputThunk[str], cast(object, None))
+    _ = assert_type(thunk.parsed, str | None)

--- a/test/typing/check_parsed.py
+++ b/test/typing/check_parsed.py
@@ -1,0 +1,28 @@
+"""Mypy checks that `ComputedModelOutputThunk.parsed` tracks the type parameter.
+
+`.parsed` is typed `S | None`, so a thunk parameterized with a Pydantic model
+(`ComputedModelOutputThunk[MyModel]`) exposes `.parsed` as `MyModel | None` —
+callers need no `cast()`. The `format=` overloads in `session.py` /
+`functional.py` bind `S` to the format model (companion issue #1274), at which
+point these checks hold end-to-end from the call site.
+"""
+
+from typing import assert_type, cast
+
+import pydantic
+
+from mellea.core import ComputedModelOutputThunk
+
+
+class _Person(pydantic.BaseModel):
+    name: str
+
+
+def check_parsed_tracks_format_model() -> None:
+    thunk = cast(ComputedModelOutputThunk[_Person], None)
+    assert_type(thunk.parsed, _Person | None)
+
+
+def check_parsed_is_str_for_str_thunk() -> None:
+    thunk = cast(ComputedModelOutputThunk[str], None)
+    assert_type(thunk.parsed, str | None)

--- a/test/typing/check_session.py
+++ b/test/typing/check_session.py
@@ -66,6 +66,25 @@ def check_act_format() -> None:
     assert_type(r, ComputedModelOutputThunk[_M])
 
 
+def check_act_format_attributes() -> None:
+    # Locks in what the format= overloads actually narrow at the attribute level.
+    r = s.act(action, format=_M)
+
+    # `parsed_repr` is the attribute the overloads narrow: it carries the generic
+    # element type S, so with format=_M it resolves to `_M | None`.
+    assert_type(r.parsed_repr, _M | None)
+
+    # KNOWN LIMITATION: `.value` is typed `-> str` unconditionally on
+    # ComputedModelOutputThunk (see mellea/core/base.py), so it does NOT narrow to
+    # `_M` even though the thunk is parameterised `[_M]`. At runtime `.value` is the
+    # raw string and `.parsed_repr` is also a plain str (Instruction._parse returns
+    # str), so `parsed_repr.value` type-checks but AttributeErrors. Asserting
+    # `assert_type(r.value, _M)` here would (correctly) fail mypy. Both the static
+    # `.value` type and the runtime parsed_repr mismatch are pending the coordinated
+    # thunk-generics / `.parsed` redesign (PR #1282).
+    assert_type(r.value, str)
+
+
 def check_instruct_format() -> None:
     r = s.instruct("test", format=_M)
     assert_type(r, ComputedModelOutputThunk[_M])

--- a/test/typing/check_session.py
+++ b/test/typing/check_session.py
@@ -2,12 +2,18 @@
 
 from typing import Any, assert_type, cast
 
+from pydantic import BaseModel
+
 from mellea.core import ComputedModelOutputThunk, ModelOutputThunk, SamplingResult
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.session import MelleaSession
 
 s = cast(MelleaSession, None)
 action: Instruction = cast(Instruction, None)
+
+
+class _M(BaseModel):
+    value: str
 
 
 async def check_aact_computed() -> None:
@@ -53,3 +59,33 @@ async def check_aquery_uncomputed() -> None:
 def check_query_sync() -> None:
     r = s.query("obj", "q")
     assert_type(r, ComputedModelOutputThunk[Any])
+
+
+def check_act_format() -> None:
+    r = s.act(action, format=_M)
+    assert_type(r, ComputedModelOutputThunk[_M])
+
+
+def check_instruct_format() -> None:
+    r = s.instruct("test", format=_M)
+    assert_type(r, ComputedModelOutputThunk[_M])
+
+
+async def check_aact_format_computed() -> None:
+    r = await s.aact(action, strategy=None, await_result=True, format=_M)
+    assert_type(r, ComputedModelOutputThunk[_M])
+
+
+async def check_aact_format_uncomputed() -> None:
+    r = await s.aact(action, strategy=None, format=_M)
+    assert_type(r, ModelOutputThunk[_M])
+
+
+async def check_ainstruct_format_computed() -> None:
+    r = await s.ainstruct("test", strategy=None, await_result=True, format=_M)
+    assert_type(r, ComputedModelOutputThunk[_M])
+
+
+async def check_ainstruct_format_uncomputed() -> None:
+    r = await s.ainstruct("test", strategy=None, format=_M)
+    assert_type(r, ModelOutputThunk[_M])


### PR DESCRIPTION
Fixes #1273. Fixes #1274.

## The problem

Getting a typed Pydantic instance from a `format=` call required two error-prone manual steps:

```python
result = m.act(Instruction("Classify sentiment"), format=Sentiment)

# Step 1 — re-name the model (type and format= can silently drift apart):
parsed = Sentiment.model_validate_json(str(result))

# Step 2 — if result hasn't been awaited, str(result) is "" and this raises a
# confusing ValidationError with no hint that the thunk was uncomputed.
print(parsed.label)
```

The return type was `ModelOutputThunk[Any]` — no narrowing, no safety net.

## What this PR delivers

```python
result = m.act(Instruction("Classify sentiment"), format=Sentiment)
#        ^^^^ now typed ComputedModelOutputThunk[Sentiment]

label = result.parsed.label   # typed Sentiment | None — runtime-safe, no cast needed
```

Two things had to land together to make this work end-to-end:

1. **`.parsed` property** (`ComputedModelOutputThunk`) — validates `self.value` via `model_validate_json` against the format type that was used at generation time. Returns `S | None`. Only lives on `ComputedModelOutputThunk`, so it can't be called on an uncomputed thunk.

2. **`format=` overloads** in `act` / `aact` / `instruct` / `ainstruct` (both `session.py` and `functional.py`) — when `format: type[BaseModelSubclass]` is passed, the return type narrows to `ComputedModelOutputThunk[BaseModelSubclass]`. The narrowing is observable on `.parsed` (typed `S | None`) and `parsed_repr` (also `S | None`); `.value` stays `str` unconditionally.

Together: `m.act(action, format=MyModel).parsed` is typed `MyModel | None` and runtime-correct, with no cast at the call site.

## Why these two PRs were collapsed

These were originally two separate PRs (#1282 for `.parsed`, #1284 for the overloads). Neither was useful alone:

- **#1282 alone** — `.parsed` exists at runtime but is typed `str | None` at every call site because the overloads don't yet bind `S`. Callers still need a cast.
- **#1284 alone** — `m.act(format=MyModel)` narrows to `ComputedModelOutputThunk[MyModel]`, but there is no `.parsed` to use that narrowing. Callers fall back to `cast(MyModel, result.value)`, which raises `AttributeError` at runtime.

@jakelorocco flagged this during review. Both halves are here now.

## Implementation notes

All five built-in backends set `_format` on the thunk in `post_processing`. Custom backends must set `mot._format` there too; the `.parsed` docstring has an explicit `Note:` for backend authors.

Downstream wrappers that forward a dynamic `format` value keep a `# type: ignore[assignment]` with inline rationale (the clean fix is branching on `format is None`; react.py and the m_serve example both have explanatory comments).

The `parsed_repr` attribute also narrows statically to `S | None` via the overloads, but has a runtime gap for the `Instruction` path: `Instruction._parse` currently ignores `_format` and returns `str`. Use `.parsed` for structured output — it is both statically typed and runtime-safe. The root cause is tracked in #1313.

## Compatibility

- `.value` is unchanged — existing callers are unaffected.
- `.parsed` is new; nothing today relies on it.
- The overloads are type-only — no runtime behaviour changes.

## Testing

- Unit tests: happy path, `None` fallback, invalid JSON, value unchanged, copy/deepcopy `_format` preservation
- E2E qualitative tests: `test_parsed_returns_pydantic_instance` for HuggingFace and Ollama backends
- Static `assert_type` checks in `test/typing/` covering all four methods, the computed/uncomputed branches, and attribute-level narrowing of `parsed_repr` and `.parsed`

### Test plan

- [ ] `uv run pytest test/core/test_base.py -k parsed`
- [ ] `uv run pytest test/core/ test/typing/ -m "not qualitative"`
- [ ] `uv run pytest test/backends/test_ollama.py -k parsed -m qualitative` (requires Ollama)
- [ ] `uv run pytest test/backends/test_huggingface.py -k parsed -m qualitative` (requires GPU)

<!-- pr-template-v1 -->