### PR TITLE
refactor(intrinsics): requirement_check_to_bool raises on schema mismatch (Epic #929 Phase 1)

### DIFF
--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -268,13 +268,13 @@ out, _ = mfuncs.act(
     ctx,
     backend,
 )
-print(out)  # {"requirement_likelihood": 1.0}
+print(out)  # {"requirement_check": {"score": 1.0}}
 ```
 
 The `Intrinsic` component loads aLoRA adapters (falling back to LoRA) by task name.
 For OpenAI backends with Granite Switch, adapters are loaded from the model's
 Hugging Face repository configuration instead of the adapter function catalog.
-Output format is task-specific — `requirement-check` returns a likelihood score.
+Output format is task-specific — `requirement-check` returns `{"requirement_check": {"score": <float>}}`.
 
 ---
 

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -204,7 +204,8 @@ class Requirement(Component[str]):
         validation_fn (Callable[[Context], ValidationResult] | None): If provided, this function is executed
             instead of LLM-as-a-Judge. The `bool()` of its return value defines pass/fail.
         output_to_bool (Callable[[CBlock | ModelOutputThunk | str], bool] | None): Translates LLM-as-a-Judge output to a boolean.
-            Defaults to a "yes"-detection heuristic.
+            Defaults to a "yes"-detection heuristic. May raise if the output does not match
+            the expected format — see `validate` for details.
         check_only (bool): When `True`, the requirement description is excluded from `Instruction` prompts.
 
     Attributes:
@@ -256,6 +257,14 @@ class Requirement(Component[str]):
 
         Returns:
             ValidationResult: The result of the validation, including a boolean pass/fail and optional metadata.
+
+        Raises:
+            Exception: Any exception raised by `output_to_bool` propagates to the caller.
+                Custom `output_to_bool` functions (including adapter-backed ones such as
+                `requirement_check_to_bool`) may raise on malformed output — e.g.
+                `AdapterSchemaMismatchError` when the adapter returns an unexpected schema.
+                Callers that previously treated all non-`True` outcomes as "requirement not
+                met" must now catch these exceptions separately.
         """
         if self.validation_fn is not None:
             # Python validation strategy

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -29,7 +29,10 @@ def check_certainty(context: ChatContext, backend: AdapterMixin) -> float:
 
 
 def requirement_check(
-    context: ChatContext, backend: AdapterMixin, requirement: str
+    context: ChatContext,
+    backend: AdapterMixin,
+    requirement: str,
+    model_options: dict | None = None,
 ) -> float:
     """Detect if text adheres to provided requirements.
 
@@ -42,12 +45,20 @@ def requirement_check(
         context: Chat context containing user question and assistant answer.
         backend: Backend instance that supports LoRA/aLoRA adapters.
         requirement: Set of requirements to satisfy.
+        model_options: Optional model-level overrides forwarded to the backend
+            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            apply.
 
     Returns:
         Score as a float between 0.0 and 1.0 (higher = more likely satisfied).
+        Raw adapter output contract: ``{"requirement_check": {"score": <float>}}``.
     """
     result_json = call_intrinsic(
-        "requirement-check", context, backend, kwargs={"requirement": requirement}
+        "requirement-check",
+        context,
+        backend,
+        kwargs={"requirement": requirement},
+        model_options=model_options,
     )
     return cast(
         float, cast(dict[str, object], result_json["requirement_check"])["score"]

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -70,6 +70,7 @@ def requirement_check(
         kwargs={"requirement": requirement},
         model_options=model_options,
     )
+    # Mirrors the validation in requirement_check_to_bool() in requirement.py; Phase 2 will consolidate via IOContract.
     req_check = result_json.get("requirement_check")
     if not isinstance(req_check, dict):
         raise AdapterSchemaMismatchError(

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -3,14 +3,18 @@
 import collections.abc
 from typing import cast
 
-from ....backends.adapters import AdapterMixin
+from ....backends.adapters import AdapterMixin, AdapterSchemaMismatchError
 from ...components import Document, Message
 from ...context import ChatContext
 from ..docs.document import _coerce_to_documents
 from ._util import _resolve_response, call_intrinsic
 
 
-def check_certainty(context: ChatContext, backend: AdapterMixin) -> float:
+def check_certainty(
+    context: ChatContext,
+    backend: AdapterMixin,
+    model_options: dict | None = None,
+) -> float:
     """Estimate the model's certainty about its last response.
 
     Adapter function that evaluates how certain the model is about the
@@ -20,12 +24,15 @@ def check_certainty(context: ChatContext, backend: AdapterMixin) -> float:
     Args:
         context: Chat context containing user question and assistant answer.
         backend: Backend instance that supports LoRA/aLoRA adapters.
+        model_options: Optional model-level overrides forwarded to the backend
+            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            apply.
 
     Returns:
         Certainty score as a float (higher = more certain).
     """
-    result_json = call_intrinsic("uncertainty", context, backend)
-    return cast(float, result_json["certainty"])
+    result_json = call_intrinsic("uncertainty", context, backend, model_options=model_options)
+    return result_json["certainty"]
 
 
 def requirement_check(
@@ -51,7 +58,10 @@ def requirement_check(
 
     Returns:
         Score as a float between 0.0 and 1.0 (higher = more likely satisfied).
-        Raw adapter output contract: ``{"requirement_check": {"score": <float>}}``.
+
+    Raises:
+        AdapterSchemaMismatchError: If the adapter output does not match the
+            expected ``{"requirement_check": {"score": <float>}}`` contract.
     """
     result_json = call_intrinsic(
         "requirement-check",
@@ -60,9 +70,21 @@ def requirement_check(
         kwargs={"requirement": requirement},
         model_options=model_options,
     )
-    return cast(
-        float, cast(dict[str, object], result_json["requirement_check"])["score"]
-    )
+    req_check = result_json.get("requirement_check")
+    if not isinstance(req_check, dict):
+        raise AdapterSchemaMismatchError(
+            name="requirement-check",
+            observed_keys=frozenset(result_json.keys()),
+            expected_keys=frozenset({"requirement_check"}),
+        )
+    score = req_check.get("score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        raise AdapterSchemaMismatchError(
+            name="requirement-check",
+            observed_keys=frozenset(req_check.keys()),
+            expected_keys=frozenset({"score"}),
+        )
+    return score
 
 
 def find_context_attributions(
@@ -70,6 +92,7 @@ def find_context_attributions(
     documents: collections.abc.Iterable[str | Document],
     context: ChatContext,
     backend: AdapterMixin,
+    model_options: dict | None = None,
 ) -> list[dict]:
     """Find sentences in conversation history and documents that most influence an LLM's response.
 
@@ -89,6 +112,9 @@ def find_context_attributions(
         context (ChatContext): Dialog context between user and assistant, ending with
             a user query.
         backend (AdapterMixin): Backend that supports intrinsic adapters.
+        model_options: Optional model-level overrides forwarded to the backend
+            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            apply.
 
     Returns:
         list[dict]: Records with fields `response_begin`, `response_end`,
@@ -108,5 +134,6 @@ def find_context_attributions(
             )
         ),
         backend,
+        model_options=model_options,
     )
     return cast(list[dict], result_json)

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -1,8 +1,8 @@
 """Adapter functions for core model capabilities."""
 
 import collections.abc
-from typing import cast
 import math
+from typing import cast
 
 from ....backends.adapters import AdapterMixin, AdapterSchemaMismatchError
 from ...components import Document, Message
@@ -33,7 +33,7 @@ def check_certainty(
     result_json = call_intrinsic(
         "uncertainty", context, backend, model_options=model_options
     )
-    return result_json["certainty"]
+    return cast(float, result_json["certainty"])
 
 
 def requirement_check(

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 from typing import cast
+import math
 
 from ....backends.adapters import AdapterMixin, AdapterSchemaMismatchError
 from ...components import Document, Message
@@ -61,7 +62,8 @@ def requirement_check(
 
     Raises:
         AdapterSchemaMismatchError: If the adapter output does not match the
-            expected ``{"requirement_check": {"score": <float>}}`` contract.
+            expected ``{"requirement_check": {"score": <float>}}`` contract, or
+            if the score is not a finite number in the range 0.0-1.0.
     """
     result_json = call_intrinsic(
         "requirement-check",
@@ -79,7 +81,12 @@ def requirement_check(
             expected_keys=frozenset({"requirement_check"}),
         )
     score = req_check.get("score")
-    if not isinstance(score, (int, float)) or isinstance(score, bool):
+    if (
+        not isinstance(score, (int, float))
+        or isinstance(score, bool)
+        or not math.isfinite(score)
+        or not 0.0 <= score <= 1.0
+    ):
         raise AdapterSchemaMismatchError(
             name="requirement-check",
             observed_keys=frozenset(req_check.keys()),

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -11,9 +11,7 @@ from ._util import _resolve_response, call_intrinsic
 
 
 def check_certainty(
-    context: ChatContext,
-    backend: AdapterMixin,
-    model_options: dict | None = None,
+    context: ChatContext, backend: AdapterMixin, model_options: dict | None = None
 ) -> float:
     """Estimate the model's certainty about its last response.
 
@@ -31,7 +29,9 @@ def check_certainty(
     Returns:
         Certainty score as a float (higher = more certain).
     """
-    result_json = call_intrinsic("uncertainty", context, backend, model_options=model_options)
+    result_json = call_intrinsic(
+        "uncertainty", context, backend, model_options=model_options
+    )
     return result_json["certainty"]
 
 

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -83,7 +83,7 @@ def requirement_check(
     score = req_check.get("score")
     if (
         not isinstance(score, (int, float))
-        or isinstance(score, bool)
+        or isinstance(score, bool)  # bool subclasses int; exclude it explicitly
         or not math.isfinite(score)
         or not 0.0 <= score <= 1.0
     ):

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -49,6 +49,7 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
     output = str(x)
     req_dict: dict[str, Any] = json.loads(output)
 
+    # Mirrors the validation in requirement_check() in core.py; Phase 2 will consolidate via IOContract.
     req_check = req_dict.get("requirement_check", None)
     if not isinstance(req_check, dict):
         raise AdapterSchemaMismatchError(
@@ -71,9 +72,9 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
 class ALoraRequirement(Requirement, Intrinsic):
     """A requirement validated by an ALoRA adapter; falls back to LLM-as-a-Judge only on generation error.
 
-    If the adapter **generation** step raises (e.g. the adapter cannot be
-    loaded), ``mellea`` falls back to LLMaJ for that requirement.  That is the
-    only case where LLMaJ will be used.
+    If the adapter is unavailable (e.g. cannot be loaded), ``mellea`` uses
+    LLMaJ for that requirement instead.  That is the only case where LLMaJ
+    will be used.
 
     If the adapter generates output but the output **fails schema validation**
     (``requirement_check_to_bool`` raises ``AdapterSchemaMismatchError``), the

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -63,7 +63,7 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
     score = req_check.get("score", None)
     if (
         not isinstance(score, (int, float))
-        or isinstance(score, bool)
+        or isinstance(score, bool)  # bool subclasses int; exclude it explicitly
         or not math.isfinite(score)
         or not 0.0 <= score <= 1.0
     ):

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -49,19 +49,19 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
     output = str(x)
     req_dict: dict[str, Any] = json.loads(output)
 
-    likelihood = req_dict.get("requirement_check", None)
-    if not isinstance(likelihood, dict):
+    req_check = req_dict.get("requirement_check", None)
+    if not isinstance(req_check, dict):
         raise AdapterSchemaMismatchError(
             name="requirement-check",
             observed_keys=frozenset(req_dict.keys()),
             expected_keys=frozenset({"requirement_check"}),
         )
 
-    score = likelihood.get("score", None)
+    score = req_check.get("score", None)
     if not isinstance(score, (int, float)) or isinstance(score, bool):
         raise AdapterSchemaMismatchError(
             name="requirement-check",
-            observed_keys=frozenset(likelihood.keys()),
+            observed_keys=frozenset(req_check.keys()),
             expected_keys=frozenset({"score"}),
         )
 

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -1,6 +1,7 @@
 """Requirements are a special type of Component used as input to the "validate" step in Instruct/Validate/Repair design patterns."""
 
 import json
+import math
 from collections.abc import Callable
 from typing import Any, overload
 
@@ -42,9 +43,10 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
     Raises:
         json.JSONDecodeError: If ``x`` is not valid JSON.
         AdapterSchemaMismatchError: If the parsed output does not contain the
-            expected ``requirement_check.score`` structure.  Callers that
-            previously treated ``False`` as "requirement not met" must now
-            catch this error separately.
+            expected ``requirement_check.score`` structure, or if the score is
+            not a finite number in the range 0.0-1.0.  Callers that previously
+            treated ``False`` as "requirement not met" must now catch this error
+            separately.
     """
     output = str(x)
     req_dict: dict[str, Any] = json.loads(output)
@@ -59,7 +61,12 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
         )
 
     score = req_check.get("score", None)
-    if not isinstance(score, (int, float)) or isinstance(score, bool):
+    if (
+        not isinstance(score, (int, float))
+        or isinstance(score, bool)
+        or not math.isfinite(score)
+        or not 0.0 <= score <= 1.0
+    ):
         raise AdapterSchemaMismatchError(
             name="requirement-check",
             observed_keys=frozenset(req_check.keys()),

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -58,7 +58,7 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
         )
 
     score = likelihood.get("score", None)
-    if score is None:
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
         raise AdapterSchemaMismatchError(
             name="requirement-check",
             observed_keys=frozenset(likelihood.keys()),
@@ -69,18 +69,25 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
 
 
 class ALoraRequirement(Requirement, Intrinsic):
-    """A requirement validated by an ALoRA adapter; falls back to LLM-as-a-Judge only on error.
+    """A requirement validated by an ALoRA adapter; falls back to LLM-as-a-Judge only on generation error.
 
-    If an exception is thrown during the ALoRA execution path, `mellea` will
-    fall back to LLMaJ. That is the only case where LLMaJ will be used.
+    If the adapter **generation** step raises (e.g. the adapter cannot be
+    loaded), ``mellea`` falls back to LLMaJ for that requirement.  That is the
+    only case where LLMaJ will be used.
+
+    If the adapter generates output but the output **fails schema validation**
+    (``requirement_check_to_bool`` raises ``AdapterSchemaMismatchError``), the
+    exception propagates to the caller — it is not caught and does not trigger
+    the LLMaJ fallback.  This is intentional: schema drift should surface
+    loudly rather than silently return a wrong result.
 
     Args:
         description (str): Human-readable requirement description.
         intrinsic_name (str | None): Name of the ALoRA intrinsic to use.
-            Defaults to `"requirement-check"`.
+            Defaults to ``"requirement-check"``.
 
     Attributes:
-        use_aloras (bool): Always `True`; this class always attempts to use
+        use_aloras (bool): Always ``True``; this class always attempts to use
             ALoRA adapters for validation.
     """
 

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -5,6 +5,7 @@ import math
 from collections.abc import Callable
 from typing import Any, overload
 
+from ...backends.adapters import AdapterSchemaMismatchError
 from ...core import (
     CBlock,
     Context,
@@ -13,7 +14,6 @@ from ...core import (
     Requirement,
     ValidationResult,
 )
-from ...backends.adapters import AdapterSchemaMismatchError
 from ..components.intrinsic import Intrinsic
 
 
@@ -30,6 +30,7 @@ class LLMaJRequirement(Requirement):
 
 def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
     """Convert a ``requirement-check`` adapter output string to a boolean result.
+
     Parses the JSON output produced by the ``requirement-check`` adapter and
     returns ``True`` when the score exceeds 0.5.
 

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -12,6 +12,7 @@ from ...core import (
     Requirement,
     ValidationResult,
 )
+from ...backends.adapters import AdapterSchemaMismatchError
 from ..components.intrinsic import Intrinsic
 
 
@@ -27,39 +28,44 @@ class LLMaJRequirement(Requirement):
 
 
 def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
-    """Checks if a given output should be marked converted to `True`.
-
-    By default, the requirement check alora outputs: `{"requirement_likelihood": 0.0}`.
-    Returns `True` if the likelihood value is > 0.5.
+    """Convert a ``requirement-check`` adapter output string to a boolean result.
+    Parses the JSON output produced by the ``requirement-check`` adapter and
+    returns ``True`` when the score exceeds 0.5.
 
     Args:
-        x: ALoRA output string or CBlock containing JSON with a
-            `requirement_likelihood` field.
+        x: Adapter output string or CBlock containing JSON with the contract
+            ``{"requirement_check": {"score": <float>}}``.
 
     Returns:
-        True if the extracted likelihood exceeds 0.5, False otherwise.
+        ``True`` if the extracted score exceeds 0.5, ``False`` otherwise.
+
+    Raises:
+        json.JSONDecodeError: If ``x`` is not valid JSON.
+        AdapterSchemaMismatchError: If the parsed output does not contain the
+            expected ``requirement_check.score`` structure.  Callers that
+            previously treated ``False`` as "requirement not met" must now
+            catch this error separately.
     """
     output = str(x)
     req_dict: dict[str, Any] = json.loads(output)
 
     likelihood = req_dict.get("requirement_check", None)
     if not isinstance(likelihood, dict):
-        MelleaLogger.get_logger().warning(
-            f"could not get value from alora requirement output; looking for `requirement_check` in {req_dict}"
+        raise AdapterSchemaMismatchError(
+            name="requirement-check",
+            observed_keys=frozenset(req_dict.keys()),
+            expected_keys=frozenset({"requirement_check"}),
         )
-        return False
 
     score = likelihood.get("score", None)
     if score is None:
-        MelleaLogger.get_logger().warning(
-            f"could not get value from alora requirement output; looking for `score` in {req_dict}"
+        raise AdapterSchemaMismatchError(
+            name="requirement-check",
+            observed_keys=frozenset(likelihood.keys()),
+            expected_keys=frozenset({"score"}),
         )
-        return False
 
-    if score > 0.5:
-        return True
-
-    return False
+    return score > 0.5
 
 
 class ALoraRequirement(Requirement, Intrinsic):

--- a/test/stdlib/components/intrinsic/test_core_schema.py
+++ b/test/stdlib/components/intrinsic/test_core_schema.py
@@ -1,0 +1,90 @@
+"""Unit tests for requirement_check schema validation in core.py.
+
+These tests mock call_intrinsic so they run without a GPU or HF backend.
+"""
+
+import math
+from unittest.mock import patch
+
+import pytest
+
+from mellea.backends.adapters import AdapterSchemaMismatchError
+from mellea.stdlib.components.intrinsic import core
+from mellea.stdlib.context import ChatContext
+
+_CTX = ChatContext()
+_BACKEND = object()
+_REQUIREMENT = "must be polite"
+_PATCH = "mellea.stdlib.components.intrinsic.core.call_intrinsic"
+
+
+def _call(result_json: dict) -> float:
+    with patch(_PATCH, return_value=result_json):
+        return core.requirement_check(_CTX, _BACKEND, _REQUIREMENT)  # type: ignore[arg-type]
+
+
+def test_valid_score_returned():
+    assert _call({"requirement_check": {"score": 0.8}}) == pytest.approx(0.8)
+
+
+def test_missing_requirement_check_key_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"other_field": 0.9})
+
+
+def test_null_requirement_check_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": None})
+
+
+def test_list_requirement_check_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": []})
+
+
+def test_missing_score_key_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"other_key": 0.9}})
+
+
+def test_null_score_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": None}})
+
+
+def test_string_score_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": "0.9"}})
+
+
+def test_bool_score_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": True}})
+
+
+def test_nan_score_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": math.nan}})
+
+
+def test_inf_score_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": math.inf}})
+
+
+def test_score_above_range_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": 1.5}})
+
+
+def test_score_below_range_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        _call({"requirement_check": {"score": -0.1}})
+
+
+def test_boundary_score_zero():
+    assert _call({"requirement_check": {"score": 0.0}}) == pytest.approx(0.0)
+
+
+def test_boundary_score_one():
+    assert _call({"requirement_check": {"score": 1.0}}) == pytest.approx(1.0)

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -90,13 +90,13 @@ def test_requirement_check_to_bool_at_threshold():
 
 
 def test_requirement_check_to_bool_raises_on_schema_mismatch():
-    """Regression test for #1008: wrong top-level key must raise, not silently return False."""
+    """Wrong top-level key must raise, not silently return False."""
     with pytest.raises(AdapterSchemaMismatchError):
         requirement_check_to_bool('{"other_field": 1.0}')
 
 
-def test_pre_1008_schema_raises():
-    """Pre-#1008 output shape (requirement_likelihood) must raise AdapterSchemaMismatchError."""
+def test_pre_schema_change_output_raises():
+    """Old output shape (requirement_likelihood) must raise AdapterSchemaMismatchError."""
     with pytest.raises(AdapterSchemaMismatchError):
         requirement_check_to_bool('{"requirement_likelihood": 0.9}')
 
@@ -105,6 +105,18 @@ def test_requirement_check_to_bool_missing_score_raises():
     """Missing nested score key must raise AdapterSchemaMismatchError."""
     with pytest.raises(AdapterSchemaMismatchError):
         requirement_check_to_bool('{"requirement_check": {"other_key": 0.9}}')
+
+
+def test_requirement_check_to_bool_null_score_raises():
+    """Null score must raise AdapterSchemaMismatchError, not TypeError."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": null}}')
+
+
+def test_requirement_check_to_bool_string_score_raises():
+    """String score must raise AdapterSchemaMismatchError, not TypeError."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": "0.9"}}')
 
 
 def test_requirement_check_to_bool_invalid_json():

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -124,6 +124,28 @@ def test_requirement_check_to_bool_invalid_json():
         requirement_check_to_bool("not json")
 
 
+def test_requirement_check_to_bool_nan_score_raises():
+    """NaN would silently evaluate as False without the finiteness guard."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": NaN}}')
+
+
+def test_requirement_check_to_bool_inf_score_raises():
+    """Infinite score must raise, not silently pass as True."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": Infinity}}')
+
+
+def test_requirement_check_to_bool_score_above_range_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": 1.5}}')
+
+
+def test_requirement_check_to_bool_score_below_range_raises():
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"score": -0.1}}')
+
+
 # --- reqify ---
 
 

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from mellea.backends.adapters import AdapterSchemaMismatchError
 from mellea.core import ModelOutputThunk, Requirement
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import LLMaJRequirement, simple_validate
@@ -88,8 +89,22 @@ def test_requirement_check_to_bool_at_threshold():
     assert requirement_check_to_bool('{"requirement_check": {"score": 0.5}}') is False
 
 
-def test_requirement_check_to_bool_missing_key():
-    assert requirement_check_to_bool('{"other_field": 1.0}') is False
+def test_requirement_check_to_bool_raises_on_schema_mismatch():
+    """Regression test for #1008: wrong top-level key must raise, not silently return False."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"other_field": 1.0}')
+
+
+def test_pre_1008_schema_raises():
+    """Pre-#1008 output shape (requirement_likelihood) must raise AdapterSchemaMismatchError."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_likelihood": 0.9}')
+
+
+def test_requirement_check_to_bool_missing_score_raises():
+    """Missing nested score key must raise AdapterSchemaMismatchError."""
+    with pytest.raises(AdapterSchemaMismatchError):
+        requirement_check_to_bool('{"requirement_check": {"other_key": 0.9}}')
 
 
 def test_requirement_check_to_bool_invalid_json():

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -205,6 +205,28 @@ def test_alora_requirement_custom_intrinsic(mock_intrinsic_init):
         intrinsic_name="custom_check",
         intrinsic_kwargs={"requirement": "must be valid"},
     )
+
+
+@patch("mellea.stdlib.requirements.requirement.Intrinsic.__init__")
+async def test_alora_validate_propagates_schema_mismatch(mock_intrinsic_init):
+    """AdapterSchemaMismatchError from output_to_bool propagates uncaught through validate().
+
+    This documents that the LLMaJ fallback in ALoraRequirement covers only
+    generation errors, not output-parsing schema mismatches.
+    """
+    mock_intrinsic_init.return_value = None
+    req = ALoraRequirement("must satisfy requirement")
+
+    mock_thunk = MagicMock()
+    mock_thunk.__str__ = MagicMock(return_value='{"requirement_likelihood": 0.9}')
+    mock_thunk.avalue = AsyncMock(return_value=None)
+    mock_thunk.value = '{"requirement_likelihood": 0.9}'
+
+    mock_backend = MagicMock()
+    mock_backend.generate_from_context = AsyncMock(return_value=(mock_thunk, ctx))
+
+    with pytest.raises(AdapterSchemaMismatchError):
+        await req.validate(mock_backend, ctx=ctx)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- pr-template -->

## Context

This is one of three parallel Wave 3 issues in Epic #929 Phase 1:

| Issue | PR | File | Status |
|-------|-----|------|--------|
| #1137 | #1321 | `rag.py` migration | ⬜ Draft |
| **#1138** | **This PR** | **`requirement_check` migration** | **This PR** |
| #1139 | — | `guardian.py` migration | ⬜ Pending |

Phase 1 is gated on #1136 (PR #1269, merged 2026-06-23), which rewrote `call_intrinsic` to use the new `resolve_adapter()` path from the Phase 0 scaffolding. All three Wave 3 issues were unblocked by that merge.

**No file overlap with #1321** — that PR touches `_util.py` and `rag.py`; this one touches `core.py`, `requirement.py`, and tests. They can merge in any order.

**Approach note:** #1321 introduces `IOContract` subclasses wired through `call_intrinsic`. This PR uses inline validation directly in the helper functions. The `IOContract`-based approach for `requirement-check` is Phase 2 work; inline validation here achieves the stated goal of #1138 (loud schema mismatch) without depending on Phase 2 being complete.

## Problem

PR #1008 changed the `requirement-check` adapter output schema from `{"requirement_likelihood": 0.9}` to `{"requirement_check": {"score": 0.9}}`, but `requirement_check_to_bool` was never updated to match. The result: every call silently returned `False` with a log warning — the kind of failure that looks like a working system until someone notices the model is never actually satisfying any requirements.

This issue is also called out in the Epic as the **worked example** for how adapter output contracts should be enforced going forward: schema drift must raise immediately, not degrade quietly.

## What changed

**Core fix**
- `requirement_check_to_bool` now raises `AdapterSchemaMismatchError` instead of returning `False` when the adapter output does not match `{"requirement_check": {"score": <float>}}`. Covers missing top-level key, missing nested `score`, and wrong-type score (null, string, etc.).
- `requirement_check` (the higher-level wrapper that calls the adapter directly) now applies the same validation — previously it raised a bare `KeyError` on bad output.

**Consistency**
- `check_certainty` and `find_context_attributions` now accept a `model_options` parameter, bringing all three intrinsic helpers in `core.py` into line.

**Documentation**
- `ALoraRequirement` docstring previously said "falls back to LLMaJ on error" without qualification. That fallback only covers generation failures (adapter not found, etc.) — output-parsing failures were always a hard raise and now correctly documented as such.
- `docs/advanced/intrinsics.md` example comment updated from the old `{"requirement_likelihood": 1.0}` schema to the current `{"requirement_check": {"score": 1.0}}`.

## Breaking change

`requirement_check_to_bool` no longer returns `False` on parse failure — it raises `AdapterSchemaMismatchError`. Any caller treating silent `False` as "requirement not met" must now also handle this exception. The old behaviour was masking real errors, so the assumption was already wrong.

## Test plan

- [x] 24 tests pass in `test/stdlib/requirements/test_requirement.py` (was 19), covering the old `requirement_likelihood` schema, missing nested key, null score, string score, and an integration test confirming the exception propagates through `ALoraRequirement.validate()`
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy mellea/stdlib/requirements/requirement.py mellea/stdlib/components/intrinsic/core.py test/stdlib/requirements/test_requirement.py --ignore-missing-imports` — clean
- [x] Broader fast suite: 2350 passed, 7 pre-existing failures (optional extras not installed)

Closes #1138