### PR TITLE
fix(sampling): migrate budget forcing to mot.generation.usage; drop _meta["usage"] writes

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1484,16 +1484,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 "completion_tokens": n_completion_tokens,
                 "total_tokens": n_prompt_tokens + n_completion_tokens,
             }
-            result = ModelOutputThunk(
-                value=decoded_result,
-                meta={
-                    "usage": {
-                        "prompt_tokens": n_prompt_tokens,
-                        "completion_tokens": n_completion_tokens,
-                        "total_tokens": n_prompt_tokens + n_completion_tokens,
-                    }
-                },
-            )
+            result = ModelOutputThunk(value=decoded_result)
             result.generation.usage = per_mot_usage
             result.generation.model = self._model_id
             result.generation.provider = self._provider

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -723,10 +723,7 @@ class LiteLLMBackend(FormatterBackend):
             output._context = None  # There is no context for generate_from_raw for now
             output._action = action
             output._model_options = model_opts
-            output._meta = {
-                "litellm_chat_response": res.model_dump(),
-                "usage": usage_dump,
-            }
+            output._meta = {"litellm_chat_response": res.model_dump()}
             output.generation.model = self._model_id
             output.generation.provider = self._provider
 

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -566,26 +566,16 @@ class OllamaModelBackend(FormatterBackend):
                 n_in = response.prompt_eval_count
                 n_out = response.eval_count
                 if n_in is not None and n_out is not None:
-                    total = n_in + n_out
                     agg_prompt += n_in
                     agg_completion += n_out
                     per_mot_usage = {
                         "prompt_tokens": n_in,
                         "completion_tokens": n_out,
-                        "total_tokens": total,
+                        "total_tokens": n_in + n_out,
                     }
-                else:
-                    total = None
                 result = ModelOutputThunk(
                     value=response.response,
-                    meta={
-                        "generate_response": response.model_dump(),
-                        "usage": {
-                            "completion_tokens": n_out,
-                            "prompt_tokens": n_in,
-                            "total_tokens": total,
-                        },
-                    },
+                    meta={"generate_response": response.model_dump()},
                 )
             result.generation.usage = per_mot_usage
             result.generation.model = self._model_id

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1240,10 +1240,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             output._context = None  # There is no context for generate_from_raw for now
             output._action = action
             output._model_options = model_opts
-            output._meta = {
-                "oai_completion_response": response.model_dump(),
-                "usage": usage_dump,
-            }
+            output._meta = {"oai_completion_response": response.model_dump()}
             output.generation.model = self._model_id
             output.generation.provider = self._provider
 

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -683,14 +683,7 @@ class WatsonxAIBackend(FormatterBackend):
                 per_mot_usage = None
             result = ModelOutputThunk(
                 value=output["generated_text"],
-                meta={
-                    "oai_completion_response": response["results"][0],
-                    "usage": {
-                        "prompt_tokens": n_in or 0,
-                        "completion_tokens": n_out or 0,
-                        "total_tokens": (n_in or 0) + (n_out or 0),
-                    },
-                },
+                meta={"oai_completion_response": response["results"][0]},
             )
             result.generation.usage = per_mot_usage
             result.generation.model = self._model_id

