### PR TITLE
fix(formatters): pass input_ids to model.generate() so peft can compute aLoRA offsets

### DIFF
--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -393,7 +393,7 @@ def generate_with_transformers(
     generate_input = generate_input.copy()
     del generate_input["input_tokens"]
 
-    generate_result = model.generate(inputs=input_tokens, **generate_input)  # type: ignore[operator]
+    generate_result = model.generate(input_ids=input_tokens, **generate_input)  # type: ignore[operator]
 
     # Result is a a 2D tensor of shape (num responses, prompt + max generated tokens)
     # containing tokens, plus a tuple of <max generated tokens> tensors of shape


### PR DESCRIPTION
## Problem

`context_relevance_alora` and `uncertainty_alora` intrinsic tests fail on CPU (and GPU) because PEFT cannot compute aLoRA prefix offsets. The warning confirms the root cause:

> Cannot calculate aLoRA offsets during generate as input_ids are not available. Disabling aLoRA.

When aLoRA fails, PEFT silently falls back to standard LoRA. Most intrinsics tolerate this, but `context_relevance` and `uncertainty` produce wrong or truncated JSON output.

## Root Cause

`mellea/formatters/granite/base/util.py:396` — the call to `model.generate()` uses `inputs=` instead of the canonical `input_ids=`:

```python
generate_result = model.generate(inputs=input_tokens, **generate_input)
```

PEFTs aLoRA hook inspects the `input_ids` kwarg at runtime. Missing it → aLoRA disabled.

## Fix

One-line change: `inputs=` → `input_ids=` in `generate_with_transformers()`.

## Testing

- All 4 aLoRA formatter tests pass with the fix: `context_relevance_alora`, `uncertainty_alora`, `answerability_answerable_alora`, `requirement_check_alora`
- Full test suite: 1237+ tests pass, 0 regressions (the only other failure was a pre-existing timeout in `query_clarification` which was confirmed by reverting this change and re-running that test with the same result)
- Pre-commit checks (ruff format, ruff check, mypy, codespell) all pass
- Confirmed against upstream/main: branch rebased on `317d5d9d`

Closes #1286