### PR TITLE
fix: improve repair instruction

### DIFF
--- a/mellea/stdlib/sampling/feedback.py
+++ b/mellea/stdlib/sampling/feedback.py
@@ -265,7 +265,8 @@ class ModelFriendlyFeedbackFormatter:
             )
             return (
                 f"Your code didn't save the plot to the expected file. "
-                f"Try: Add plt.savefig('{expected_path}') before plt.show() or plt.close()."
+                f"Try: Add plt.savefig('{expected_path}') before plt.show() or plt.close(). "
+                f"Do not use a variable as an argument of plt.savefig.  Use a string literal as the argument like plt.savefig('{expected_path}'). "
             )
         else:
             return (

--- a/test/stdlib/sampling/test_presets.py
+++ b/test/stdlib/sampling/test_presets.py
@@ -282,6 +282,7 @@ class TestModelFriendlyFeedbackFormatter:
         assert "plot.png" in formatted
         assert "plt.savefig('plot.png')" in formatted
         assert "Try:" in formatted
+        assert "Do not use a variable as an argument" in formatted
 
     def test_matplotlib_plot_file_saved_error_with_custom_path(self):
         """Test PlotFileSaved error formatting with custom output path."""
@@ -290,6 +291,7 @@ class TestModelFriendlyFeedbackFormatter:
         formatted = ModelFriendlyFeedbackFormatter.format_matplotlib_error(result)
         assert "/tmp/output.png" in formatted
         assert "plt.savefig('/tmp/output.png')" in formatted
+        assert "Do not use a variable as an argument" in formatted
 
     def test_matplotlib_plot_file_saved_error_fallback(self):
         """Test PlotFileSaved error formatting with malformed reason (fallback)."""


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1308

## Description
<!-- What does this PR do and why? -->
Improve the repair hint string to make LLM generate the code meet requirement validation.
It instructs to generate code like following
```
# Save the graph to file
plt.savefig('/var/folders/kl/cljphvzd64qgtl2sqnh30fs00000gn/T/graph_5.png')
```
instead of 
```
# Save the graph to file
output_path = '/var/folders/kl/cljphvzd64qgtl2sqnh30fs00000gn/T/graph_5.png'
plt.savefig(output_path)
```
### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
