### PR TITLE
fix(tracing+ollama): split streaming span test into fast mock + slow e2e; add 300s default timeout

### DIFF
--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -162,7 +162,7 @@ class OllamaModelBackend(FormatterBackend):
         """Requests generic info about the Ollama server to ensure it's running."""
         try:
             self._client.ps()
-        except ConnectionError:
+        except (ConnectionError, httpx.TimeoutException, httpx.ConnectError):
             return False
         return True
 

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -6,6 +6,7 @@ import functools
 from collections.abc import AsyncIterator, Coroutine, Sequence
 from typing import Any
 
+import httpx
 import ollama
 from tqdm import tqdm
 
@@ -222,7 +223,7 @@ class OllamaModelBackend(FormatterBackend):
             for pbar in progress_bars.values():
                 pbar.close()
             return True
-        except ollama.ResponseError:
+        except (ollama.ResponseError, httpx.TimeoutException, httpx.ConnectError):
             return False
 
     @property

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -68,10 +68,11 @@ class OllamaModelBackend(FormatterBackend):
         base_url (str | None): Ollama server endpoint; defaults to
             ``env(OLLAMA_HOST)`` or ``http://localhost:11434``.
         model_options (dict | None): Default model options for generation requests.
-        timeout (float | None): Request timeout in seconds for the underlying HTTP
-            client. ``None`` (the default) preserves the upstream ``ollama`` SDK
-            default. Set this to bound how long a single request will wait when
-            the Ollama server is overloaded or stalled.
+        timeout (float | None): Per-operation HTTP timeout in seconds (connect,
+            read, write, pool). Defaults to 300 s. For streaming requests this
+            bounds the wait between consecutive chunks; for non-streaming requests
+            it bounds total time-to-response. Pass ``None`` to use the upstream
+            ``ollama`` SDK default (no timeout).
 
     Attributes:
         to_mellea_model_opts_map (dict): Mapping from Ollama-specific option names
@@ -86,7 +87,7 @@ class OllamaModelBackend(FormatterBackend):
         formatter: ChatFormatter | None = None,
         base_url: str | None = None,
         model_options: dict | None = None,
