### PR TITLE
refactor(core): promote ModelOutputThunk.thinking and deprecate _thin…

### DIFF
--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -357,7 +357,7 @@ Diagnose with:
 result = m.instruct("What is 2 + 2?")
 print(repr(result.value))                    # ''
 print(result.generation.usage)               # {'completion_tokens': 9, ...}
-print(result._thinking)                      # populated reasoning content, if any
+print(result.thinking)                       # populated reasoning content, if any
 ```
 
 This affects models that default to thinking mode, most commonly Qwen3 served
@@ -383,7 +383,7 @@ m = MelleaSession(
 
 Other inference servers expose the same control under different names — check
 your runtime's documentation. If you intend to use thinking mode, read the
-reasoning trace from `result._thinking` rather than `result.value`.
+reasoning trace from `result.thinking` rather than `result.value`.
 
 ---
 

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -470,8 +470,8 @@ class LiteLLMBackend(FormatterBackend):
             chunk (litellm.ModelResponse | litellm.ModelResponseStream): A single
                 response object or streaming chunk from LiteLLM.
         """
-        if mot._thinking is None:
-            mot._thinking = ""
+        if mot.thinking is None:
+            mot.thinking = ""
         if mot._underlying_value is None:
             mot._underlying_value = ""
 
@@ -490,7 +490,7 @@ class LiteLLMBackend(FormatterBackend):
             if thinking_chunk is None:
                 thinking_chunk = message.get("reasoning")
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message.content
             if content_chunk is not None:
@@ -509,7 +509,7 @@ class LiteLLMBackend(FormatterBackend):
             if thinking_chunk is None:
                 thinking_chunk = message_delta.get("reasoning")
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message_delta.content
             if content_chunk is not None:

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -683,11 +683,11 @@ class OllamaModelBackend(FormatterBackend):
             tools (dict[str, AbstractMelleaTool]): Available tools, keyed by name,
                 used for extracting tool call requests from the response.
         """
-        if mot._thinking is None:
-            mot._thinking = ""
+        if mot.thinking is None:
+            mot.thinking = ""
         thinking_chunk = chunk.message.thinking
         if thinking_chunk is not None:
-            mot._thinking += thinking_chunk
+            mot.thinking += thinking_chunk
 
         if mot._underlying_value is None:
             mot._underlying_value = ""

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1002,8 +1002,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             chunk (ChatCompletion | ChatCompletionChunk): A single response object or
                 streaming delta from the OpenAI API.
         """
-        if mot._thinking is None:
-            mot._thinking = ""
+        if mot.thinking is None:
+            mot.thinking = ""
         if mot._underlying_value is None:
             mot._underlying_value = ""
 
@@ -1016,7 +1016,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             if thinking_chunk is None:
                 thinking_chunk = (message.model_extra or {}).get("reasoning")
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message.content
             if content_chunk is not None:
@@ -1041,7 +1041,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             if thinking_chunk is None:
                 thinking_chunk = (message_delta.model_extra or {}).get("reasoning")
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message_delta.content
             if content_chunk is not None:

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -484,8 +484,8 @@ class WatsonxAIBackend(FormatterBackend):
             mot (ModelOutputThunk): The output thunk being populated.
             chunk (dict): A single response dict or streaming delta from the WatsonX API.
         """
-        if mot._thinking is None:
-            mot._thinking = ""
+        if mot.thinking is None:
+            mot.thinking = ""
         if mot._underlying_value is None:
             mot._underlying_value = ""
 
@@ -499,7 +499,7 @@ class WatsonxAIBackend(FormatterBackend):
 
             thinking_chunk = message.get("reasoning_content", None)
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message.get("content", "")
             if content_chunk is not None:
@@ -515,7 +515,7 @@ class WatsonxAIBackend(FormatterBackend):
 
             thinking_chunk = message_delta.get("reasoning_content", None)
             if thinking_chunk is not None:
-                mot._thinking += thinking_chunk
+                mot.thinking += thinking_chunk
 
             content_chunk = message_delta.get("content", None)
             if content_chunk is not None:

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -18,6 +18,7 @@ import binascii
 import datetime
 import enum
 import logging
+import warnings
 from collections.abc import Callable, Coroutine, Iterable, Mapping
 from copy import copy, deepcopy
 from dataclasses import dataclass
@@ -394,7 +395,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
 
         # Additional fields that should be standardized across apis.
         self.tool_calls = tool_calls
-        self._thinking: str | None = None
+        self.thinking: str | None = None
         self.generation: GenerationMetadata = GenerationMetadata()
         """Backend execution metadata populated during generation."""
 
@@ -594,7 +595,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._meta = other._meta
         self.parsed_repr = other.parsed_repr
         self.tool_calls = other.tool_calls
-        self._thinking = other._thinking
+        self.thinking = other.thinking
         self.generation = other.generation
         self._generate_log = other._generate_log
         self._cancelled = other._cancelled
@@ -610,6 +611,26 @@ class ModelOutputThunk(CBlock, Generic[S]):
             `True` if the thunk value has been set, `False` otherwise.
         """
         return self._computed
+
+    @property
+    def _thinking(self) -> str | None:
+        """Deprecated alias for :attr:`thinking`.
+
+        Returns:
+            str | None: The model's reasoning/thinking trace.
+        """
+        warnings.warn(
+            "`ModelOutputThunk._thinking` is deprecated and will be removed in a "
+            "future minor release. Use `ModelOutputThunk.thinking` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.thinking
+
+    @_thinking.setter
+    def _thinking(self, value: str | None) -> None:
+        """Deprecated write alias for :attr:`thinking`."""
+        self.thinking = value
 
     @property
     def value(self) -> str | None:
@@ -829,7 +850,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # _cancel_hook is not forwarded: a copied MOT is a distinct computation
         # and must not share the original's backend thread signal.
         copied._cancel_hook = None
-        copied._thinking = self._thinking
+        copied.thinking = self.thinking
         copied._action = self._action
         copied._context = self._context
         copied._generate_log = self._generate_log
@@ -862,7 +883,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # _cancel_hook is not forwarded: a deepcopied MOT is a distinct computation
         # and must not share the original's backend thread signal.
         deepcopied._cancel_hook = None
-        deepcopied._thinking = self._thinking
+        deepcopied.thinking = self.thinking
         deepcopied._action = deepcopy(self._action)
         deepcopied._context = copy(
             self._context

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -18,7 +18,6 @@ import binascii
 import datetime
 import enum
 import logging
-import warnings
 from collections.abc import Callable, Coroutine, Iterable, Mapping
 from copy import copy, deepcopy
 from dataclasses import dataclass
@@ -611,26 +610,6 @@ class ModelOutputThunk(CBlock, Generic[S]):
             `True` if the thunk value has been set, `False` otherwise.
         """
         return self._computed
-
-    @property
-    def _thinking(self) -> str | None:
-        """Deprecated alias for :attr:`thinking`.
-
-        Returns:
-            str | None: The model's reasoning/thinking trace.
-        """
-        warnings.warn(
-            "`ModelOutputThunk._thinking` is deprecated and will be removed in a "
-            "future minor release. Use `ModelOutputThunk.thinking` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.thinking
-
-    @_thinking.setter
-    def _thinking(self, value: str | None) -> None:
-        """Deprecated write alias for :attr:`thinking`."""
-        self.thinking = value
 
     @property
     def value(self) -> str | None:

--- a/mellea/stdlib/requirements/safety/guardian.py
+++ b/mellea/stdlib/requirements/safety/guardian.py
@@ -389,7 +389,7 @@ class GuardianCheck(Requirement):
         await mot.avalue()
 
         # Prefer explicit thinking if available, else try to split from output text.
-        trace = getattr(mot, "_thinking", None)
+        trace = mot.thinking
         text = mot.value or ""
         if trace is None and "</think>" in text:
             parts = text.split("</think>")

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -1,4 +1,4 @@
-"""Unit tests for LiteLLMBackend mot._thinking population.
+"""Unit tests for LiteLLMBackend mot.thinking population.
 
 Covers the vLLM case where the wire key is ``"reasoning"`` instead of
 ``"reasoning_content"``, and the case where LiteLLM has already normalised
@@ -75,7 +75,7 @@ async def test_processing_non_streaming_reasoning_content_key(backend: LiteLLMBa
         reasoning_value="France has its capital in Paris.",
     )
     await backend.processing(mot, chunk)
-    assert mot._thinking == "France has its capital in Paris."
+    assert mot.thinking == "France has its capital in Paris."
     assert mot._underlying_value == "Paris"
 
 
@@ -88,7 +88,7 @@ async def test_processing_non_streaming_reasoning_raw_key(backend: LiteLLMBacken
         reasoning_value="France has its capital in Paris.",
     )
     await backend.processing(mot, chunk)
-    assert mot._thinking == "France has its capital in Paris."
+    assert mot.thinking == "France has its capital in Paris."
     assert mot._underlying_value == "Paris"
 
 
@@ -109,7 +109,7 @@ async def test_processing_non_streaming_reasoning_content_wins_over_reasoning(
         object="chat.completion",
     )
     await backend.processing(mot, chunk)
-    assert mot._thinking == "from_reasoning_content"
+    assert mot.thinking == "from_reasoning_content"
 
 
 async def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
@@ -121,7 +121,7 @@ async def test_processing_non_streaming_no_reasoning(backend: LiteLLMBackend):
         reasoning_value="should be ignored",
     )
     await backend.processing(mot, chunk)
-    assert mot._thinking == ""
+    assert mot.thinking == ""
     assert mot._underlying_value == "Paris"
 
 
@@ -147,7 +147,7 @@ async def test_processing_non_streaming_empty_reasoning_content_does_not_fall_ba
         object="chat.completion",
     )
     await backend.processing(mot, chunk)
-    assert mot._thinking == ""
+    assert mot.thinking == ""
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +163,7 @@ async def test_processing_streaming_reasoning_content_key(backend: LiteLLMBacken
             content="", reasoning_key="reasoning_content", reasoning_value=text
         )
         await backend.processing(mot, stream_chunk)
-    assert mot._thinking == "chunk1 chunk2"
+    assert mot.thinking == "chunk1 chunk2"
 
 
 async def test_processing_streaming_reasoning_raw_key(backend: LiteLLMBackend):
@@ -174,7 +174,7 @@ async def test_processing_streaming_reasoning_raw_key(backend: LiteLLMBackend):
             content="", reasoning_key="reasoning", reasoning_value=text
         )
         await backend.processing(mot, stream_chunk)
-    assert mot._thinking == "chunk1 chunk2"
+    assert mot.thinking == "chunk1 chunk2"
 
 
 async def test_processing_streaming_reasoning_content_wins_over_reasoning(
@@ -190,7 +190,7 @@ async def test_processing_streaming_reasoning_content_wins_over_reasoning(
         id="test", choices=[chunk_choice], created=0, model="openai/qwen3"
     )
     await backend.processing(mot, stream_chunk)
-    assert mot._thinking == "from_reasoning_content"
+    assert mot.thinking == "from_reasoning_content"
 
 
 async def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
@@ -200,7 +200,7 @@ async def test_processing_streaming_no_reasoning(backend: LiteLLMBackend):
         content="Paris", reasoning_key="unrelated_key", reasoning_value="ignored"
     )
     await backend.processing(mot, stream_chunk)
-    assert mot._thinking == ""
+    assert mot.thinking == ""
     assert mot._underlying_value == "Paris"
 
 
@@ -220,7 +220,7 @@ async def test_processing_streaming_empty_reasoning_content_does_not_fall_back(
         id="test", choices=[chunk_choice], created=0, model="openai/qwen3"
     )
     await backend.processing(mot, stream_chunk)
-    assert mot._thinking == ""
+    assert mot.thinking == ""
 
 
 # ---------------------------------------------------------------------------

--- a/test/backends/test_ollama_unit.py
+++ b/test/backends/test_ollama_unit.py
@@ -204,6 +204,18 @@ def test_delta_merge_thinking_concatenated():
     assert mot._meta["chat_response"].message.thinking == "step 1 step 2"
 
 
+@pytest.mark.asyncio
+async def test_processing_initializes_and_accumulates_thinking(
+    backend: OllamaModelBackend,
+):
+    """processing() initializes thinking and accumulates chunk thinking text."""
+    mot = ModelOutputThunk(value=None)
+    await backend.processing(mot, _make_delta("answer", thinking="step 1"), {})
+
+    assert mot.thinking == "step 1"
+    assert mot._underlying_value == "answer"
+
+
 # --- timeout wiring ---
 
 

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -193,7 +193,7 @@ def _vllm_chat_completion(reasoning: str, content: str | None) -> ChatCompletion
 
 
 async def test_processing_captures_vllm_reasoning_field(backend):
-    """Non-streaming: mot._thinking captures the raw ``reasoning`` key from vLLM."""
+    """Non-streaming: mot.thinking captures the raw ``reasoning`` key from vLLM."""
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     chunk = _vllm_chat_completion(reasoning="2 + 2 equals 4.", content="4")
     # Sanity check: the SDK object does not expose reasoning_content
@@ -201,7 +201,7 @@ async def test_processing_captures_vllm_reasoning_field(backend):
 
     await backend.processing(mot, chunk)
 
-    assert mot._thinking == "2 + 2 equals 4."
+    assert mot.thinking == "2 + 2 equals 4."
     assert mot._underlying_value == "4"
 
 
@@ -212,12 +212,12 @@ async def test_processing_vllm_reasoning_with_null_content(backend):
 
     await backend.processing(mot, chunk)
 
-    assert mot._thinking == "some thinking"
+    assert mot.thinking == "some thinking"
     assert mot._underlying_value == ""
 
 
 async def test_processing_streaming_captures_vllm_reasoning_field(backend):
-    """Streaming: per-chunk ``reasoning`` deltas accumulate into mot._thinking."""
+    """Streaming: per-chunk ``reasoning`` deltas accumulate into mot.thinking."""
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     chunk_a = ChatCompletionChunk.model_validate(
         {
@@ -257,7 +257,7 @@ async def test_processing_streaming_captures_vllm_reasoning_field(backend):
     await backend.processing(mot, chunk_a)
     await backend.processing(mot, chunk_b)
 
-    assert mot._thinking == "first second"
+    assert mot.thinking == "first second"
     assert mot._underlying_value == "ans"
 
 
@@ -287,7 +287,7 @@ async def test_processing_reasoning_content_still_used(backend):
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     await backend.processing(mot, chunk)
 
-    assert mot._thinking == "attribute-style trace"
+    assert mot.thinking == "attribute-style trace"
     assert mot._underlying_value == "answer"
 
 
@@ -311,7 +311,7 @@ async def test_processing_reasoning_content_takes_precedence_over_reasoning(back
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     await backend.processing(mot, chunk)
 
-    assert mot._thinking == "attr-trace"
+    assert mot.thinking == "attr-trace"
     assert mot._underlying_value == "answer"
 
 

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -142,7 +142,7 @@ async def test_watsonx_processing_non_streaming_captures_reasoning_content():
 
     assert mot.thinking == "trace"
     assert mot._underlying_value == "answer content"
-    assert mot._meta["oai_chat_response_choice"] == chunk["choices"][0]
+    assert mot.raw.response["choices"][0] == chunk["choices"][0]
 
 
 @pytest.mark.asyncio
@@ -159,7 +159,7 @@ async def test_watsonx_processing_streaming_captures_reasoning_content():
 
     assert mot.thinking == "ab"
     assert mot._underlying_value == "xy"
-    assert len(mot._meta["oai_chat_response_streamed"]) == 2
+    assert len(mot.raw.streamed_chunks) == 2
 
 
 # --- HuggingFace ---

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -11,6 +11,7 @@ import pytest
 from mellea.backends import ModelOption
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
+from mellea.core import ModelOutputThunk
 
 # --- OpenAI ---
 
@@ -125,6 +126,40 @@ def test_watsonx_stop_sequences_round_trip(is_chat, native_key):
     )
     assert backend_specific[native_key] == stops
     assert ModelOption.STOP_SEQUENCES not in backend_specific
+
+
+@pytest.mark.asyncio
+async def test_watsonx_processing_non_streaming_captures_reasoning_content():
+    backend = _make_watsonx_backend()
+    mot = ModelOutputThunk(value=None)
+
+    chunk = {
+        "choices": [
+            {"message": {"reasoning_content": "trace", "content": "answer content"}}
+        ]
+    }
+    await backend.processing(mot, chunk)
+
+    assert mot.thinking == "trace"
+    assert mot._underlying_value == "answer content"
+    assert mot._meta["oai_chat_response_choice"] == chunk["choices"][0]
+
+
+@pytest.mark.asyncio
+async def test_watsonx_processing_streaming_captures_reasoning_content():
+    backend = _make_watsonx_backend()
+    mot = ModelOutputThunk(value=None)
+
+    await backend.processing(
+        mot, {"choices": [{"delta": {"reasoning_content": "a", "content": "x"}}]}
+    )
+    await backend.processing(
+        mot, {"choices": [{"delta": {"reasoning_content": "b", "content": "y"}}]}
+    )
+
+    assert mot.thinking == "ab"
+    assert mot._underlying_value == "xy"
+    assert len(mot._meta["oai_chat_response_streamed"]) == 2
 
 
 # --- HuggingFace ---

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -281,19 +281,6 @@ def test_mot_thinking_public_field_round_trip():
     assert mot.thinking == "reasoning trace"
 
 
-def test_mot__thinking_deprecated_alias_warns_on_read():
-    mot = ModelOutputThunk(value="x")
-    mot.thinking = "reasoning trace"
-    with pytest.warns(DeprecationWarning, match="ModelOutputThunk._thinking"):
-        assert mot._thinking == "reasoning trace"
-
-
-def test_mot__thinking_deprecated_alias_write_sets_public_field():
-    mot = ModelOutputThunk(value="x")
-    mot._thinking = "reasoning trace"
-    assert mot.thinking == "reasoning trace"
-
-
 if __name__ == "__main__":
     pytest.main([__file__])
 

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -275,6 +275,19 @@ def test_mot_error_carried_by_copy_methods() -> None:
     assert target.error is err
 
 
+def test_mot_thinking_public_field_round_trip():
+    mot = ModelOutputThunk(value="x")
+    mot.thinking = "reasoning trace"
+    assert mot.thinking == "reasoning trace"
+
+
+def test_mot__thinking_deprecated_alias_warns_on_read():
+    mot = ModelOutputThunk(value="x")
+    mot.thinking = "reasoning trace"
+    with pytest.warns(DeprecationWarning, match="ModelOutputThunk._thinking"):
+        assert mot._thinking == "reasoning trace"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
 

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -288,6 +288,12 @@ def test_mot__thinking_deprecated_alias_warns_on_read():
         assert mot._thinking == "reasoning trace"
 
 
+def test_mot__thinking_deprecated_alias_write_sets_public_field():
+    mot = ModelOutputThunk(value="x")
+    mot._thinking = "reasoning trace"
+    assert mot.thinking == "reasoning trace"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
 

--- a/test/stdlib/requirements/test_guardian_check_unit.py
+++ b/test/stdlib/requirements/test_guardian_check_unit.py
@@ -1,0 +1,32 @@
+"""Unit tests for GuardianCheck requirement behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mellea.core import ModelOutputThunk
+from mellea.stdlib.components import Message
+from mellea.stdlib.context import ChatContext
+from mellea.stdlib.requirements.safety.guardian import GuardianCheck
+
+
+@pytest.mark.asyncio
+async def test_guardian_validate_uses_thinking_trace_in_reason() -> None:
+    """validate() should include explicit mot.thinking content in the reason."""
+    mot = ModelOutputThunk(value="<score>no</score>")
+    mot.thinking = "grounded in provided content"
+
+    backend = MagicMock()
+    backend.generate_from_context = AsyncMock(return_value=(mot, ChatContext()))
+
+    with pytest.warns(DeprecationWarning, match="GuardianCheck is deprecated"):
+        req = GuardianCheck(risk="harm", backend=backend, backend_type="ollama")
+
+    ctx = ChatContext().add(Message("user", "Is this safe?")).add(
+        Message("assistant", "Yes.")
+    )
+    result = await req.validate(backend, ctx)
+
+    assert result.as_bool() is True
+    assert result.reason is not None
+    assert "Reasoning: grounded in provided content" in result.reason

--- a/test/stdlib/requirements/test_guardian_check_unit.py
+++ b/test/stdlib/requirements/test_guardian_check_unit.py
@@ -22,8 +22,10 @@ async def test_guardian_validate_uses_thinking_trace_in_reason() -> None:
     with pytest.warns(DeprecationWarning, match="GuardianCheck is deprecated"):
         req = GuardianCheck(risk="harm", backend=backend, backend_type="ollama")
 
-    ctx = ChatContext().add(Message("user", "Is this safe?")).add(
-        Message("assistant", "Yes.")
+    ctx = (
+        ChatContext()
+        .add(Message("user", "Is this safe?"))
+        .add(Message("assistant", "Yes."))
     )
     result = await req.validate(backend, ctx)
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes [#1217](https://github.com/generative-computing/mellea/issues/1217)

## Description
- Promoted ModelOutputThunk.thinking to the public reasoning-trace field in mellea/core/base.py, with a temporary deprecated _thinking alias that emits DeprecationWarning.
- Updated reasoning capture across backends (openai, litellm, ollama, watsonx) to write into mot.thinking.
- Updated safety/guardian requirement logic to read mot.thinking.
- Updated docs to reference result.thinking instead of result._thinking.
- Updated backend unit tests to assert mot.thinking, and added core tests for the new public field plus deprecated alias behavior.
- Resolved merge conflict in test/core/test_base.py by keeping both your new thinking-related tests and upstream base tests.

### Testing
- [X ] Tests added to the respective file if code was changed
- [X ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
