### PR TITLE
feat(stdlib): public error and generate_log surface on ModelOutputThunk

### DIFF
--- a/docs/docs/how-to/unit-test-generative-code.md
+++ b/docs/docs/how-to/unit-test-generative-code.md
@@ -220,8 +220,9 @@ def test_instruct_returns_string(session):
 
 ### Inspecting logged model options
 
-`_generate_log.model_options` lets you confirm that options you passed were
-forwarded to the model. This is useful when testing custom model option handling:
+`result.generate_log.model_options` lets you confirm that options you passed
+were forwarded to the model. This is useful when testing custom model option
+handling:
 
 ```python
 # Requires: mellea, pytest
@@ -239,12 +240,12 @@ def test_model_options_forwarded(session):
         "Write a one-sentence summary.",
         model_options=model_options,
     )
-    assert "custom_param" in res._generate_log.model_options
+    assert "custom_param" in res.generate_log.model_options
 ```
 
-> **Note:** `_generate_log` is an internal attribute. Its structure may change
-> between Mellea versions. Use it for debugging and option-forwarding tests, not
-> as a primary correctness check.
+> **Note:** `GenerateLog` is recorded for every generation, but its field set
+> may change between Mellea versions. Use it for debugging and
+> option-forwarding tests, not as a primary correctness check.
 
 ## Using `simple_validate` for deterministic checks
 

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -497,10 +497,9 @@ class OllamaModelBackend(FormatterBackend):
 
                 If Ollama returns an empty done response (``response=""``,
                 ``done=True``, no thinking content) for an action, that thunk
-                soft-fails: it has ``value=""``, with the ``RuntimeError`` stored
-                at ``thunk._generate_log.extra["error"]`` and the serialized
-                response dict at ``thunk._generate_log.extra["empty_response"]``.
-                Other actions in the batch are unaffected.
+                soft-fails: it has ``value=""`` and ``thunk.error`` carries the
+                ``RuntimeError`` describing the cause. Other actions in the
+                batch are unaffected.
 
         Note:
             Requests are awaited with ``asyncio.gather`` (all-or-nothing): if any
@@ -548,7 +547,6 @@ class OllamaModelBackend(FormatterBackend):
         agg_completion = 0
         for i, response in enumerate(responses):
             result = None
-            error = None
             per_mot_usage: dict[str, Any] | None = None
             if response.done and not response.response and not response.thinking:
                 # Empty done response with no thinking content. Commonly caused by the
@@ -563,7 +561,7 @@ class OllamaModelBackend(FormatterBackend):
                 )
                 MelleaLogger.get_logger().warning(str(empty_err))
                 result = ModelOutputThunk(value="")
-                error = empty_err
+                result._error = empty_err
             else:
                 n_in = response.prompt_eval_count
                 n_out = response.eval_count
@@ -600,10 +598,6 @@ class OllamaModelBackend(FormatterBackend):
                 "seed": model_opts.get(ModelOption.SEED, None),
             }
             generate_log.action = action
-
-            if error:
-                generate_log.extra["error"] = error
-                generate_log.extra["empty_response"] = response.model_dump()
             result._generate_log = generate_log
 
             results.append(result)

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -398,6 +398,9 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._start: datetime.datetime | None = None
         self._first_chunk_received: bool = False
         self._generate_log: GenerateLog | None = None
+        # Soft-failure cause recorded by backends that return a placeholder
+        # MOT instead of raising. Sibling to `_cancelled`.
+        self._error: Exception | None = None
         # Mellea-side hook correlation ID; distinct from the provider-assigned
         # `GenerationMetadata.response_id`.
         self._generation_id: str | None = None
@@ -528,6 +531,26 @@ class ModelOutputThunk(CBlock, Generic[S]):
         """
         return self._cancelled
 
+    @property
+    def error(self) -> Exception | None:
+        """Soft-failure cause recorded by the backend, or `None` on success.
+
+        Sibling to `cancelled`: `error` is involuntary (the backend produced
+        an unusable result without raising); `cancelled` is voluntary (a
+        consumer stopped the generation via `cancel_generation`). The two
+        are recorded independently.
+        """
+        return self._error
+
+    @property
+    def generate_log(self) -> GenerateLog | None:
+        """The `GenerateLog` recorded for this generation.
+
+        Returned by reference; mutating the returned object mutates the MOT's
+        log.
+        """
+        return self._generate_log
+
     def _copy_from(self, other: ModelOutputThunk) -> None:
         """Copy computed-output fields from *other* into *self*.
 
@@ -543,6 +566,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self.generation = other.generation
         self._generate_log = other._generate_log
         self._cancelled = other._cancelled
+        self._error = other._error
         # _cancel_hook is deliberately not copied: _copy_from swaps output state,
         # not backend-thread plumbing, which is tied to the original computation.
         self._cancel_hook = None
@@ -769,6 +793,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
 
         copied._computed = self._computed
         copied._cancelled = self._cancelled
+        copied._error = self._error
         # _cancel_hook is not forwarded: a copied MOT is a distinct computation
         # and must not share the original's backend thread signal.
         copied._cancel_hook = None
@@ -801,6 +826,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         deepcopied.tool_calls = deepcopy(self.tool_calls)
         deepcopied._computed = self._computed
         deepcopied._cancelled = self._cancelled