-        timeout: float | None = None,
+        timeout: float | None = 300.0,
     ):
         """Initialize an Ollama backend, connecting to the server and pulling the model if needed."""
         super().__init__(

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -207,8 +207,8 @@ def test_delta_merge_thinking_concatenated():
 # --- timeout wiring ---
 
 
-def test_timeout_default_not_passed_to_clients():
-    """When timeout is omitted, it must not be forwarded to the Ollama clients."""
+def test_timeout_default_forwarded_to_clients():
+    """When timeout is omitted, the 300 s default must be forwarded to both Ollama clients."""
     with (
         patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
         patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
@@ -218,9 +218,9 @@ def test_timeout_default_not_passed_to_clients():
         OllamaModelBackend(model_id="granite3.3:8b")
 
     _, sync_kwargs = mock_client.call_args
-    assert "timeout" not in sync_kwargs
+    assert sync_kwargs.get("timeout") == 300.0
     _, async_kwargs = mock_async_client.call_args
-    assert "timeout" not in async_kwargs
+    assert async_kwargs.get("timeout") == 300.0
 
 
 def test_timeout_forwarded_to_sync_and_async_clients():

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -223,6 +223,22 @@ def test_timeout_default_forwarded_to_clients():
     assert async_kwargs.get("timeout") == 300.0
 
 
+def test_timeout_none_not_forwarded_to_clients():
+    """Explicit timeout=None must omit the key — preserves the upstream SDK default (no timeout)."""
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client") as mock_client,
+        patch("mellea.backends.ollama.ollama.AsyncClient") as mock_async_client,
+    ):
+        OllamaModelBackend(model_id="granite3.3:8b", timeout=None)
+
+    _, sync_kwargs = mock_client.call_args
+    assert "timeout" not in sync_kwargs
+    _, async_kwargs = mock_async_client.call_args
+    assert "timeout" not in async_kwargs
+
+
 def test_timeout_forwarded_to_sync_and_async_clients():
     """When timeout is set, it must reach both ollama.Client and ollama.AsyncClient."""
     with (

--- a/test/telemetry/test_streaming_tracing_integration.py
+++ b/test/telemetry/test_streaming_tracing_integration.py
@@ -138,7 +138,8 @@ async def test_streaming_span_creates_and_closes_span(span_exporter):
     )
 
     span_duration_s = (backend_span.end_time - backend_span.start_time) / 1e9
-    assert span_duration_s >= 0.05, (
+    # fake stream is 3 chunks x 50 ms ~= 150 ms; >= 0.1 confirms span survived past first chunk
+    assert span_duration_s >= 0.1, (
         f"Span closed too early — duration {span_duration_s:.3f}s is shorter than "
         "the streaming delay, suggesting the span did not stay open for the full stream"
     )

--- a/test/telemetry/test_streaming_tracing_integration.py
+++ b/test/telemetry/test_streaming_tracing_integration.py
@@ -1,0 +1,144 @@
+"""Integration tests for streaming span tracing with a mocked Ollama client.
+
+Verifies that the TracingPlugin correctly opens and closes a span during
+streaming without requiring a live Ollama server.  This complements
+``test_tracing_backend.py::test_streaming_span_duration``, which tests
+real-model streaming but is marked ``slow`` and excluded from standard CI.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import ollama
+import pytest
+
+from mellea.backends.model_options import ModelOption
+from mellea.backends.ollama import OllamaModelBackend
+from mellea.plugins.manager import (
+    disable_background_collection,
+    discard_background_tasks,
+    drain_background_tasks,
+    enable_background_collection,
+)
+from mellea.stdlib.components import Message
+from mellea.stdlib.context import SimpleContext
+from test.telemetry.conftest import reset_tracing_state
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
+pytestmark = [
+    pytest.mark.skipif(not OTEL_AVAILABLE, reason="OpenTelemetry not installed"),
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_telemetry():
+    """Enable tracing for all tests in this module."""
+    mp = pytest.MonkeyPatch()
+    mp.setenv("MELLEA_TRACES_ENABLED", "true")
+    reset_tracing_state()
+
+    yield
+
+    mp.undo()
+    reset_tracing_state()
+
+
+@pytest.fixture
+def span_exporter():
+    """Create an in-memory span exporter attached to the tracing module's provider."""
+    from mellea.telemetry import tracing
+
+    tracing.get_backend_tracer()
+    provider = tracing._tracer_provider
+
+    if provider is None:
+        pytest.skip("Telemetry not initialized")
+
+    enable_background_collection()
+    discard_background_tasks()
+
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    yield exporter
+
+    exporter.clear()
+    disable_background_collection()
+
+
+@pytest.mark.asyncio
+async def test_streaming_span_creates_and_closes_span(span_exporter):
+    """Streaming backend call creates a chat span that closes after the stream completes.
+
+    Uses a mocked Ollama client so no server is needed.  Verifies the core
+    TracingPlugin invariant: the span must remain open for the full duration of
+    streaming and close only once all chunks are consumed.
+    """
+
+    async def fake_chat_stream(*args, **kwargs):
+        for content in ["1", " 2", " 3"]:
+            await asyncio.sleep(0.05)
+            yield ollama.ChatResponse(
+                model="test-model",
+                created_at=None,
+                message=ollama.Message(role="assistant", content=content),
+                done=False,
+            )
+        yield ollama.ChatResponse(
+            model="test-model",
+            created_at=None,
+            message=ollama.Message(role="assistant", content=""),
+            done=True,
+            eval_count=10,
+            prompt_eval_count=5,
+        )
+
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client"),
+        patch("mellea.backends.ollama.ollama.AsyncClient") as mock_async_client_cls,
+    ):
+        mock_async_instance = MagicMock()
+        mock_async_instance.chat.side_effect = fake_chat_stream
+        mock_async_client_cls.return_value = mock_async_instance
+
+        backend = OllamaModelBackend(model_id="test-model")
+        ctx = SimpleContext().add(Message(role="user", content="Count to 3"))
+
+        mot, _ = await backend.generate_from_context(
+            Message(role="assistant", content=""),
+            ctx,
+            model_options={ModelOption.STREAM: True},
+        )
+
+        await mot.astream()
+        await mot.avalue()
+        await drain_background_tasks()
+
+    trace.get_tracer_provider().force_flush()
+
+    spans = span_exporter.get_finished_spans()
+    backend_span = next((s for s in spans if s.name == "chat"), None)
+
+    assert backend_span is not None, "Backend span not found"
+    assert backend_span.end_time > backend_span.start_time, (
+        "Span must have nonzero duration"
+    )
+
+    span_duration_s = (backend_span.end_time - backend_span.start_time) / 1e9
+    assert span_duration_s >= 0.05, (
+        f"Span closed too early — duration {span_duration_s:.3f}s is shorter than "
+        "the streaming delay, suggesting the span did not stay open for the full stream"
+    )

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -278,6 +278,7 @@ async def test_multiple_generations_separate_spans(span_exporter):
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_streaming_span_duration(span_exporter):
     """Test that streaming operations have accurate span durations."""
 


### PR DESCRIPTION
The test was hanging because two things combined badly: \`OllamaModelBackend\` had no httpx timeout at all, so a stalled stream would park the event loop forever; and the test wasn't marked \`slow\`, so it ran on every push on a CPU-only runner where after ~30 min the model gets evicted and takes minutes to reload — longer than any safe scalar timeout.

The main fix is moving the test out of standard CI. A new \`integration\`-marked test does the same structural check against a mocked backend (no Ollama needed, ~200 ms). The original real-model test stays but picks up \`@pytest.mark.slow\`, so \`pyproject.toml\`'s \`addopts = "-m not slow"\` keeps it off standard CI pushes. The 300 s default timeout is a secondary safety net for when the slow test does run.

| Test | Markers | What it verifies |
|------|---------|-----------------|
| \`test_streaming_span_creates_and_closes_span\` (new) | \`integration\` | TracingPlugin opens a \`chat\` span, keeps it open for the full stream, and closes it when done — mocked \`AsyncClient.chat\` returning a fake async-generator with artificial per-chunk delays |
| \`test_streaming_span_duration\` (existing) | \`e2e + ollama + slow\` | Same invariant against a real Ollama model — belongs on the nightly GPU runner |

**Why not \`httpx.Timeout(connect=30, read=600, ...)\`?** A structured timeout would let us tune connection setup and read time independently. The trade-off is an explicit \`import httpx\` in \`ollama.py\` and a wider type annotation. The scalar is fine for now; a follow-up can add the structured form if we need finer control.

## Breaking change: default timeout

\`OllamaModelBackend\` now defaults to a **300 s timeout** (previously unlimited). Users running large models on CPU, very long contexts, or multi-minute generations may hit \`httpx.ReadTimeout\` where they previously saw the call complete eventually. Pass \`timeout=None\` to restore the previous unlimited behaviour:

\`\`\`python
backend = OllamaModelBackend("granite3.1-dense:8b", timeout=None)
\`\`\`

## Tested

**Mocked integration test** — no Ollama needed, runs in standard CI:

\`\`\`
uv run pytest test/telemetry/test_streaming_tracing_integration.py -v
\`\`\`

Passed locally in ~4.75 s. CI: ✅ passes on 3.11, 3.12, 3.13.

**Slow e2e test** — real Ollama with \`granite3.1-dense:8b\`, excluded from standard CI via \`-m not slow\`:

\`\`\`
uv run pytest test/telemetry/test_tracing_backend.py::test_streaming_span_duration -v -m slow
\`\`\`

Passed locally in ~6 s against a local Ollama instance. This test is excluded from standard CI pushes and will run in overnight/nightly runs where a GPU-backed Ollama server is available.

Closes #1272

<!-- pr-template -->