### PR TITLE
refactor(telemetry): migrate application spans to plugin hooks

### DIFF
--- a/docs/docs/examples/traced-generation-loop.md
+++ b/docs/docs/examples/traced-generation-loop.md
@@ -308,7 +308,7 @@ applicable:
 | Attribute | Description |
 | --------- | ----------- |
 | `mellea.model_id` | Model identifier used for the call |
-| `mellea.backend` | Backend class name (e.g. `OllamaModelBackend`) |
+| `mellea.backend` | Backend identifier (e.g. `"ollama"`) |
 | `mellea.action_type` | Component type (e.g. `generative`, `instruct`) |
 | `mellea.context_size` | Number of context items passed |
 | `mellea.has_requirements` | Whether requirements were specified |

--- a/docs/docs/observability/telemetry.md
+++ b/docs/docs/observability/telemetry.md
@@ -98,11 +98,11 @@ Mellea has two trace scopes:
 Enable tracing for full observability. Backend spans nest inside application spans:
 
 ```text
-session_context          (mellea.application)
-├── aact                 (mellea.application)
+session                  (mellea.application)
+├── action               (mellea.application)
 │   ├── chat             (mellea.backend) [gen_ai.provider.name=ollama]
 │   └── requirement_validation  (mellea.application)
-└── aact                 (mellea.application)
+└── action               (mellea.application)
     └── chat             (mellea.backend) [gen_ai.provider.name=openai]
 ```
 

--- a/docs/docs/observability/tracing.md
+++ b/docs/docs/observability/tracing.md
@@ -106,15 +106,36 @@ Mellea has two trace scopes.
 Application spans cover user-facing Mellea operations. They appear whenever you
 call `m.act()`, `m.instruct()`, `m.chat()`, or a `@generative` function.
 
+The `session` span:
+
 | Attribute | Description |
 | --------- | ----------- |
-| `mellea.backend` | Backend class name (e.g., `OllamaModelBackend`) |
+| `mellea.session_id` | UUID identifying this session |
+| `mellea.context_type` | Context class name (e.g., `SimpleContext`) |
+| `mellea.backend` | Backend identifier (e.g., `"ollama"`); set when known |
+
+The `start_session` span:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `mellea.backend` | Backend identifier (e.g., `"ollama"`) |
+| `mellea.model_id` | Resolved model id string |
+| `mellea.context_type` | Context class name |
+
+The `action` span:
+
+| Attribute | Description |
+| --------- | ----------- |
 | `mellea.action_type` | Component class being executed (e.g., `Instruction`) |
-| `mellea.context_size` | Length of the context at call time |
+| `mellea.has_requirements` | Whether requirements were supplied |
+| `mellea.has_strategy` | Whether a sampling strategy was supplied |
+| `mellea.strategy_type` | Sampling strategy class name when present |
 | `mellea.has_format` | Whether a format constraint was specified |
-| `mellea.sampling_success` | Whether the sampling strategy succeeded |
+| `mellea.tool_calls` | Whether tool calling is enabled |
 | `mellea.num_generate_logs` | Number of generation attempts (>1 means retries occurred) |
-| `mellea.response` | Model response truncated to 500 characters |
+| `mellea.sampling_success` | Whether the sampling strategy succeeded |
+| `mellea.response` | Model response truncated to 500 characters; recorded only when `MELLEA_TRACES_CONTENT=true` |
+| `mellea.response_length` | Length of the model response (always recorded) |
 
 ### Backend spans (`mellea.backend`)
 
@@ -137,7 +158,6 @@ Mellea also adds context-specific attributes to backend spans:
 
 | Attribute | Description |
 | --------- | ----------- |
-| `mellea.backend` | Backend class name (e.g., `OpenAIBackend`) |
 | `mellea.action_type` | Component type being executed |
 | `mellea.context_size` | Number of items in context |
 | `mellea.has_format` | Whether structured output format is specified |
