### PR TITLE
docs: document PR review states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 Pre-commit runs: ruff, mypy, uv-lock, codespell
 
+**Review states**: when reviewing a PR, see [CONTRIBUTING.md → Review States](CONTRIBUTING.md#review-states) for when to use `APPROVE` vs `REQUEST CHANGES` vs `COMMENT`.
+
 For AI attribution trailers, see [Section 7 (AI Attribution)](#7-ai-attribution).
 
 ## 7. AI Attribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -393,6 +393,31 @@ as it can corrupt state.
 8. **Push to your fork** and create a pull request to the main repository
 9. **Follow the automated PR workflow** instructions
 
+### Review States
+
+When submitting a PR review, pick one of GitHub's three states. Using them consistently keeps the merge signal meaningful: an `APPROVE` should mean the reviewer is willing to support the change, and a `REQUEST CHANGES` should mean something is actually blocking.
+
+| State | Use when |
+|-------|----------|
+| `APPROVE` | You'd be fine if this merged as-is. |
+| `REQUEST CHANGES` | This PR shouldn't merge in its current form. |
+| `COMMENT` | Anything else, or a follow-up that doesn't change the prior status. |
+
+**`APPROVE`** — the reviewer is willing to support the change.
+- The PR is ready to merge as-is, with or without non-blocking nits or follow-up suggestions that the author may address or skip with no harm.
+- The standard open-source "LGTM" signal: the reviewer stands behind the change.
+
+**`REQUEST CHANGES`** — the PR should not merge in its current form. Use when:
+- There is an actual blocking or breaking issue (correctness, regression, missing tests, etc.).
+- The reviewer wants to personally validate something before the PR merges, and is withholding their approval until the next round.
+- Important follow-up issues have not yet been opened, and the reviewer doesn't want them forgotten. The expectation here is that the issues get filed, not that the PR itself changes.
+
+**`COMMENT`** — for everything else. Use when:
+- Posting a follow-up review that shouldn't change the PR's status from a prior `APPROVE` or `REQUEST CHANGES` (e.g., re-reviewing after a push when nothing material changed).
+- The review falls between `APPROVE` and `REQUEST CHANGES` and the reviewer doesn't want to block.
+- The reviewer wants to defer the final call to other reviewers.
+- The review is purely informational and the reviewer isn't gating on the PR at all.
+
 ## Testing
 
 ### Quick Reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,7 +416,7 @@ When submitting a PR review, pick one of GitHub's three states. Using them consi
 **`REQUEST CHANGES`** — the PR should not merge in its current form. Use when:
 - There is an actual blocking or breaking issue (correctness, regression, missing tests, etc.).
 - The reviewer needs to validate a concrete concern (a suspected regression, an incomplete change) before the PR merges, and is withholding approval until the next round. Wanting another pass without a specific concern isn't on its own a reason to block; coordinate with the author by comment instead.
-- Important follow-up issues have not yet been opened, and the reviewer doesn't want them forgotten. The expectation here is that the issues get filed, not that the PR itself changes.
+- Important follow-up issues have not yet been opened, and the reviewer doesn't want them forgotten. The resolution is to file the issues, not to change the PR; once they're filed the reviewer re-approves to clear the block.
 
 **`COMMENT`** — for everything else. Use when:
 - Posting a follow-up review that shouldn't change the PR's status from a prior `APPROVE` or `REQUEST CHANGES` (e.g., re-reviewing after a push when nothing material changed).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -393,6 +393,12 @@ as it can corrupt state.
 8. **Push to your fork** and create a pull request to the main repository
 9. **Follow the automated PR workflow** instructions
 
+### Review Assignment
+
+When a PR is opened, a subset of the relevant CODEOWNERS are requested for review at random. A PR becomes mergeable once CI passes and it has at least one approving review from a relevant CODEOWNER.
+
+Being one of several requested reviewers does not obligate you to review every PR; one approval satisfies the merge requirement. Review when the change touches an area you maintain or when an existing approval lacks the context you need to judge it. When a PR falls in an area another maintainer owns more than you, request them as a reviewer or defer to them.
+
 ### Review States
 
 When submitting a PR review, pick one of GitHub's three states. Using them consistently keeps the merge signal meaningful: an `APPROVE` should mean the reviewer is willing to support the change, and a `REQUEST CHANGES` should mean something is actually blocking.
@@ -404,12 +410,12 @@ When submitting a PR review, pick one of GitHub's three states. Using them consi
 | `COMMENT` | Anything else, or a follow-up that doesn't change the prior status. |
 
 **`APPROVE`** — the reviewer is willing to support the change.
-- The PR is ready to merge as-is, with or without non-blocking nits or follow-up suggestions that the author may address or skip with no harm.
-- The standard open-source "LGTM" signal: the reviewer stands behind the change.
+- The PR is ready to merge as-is. Any nits or suggestions are non-blocking; the author may address or skip them with no harm. If something needs a follow-up so it isn't forgotten, that belongs under `REQUEST CHANGES` instead.
+- The standard open-source "LGTM" signal: the reviewer stands behind the change and shares responsibility for maintaining that area going forward.
 
 **`REQUEST CHANGES`** — the PR should not merge in its current form. Use when:
 - There is an actual blocking or breaking issue (correctness, regression, missing tests, etc.).
-- The reviewer wants to personally validate something before the PR merges, and is withholding their approval until the next round.
+- The reviewer needs to validate a concrete concern (a suspected regression, an incomplete change) before the PR merges, and is withholding approval until the next round. Wanting another pass without a specific concern isn't on its own a reason to block; coordinate with the author by comment instead.
 - Important follow-up issues have not yet been opened, and the reviewer doesn't want them forgotten. The expectation here is that the issues get filed, not that the PR itself changes.
 
 **`COMMENT`** — for everything else. Use when:
@@ -417,6 +423,18 @@ When submitting a PR review, pick one of GitHub's three states. Using them consi
 - The review falls between `APPROVE` and `REQUEST CHANGES` and the reviewer doesn't want to block.
 - The reviewer wants to defer the final call to other reviewers.
 - The review is purely informational and the reviewer isn't gating on the PR at all.
+
+### Merging
+
+Merging is a maintainer action, performed by either the author or a reviewer; "merge when ready" only schedules it once requirements pass. Whoever merges confirms the PR is actually ready, not just that the queue requirements are green. CI passing and the minimum approval make a PR *mergeable*, but a concern raised in discussion that never became an explicit `REQUEST CHANGES` should still be resolved first.
+
+The `do-not-merge/hold` label blocks merging while it is applied, enforced by CI independent of review state. It is a separate mechanism from a `REQUEST CHANGES` review and is removed once the blocking condition clears.
+
+### Review comments
+
+For small nits on a `COMMENT` or `APPROVE` review, prefer a GitHub suggestion block — it lets the author apply the change in one click and keeps non-blocking feedback from adding review-cycle friction.
+
+Resolve a review conversation once its specific point is handled; prefer the reviewer who raised it to resolve it, so an unresolved thread reliably means "still open."
 
 ## Testing
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #

## Description
Adds a `Review States` subsection to CONTRIBUTING.md describing when to use GitHub's three PR review states — `APPROVE`, `REQUEST CHANGES`, and `COMMENT`. Adds a one-line pointer in AGENTS.md Section 6 so AI reviewers find it.

A few spots worth weighing in on during review:
- The "personally want to validate before merge" case under `REQUEST CHANGES` — does the team agree this belongs there, or is it a `COMMENT` + re-request review?
- The "follow-up issues not yet filed" case — wording reads as "the action is filing issues, not changing the PR." OK?
- Quick-reference table at the top — keep it, or is the prose alone enough?

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs.  -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