--- a/mellea/stdlib/sampling/sampling_algos/budget_forcing_alg.py
+++ b/mellea/stdlib/sampling/sampling_algos/budget_forcing_alg.py
@@ -8,8 +8,6 @@ answer pass (bounded by `answer_max_tokens`), using the raw completions API of a
 `OllamaModelBackend`.
 """
 
-from typing import Any
-
 from ....backends import ModelOption
 from ....backends.ollama import OllamaModelBackend
 from ....core import (
@@ -69,8 +67,8 @@ async def think_budget_forcing(
         ModelOutputThunk: The assembled thinking and answer response.
 
     Raises:
-        Exception: If the backend returns generation results without the
-            required `meta` information (e.g. token usage counts).
+        RuntimeError: If a sub-call's `generation.usage` is `None` (no token
+            counts available to accumulate against the budget).
 
     Assumptions:
         -  The chat template is applied on prompt, with think mode enabled
@@ -97,7 +95,7 @@ async def think_budget_forcing(
     gen_tok_count = 0
     curr_prompt = prompt
     _generate_logs: list[GenerateLog | None] = []
-    _meta_logs: list[dict[str, Any]] = []
+    _prompt_tokens: int | None = None  # captured from the first sub-call
     min_char_len = 10
 
     # think block indefinite multi-step operation to satisfy user's budget
@@ -114,11 +112,15 @@ async def think_budget_forcing(
             format=format,
         )
         _generate_logs.append(result[0]._generate_log)
-        if result[0]._meta is None:
-            raise Exception("Requires meta information in generation results.")
-
-        _meta_logs.append(result[0]._meta)
-        gen_tok_count += result[0]._meta["usage"]["completion_tokens"]
+        usage = result[0].generation.usage
+        if usage is None:
+            raise RuntimeError(
+                "think_budget_forcing requires per-call token counts; "
+                "backend returned `mot.generation.usage = None`."
+            )
+        if _prompt_tokens is None:
+            _prompt_tokens = usage["prompt_tokens"]
+        gen_tok_count += usage["completion_tokens"]
         rem_toks = think_max_tokens - gen_tok_count
         response = result[0].value if result[0].value else ""
 
@@ -147,15 +149,18 @@ async def think_budget_forcing(
     response = "".join(responses)
 
     if answer_suffix is None:
+        if _prompt_tokens is None:
+            raise RuntimeError(
+                "think_budget_forcing produced no generations; "
+                "check `think_max_tokens` and `answer_suffix`."
+            )
         # create response ModelOutputThunk object
-        _meta = _meta_logs[-1]  # Initialize using the last meta object
-        _meta["usage"]["completion_tokens"] = gen_tok_count
-        # the first prompt is the true prompt
-        _meta["usage"]["prompt_tokens"] = _meta_logs[0]["usage"]["prompt_tokens"]
-        _meta["usage"]["total_tokens"] = (
-            _meta["usage"]["prompt_tokens"] + _meta["usage"]["completion_tokens"]
-        )
-        _res = ModelOutputThunk(value=response, meta=_meta)
+        _res = ModelOutputThunk(value=response)
+        _res.generation.usage = {
+            "prompt_tokens": _prompt_tokens,
+            "completion_tokens": gen_tok_count,
+            "total_tokens": _prompt_tokens + gen_tok_count,
+        }
         # we will simply take the last log output as a representative log, alternatively we can merge the logs but that function is not available yet
         _res._generate_log = _generate_logs[-1]
         return _res
@@ -188,17 +193,23 @@ async def think_budget_forcing(
     )
     _generate_logs.append(result[0]._generate_log)
     response += result[0].value if result[0].value else ""
-    _meta_logs.append(result[0]._meta)
-    gen_tok_count += result[0]._meta["usage"]["completion_tokens"]
+    usage = result[0].generation.usage
+    if usage is None:
+        raise RuntimeError(
+            "think_budget_forcing requires per-call token counts; "
+            "backend returned `mot.generation.usage = None`."
+        )
+    if _prompt_tokens is None:
+        # zero-think case: capture prompt count from this answer pass.
+        _prompt_tokens = usage["prompt_tokens"]
+    gen_tok_count += usage["completion_tokens"]
     # create response ModelOutputThunk object
-    _meta = _meta_logs[-1]  # Initialize using the last meta object
-    _meta["usage"]["completion_tokens"] = gen_tok_count
-    # the first prompt is the true prompt
-    _meta["usage"]["prompt_tokens"] = _meta_logs[0]["usage"]["prompt_tokens"]
-    _meta["usage"]["total_tokens"] = (
-        _meta["usage"]["prompt_tokens"] + _meta["usage"]["completion_tokens"]
-    )
-    _res = ModelOutputThunk(value=response, meta=_meta)
+    _res = ModelOutputThunk(value=response)
+    _res.generation.usage = {
+        "prompt_tokens": _prompt_tokens,
+        "completion_tokens": gen_tok_count,
+        "total_tokens": _prompt_tokens + gen_tok_count,
+    }
     # we will simply take the last log output as a representative log, alternatively we can merge the logs but that function is not available yet
     _res._generate_log = _generate_logs[-1]
     return _res


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1218

## Description
- Migrates `think_budget_forcing` to read `mot.generation.usage` exclusively. Raises a named `RuntimeError` when usage is `None`, replacing the previous opaque `TypeError` from arithmetic on `None` (Ollama's `eval_count` can be `None`).
- Drops `_meta["usage"]` writes from all five backends' `generate_from_raw` paths now that `mot.generation.usage` is the unified field. The additive half (writing the field from raw paths) landed with #1264.
- Replaces an implicit `IndexError` in the no-sub-calls edge case (`think_max_tokens=0` + `answer_suffix=None`) with a named `RuntimeError`.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