@@ -150,17 +170,20 @@ Mellea also adds context-specific attributes to backend spans:
 Backend spans nest inside application spans:
 
 ```text
-session_context           (mellea.application)
-├── aact                  (mellea.application)
+start_session             (mellea.application)
+                          [mellea.backend=ollama]
+                          [mellea.model_id=granite4.1:3b]
+
+session                   (mellea.application)
+├── action                (mellea.application)
 │   │                     [mellea.action_type=Instruction]
-│   │                     [mellea.backend=OllamaModelBackend]
 │   ├── chat              (mellea.backend)
 │   │                     [gen_ai.provider.name=ollama]
 │   │                     [gen_ai.request.model=granite4.1:3b]
 │   │                     [gen_ai.usage.input_tokens=150]
 │   │                     [gen_ai.usage.output_tokens=42]
 │   └── requirement_validation  (mellea.application)
-└── aact                  (mellea.application)
+└── action                (mellea.application)
     └── chat              (mellea.backend)
                           [gen_ai.provider.name=openai]
                           [gen_ai.request.model=gpt-4o]
@@ -170,12 +193,12 @@ session_context           (mellea.application)
 
 When you open a trace in your backend, look for these patterns:
 
-**High input token counts on early spans.** A single `aact` span with
+**High input token counts on early spans.** A single `action` span with
 `gen_ai.usage.input_tokens` much larger than expected usually means the context
 has accumulated many previous messages. Use
 [prefix caching](../advanced/prefix-caching-and-kv-blocks) to reduce cost.
 
-**Repeated `requirement_validation` spans beneath one `aact`.** The value of
+**Repeated `requirement_validation` spans beneath one `action`.** The value of
 `mellea.num_generate_logs` in the parent span tells you how many retries occurred.
 If the model keeps retrying, read the `mellea.response` attribute on each attempt to
 understand why validation is failing.

--- a/mellea/helpers/event_loop_helper.py
+++ b/mellea/helpers/event_loop_helper.py
@@ -1,6 +1,7 @@
 """Helper for event loop management. Allows consistently running async generate requests in sync code."""
 
 import asyncio
+import contextvars
 import os
 import threading
 from collections.abc import Coroutine
@@ -69,12 +70,25 @@ class _EventLoopHandler:
             self._event_loop.stop()
 
     def __call__(self, co: Coroutine[Any, Any, R]) -> R:
-        """Runs the coroutine in the event loop."""
+        """Run the coroutine in the event loop, propagating the calling thread's contextvars.
+
+        The caller's `contextvars` snapshot is applied inside the new Task so
+        contextvar-backed state is visible to the coroutine. One-way:
+        mutations inside the Task don't leak back.
+        """
         self._reinit_if_forked()
         if self._event_loop == get_current_event_loop():
             # If this gets called from the same event loop, launch in a separate thread to prevent blocking.
             return _EventLoopHandler()(co)
-        return asyncio.run_coroutine_threadsafe(co, self._event_loop).result()
+
+        parent_ctx = contextvars.copy_context()
+
+        async def _wrapped() -> R:
+            for var, value in parent_ctx.items():
+                var.set(value)
+            return await co
+
+        return asyncio.run_coroutine_threadsafe(_wrapped(), self._event_loop).result()
 
 
 # Instantiate this class once. It will not be re-instantiated.

--- a/mellea/plugins/hooks/component.py
+++ b/mellea/plugins/hooks/component.py
@@ -11,6 +11,7 @@ class ComponentPreExecutePayload(MelleaBasePayload):
     """Payload for `component_pre_execute` — before component execution via `aact()`.
 
     Attributes:
+        component_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the component being executed.
         action: The `Component` or `CBlock` about to be executed.
         context_view: Optional snapshot of the context as a list.
@@ -21,6 +22,7 @@ class ComponentPreExecutePayload(MelleaBasePayload):
         tool_calls_enabled: Whether tool calling is enabled for this execution (writable).
     """
 
+    component_id: str = ""
     component_type: str = ""
     action: Any = None
     context_view: list[Any] | None = None
@@ -35,6 +37,7 @@ class ComponentPostSuccessPayload(MelleaBasePayload):
     """Payload for `component_post_success` — after successful component execution.
 
     Attributes:
+        component_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the executed component.
         action: The `Component` or `CBlock` that was executed.
 
@@ -45,9 +48,11 @@ class ComponentPostSuccessPayload(MelleaBasePayload):
 
         generate_log: The `GenerateLog` from the final generation pass.
         sampling_results: Optional list of `ModelOutputThunk` from all sampling attempts.
+        sampling_success: Whether the sampling strategy produced a passing result; `None` when no sampling strategy ran.
         latency_ms: Wall-clock time for the full execution in milliseconds.
     """
 
+    component_id: str = ""
     component_type: str = ""
     action: Any = None
     result: Any = None
@@ -55,6 +60,7 @@ class ComponentPostSuccessPayload(MelleaBasePayload):
     context_after: Any = None
     generate_log: Any = None
     sampling_results: list[Any] | None = None
+    sampling_success: bool | None = None
     latency_ms: int = 0
 
 
@@ -62,6 +68,7 @@ class ComponentPostErrorPayload(MelleaBasePayload):
     """Payload for `component_post_error` — after component execution fails.
 
     Attributes:
+        component_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the component that failed.
         action: The `Component` or `CBlock` that was being executed.
 
@@ -73,6 +80,7 @@ class ComponentPostErrorPayload(MelleaBasePayload):
         model_options: Dict of model options that were in effect.
     """
 
+    component_id: str = ""
     component_type: str = ""
     action: Any = None
     error: Any = None

--- a/mellea/plugins/hooks/component.py
+++ b/mellea/plugins/hooks/component.py
@@ -11,7 +11,7 @@ class ComponentPreExecutePayload(MelleaBasePayload):
     """Payload for `component_pre_execute` — before component execution via `aact()`.
 
     Attributes:
-        component_id: UUID correlating pre/post hooks for a single component execution.
+        action_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the component being executed.
         action: The `Component` or `CBlock` about to be executed.
         context_view: Optional snapshot of the context as a list.
@@ -22,7 +22,7 @@ class ComponentPreExecutePayload(MelleaBasePayload):
         tool_calls_enabled: Whether tool calling is enabled for this execution (writable).
     """
 
-    component_id: str = ""
+    action_id: str = ""
     component_type: str = ""
     action: Any = None
     context_view: list[Any] | None = None
@@ -37,7 +37,7 @@ class ComponentPostSuccessPayload(MelleaBasePayload):
     """Payload for `component_post_success` — after successful component execution.
 
     Attributes:
-        component_id: UUID correlating pre/post hooks for a single component execution.
+        action_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the executed component.
         action: The `Component` or `CBlock` that was executed.
 
@@ -52,7 +52,7 @@ class ComponentPostSuccessPayload(MelleaBasePayload):
         latency_ms: Wall-clock time for the full execution in milliseconds.
     """
 
-    component_id: str = ""
+    action_id: str = ""
     component_type: str = ""
     action: Any = None
     result: Any = None
@@ -68,7 +68,7 @@ class ComponentPostErrorPayload(MelleaBasePayload):
     """Payload for `component_post_error` — after component execution fails.
 
     Attributes:
-        component_id: UUID correlating pre/post hooks for a single component execution.
+        action_id: UUID correlating pre/post hooks for a single component execution.
         component_type: Class name of the component that failed.
         action: The `Component` or `CBlock` that was being executed.
 
@@ -80,7 +80,7 @@ class ComponentPostErrorPayload(MelleaBasePayload):
         model_options: Dict of model options that were in effect.
     """
 
-    component_id: str = ""
+    action_id: str = ""
     component_type: str = ""
     action: Any = None
     error: Any = None

--- a/mellea/plugins/hooks/session.py
+++ b/mellea/plugins/hooks/session.py
@@ -14,6 +14,7 @@ class SessionPreInitPayload(MelleaBasePayload):
     """Payload for `session_pre_init` — before backend initialization.
 
     Attributes:
+        session_id: UUID string identifying this session.
         backend_name: Name of the backend (e.g. `"ollama"`, `"openai"`).
         model_id: Model identifier string (writable).
         model_options: Optional dict of model options like temperature, max_tokens (writable).
@@ -58,7 +59,11 @@ class SessionCleanupPayload(MelleaBasePayload):
         context: The `Context` at the time of cleanup (observe-only).
 
         interaction_count: Number of items in the context at cleanup time.
+
+        exception: The exception that triggered cleanup, or `None` for normal
+            teardown. Set when `MelleaSession.__exit__` propagates an error.
     """
 
     context: Any = None
     interaction_count: int = 0
+    exception: BaseException | None = None

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -32,7 +32,6 @@ from ..helpers import _run_async_in_thread
 from ..plugins.hooks.tool import ToolPostInvokePayload, ToolPreInvokePayload
 from ..plugins.manager import has_plugins, invoke_hook, is_internal_tool
 from ..plugins.types import HookType
-from ..telemetry import set_span_attribute, trace_application
 from .components import (
     Document,
     Instruction,
@@ -576,190 +575,158 @@ async def aact(
     """
     import time
     import traceback
+    import uuid
 
-    with trace_application(
-        "aact",
-        **{
-            "mellea.action_type": action.__class__.__name__,
-            "mellea.has_requirements": requirements is not None
-            and len(requirements) > 0,
-            "mellea.has_strategy": strategy is not None,
-            "mellea.strategy_type": strategy.__class__.__name__ if strategy else None,
-            "mellea.has_format": format is not None,
-            "mellea.tool_calls": tool_calls,
-        },
-    ) as span:
-        if not silence_context_type_warning and not isinstance(context, SimpleContext):
-            MelleaLogger.get_logger().warning(
-                "Not using a SimpleContext with asynchronous requests could cause unexpected results due to stale contexts. Ensure you await between requests."
-                "\nSee the async section of the docs: https://docs.mellea.ai/how-to/use-async-and-streaming"
+    component_id = str(uuid.uuid4())
+
+    if not silence_context_type_warning and not isinstance(context, SimpleContext):
+        MelleaLogger.get_logger().warning(
+            "Not using a SimpleContext with asynchronous requests could cause unexpected results due to stale contexts. Ensure you await between requests."
+            "\nSee the async section of the docs: https://docs.mellea.ai/how-to/use-async-and-streaming"
+        )
+
+    _component_type_name = type(action).__name__
+
+    # --- component_pre_execute hook ---
+    if has_plugins(HookType.COMPONENT_PRE_EXECUTE):
+        from ..plugins.hooks.component import ComponentPreExecutePayload
+
+        pre_exec_payload = ComponentPreExecutePayload(
+            component_id=component_id,
+            component_type=_component_type_name,
+            action=action,
+            context_view=context.view_for_generation(),
+            requirements=requirements or [],
+            model_options=model_options or {},
+            format=format,
+            strategy=strategy,
+            tool_calls_enabled=tool_calls,
+        )
+        _, pre_exec_payload = await invoke_hook(
+            HookType.COMPONENT_PRE_EXECUTE, pre_exec_payload, backend=backend
+        )
+        strategy = pre_exec_payload.strategy or strategy
+        requirements = pre_exec_payload.requirements or requirements
+        model_options = pre_exec_payload.model_options or model_options
+        format = pre_exec_payload.format
+        tool_calls = pre_exec_payload.tool_calls_enabled
+
+    t0 = time.monotonic()
+
+    try:
+        sampling_result: SamplingResult | None = None
+        generate_logs: list[GenerateLog] = []
+
+        if return_sampling_results:
+            assert strategy is not None, (
+                "Must provide a SamplingStrategy when return_sampling_results==True"
             )
 
-        _component_type_name = type(action).__name__
+        if strategy is None:
+            # Only use the strategy if one is provided. Add a warning if requirements were passed in though.
+            if requirements is not None and len(requirements) > 0:
+                MelleaLogger.get_logger().warning(
+                    "Calling the function with NO strategy BUT requirements. No requirement is being checked!"
+                )
 
-        # --- component_pre_execute hook ---
-        if has_plugins(HookType.COMPONENT_PRE_EXECUTE):
-            from ..plugins.hooks.component import ComponentPreExecutePayload
+            result, new_ctx = await backend.generate_from_context(
+                action,
+                ctx=context,
+                format=format,
+                model_options=model_options,
+                tool_calls=tool_calls,
+            )
+            # Only await and wrap if await_result is True
+            if await_result:
+                await result.avalue()
 
-            pre_exec_payload = ComponentPreExecutePayload(
+                # ._generate_log should never be None after generation.
+                assert result._generate_log is not None
+                result._generate_log.is_final_result = True
+                generate_logs.append(result._generate_log)
+
+                # Wrap in ComputedModelOutputThunk to indicate it's fully computed
+                computed_result = ComputedModelOutputThunk(result)
+                result = computed_result  # type: ignore
+
+        else:
+            # Always sample if a strategy is provided, even if no requirements were provided.
+            # Some sampling strategies don't use requirements or set them when instantiated.
+
+            sampling_result = await strategy.sample(
+                action,
+                context=context,
+                backend=backend,
+                requirements=requirements,
+                validation_ctx=None,
+                format=format,
+                model_options=model_options,
+                tool_calls=tool_calls,
+            )
+
+            assert sampling_result.sample_generations is not None
+            for gen_result in sampling_result.sample_generations:
+                assert (
+                    gen_result._generate_log is not None
+                )  # Cannot be None after generation.
+                generate_logs.append(gen_result._generate_log)
+
+            new_ctx = sampling_result.result_ctx
+            result = sampling_result.result
+            assert sampling_result.result._generate_log is not None
+            assert sampling_result.result._generate_log.is_final_result, (
+                "generate logs from the final result returned by the sampling strategy must be marked as final"
+            )
+
+        # --- component_post_success hook ---
+        if has_plugins(HookType.COMPONENT_POST_SUCCESS):
+            from ..plugins.hooks.component import ComponentPostSuccessPayload
+
+            success_payload = ComponentPostSuccessPayload(
+                component_id=component_id,
                 component_type=_component_type_name,
                 action=action,
-                context_view=context.view_for_generation(),
-                requirements=requirements or [],
+                result=result,
+                context_before=context,
+                context_after=new_ctx,
+                generate_log=generate_logs[-1] if generate_logs else None,
+                sampling_results=sampling_result.sample_generations
+                if sampling_result
+                else None,
+                sampling_success=sampling_result.success if sampling_result else None,
+                latency_ms=int((time.monotonic() - t0) * 1000),
+            )
+            await invoke_hook(
+                HookType.COMPONENT_POST_SUCCESS, success_payload, backend=backend
+            )
+
+        if return_sampling_results:
+            assert (
+                sampling_result is not None
+            )  # Needed for the type checker but should never happen.
+            return sampling_result
+        else:
+            return result, new_ctx
+
+    except Exception as exc:
+        # --- component_post_error hook ---
+        if has_plugins(HookType.COMPONENT_POST_ERROR):
+            from ..plugins.hooks.component import ComponentPostErrorPayload
+
+            error_payload = ComponentPostErrorPayload(
+                component_id=component_id,
+                component_type=_component_type_name,
+                action=action,
+                error=exc,
+                error_type=type(exc).__name__,
+                stack_trace=traceback.format_exc(),
+                context=context,
                 model_options=model_options or {},
-                format=format,
-                strategy=strategy,
-                tool_calls_enabled=tool_calls,
             )
-            _, pre_exec_payload = await invoke_hook(
-                HookType.COMPONENT_PRE_EXECUTE, pre_exec_payload, backend=backend
+            await invoke_hook(
+                HookType.COMPONENT_POST_ERROR, error_payload, backend=backend
             )
-            strategy = pre_exec_payload.strategy or strategy
-            requirements = pre_exec_payload.requirements or requirements
-            model_options = pre_exec_payload.model_options or model_options
-            format = pre_exec_payload.format
-            tool_calls = pre_exec_payload.tool_calls_enabled
-
-        t0 = time.monotonic()
-
-        try:
-            sampling_result: SamplingResult | None = None
-            generate_logs: list[GenerateLog] = []
-
-            if return_sampling_results:
-                assert strategy is not None, (
-                    "Must provide a SamplingStrategy when return_sampling_results==True"
-                )
-
-            if strategy is None:
-                # Only use the strategy if one is provided. Add a warning if requirements were passed in though.
-                if requirements is not None and len(requirements) > 0:
-                    MelleaLogger.get_logger().warning(
-                        "Calling the function with NO strategy BUT requirements. No requirement is being checked!"
-                    )
-
-                result, new_ctx = await backend.generate_from_context(
-                    action,
-                    ctx=context,
-                    format=format,
-                    model_options=model_options,
-                    tool_calls=tool_calls,
-                )
-                # Only await and wrap if await_result is True
-                if await_result:
-                    await result.avalue()
-
-                    # ._generate_log should never be None after generation.
-                    assert result._generate_log is not None
-                    result._generate_log.is_final_result = True
-                    generate_logs.append(result._generate_log)
-
-                    # Wrap in ComputedModelOutputThunk to indicate it's fully computed
-                    computed_result = ComputedModelOutputThunk(result)
-                    result = computed_result  # type: ignore
-
-            else:
-                # Always sample if a strategy is provided, even if no requirements were provided.
-                # Some sampling strategies don't use requirements or set them when instantiated.
-
-                sampling_result = await strategy.sample(
-                    action,
-                    context=context,
-                    backend=backend,
-                    requirements=requirements,
-                    validation_ctx=None,
-                    format=format,
-                    model_options=model_options,
-                    tool_calls=tool_calls,
-                )
-
-                assert sampling_result.sample_generations is not None
-                for gen_result in sampling_result.sample_generations:
-                    assert (
-                        gen_result._generate_log is not None
-                    )  # Cannot be None after generation.
-                    generate_logs.append(gen_result._generate_log)
-
-                new_ctx = sampling_result.result_ctx
-                result = sampling_result.result
-                assert sampling_result.result._generate_log is not None
-                assert sampling_result.result._generate_log.is_final_result, (
-                    "generate logs from the final result returned by the sampling strategy must be marked as final"
-                )
-
-            # Add span attributes for the result
-            set_span_attribute(span, "mellea.num_generate_logs", len(generate_logs))
-            if sampling_result:
-                set_span_attribute(
-                    span, "mellea.sampling_success", bool(sampling_result.result)
-                )
-
-            # Log the model response (truncated for large responses)
-            try:
-                response_value = (
-                    str(result.value)
-                    if hasattr(result, "value") and result.value
-                    else str(result)
-                )
-                # Truncate to 500 chars to avoid overwhelming trace storage
-                if len(response_value) > 500:
-                    response_value = response_value[:500] + "..."
-                set_span_attribute(span, "mellea.response", response_value)
-                set_span_attribute(
-                    span,
-                    "mellea.response_length",
-                    len(str(result.value) if hasattr(result, "value") else str(result)),
-                )
-            except Exception:
-                # If we can't get the response, don't fail the trace
-                pass
-
-            # --- component_post_success hook ---
-            if has_plugins(HookType.COMPONENT_POST_SUCCESS):
-                from ..plugins.hooks.component import ComponentPostSuccessPayload
-
-                success_payload = ComponentPostSuccessPayload(
-                    component_type=_component_type_name,
-                    action=action,
-                    result=result,
-                    context_before=context,
-                    context_after=new_ctx,
-                    generate_log=generate_logs[-1] if generate_logs else None,
-                    sampling_results=sampling_result.sample_generations
-                    if sampling_result
-                    else None,
-                    latency_ms=int((time.monotonic() - t0) * 1000),
-                )
-                await invoke_hook(
-                    HookType.COMPONENT_POST_SUCCESS, success_payload, backend=backend
-                )
-
-            if return_sampling_results:
-                assert (
-                    sampling_result is not None
-                )  # Needed for the type checker but should never happen.
-                return sampling_result
-            else:
-                return result, new_ctx
-
-        except Exception as exc:
-            # --- component_post_error hook ---
-            if has_plugins(HookType.COMPONENT_POST_ERROR):
-                from ..plugins.hooks.component import ComponentPostErrorPayload
-
-                error_payload = ComponentPostErrorPayload(
-                    component_type=_component_type_name,
-                    action=action,
-                    error=exc,
-                    error_type=type(exc).__name__,
-                    stack_trace=traceback.format_exc(),
-                    context=context,
-                    model_options=model_options or {},
-                )
-                await invoke_hook(
-                    HookType.COMPONENT_POST_ERROR, error_payload, backend=backend
-                )
-            raise
+        raise
 
 
 @overload

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -577,7 +577,7 @@ async def aact(
     import traceback
     import uuid
 
-    component_id = str(uuid.uuid4())
+    action_id = str(uuid.uuid4())
 
     if not silence_context_type_warning and not isinstance(context, SimpleContext):
         MelleaLogger.get_logger().warning(
@@ -592,7 +592,7 @@ async def aact(
         from ..plugins.hooks.component import ComponentPreExecutePayload
 
         pre_exec_payload = ComponentPreExecutePayload(
-            component_id=component_id,
+            action_id=action_id,
             component_type=_component_type_name,
             action=action,
             context_view=context.view_for_generation(),
@@ -683,7 +683,7 @@ async def aact(
             from ..plugins.hooks.component import ComponentPostSuccessPayload
 
             success_payload = ComponentPostSuccessPayload(
-                component_id=component_id,
+                action_id=action_id,
                 component_type=_component_type_name,
                 action=action,
                 result=result,
@@ -714,7 +714,7 @@ async def aact(
             from ..plugins.hooks.component import ComponentPostErrorPayload
 
             error_payload = ComponentPostErrorPayload(
-                component_id=component_id,
+                action_id=action_id,
                 component_type=_component_type_name,
                 action=action,
                 error=exc,

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -46,8 +46,13 @@ from ..helpers import _run_async_in_thread
 from ..plugins.manager import has_plugins, invoke_hook
 from ..plugins.types import HookType
 from ..stdlib import functional as mfuncs
-from ..telemetry import set_span_attribute, trace_application
 from ..telemetry.context import with_context
+from ..telemetry.tracing import (
+    finish_session_span,
+    finish_session_startup_span,
+    start_session_span,
+    start_session_startup_span,
+)
 from .components import Document, Message
 from .context import ChatContext, SimpleContext
 from .sampling import RejectionSamplingStrategy
@@ -151,6 +156,8 @@ def start_session(
         session.cleanup()
         ```
     """
+    import uuid
+
     logger = MelleaLogger.get_logger()
 
     # Validate args.
@@ -163,19 +170,24 @@ def start_session(
             "`ollama`, `hf`, `openai`, `watsonx`, `litellm`."
         )
 
-    with trace_application(
-        "start_session",
-        **{
-            "mellea.backend": backend_name,
-            "mellea.model_id": model_id_str,
-            "mellea.context_type": resolved_ctx.__class__.__name__,
-        },
-    ):
+    # Pre-generate so the startup span and session_pre_init payload share an id.
+    session_id = str(uuid.uuid4())
+
+    # Called directly, not via hook: OTel Token attach/detach is task-affine,
+    # and each hook firing runs in a separate _run_async_in_thread Task.
+    start_session_startup_span(
+        session_id,
+        backend=backend_name,
+        model_id=model_id_str,
+        context_type=resolved_ctx.__class__.__name__,
+    )
+    try:
         # --- session_pre_init hook ---
         if has_plugins(HookType.SESSION_PRE_INIT):
             from ..plugins.hooks.session import SessionPreInitPayload
 
             pre_payload = SessionPreInitPayload(
+                session_id=session_id,
                 backend_name=backend_name,
                 model_id=model_id_str,
                 model_options=model_options,
@@ -212,7 +224,7 @@ def start_session(
             + (f", model_options={model_options}" if model_options else "")
         )
 
-        session = MelleaSession(backend, resolved_ctx)
+        session = MelleaSession(backend, resolved_ctx, session_id=session_id)
 
         # Register session-scoped plugins
         if plugins:
@@ -230,8 +242,13 @@ def start_session(
             _run_async_in_thread(
                 invoke_hook(HookType.SESSION_POST_INIT, post_payload, backend=backend)
             )
+    except BaseException as exc:
+        finish_session_startup_span(session_id, exception=exc)
+        raise
+    else:
+        finish_session_startup_span(session_id)
 
-        return session
+    return session
 
 
 class MelleaSession:
@@ -262,29 +279,33 @@ class MelleaSession:
 
     ctx: Context
 
-    def __init__(self, backend: Backend, ctx: Context | None = None):
+    def __init__(
+        self,
+        backend: Backend,
+        ctx: Context | None = None,
+        *,
+        session_id: str | None = None,
+    ):
         """Initialize MelleaSession with a backend and optional conversation context."""
         import uuid
 
-        self.id = str(uuid.uuid4())
+        self.id = session_id if session_id is not None else str(uuid.uuid4())
         self.backend = backend
         self.ctx: Context = ctx if ctx is not None else SimpleContext()
         self._session_logger = MelleaLogger.get_logger()
         self._context_token = None
         self._log_context_token = None
-        self._session_span = None
         self._exit_stack: contextlib.ExitStack | None = None
 
     def __enter__(self):
         """Enter context manager and set this session as the current global session."""
-        # Start a session span that will last for the entire context manager lifetime
-        self._session_span = trace_application(
-            "session_context",
-            **{
-                "mellea.backend": self.backend.__class__.__name__,
-                "mellea.context_type": self.ctx.__class__.__name__,
-            },
-        ).__enter__()
+        # Called directly, not via hook: OTel Token attach/detach is task-affine,
+        # and each hook firing runs in a separate _run_async_in_thread Task.
+        start_session_span(
+            self.id,
+            context_type=self.ctx.__class__.__name__,
+            backend=self.backend._provider,
+        )
         self._context_token = _context_session.set(self)
         # TODO: Migrate telemetry fields from _log_context to with_context() system.
         # Currently session_id and model_id are duplicated in both systems. The
@@ -308,7 +329,7 @@ class MelleaSession:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit context manager and cleanup session."""
-        self.cleanup()
+        self.cleanup(exception=exc_val)
         if self._log_context_token is not None:
             _log_context.reset(self._log_context_token)
             self._log_context_token = None