+        deepcopied._error = self._error
         # _cancel_hook is not forwarded: a deepcopied MOT is a distinct computation
         # and must not share the original's backend thread signal.
         deepcopied._cancel_hook = None

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -276,7 +276,7 @@ async def test_generate_from_raw_empty_response_soft_fails(mock_ollama_backend) 
 
     The result list must have the same length as the input actions so that
     sibling results from the same gather call are not discarded. The failing
-    slot must have value="" and carry the RuntimeError in generate_log.extra["error"].
+    slot must have value="" and carry the RuntimeError on `mot.error`.
     """
     backend = mock_ollama_backend()
     empty = ollama.GenerateResponse(response="", done=True)
@@ -295,15 +295,15 @@ async def test_generate_from_raw_empty_response_soft_fails(mock_ollama_backend) 
         "result list must match action count even on empty response"
     )
     assert results[0].value == "", "empty-response slot should have value=''"
-    log = results[0]._generate_log
-    assert log is not None
-    assert log.extra is not None
-    err = log.extra.get("error")
+    err = results[0].error
     assert isinstance(err, RuntimeError), (
-        f"expected RuntimeError in generate_log, got {err!r}"
+        f"expected RuntimeError on mot.error, got {err!r}"
     )
     assert "599" in str(err), "error message should reference issue #599"
     assert "16326" in str(err), "error message should reference upstream Ollama issue"
+    assert results[0].cancelled is False, (
+        "soft-fail must not flip the cancelled flag — it is a sibling channel"
+    )
 
 
 async def test_generate_from_raw_thinking_response_not_flagged(
@@ -331,10 +331,7 @@ async def test_generate_from_raw_thinking_response_not_flagged(
         )
 
     assert len(results) == 1
-    log = results[0]._generate_log
-    assert log is not None
-    assert log.extra is not None
-    assert log.extra.get("error") is None, (
+    assert results[0].error is None, (
         "thinking-only response should not be flagged as a model-load race"
     )
 
@@ -362,12 +359,11 @@ async def test_generate_from_raw_preserves_sibling_results_on_empty(
 
     assert len(results) == 3, "all three slots should be returned"
     assert results[0].value == "2"
+    assert results[0].error is None
     assert results[1].value == ""
-    log1 = results[1]._generate_log
-    assert log1 is not None
-    assert log1.extra is not None
-    assert log1.extra.get("error") is not None
+    assert results[1].error is not None
     assert results[2].value == "2"
+    assert results[2].error is None
 
 
 if __name__ == "__main__":

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -189,6 +189,51 @@ def test_mot_deep_copy_clones_generation():
     assert deepcopied.generation.ttfb_ms == 42.0
 
 
+# --- Public error / generate_log surface ---
+
+
+def test_mot_generate_log_property_aliases_private_attr() -> None:
+    """`mot.generate_log` returns the same object as `_generate_log`."""
+    from mellea.core.base import GenerateLog
+
+    mot = ModelOutputThunk(value="x")
+    assert mot.generate_log is None
+    glog = GenerateLog()
+    mot._generate_log = glog
+    assert mot.generate_log is glog
+
+
+def test_mot_error_and_cancelled_are_independent_channels() -> None:
+    """Setting `_error` must not flip `cancelled`, and vice versa."""
+    soft_failed = ModelOutputThunk(value="")
+    soft_failed._error = RuntimeError("backend soft-failure")
+    assert soft_failed.error is not None
+    assert soft_failed.cancelled is False
+
+    cancelled = ModelOutputThunk(value="partial")
+    cancelled._cancelled = True
+    assert cancelled.cancelled is True
+    assert cancelled.error is None
+
+
+def test_mot_error_carried_by_copy_methods() -> None:
+    """`_error` survives `copy`, `deepcopy`, and `_copy_from`."""
+    mot = ModelOutputThunk(value="")
+    err = RuntimeError("recorded")
+    mot._error = err
+
+    shallow = copy.copy(mot)
+    assert shallow.error is err
+
+    deep = copy.deepcopy(mot)
+    assert isinstance(deep.error, RuntimeError)
+    assert str(deep.error) == "recorded"
+
+    target = ModelOutputThunk(value=None)
+    target._copy_from(mot)
+    assert target.error is err
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1191

## Description

Adds two read properties to `ModelOutputThunk` so callers can detect a backend soft-failure without reaching into private attributes:

- `mot.error: Exception | None` — soft-failure cause recorded by the backend, or `None` on success. Sibling to `cancelled`: involuntary backend failure vs voluntary consumer stop, recorded independently.
- `mot.generate_log: GenerateLog | None` — read alias for `_generate_log`.

Migrates the `OllamaBackend._generate_from_raw` empty-done soft-fail path from stashing the error at `generate_log.extra["error"]` / `extra["empty_response"]` to `result._error`. The legacy `extra` keys are no longer written.

`_error` is carried through `__copy__`, `__deepcopy__`, and `_copy_from`.

The new caller-facing pattern:

```python
results = await asyncio.gather(*calls)
for r in results:
    if r.error is not None:
        ...  # soft-failure
    elif r.cancelled:
        ...  # explicit cancellation
    else:
        use(r.value)
```

Design captured in #1191. This is Area 5 of the #909 epic.

## Follow-ups (not in this PR)

- **`GenerateLog` deprecation** — out of scope per the #1191 design; to be filed as a separate issue once the post-#909 dust settles.
- **Raw empty-done response** — the dropped `extra["empty_response"]` key carried the raw Ollama response. Callers needing it should look to #1215 (Area 1: `mot.raw.response`).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