@@ -318,9 +339,7 @@ class MelleaSession:
         if self._exit_stack is not None:
             self._exit_stack.__exit__(exc_type, exc_val, exc_tb)
             self._exit_stack = None
-        if self._session_span is not None:
-            self._session_span.__exit__(exc_type, exc_val, exc_tb)
-            self._session_span = None
+        finish_session_span(self.id, exception=exc_val)
 
     def __copy__(self):
         """Use self.clone. Copies the current session but keeps references to the backend and context."""
@@ -371,13 +390,21 @@ class MelleaSession:
             )
         self.ctx = self.ctx.reset_to_new()
 
-    def cleanup(self) -> None:
-        """Clean up session resources and deregister session-scoped plugins."""
+    def cleanup(self, *, exception: BaseException | None = None) -> None:
+        """Clean up session resources and deregister session-scoped plugins.
+
+        Args:
+            exception: Optional exception that triggered cleanup. Forwarded
+                to plugins via `SessionCleanupPayload.exception`.
+        """
         if has_plugins(HookType.SESSION_CLEANUP):
             from ..plugins.hooks.session import SessionCleanupPayload
 
             payload = SessionCleanupPayload(
-                context=self.ctx, interaction_count=len(self.ctx.as_list())
+                session_id=self.id,
+                context=self.ctx,
+                interaction_count=len(self.ctx.as_list()),
+                exception=exception,
             )
             _run_async_in_thread(
                 invoke_hook(HookType.SESSION_CLEANUP, payload, backend=self.backend)

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -369,6 +369,250 @@ def finish_backend_span_error(
         span.end()
 
 
+def _start_application_span(
+    name: str, key: str, attributes: dict[str, Any]
+) -> Span | None:
+    """Open an application span, attach it to the OTel context, and stash by key.
+
+    Args:
+        name: Span name.
+        key: Correlation key for the in-flight stash.
+        attributes: Initial attributes; `None` values are skipped.
+
+    Returns:
+        The span, or `None` if the application tracer is unavailable.
+    """
+    tracer = get_application_tracer()
+    if tracer is None:
+        return None
+
+    span = tracer.start_span(name)
+    for k, v in attributes.items():
+        if v is not None:
+            _set_attribute_safe(span, k, v)
+
+    token = otel_context.attach(trace.set_span_in_context(span))
+    _in_flight_spans[key] = (span, token)
+    return span
+
+
+def _finish_application_span(
+    key: str,
+    *,
+    extra_attributes: dict[str, Any] | None = None,
+    exception: BaseException | None = None,
+) -> None:
+    """End an in-flight application span, optionally marking it ERROR.
+
+    Detach the OTel context token before ending so subsequent work parents
+    correctly. Tokens are task-affine — callers must arrange for detach to
+    happen on the same task that attached.
+
+    Args:
+        key: Correlation key from the matching open call.
+        extra_attributes: Optional response-side attributes; `None` values are skipped.
+        exception: If provided, mark the span ERROR and record the exception.
+    """
+    entry = _in_flight_spans.pop(key, None)
+    if entry is None:
+        return
+    span, token = entry
+    try:
+        if extra_attributes:
+            for k, v in extra_attributes.items():
+                if v is not None:
+                    _set_attribute_safe(span, k, v)
+        if exception is not None:
+            span.record_exception(exception)
+            span.set_status(trace.Status(trace.StatusCode.ERROR, str(exception)))
+            span.set_attribute("error.type", type(exception).__name__)
+    finally:
+        otel_context.detach(token)
+        span.end()
+
+
+_SESSION_STARTUP_KEY_SUFFIX = ":startup"
+
+
+def start_session_startup_span(
+    session_id: str,
+    *,
+    backend: str | None,
+    model_id: str | None,
+    context_type: str | None,
+) -> Span | None:
+    """Open the `start_session` span around backend construction.
+
+    Carries construction-time attributes (`mellea.session_id`,
+    `mellea.backend`, `mellea.model_id`, `mellea.context_type`). Stashed
+    under a derived key so it doesn't collide with the long-lived
+    `session` span when both share a `session_id`.
+
+    Args:
+        session_id: Session UUID. The in-flight key is derived from this.
+        backend: Backend identifier (e.g. `"ollama"`); stamped as `mellea.backend`.
+        model_id: Resolved model id string.
+        context_type: Context class name (e.g. `"SimpleContext"`).
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    return _start_application_span(
+        "start_session",
+        session_id + _SESSION_STARTUP_KEY_SUFFIX,
+        {
+            "mellea.session_id": session_id,
+            "mellea.backend": backend,
+            "mellea.model_id": model_id,
+            "mellea.context_type": context_type,
+        },
+    )
+
+
+def finish_session_startup_span(
+    session_id: str, *, exception: BaseException | None = None
+) -> bool:
+    """End the nested `start_session` span if one is in flight.
+
+    Args:
+        session_id: Session UUID from the matching open call. The in-flight
+            key is derived from this.
+        exception: If provided, mark the span ERROR.
+
+    Returns:
+        True if a child span was open and was finished; False if no-op.
+    """
+    key = session_id + _SESSION_STARTUP_KEY_SUFFIX
+    if key not in _in_flight_spans:
+        return False
+    _finish_application_span(key, exception=exception)
+    return True
+
+
+def start_session_span(
+    session_id: str, *, context_type: str | None, backend: str | None = None
+) -> Span | None:
+    """Open the long-lived `session` span over a session's lifetime.
+
+    Args:
+        session_id: Session UUID, used as the correlation key and stamped
+            as `mellea.session_id`.
+        context_type: Context class name.
+        backend: Backend identifier (e.g. `"ollama"`); stamped as
+            `mellea.backend` when provided.
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    return _start_application_span(
+        "session",
+        session_id,
+        {
+            "mellea.session_id": session_id,
+            "mellea.context_type": context_type,
+            "mellea.backend": backend,
+        },
+    )
+
+
+def finish_session_span(
+    session_id: str, *, exception: BaseException | None = None
+) -> None:
+    """End the long-lived `session` span.
+
+    Args:
+        session_id: Correlation key from the matching open call.
+        exception: If provided, mark the span ERROR.
+    """
+    _finish_application_span(session_id, exception=exception)
+
+
+def start_action_span(
+    component_id: str,
+    *,
+    action_class_name: str | None,
+    has_requirements: bool | None,
+    has_strategy: bool | None,
+    strategy_type: str | None,
+    has_format: bool | None,
+    tool_calls: bool | None,
+) -> Span | None:
+    """Open the `action` span for a single component execution.
+
+    Args:
+        component_id: UUID correlating this component execution across hooks.
+        action_class_name: Class name of the component being executed.
+        has_requirements: Whether requirements were supplied.
+        has_strategy: Whether a sampling strategy was supplied.
+        strategy_type: Sampling strategy class name when present.
+        has_format: Whether a structured-output format was supplied.
+        tool_calls: Whether tool calling is enabled.
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    return _start_application_span(
+        "action",
+        component_id,
+        {
+            "mellea.action_type": action_class_name,
+            "mellea.has_requirements": has_requirements,
+            "mellea.has_strategy": has_strategy,
+            "mellea.strategy_type": strategy_type,
+            "mellea.has_format": has_format,
+            "mellea.tool_calls": tool_calls,
+        },
+    )
+
+
+def finish_action_span_success(
+    component_id: str,
+    *,
+    num_generate_logs: int | None = None,
+    sampling_success: bool | None = None,
+    response_text: str | None = None,
+    response_length: int | None = None,
+) -> None:
+    """End the action span with response-side attributes.
+
+    `mellea.response` is recorded only when `is_content_tracing_enabled()`
+    returns true; the helper truncates to 500 chars before recording.
+    `mellea.response_length` is always recorded (a non-content metric).
+
+    Args:
+        component_id: Correlation key from the matching open call.
+        num_generate_logs: `mellea.num_generate_logs`.
+        sampling_success: `mellea.sampling_success` (set when a strategy ran).
+        response_text: Raw response text. Recorded as `mellea.response` only
+            when content tracing is enabled.
+        response_length: `mellea.response_length` (always safe; ungated).
+    """
+    response_value: str | None = None
+    if response_text is not None and is_content_tracing_enabled():
+        response_value = (
+            response_text[:500] + "..." if len(response_text) > 500 else response_text
+        )
+    _finish_application_span(
+        component_id,
+        extra_attributes={
+            "mellea.num_generate_logs": num_generate_logs,
+            "mellea.sampling_success": sampling_success,
+            "mellea.response": response_value,
+            "mellea.response_length": response_length,
+        },
+    )
+
+
+def finish_action_span_error(component_id: str, *, exception: BaseException) -> None:
+    """End the action span with ERROR status.
+
+    Args:
+        component_id: Correlation key from the matching open call.
+        exception: The exception that ended the action.
+    """
+    _finish_application_span(component_id, exception=exception)
+
+
 @contextmanager
 def trace_application(name: str, **attributes: Any) -> Generator[Any, None, None]:
     """Create an application trace span if application tracing is enabled.

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -528,7 +528,7 @@ def finish_session_span(
 
 
 def start_action_span(
-    component_id: str,
+    action_id: str,
     *,
     action_class_name: str | None,
     has_requirements: bool | None,
@@ -540,7 +540,7 @@ def start_action_span(
     """Open the `action` span for a single component execution.
 
     Args:
-        component_id: UUID correlating this component execution across hooks.
+        action_id: UUID correlating this component execution across hooks.
         action_class_name: Class name of the component being executed.
         has_requirements: Whether requirements were supplied.
         has_strategy: Whether a sampling strategy was supplied.
@@ -553,7 +553,7 @@ def start_action_span(
     """
     return _start_application_span(
         "action",
-        component_id,
+        action_id,
         {
             "mellea.action_type": action_class_name,
             "mellea.has_requirements": has_requirements,
@@ -566,7 +566,7 @@ def start_action_span(
 
 
 def finish_action_span_success(
-    component_id: str,
+    action_id: str,
     *,
     num_generate_logs: int | None = None,
     sampling_success: bool | None = None,
@@ -580,7 +580,7 @@ def finish_action_span_success(
     `mellea.response_length` is always recorded (a non-content metric).
 
     Args:
-        component_id: Correlation key from the matching open call.
+        action_id: Correlation key from the matching open call.
         num_generate_logs: `mellea.num_generate_logs`.
         sampling_success: `mellea.sampling_success` (set when a strategy ran).
         response_text: Raw response text. Recorded as `mellea.response` only
@@ -593,7 +593,7 @@ def finish_action_span_success(
             response_text[:500] + "..." if len(response_text) > 500 else response_text
         )
     _finish_application_span(
-        component_id,
+        action_id,
         extra_attributes={
             "mellea.num_generate_logs": num_generate_logs,
             "mellea.sampling_success": sampling_success,
@@ -603,14 +603,14 @@ def finish_action_span_success(
     )
 
 
-def finish_action_span_error(component_id: str, *, exception: BaseException) -> None:
+def finish_action_span_error(action_id: str, *, exception: BaseException) -> None:
     """End the action span with ERROR status.
 
     Args:
-        component_id: Correlation key from the matching open call.
+        action_id: Correlation key from the matching open call.
         exception: The exception that ended the action.
     """
-    _finish_application_span(component_id, exception=exception)
+    _finish_application_span(action_id, exception=exception)
 
 
 @contextmanager

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -1,10 +1,12 @@
 """Tracing plugins for emitting OpenTelemetry spans via hooks.
 
-This module contains plugins that hook into the generation pipeline to
-automatically emit spans when tracing is enabled:
+This module contains plugins that hook into the generation and component
+pipelines to automatically emit spans when tracing is enabled:
 
 - BackendTracingPlugin: Emits Gen-AI semconv backend spans for every LLM
-  generation, on both chat and raw (batch) paths
+  generation, on both chat and raw (batch) paths.
+- ComponentTracingPlugin: Emits application-level spans tracking component
+  execution.
 """
 
 from __future__ import annotations
@@ -15,6 +17,11 @@ from mellea.plugins.base import Plugin
 from mellea.plugins.decorators import hook
 
 if TYPE_CHECKING:
+    from mellea.plugins.hooks.component import (
+        ComponentPostErrorPayload,
+        ComponentPostSuccessPayload,
+        ComponentPreExecutePayload,
+    )
     from mellea.plugins.hooks.generation import (
         GenerationBatchErrorPayload,
         GenerationBatchPostCallPayload,
@@ -25,7 +32,7 @@ if TYPE_CHECKING:
     )
 
 
-class BackendTracingPlugin(Plugin, name="backend_tracing", priority=50):
+class BackendTracingPlugin(Plugin, name="backend_tracing", priority=40):
     """Emits Gen-AI semconv backend spans for every LLM generation.
 
     This plugin hooks into the generation pre-call, post-call, and error
@@ -150,5 +157,90 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=50):
         )
 
 
+class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
+    """Emits application-level spans tracking component execution.
+
+    This plugin hooks into component pre-execute, post-success, and
+    post-error events to emit one span per component execution. Spans are
+    correlated across hooks via component_id.
+
+    All hooks run SEQUENTIAL so the OTel context token attached on each open
+    hook can be detached on the same task on the corresponding close hook.
+    """
+
+    @hook("component_pre_execute")
+    async def on_component_pre_execute(
+        self, payload: ComponentPreExecutePayload, context: dict[str, Any]
+    ) -> None:
+        """Open the action span for this component execution."""
+        if not payload.component_id:
+            return
+        from mellea.telemetry.tracing import start_action_span
+
+        action = payload.action
+        strategy = payload.strategy
+        start_action_span(
+            payload.component_id,
+            action_class_name=action.__class__.__name__ if action is not None else None,
+            has_requirements=bool(payload.requirements),
+            has_strategy=strategy is not None,
+            strategy_type=strategy.__class__.__name__ if strategy is not None else None,
+            has_format=payload.format is not None,
+            tool_calls=payload.tool_calls_enabled,
+        )
+
+    @hook("component_post_success")
+    async def on_component_post_success(
+        self, payload: ComponentPostSuccessPayload, context: dict[str, Any]
+    ) -> None:
+        """End the action span with response-side attributes."""
+        if not payload.component_id:
+            return
+        from mellea.telemetry.tracing import finish_action_span_success
+
+        result = payload.result
+        sampling = payload.sampling_results
+
+        response_text: str | None = None
+        response_length: int | None = None
+        if result is not None:
+            try:
+                response_text = (
+                    str(result.value)
+                    if hasattr(result, "value") and result.value
+                    else str(result)
+                )
+                response_length = len(response_text)
+            except Exception:
+                # Never let attribute capture fail the post hook.
+                pass
+
+        sampling_success = payload.sampling_success
+
+        num_logs = 1 if payload.generate_log is not None else 0
+        if sampling is not None:
+            num_logs = len(sampling)
+
+        finish_action_span_success(
+            payload.component_id,
+            num_generate_logs=num_logs,
+            sampling_success=sampling_success,
+            response_text=response_text,
+            response_length=response_length,
+        )
+
+    @hook("component_post_error")
+    async def on_component_post_error(
+        self, payload: ComponentPostErrorPayload, context: dict[str, Any]
+    ) -> None:
+        """End the action span with ERROR status."""
+        if not payload.component_id:
+            return
+        from mellea.telemetry.tracing import finish_action_span_error
+
+        exc = payload.error if payload.error is not None else Exception("unknown error")
+        finish_action_span_error(payload.component_id, exception=exc)
+
+
 # All tracing plugins to auto-register when tracing is enabled.
-_TRACING_PLUGIN_CLASSES = (BackendTracingPlugin,)
+_TRACING_PLUGIN_CLASSES = (BackendTracingPlugin, ComponentTracingPlugin)

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -162,7 +162,7 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
 
     This plugin hooks into component pre-execute, post-success, and
     post-error events to emit one span per component execution. Spans are
-    correlated across hooks via component_id.
+    correlated across hooks via action_id.
 
     All hooks run SEQUENTIAL so the OTel context token attached on each open
     hook can be detached on the same task on the corresponding close hook.
@@ -173,14 +173,14 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
         self, payload: ComponentPreExecutePayload, context: dict[str, Any]
     ) -> None:
         """Open the action span for this component execution."""
-        if not payload.component_id:
+        if not payload.action_id:
             return
         from mellea.telemetry.tracing import start_action_span
 
         action = payload.action
         strategy = payload.strategy
         start_action_span(
-            payload.component_id,
+            payload.action_id,
             action_class_name=action.__class__.__name__ if action is not None else None,
             has_requirements=bool(payload.requirements),
             has_strategy=strategy is not None,
@@ -194,7 +194,7 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
         self, payload: ComponentPostSuccessPayload, context: dict[str, Any]
     ) -> None:
         """End the action span with response-side attributes."""
-        if not payload.component_id:
+        if not payload.action_id:
             return
         from mellea.telemetry.tracing import finish_action_span_success
 
@@ -222,7 +222,7 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
             num_logs = len(sampling)
 
         finish_action_span_success(
-            payload.component_id,
+            payload.action_id,
             num_generate_logs=num_logs,
             sampling_success=sampling_success,
             response_text=response_text,
@@ -234,12 +234,12 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
         self, payload: ComponentPostErrorPayload, context: dict[str, Any]
     ) -> None:
         """End the action span with ERROR status."""
-        if not payload.component_id:
+        if not payload.action_id:
             return
         from mellea.telemetry.tracing import finish_action_span_error
 
         exc = payload.error if payload.error is not None else Exception("unknown error")
-        finish_action_span_error(payload.component_id, exception=exc)
+        finish_action_span_error(payload.action_id, exception=exc)
 
 
 # All tracing plugins to auto-register when tracing is enabled.

--- a/test/helpers/test_event_loop_helper.py
+++ b/test/helpers/test_event_loop_helper.py
@@ -1,3 +1,4 @@
+import contextvars
 import multiprocessing
 
 import pytest
@@ -16,6 +17,50 @@ def test_run_async_in_thread():
         return True
 
     assert elh._run_async_in_thread(testing()), "somehow the wrong value was returned"
+
+
+def test_run_async_in_thread_propagates_calling_thread_contextvars():
+    """The calling thread's contextvars are visible inside the new Task."""
+    var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "test_var", default=None
+    )
+    var.set("from-calling-thread")
+
+    async def read_var() -> str | None:
+        return var.get()
+
+    assert elh._run_async_in_thread(read_var()) == "from-calling-thread"
+
+
+def test_run_async_in_thread_does_not_leak_task_mutations_back():
+    """Mutations to contextvars inside the Task don't reflect on the caller."""
+    var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "test_var2", default="caller-value"
+    )
+
+    async def mutate() -> None:
+        var.set("task-mutation")
+
+    elh._run_async_in_thread(mutate())
+    assert var.get() == "caller-value"
+
+
+def test_run_async_in_thread_same_loop_recursion_propagates_contextvars():
+    """Same-loop recursion still propagates the caller's contextvars."""
+    var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "test_var_recursive", default=None
+    )
+    var.set("outer-value")
+
+    async def inner_read() -> str | None:
+        return var.get()
+
+    async def outer() -> str | None:
+        # We're on the singleton's event loop now. A nested call from here
+        # takes the same-loop branch in _EventLoopHandler.__call__.
+        return elh._run_async_in_thread(inner_read())
+
+    assert elh._run_async_in_thread(outer()) == "outer-value"
 
 
 def test_event_loop_handler_init_and_del():

--- a/test/telemetry/test_tracing_application.py
+++ b/test/telemetry/test_tracing_application.py
@@ -1,0 +1,501 @@
+"""Tests for application-level tracing — session and action spans.
+
+This file covers the application-tracing surface in three layers:
+
+1. Helper-level unit tests (mock tracer): pin attribute shapes, key
+   derivation, and content-gating in the typed helpers in `tracing.py`.
+2. Plugin-disabled / no-op contracts: confirm helpers stay quiet when
+   tracing is off.
+3. Integration tests through real call sites (real OTel SDK, in-memory
+   exporter, mock backend): verify the full nesting works end-to-end via
+   `MelleaSession.__enter__/__exit__` and `m.act(...)`.
+"""
+
+import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry", reason="opentelemetry not installed — install mellea[telemetry]"
+)
+pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from mellea.core.backend import Backend
+from mellea.core.base import GenerateLog, ModelOutputThunk
+from mellea.stdlib.components import Message
+from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.session import MelleaSession, start_session
+from mellea.telemetry import tracing
+from mellea.telemetry.tracing import (
+    finish_action_span_error,
+    finish_action_span_success,
+    finish_session_span,
+    finish_session_startup_span,
+    start_action_span,
+    start_session_span,
+    start_session_startup_span,
+)
+from test.telemetry.conftest import reset_tracing_state
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def enabled_tracing(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_ENABLED", "true")
+    reset_tracing_state()
+    yield
+    reset_tracing_state()
+
+
+@pytest.fixture
+def disabled_tracing(monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_ENABLED", raising=False)
+    reset_tracing_state()
+    yield
+    reset_tracing_state()
+
+
+@pytest.fixture
+def span_exporter(enabled_tracing):
+    """Attach an in-memory span exporter to the active tracer provider."""
+    if tracing._tracer_provider is None:
+        pytest.skip("Telemetry not initialized")
+    exporter = InMemorySpanExporter()
+    tracing._tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter
+    exporter.clear()
+
+
+def _patch_app_tracer() -> tuple[MagicMock, MagicMock]:
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+    return fake_span, fake_tracer
+
+
+def _attrs(span: MagicMock) -> dict:
+    return {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+
+
+def _spans_by_name(exporter: InMemorySpanExporter) -> dict[str, Any]:
+    tracing._tracer_provider.force_flush()  # type: ignore[union-attr]
+    return {s.name: s for s in exporter.get_finished_spans()}
+
+
+# ---------------------------------------------------------------------------
+# Mock backend (no LLM calls)
+# ---------------------------------------------------------------------------
+
+
+class _MockBackend(Backend):
+    """Minimal backend that returns a faked ModelOutputThunk — no LLM API calls."""
+
+    model_id = "mock-model"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Discard constructor args; real backends need model_id etc.
+        self._model_id: str = "mock-model"
+        self._provider: str = "mock-provider"
+
+    async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
+        mot = MagicMock(spec=ModelOutputThunk)
+        glog = GenerateLog()
+        glog.prompt = "mocked formatted prompt"
+        mot._generate_log = glog
+        mot.parsed_repr = None
+        mot._start = datetime.datetime.now()
+
+        async def _avalue() -> str:
+            return "mocked output"
+
+        mot.avalue = _avalue
+        mot.value = "mocked output"
+        return mot, SimpleContext()
+
+    async def _generate_from_raw(self, actions: Any, ctx: Any, **kwargs: Any):
+        return [], None
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests (mock tracer)
+# ---------------------------------------------------------------------------
+
+
+def test_start_session_span_stamps_attrs_and_stashes_under_session_id(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_session_span("sess-1", context_type="SimpleContext")
+
+    fake_tracer.start_span.assert_called_once_with("session")
+    assert "sess-1" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.session_id"] == "sess-1"
+    assert attrs["mellea.context_type"] == "SimpleContext"
+    # `backend` not passed → no `mellea.backend` attribute.
+    assert "mellea.backend" not in attrs
+
+
+def test_start_session_span_stamps_backend_when_provided(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_session_span("sess-b", context_type="SimpleContext", backend="ollama")
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.backend"] == "ollama"
+
+
+def test_start_session_startup_span_stashes_under_suffixed_key(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_session_startup_span(
+            "sess-2",
+            backend="ollama",
+            model_id="granite4.1:3b",
+            context_type="SimpleContext",
+        )
+
+    fake_tracer.start_span.assert_called_once_with("start_session")
+    assert "sess-2" not in tracing._in_flight_spans
+    assert "sess-2:startup" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.session_id"] == "sess-2"
+    assert attrs["mellea.backend"] == "ollama"
+    assert attrs["mellea.model_id"] == "granite4.1:3b"
+    assert attrs["mellea.context_type"] == "SimpleContext"
+
+
+def test_finish_session_startup_span_returns_true_when_in_flight(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_session_startup_span(
+            "sess-3", backend="ollama", model_id="m", context_type="SimpleContext"
+        )
+        result = finish_session_startup_span("sess-3")
+
+    assert result is True
+    fake_span.end.assert_called_once()
+    assert "sess-3:startup" not in tracing._in_flight_spans
+
+
+def test_finish_session_startup_span_returns_false_when_not_in_flight(enabled_tracing):
+    result = finish_session_startup_span("never-opened")
+    assert result is False
+
+
+def test_finish_session_span_marks_error_with_exception(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_session_span("sess-err", context_type="SimpleContext")
+        finish_session_span("sess-err", exception=RuntimeError("boom"))
+
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["error.type"] == "RuntimeError"
+
+
+def test_finish_session_span_no_op_when_not_in_flight(enabled_tracing):
+    # Contract: missing key → silent no-op.
+    finish_session_span("never-opened")  # should not raise
+    assert "never-opened" not in tracing._in_flight_spans
+
+
+def test_start_action_span_stamps_request_attrs(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_action_span(
+            "cid-1",
+            action_class_name="Instruction",
+            has_requirements=True,
+            has_strategy=True,
+            strategy_type="RejectionSamplingStrategy",
+            has_format=False,
+            tool_calls=False,
+        )
+
+    fake_tracer.start_span.assert_called_once_with("action")
+    assert "cid-1" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.action_type"] == "Instruction"
+    assert attrs["mellea.has_requirements"] is True
+    assert attrs["mellea.has_strategy"] is True
+    assert attrs["mellea.strategy_type"] == "RejectionSamplingStrategy"
+    assert attrs["mellea.has_format"] is False
+    assert attrs["mellea.tool_calls"] is False
+
+
+def test_finish_action_span_success_records_length_always(enabled_tracing, monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    monkeypatch.delenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False
+    )
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_action_span(
+            "cid-2",
+            action_class_name="X",
+            has_requirements=False,
+            has_strategy=False,
+            strategy_type=None,
+            has_format=False,
+            tool_calls=False,
+        )
+        finish_action_span_success(
+            "cid-2", response_text="hello world", response_length=11
+        )
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response_length"] == 11
+    assert "mellea.response" not in attrs
+
+
+def test_finish_action_span_success_records_response_when_content_enabled(
+    enabled_tracing, monkeypatch
+):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_action_span(
+            "cid-3",
+            action_class_name="X",
+            has_requirements=False,
+            has_strategy=False,
+            strategy_type=None,
+            has_format=False,
+            tool_calls=False,
+        )
+        finish_action_span_success(
+            "cid-3", response_text="captured text", response_length=13
+        )
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response"] == "captured text"
+    assert attrs["mellea.response_length"] == 13
+
+
+def test_finish_action_span_success_truncates_long_response(
+    enabled_tracing, monkeypatch
+):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    fake_span, fake_tracer = _patch_app_tracer()
+    long_text = "a" * 800
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_action_span(
+            "cid-4",
+            action_class_name="X",
+            has_requirements=False,
+            has_strategy=False,
+            strategy_type=None,
+            has_format=False,
+            tool_calls=False,
+        )
+        finish_action_span_success(
+            "cid-4", response_text=long_text, response_length=800
+        )
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response"].endswith("...")
+    assert len(attrs["mellea.response"]) == 503  # 500 chars + "..."
+    assert attrs["mellea.response_length"] == 800
+
+
+def test_finish_action_span_error_marks_and_ends(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    err = ValueError("nope")
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_action_span(
+            "cid-err",
+            action_class_name="X",
+            has_requirements=False,
+            has_strategy=False,
+            strategy_type=None,
+            has_format=False,
+            tool_calls=False,
+        )
+        finish_action_span_error("cid-err", exception=err)
+
+    fake_span.record_exception.assert_called_once_with(err)
+    fake_span.set_status.assert_called_once()
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["error.type"] == "ValueError"
+    assert "cid-err" not in tracing._in_flight_spans
+
+
+# ---------------------------------------------------------------------------
+# No-op contract: stdlib helpers stay quiet when tracing is disabled
+# ---------------------------------------------------------------------------
+
+
+def test_helpers_are_silent_when_tracing_disabled(disabled_tracing):
+    """Direct calls to span helpers no-op cleanly when tracing is off."""
+    # No tracer is set up; helpers must return None / not raise.
+    assert start_session_span("sess-d", context_type="SimpleContext") is None
+    assert (
+        start_session_startup_span(
+            "sess-d", backend="x", model_id="m", context_type="C"
+        )
+        is None
+    )
+    assert (
+        start_action_span(
+            "cid-d",
+            action_class_name=None,
+            has_requirements=None,
+            has_strategy=None,
+            strategy_type=None,
+            has_format=None,
+            tool_calls=None,
+        )
+        is None
+    )
+    finish_session_startup_span("sess-d")  # should not raise
+    finish_session_span("sess-d")  # should not raise
+    finish_action_span_success("cid-d")  # should not raise
+    finish_action_span_error("cid-d", exception=RuntimeError("x"))  # should not raise
+    assert tracing._in_flight_spans == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: real call sites + real OTel SDK + mock backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_session_with_block_emits_session_action_nesting(span_exporter):
+    """`with start_session(...) as m: m.act(...)` emits a properly nested span tree.
+
+    Verifies the load-bearing nesting fix: action span (created inside
+    `_run_async_in_thread` Task) nests under session span (created on the
+    user thread). Backend (chat) span emission is covered against a real
+    LLM in `test_tracing_backend.py`; this mock backend's custom `avalue`
+    starts the chat span but doesn't fire `generation_post_call`, so the
+    chat span stays open and isn't visible in the exporter.
+
+    `start_session` is a sibling root (it lives inside `start_session()`'s
+    body, before `__enter__` opens the long-lived session span — same
+    relationship as pre-this-PR).
+    """
+    with patch(
+        "mellea.stdlib.session.backend_name_to_class", return_value=_MockBackend
+    ):
+        with start_session("ollama") as m:
+            m.act(Message(role="user", content="hi"), strategy=None)
+
+    by_name = _spans_by_name(span_exporter)
+
+    assert "session" in by_name
+    assert "start_session" in by_name
+    assert "action" in by_name
+
+    session_span = by_name["session"]
+    startup_span = by_name["start_session"]
+    action_span = by_name["action"]
+
+    # Session is a root.
+    assert session_span.parent is None
+    # start_session is a separate root — opened by start_session() before __enter__.
+    assert startup_span.parent is None
+    # Action nests under session — the load-bearing assertion that validates
+    # one-way contextvar propagation in `_run_async_in_thread`.
+    assert action_span.parent is not None
+    assert action_span.parent.span_id == session_span.context.span_id
+    # mellea.backend on the session span comes from `backend._provider`.
+    assert session_span.attributes is not None
+    assert session_span.attributes.get("mellea.backend") == "mock-provider"
+
+
+@pytest.mark.integration
+def test_bare_construction_emits_no_session_span(span_exporter):
+    """Bare `MelleaSession(...)` (no `with`) doesn't open a session span — pre-this-PR shape preserved."""
+    backend = _MockBackend()
+    m = MelleaSession(backend, ctx=SimpleContext())
+    try:
+        m.act(Message(role="user", content="hi"), strategy=None)
+    finally:
+        m.cleanup()
+
+    by_name = _spans_by_name(span_exporter)
+
+    # No session span (no __enter__ → no start_session_span).
+    assert "session" not in by_name
+    assert "start_session" not in by_name
+    # action still emits (plugin-driven from inside aact).
+    assert "action" in by_name
+
+
+@pytest.mark.integration
+def test_session_span_marks_error_on_with_block_exception(span_exporter):
+    """Exception inside the `with` block propagates to session span ERROR status."""
+    with patch(
+        "mellea.stdlib.session.backend_name_to_class", return_value=_MockBackend
+    ):
+        with pytest.raises(RuntimeError):
+            with start_session("ollama"):
+                raise RuntimeError("user code failed")
+
+    by_name = _spans_by_name(span_exporter)
+    session_span = by_name["session"]
+
+    from opentelemetry.trace import StatusCode
+
+    assert session_span.status.status_code == StatusCode.ERROR
+    event_names = [e.name for e in session_span.events]
+    assert "exception" in event_names
+
+
+@pytest.mark.integration
+def test_start_session_span_marks_error_on_backend_construction_failure(span_exporter):
+    """Backend construction failure during `start_session()` marks the startup span ERROR."""
+
+    class _BoomBackend:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("backend init failed")
+
+    with patch(
+        "mellea.stdlib.session.backend_name_to_class", return_value=_BoomBackend
+    ):
+        with pytest.raises(RuntimeError):
+            start_session("ollama")
+
+    by_name = _spans_by_name(span_exporter)
+    startup_span = by_name["start_session"]
+
+    from opentelemetry.trace import StatusCode
+
+    assert startup_span.status.status_code == StatusCode.ERROR
+    event_names = [e.name for e in startup_span.events]
+    assert "exception" in event_names
+    assert startup_span.attributes is not None
+    assert startup_span.attributes.get("error.type") == "RuntimeError"
+    # No long-lived `session` span — __enter__ never ran.
+    assert "session" not in by_name

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -11,6 +11,11 @@ pytest.importorskip(
 pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
 
 from mellea.core.base import GenerationMetadata, ModelOutputThunk
+from mellea.plugins.hooks.component import (
+    ComponentPostErrorPayload,
+    ComponentPostSuccessPayload,
+    ComponentPreExecutePayload,
+)
 from mellea.plugins.hooks.generation import (
     GenerationBatchErrorPayload,
     GenerationBatchPostCallPayload,
@@ -20,13 +25,21 @@ from mellea.plugins.hooks.generation import (
     GenerationPreCallPayload,
 )
 from mellea.telemetry import tracing
-from mellea.telemetry.tracing_plugins import BackendTracingPlugin
+from mellea.telemetry.tracing_plugins import (
+    BackendTracingPlugin,
+    ComponentTracingPlugin,
+)
 from test.telemetry.conftest import reset_tracing_state
 
 
 @pytest.fixture
-def plugin():
+def backend_plugin():
     return BackendTracingPlugin()
+
+
+@pytest.fixture
+def component_plugin():
+    return ComponentTracingPlugin()
 
 
 @pytest.fixture
@@ -52,7 +65,7 @@ def _attrs(span: MagicMock) -> dict:
 
 @pytest.mark.asyncio
 async def test_pre_call_starts_span_and_stashes_by_generation_id(
-    plugin, enabled_tracing
+    backend_plugin, enabled_tracing
 ):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
@@ -61,7 +74,7 @@ async def test_pre_call_starts_span_and_stashes_by_generation_id(
     payload = GenerationPreCallPayload(action=None, context=None, generation_id="gid-1")
 
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(payload, {})
+        await backend_plugin.on_pre_call(payload, {})
 
     fake_tracer.start_span.assert_called_once_with("chat")
     assert "gid-1" in tracing._in_flight_spans
@@ -71,14 +84,16 @@ async def test_pre_call_starts_span_and_stashes_by_generation_id(
 
 
 @pytest.mark.asyncio
-async def test_post_call_finishes_span_with_usage_attrs(plugin, enabled_tracing):
+async def test_post_call_finishes_span_with_usage_attrs(
+    backend_plugin, enabled_tracing
+):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="gid-2")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     mot = ModelOutputThunk("hello")
     mot.generation = GenerationMetadata(
@@ -89,7 +104,7 @@ async def test_post_call_finishes_span_with_usage_attrs(plugin, enabled_tracing)
     post = GenerationPostCallPayload(
         prompt="p", model_output=mot, latency_ms=100.0, generation_id="gid-2"
     )
-    await plugin.on_post_call(post, {})
+    await backend_plugin.on_post_call(post, {})
 
     fake_span.end.assert_called_once()
     attrs = _attrs(fake_span)
@@ -102,14 +117,14 @@ async def test_post_call_finishes_span_with_usage_attrs(plugin, enabled_tracing)
 
 
 @pytest.mark.asyncio
-async def test_error_finishes_span_with_error_status(plugin, enabled_tracing):
+async def test_error_finishes_span_with_error_status(backend_plugin, enabled_tracing):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="gid-err")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     err = ValueError("rate limit")
     mot = ModelOutputThunk(None)
@@ -117,7 +132,7 @@ async def test_error_finishes_span_with_error_status(plugin, enabled_tracing):
     err_payload = GenerationErrorPayload(
         exception=err, model_output=mot, generation_id="gid-err"
     )
-    await plugin.on_error(err_payload, {})
+    await backend_plugin.on_error(err_payload, {})
 
     fake_span.record_exception.assert_called_once_with(err)
     fake_span.set_status.assert_called_once()
@@ -128,26 +143,26 @@ async def test_error_finishes_span_with_error_status(plugin, enabled_tracing):
 
 
 @pytest.mark.asyncio
-async def test_pre_call_no_op_when_disabled(plugin, disabled_tracing):
+async def test_pre_call_no_op_when_disabled(backend_plugin, disabled_tracing):
     payload = GenerationPreCallPayload(action=None, context=None, generation_id="x")
-    await plugin.on_pre_call(payload, {})
+    await backend_plugin.on_pre_call(payload, {})
     assert "x" not in tracing._in_flight_spans
 
 
 @pytest.mark.asyncio
-async def test_pre_call_no_op_with_none_generation_id(plugin, enabled_tracing):
+async def test_pre_call_no_op_with_none_generation_id(backend_plugin, enabled_tracing):
     """generation_id=None (e.g. from a non-tracing-aware caller) is skipped."""
     fake_tracer = MagicMock()
     payload = GenerationPreCallPayload(action=None, context=None, generation_id=None)
 
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(payload, {})
+        await backend_plugin.on_pre_call(payload, {})
 
     fake_tracer.start_span.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_concurrent_generations_do_not_collide(plugin, enabled_tracing):
+async def test_concurrent_generations_do_not_collide(backend_plugin, enabled_tracing):
     """Two concurrent generations with distinct UUIDs each get their own span."""
     fake_span_a = MagicMock(name="span-A")
     fake_span_b = MagicMock(name="span-B")
@@ -158,8 +173,8 @@ async def test_concurrent_generations_do_not_collide(plugin, enabled_tracing):
     pre_b = GenerationPreCallPayload(action=None, context=None, generation_id="B")
 
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre_a, {})
-        await plugin.on_pre_call(pre_b, {})
+        await backend_plugin.on_pre_call(pre_a, {})
+        await backend_plugin.on_pre_call(pre_b, {})
 
     assert "A" in tracing._in_flight_spans
     assert "B" in tracing._in_flight_spans
@@ -171,7 +186,7 @@ async def test_concurrent_generations_do_not_collide(plugin, enabled_tracing):
     mot_a = ModelOutputThunk("a")
     mot_a.generation = GenerationMetadata(model="m", provider="p")
 
-    await plugin.on_post_call(
+    await backend_plugin.on_post_call(
         GenerationPostCallPayload(
             prompt="", model_output=mot_a, latency_ms=1.0, generation_id="A"
         ),
@@ -180,7 +195,7 @@ async def test_concurrent_generations_do_not_collide(plugin, enabled_tracing):
     fake_span_a.end.assert_called_once()
     fake_span_b.end.assert_not_called()
 
-    await plugin.on_post_call(
+    await backend_plugin.on_post_call(
         GenerationPostCallPayload(
             prompt="", model_output=mot_b, latency_ms=1.0, generation_id="B"
         ),
@@ -190,7 +205,7 @@ async def test_concurrent_generations_do_not_collide(plugin, enabled_tracing):
 
 
 @pytest.mark.asyncio
-async def test_cache_and_reasoning_attrs_emitted(plugin, enabled_tracing):
+async def test_cache_and_reasoning_attrs_emitted(backend_plugin, enabled_tracing):
     """Cache and reasoning token attrs are emitted from the usage dict."""
     fake_span = MagicMock()
     fake_tracer = MagicMock()
@@ -198,7 +213,7 @@ async def test_cache_and_reasoning_attrs_emitted(plugin, enabled_tracing):
 
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="cache-gid")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     mot = ModelOutputThunk("x")
     mot.generation = GenerationMetadata(
@@ -216,7 +231,7 @@ async def test_cache_and_reasoning_attrs_emitted(plugin, enabled_tracing):
     post = GenerationPostCallPayload(
         prompt="", model_output=mot, latency_ms=1.0, generation_id="cache-gid"
     )
-    await plugin.on_post_call(post, {})
+    await backend_plugin.on_post_call(post, {})
 
     attrs = _attrs(fake_span)
     assert attrs["gen_ai.usage.cache_read.input_tokens"] == 75
@@ -225,7 +240,7 @@ async def test_cache_and_reasoning_attrs_emitted(plugin, enabled_tracing):
 
 
 @pytest.mark.asyncio
-async def test_conversation_id_set_from_session_id(plugin, enabled_tracing):
+async def test_conversation_id_set_from_session_id(backend_plugin, enabled_tracing):
     """`gen_ai.conversation.id` is sourced from the session_id ContextVar."""
     from mellea.telemetry.context import with_context
 
@@ -236,7 +251,7 @@ async def test_conversation_id_set_from_session_id(plugin, enabled_tracing):
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="conv-gid")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
         with with_context(session_id="sess-123"):
-            await plugin.on_pre_call(pre, {})
+            await backend_plugin.on_pre_call(pre, {})
 
     attrs = _attrs(fake_span)
     assert attrs["gen_ai.conversation.id"] == "sess-123"
@@ -247,7 +262,9 @@ class _DummyFormat:
 
 
 @pytest.mark.asyncio
-async def test_pre_call_emits_request_side_mellea_attrs(plugin, enabled_tracing):
+async def test_pre_call_emits_request_side_mellea_attrs(
+    backend_plugin, enabled_tracing
+):
     """`mellea.has_format`, `mellea.format_type`, and `mellea.tool_calls_enabled` come through the pre_call payload."""
     fake_span = MagicMock()
     fake_tracer = MagicMock()
@@ -261,7 +278,7 @@ async def test_pre_call_emits_request_side_mellea_attrs(plugin, enabled_tracing)
         tool_calls=True,
     )
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     attrs = _attrs(fake_span)
     assert "mellea.backend" not in attrs
@@ -273,7 +290,9 @@ async def test_pre_call_emits_request_side_mellea_attrs(plugin, enabled_tracing)
 
 
 @pytest.mark.asyncio
-async def test_pre_call_omits_format_type_when_no_format(plugin, enabled_tracing):
+async def test_pre_call_omits_format_type_when_no_format(
+    backend_plugin, enabled_tracing
+):
     """`mellea.format_type` is not emitted when no format is supplied; `mellea.has_format` is still emitted as False."""
     fake_span = MagicMock()
     fake_tracer = MagicMock()
@@ -287,7 +306,7 @@ async def test_pre_call_omits_format_type_when_no_format(plugin, enabled_tracing
         tool_calls=False,
     )
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     attrs = _attrs(fake_span)
     assert attrs["mellea.has_format"] is False
@@ -297,7 +316,7 @@ async def test_pre_call_omits_format_type_when_no_format(plugin, enabled_tracing
 
 
 @pytest.mark.asyncio
-async def test_post_call_emits_response_side_attrs(plugin, enabled_tracing):
+async def test_post_call_emits_response_side_attrs(backend_plugin, enabled_tracing):
     """`gen_ai.response.{model,id,finish_reasons}` populated from `mot.generation` in post_call."""
     fake_span = MagicMock()
     fake_tracer = MagicMock()
@@ -305,7 +324,7 @@ async def test_post_call_emits_response_side_attrs(plugin, enabled_tracing):
 
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="resp-gid")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     mot = ModelOutputThunk("hi")
     mot.generation = GenerationMetadata(
@@ -318,7 +337,7 @@ async def test_post_call_emits_response_side_attrs(plugin, enabled_tracing):
     post = GenerationPostCallPayload(
         prompt="p", model_output=mot, latency_ms=1.0, generation_id="resp-gid"
     )
-    await plugin.on_post_call(post, {})
+    await backend_plugin.on_post_call(post, {})
 
     attrs = _attrs(fake_span)
     assert attrs["gen_ai.response.model"] == "gpt-4o-2024-08-06"
@@ -327,7 +346,9 @@ async def test_post_call_emits_response_side_attrs(plugin, enabled_tracing):
 
 
 @pytest.mark.asyncio
-async def test_post_call_skips_response_attrs_when_unset(plugin, enabled_tracing):
+async def test_post_call_skips_response_attrs_when_unset(
+    backend_plugin, enabled_tracing
+):
     """Response attrs are skipped when the backend didn't populate them
     (e.g. HuggingFace, which has no provider response object)."""
     fake_span = MagicMock()
@@ -336,14 +357,14 @@ async def test_post_call_skips_response_attrs_when_unset(plugin, enabled_tracing
 
     pre = GenerationPreCallPayload(action=None, context=None, generation_id="hf-gid")
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
     mot = ModelOutputThunk("hi")
     mot.generation = GenerationMetadata(model="m", provider="huggingface")
     post = GenerationPostCallPayload(
         prompt="p", model_output=mot, latency_ms=1.0, generation_id="hf-gid"
     )
-    await plugin.on_post_call(post, {})
+    await backend_plugin.on_post_call(post, {})
 
     attrs = _attrs(fake_span)
     assert "gen_ai.response.model" not in attrs
@@ -352,7 +373,9 @@ async def test_post_call_skips_response_attrs_when_unset(plugin, enabled_tracing
 
 
 @pytest.mark.asyncio
-async def test_batch_pre_call_starts_text_completion_span(plugin, enabled_tracing):
+async def test_batch_pre_call_starts_text_completion_span(
+    backend_plugin, enabled_tracing
+):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
@@ -368,7 +391,7 @@ async def test_batch_pre_call_starts_text_completion_span(plugin, enabled_tracin
     )
 
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_batch_pre_call(payload, {})
+        await backend_plugin.on_batch_pre_call(payload, {})
 
     fake_tracer.start_span.assert_called_once_with("text_completion")
     assert "batch-1" in tracing._in_flight_spans
@@ -384,7 +407,9 @@ async def test_batch_pre_call_starts_text_completion_span(plugin, enabled_tracin
 
 
 @pytest.mark.asyncio
-async def test_batch_post_call_finishes_with_aggregate_usage(plugin, enabled_tracing):
+async def test_batch_post_call_finishes_with_aggregate_usage(
+    backend_plugin, enabled_tracing
+):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
@@ -397,7 +422,7 @@ async def test_batch_post_call_finishes_with_aggregate_usage(plugin, enabled_tra
         provider="watsonx",
     )
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_batch_pre_call(pre, {})
+        await backend_plugin.on_batch_pre_call(pre, {})
 
     post = GenerationBatchPostCallPayload(
         generation_id="batch-2",
@@ -407,7 +432,7 @@ async def test_batch_post_call_finishes_with_aggregate_usage(plugin, enabled_tra
         provider="watsonx",
         latency_ms=200.0,
     )
-    await plugin.on_batch_post_call(post, {})
+    await backend_plugin.on_batch_post_call(post, {})
 
     fake_span.end.assert_called_once()
     attrs = _attrs(fake_span)
@@ -418,7 +443,7 @@ async def test_batch_post_call_finishes_with_aggregate_usage(plugin, enabled_tra
 
 
 @pytest.mark.asyncio
-async def test_batch_error_finishes_with_error_status(plugin, enabled_tracing):
+async def test_batch_error_finishes_with_error_status(backend_plugin, enabled_tracing):
     fake_span = MagicMock()
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
@@ -427,7 +452,7 @@ async def test_batch_error_finishes_with_error_status(plugin, enabled_tracing):
         actions=(), generation_id="batch-err", num_actions=1, model="m", provider="p"
     )
     with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
-        await plugin.on_batch_pre_call(pre, {})
+        await backend_plugin.on_batch_pre_call(pre, {})
 
     err = RuntimeError("boom")
     err_payload = GenerationBatchErrorPayload(
@@ -437,7 +462,7 @@ async def test_batch_error_finishes_with_error_status(plugin, enabled_tracing):
         provider="p",
         latency_ms=50.0,
     )
-    await plugin.on_batch_error(err_payload, {})
+    await backend_plugin.on_batch_error(err_payload, {})
 
     fake_span.record_exception.assert_called_once_with(err)
     fake_span.set_status.assert_called_once()
@@ -448,7 +473,7 @@ async def test_batch_error_finishes_with_error_status(plugin, enabled_tracing):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_span_has_correct_parent(plugin, enabled_tracing):
+async def test_span_has_correct_parent(backend_plugin, enabled_tracing):
     """A backend span started inside a user span gets the user span as parent."""
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -467,14 +492,14 @@ async def test_span_has_correct_parent(plugin, enabled_tracing):
         pre = GenerationPreCallPayload(
             action=None, context=None, generation_id="parent-gid"
         )
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
         mot = ModelOutputThunk("x")
         mot.generation = GenerationMetadata(model="m", provider="p")
         post = GenerationPostCallPayload(
             prompt="", model_output=mot, latency_ms=1.0, generation_id="parent-gid"
         )
-        await plugin.on_post_call(post, {})
+        await backend_plugin.on_post_call(post, {})
 
     tracing._tracer_provider.force_flush()
     spans = exporter.get_finished_spans()
@@ -490,7 +515,7 @@ async def test_span_has_correct_parent(plugin, enabled_tracing):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_nested_span_during_call_parents_under_backend_span(
-    plugin, enabled_tracing
+    backend_plugin, enabled_tracing
 ):
     """A span started between pre_call and post_call parents under the backend span."""
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -505,7 +530,7 @@ async def test_nested_span_during_call_parents_under_backend_span(
     pre = GenerationPreCallPayload(
         action=None, context=None, generation_id="active-gid"
     )
-    await plugin.on_pre_call(pre, {})
+    await backend_plugin.on_pre_call(pre, {})
 
     backend_span_id = (
         tracing._in_flight_spans["active-gid"][0].get_span_context().span_id
@@ -526,7 +551,7 @@ async def test_nested_span_during_call_parents_under_backend_span(
     post = GenerationPostCallPayload(
         prompt="", model_output=mot, latency_ms=1.0, generation_id="active-gid"
     )
-    await plugin.on_post_call(post, {})
+    await backend_plugin.on_post_call(post, {})
 
     tracing._tracer_provider.force_flush()
     by_name = {s.name: s for s in exporter.get_finished_spans()}
@@ -539,7 +564,9 @@ async def test_nested_span_during_call_parents_under_backend_span(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_sequential_backend_calls_produce_siblings(plugin, enabled_tracing):
+async def test_sequential_backend_calls_produce_siblings(
+    backend_plugin, enabled_tracing
+):
     """Two back-to-back backend calls in the same task with no enclosing app span are siblings, not parent/child."""
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -552,14 +579,14 @@ async def test_sequential_backend_calls_produce_siblings(plugin, enabled_tracing
 
     for gid in ("call-a", "call-b"):
         pre = GenerationPreCallPayload(action=None, context=None, generation_id=gid)
-        await plugin.on_pre_call(pre, {})
+        await backend_plugin.on_pre_call(pre, {})
 
         mot = ModelOutputThunk("x")
         mot.generation = GenerationMetadata(model="m", provider="p")
         post = GenerationPostCallPayload(
             prompt="", model_output=mot, latency_ms=1.0, generation_id=gid
         )
-        await plugin.on_post_call(post, {})
+        await backend_plugin.on_post_call(post, {})
 
     tracing._tracer_provider.force_flush()
     chat_spans = [s for s in exporter.get_finished_spans() if s.name == "chat"]
@@ -572,3 +599,172 @@ async def test_sequential_backend_calls_produce_siblings(plugin, enabled_tracing
             f"backend span {s.context.span_id:x} unexpectedly has parent "
             f"{s.parent.span_id:x} — context token detach is missing"
         )
+
+
+@pytest.mark.asyncio
+async def test_action_pre_execute_emits_request_attrs(
+    component_plugin, enabled_tracing
+):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    class Foo:
+        pass
+
+    class FakeStrategy:
+        pass
+
+    pre = ComponentPreExecutePayload(
+        component_id="cid-1",
+        component_type="Foo",
+        action=Foo(),
+        requirements=["r1"],
+        strategy=FakeStrategy(),
+        format=_DummyFormat,
+        tool_calls_enabled=True,
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+
+    fake_tracer.start_span.assert_called_once_with("action")
+    assert "cid-1" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.action_type"] == "Foo"
+    assert attrs["mellea.has_requirements"] is True
+    assert attrs["mellea.has_strategy"] is True
+    assert attrs["mellea.strategy_type"] == "FakeStrategy"
+    assert attrs["mellea.has_format"] is True
+    assert attrs["mellea.tool_calls"] is True
+
+
+@pytest.mark.asyncio
+async def test_action_post_success_records_response_length_always(
+    component_plugin, enabled_tracing, monkeypatch
+):
+    """`mellea.response_length` is recorded regardless of MELLEA_TRACES_CONTENT."""
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    monkeypatch.delenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ComponentPreExecutePayload(component_id="cid-2", component_type="X")
+    result = MagicMock()
+    result.value = "hello world"
+    success = ComponentPostSuccessPayload(
+        component_id="cid-2", result=result, generate_log=MagicMock()
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+        await component_plugin.on_component_post_success(success, {})
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response_length"] == len("hello world")
+    assert "mellea.response" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_action_post_success_records_response_when_content_enabled(
+    component_plugin, enabled_tracing, monkeypatch
+):
+    """`mellea.response` is recorded only when `MELLEA_TRACES_CONTENT=true`."""
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ComponentPreExecutePayload(component_id="cid-3", component_type="X")
+    result = MagicMock()
+    result.value = "captured text"
+    success = ComponentPostSuccessPayload(
+        component_id="cid-3", result=result, generate_log=MagicMock()
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+        await component_plugin.on_component_post_success(success, {})
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response"] == "captured text"
+    assert attrs["mellea.response_length"] == len("captured text")
+
+
+@pytest.mark.asyncio
+async def test_action_post_success_truncates_long_response(
+    component_plugin, enabled_tracing, monkeypatch
+):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ComponentPreExecutePayload(component_id="cid-4", component_type="X")
+    long_text = "a" * 800
+    result = MagicMock()
+    result.value = long_text
+    success = ComponentPostSuccessPayload(
+        component_id="cid-4", result=result, generate_log=MagicMock()
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+        await component_plugin.on_component_post_success(success, {})
+
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.response"].endswith("...")
+    assert len(attrs["mellea.response"]) == 503
+    assert attrs["mellea.response_length"] == 800
+
+
+@pytest.mark.asyncio
+async def test_action_post_error_marks_error_status(component_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ComponentPreExecutePayload(component_id="cid-err", component_type="X")
+    err = ValueError("nope")
+    error_payload = ComponentPostErrorPayload(
+        component_id="cid-err", error=err, error_type="ValueError"
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+        await component_plugin.on_component_post_error(error_payload, {})
+
+    fake_span.record_exception.assert_called_once_with(err)
+    fake_span.set_status.assert_called_once()
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["error.type"] == "ValueError"
+    assert "cid-err" not in tracing._in_flight_spans
+
+
+@pytest.mark.asyncio
+async def test_action_pre_execute_no_op_with_empty_component_id(
+    component_plugin, enabled_tracing
+):
+    fake_tracer = MagicMock()
+    pre = ComponentPreExecutePayload(component_id="", component_type="X")
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await component_plugin.on_component_pre_execute(pre, {})
+    fake_tracer.start_span.assert_not_called()

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -616,7 +616,7 @@ async def test_action_pre_execute_emits_request_attrs(
         pass
 
     pre = ComponentPreExecutePayload(
-        component_id="cid-1",
+        action_id="cid-1",
         component_type="Foo",
         action=Foo(),
         requirements=["r1"],
@@ -654,11 +654,11 @@ async def test_action_post_success_records_response_length_always(
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
-    pre = ComponentPreExecutePayload(component_id="cid-2", component_type="X")
+    pre = ComponentPreExecutePayload(action_id="cid-2", component_type="X")
     result = MagicMock()
     result.value = "hello world"
     success = ComponentPostSuccessPayload(
-        component_id="cid-2", result=result, generate_log=MagicMock()
+        action_id="cid-2", result=result, generate_log=MagicMock()
     )
 
     with patch(
@@ -683,11 +683,11 @@ async def test_action_post_success_records_response_when_content_enabled(
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
-    pre = ComponentPreExecutePayload(component_id="cid-3", component_type="X")
+    pre = ComponentPreExecutePayload(action_id="cid-3", component_type="X")
     result = MagicMock()
     result.value = "captured text"
     success = ComponentPostSuccessPayload(
-        component_id="cid-3", result=result, generate_log=MagicMock()
+        action_id="cid-3", result=result, generate_log=MagicMock()
     )
 
     with patch(
@@ -711,12 +711,12 @@ async def test_action_post_success_truncates_long_response(
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
-    pre = ComponentPreExecutePayload(component_id="cid-4", component_type="X")
+    pre = ComponentPreExecutePayload(action_id="cid-4", component_type="X")
     long_text = "a" * 800
     result = MagicMock()
     result.value = long_text
     success = ComponentPostSuccessPayload(
-        component_id="cid-4", result=result, generate_log=MagicMock()
+        action_id="cid-4", result=result, generate_log=MagicMock()
     )
 
     with patch(
@@ -737,10 +737,10 @@ async def test_action_post_error_marks_error_status(component_plugin, enabled_tr
     fake_tracer = MagicMock()
     fake_tracer.start_span.return_value = fake_span
 
-    pre = ComponentPreExecutePayload(component_id="cid-err", component_type="X")
+    pre = ComponentPreExecutePayload(action_id="cid-err", component_type="X")
     err = ValueError("nope")
     error_payload = ComponentPostErrorPayload(
-        component_id="cid-err", error=err, error_type="ValueError"
+        action_id="cid-err", error=err, error_type="ValueError"
     )
 
     with patch(
@@ -758,11 +758,11 @@ async def test_action_post_error_marks_error_status(component_plugin, enabled_tr
 
 
 @pytest.mark.asyncio
-async def test_action_pre_execute_no_op_with_empty_component_id(
+async def test_action_pre_execute_no_op_with_empty_action_id(
     component_plugin, enabled_tracing
 ):
     fake_tracer = MagicMock()
-    pre = ComponentPreExecutePayload(component_id="", component_type="X")
+    pre = ComponentPreExecutePayload(action_id="", component_type="X")
     with patch(
         "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
     ):


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1048. Phase 2 of #444.

## Description

Action span emission moves from inline `trace_application` calls in `stdlib/functional.py` to a new `ComponentTracingPlugin` subscribed to `component_*` hooks. Session and `start_session` spans stay in stdlib but route through clean typed helpers in `tracing.py` instead of the deprecated `trace_application` surface. Hooks fit spans whose lifecycle lives inside one async function (one Task); session lifecycle crosses multiple `_run_async_in_thread` calls and OTel Token attach/detach is task-affine, so direct emission is the right shape there.

**Reviewer call-outs:**

1. **`_run_async_in_thread` now propagates the calling thread's contextvars into the new Task.** One-way, no copy-back. Without it, `asyncio.run_coroutine_threadsafe` starts the new Task with empty contextvars, so contextvar-backed state on the user thread (OTel active span, Mellea's `session_id` / `request_id` / `model_id` / `sampling_iteration`, log context) is invisible inside Mellea's async work — including the `session > action > chat` hierarchy that the docs have promised since #355. With this PR, that hierarchy actually forms in real usage for the first time. ~6 lines in `event_loop_helper.py`; aligns Mellea with how `asyncio.create_task` already inherits Context within a thread.

2. **Span renames.** `session_context` → `session`; `aact` → `action`. `session_context`'s suffix was redundant, and `aact` named a Mellea internal function rather than the operation. Trace-tooling consumers filtering on the old names need to update.

3. **Scope-narrowing change vs. the original issue.** Issue #1048 asked for session and act spans via plugin hooks. Action lands as planned (`ComponentTracingPlugin`); session does not. Session lifecycle crosses multiple `_run_async_in_thread` calls (sync `__enter__`, sync `m.act(...)`, sync `__exit__`/`cleanup()`), each scheduled as a separate Task with its own `contextvars.Context`. OTel `Token.reset` is bound to the originating Context, so a span attached in one hook's Task can't be detached in another. Session spans now emit directly from `MelleaSession.__enter__/__exit__` and `start_session()` via typed helpers in `tracing.py`. The `SESSION_*` hooks still fire as observation points for non-tracing plugins.

4. **Component payload `component_id`.** Adds a UUID correlation field on `ComponentPreExecutePayload` / `ComponentPostSuccessPayload` / `ComponentPostErrorPayload`, matching the existing `generation_id` pattern on generation payloads. Plugin authors subscribing to `component_*` hooks gain a correlation key.

5. **Bug fix from #1181 review.** `mellea.response` is now gated on `MELLEA_TRACES_CONTENT` / `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Pre-this-PR it was captured unconditionally; this is the first real caller of `is_content_tracing_enabled()` (per @planetf1's #1181 review).

6. **Streaming out of scope.** `mellea/stdlib/streaming.py` was added in PR #1095 mid-epic, after the original Phase 2 plan was set, and it imports the deprecated `trace_application` surface. Migrating it is tracked as a follow-up Phase 2 sub-issue #1290. The four deprecated public helpers (`trace_application`, `set_span_attribute`, `set_span_error`, `set_span_status_error`) stay in `tracing.py` until streaming migrates off them.

7. **Docs touched only where existing claims went stale.** Span-hierarchy diagrams updated for the renames; one stale Phase-1 entry corrected (`mellea.backend` is a string identifier, not a class name). Broader docs cleanup is tracked in #945.

8. **Bug fix: `mellea.sampling_success` now reflects the actual flag.** Pre-this-PR the attribute was `bool(sampling_result.result)` — i.e. truthiness of the chosen `ModelOutputThunk`, which is `True` whenever sampling produced any non-None output even if no requirement passed. Post-this-PR it reads `sampling_result.success`, the flag the field name has always promised. Traces where sampling exhausted retries without satisfying requirements will now correctly show `mellea.sampling_success=false`.


BREAKING CHANGE: Span names renamed:
- `session_context` → `session`
- `aact` → `action`
Trace-tooling consumers filtering on the old names need to update.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
