### PR TITLE
refactor(intrinsics): migrate rag.py to new Adapter types (Epic #929 Phase 1 Wave 3)

### DIFF
--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -93,7 +93,7 @@ def call_intrinsic(
     kwargs: dict | None = None,
     model_options: dict | None = None,
     io_contract: IOContract | None = None,
-):
+) -> dict[str, object]:
     """Invoke an adapter function via the backend, returning parsed and optionally validated JSON output.
 
     Uses :meth:`~mellea.backends.adapters.AdapterMixin.resolve_adapter` to find
@@ -117,7 +117,7 @@ def call_intrinsic(
             raw model output.  When ``None``, ``json.loads`` is used directly.
 
     Returns:
-        dict: Parsed (and optionally validated) JSON output from the adapter function.
+        dict[str, object]: Parsed (and optionally validated) JSON output from the adapter function.
 
     Raises:
         ValueError: When the model output is ``None`` or is not valid JSON.

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -121,6 +121,8 @@ def call_intrinsic(
 
     Raises:
         ValueError: When the model output is ``None`` or is not valid JSON.
+        AdapterSchemaMismatchError: When *io_contract* is provided and the
+            model output is missing a required field.
     """
     # Ensure the adapter is registered; resolve_adapter creates it if absent.
     backend.resolve_adapter(intrinsic_name)

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -94,7 +94,7 @@ def call_intrinsic(
     model_options: dict | None = None,
     io_contract: IOContract | None = None,
 ):
-    """Invoke an adapter function via the backend, returning parsed JSON output.
+    """Invoke an adapter function via the backend, returning parsed and optionally validated JSON output.
 
     Uses :meth:`~mellea.backends.adapters.AdapterMixin.resolve_adapter` to find
     or lazily register the adapter, then executes via ``mfuncs.act``.
@@ -118,6 +118,9 @@ def call_intrinsic(
 
     Returns:
         dict: Parsed (and optionally validated) JSON output from the adapter function.
+
+    Raises:
+        ValueError: When the model output is ``None`` or is not valid JSON.
     """
     # Ensure the adapter is registered; resolve_adapter creates it if absent.
     backend.resolve_adapter(intrinsic_name)

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -3,7 +3,7 @@
 import json
 
 from ....backends import ModelOption
-from ....backends.adapters import AdapterMixin, AdapterType
+from ....backends.adapters import AdapterMixin, AdapterType, IOContract
 from ....core import Backend
 from ....stdlib import functional as mfuncs
 from ...components import Document
@@ -92,11 +92,18 @@ def call_intrinsic(
     /,
     kwargs: dict | None = None,
     model_options: dict | None = None,
+    io_contract: IOContract | None = None,
 ):
     """Invoke an adapter function via the backend, returning parsed JSON output.
 
     Uses :meth:`~mellea.backends.adapters.AdapterMixin.resolve_adapter` to find
     or lazily register the adapter, then executes via ``mfuncs.act``.
+
+    When *io_contract* is provided its :meth:`~mellea.backends.adapters.IOContract.parse`
+    method is called on the raw output string before returning.  The contract validates
+    required fields and raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`
+    on contract-breaking deltas; forward-compatible additions (extra optional fields) do
+    not raise.  When *io_contract* is ``None`` the raw ``json.loads`` result is returned.
 
     Args:
         intrinsic_name (str): Capability name of the adapter function
@@ -106,9 +113,11 @@ def call_intrinsic(
         kwargs (dict | None): Extra keyword arguments forwarded to the
             adapter function's input template.
         model_options (dict | None): Model options that override defaults.
+        io_contract (IOContract | None): Output contract to validate and parse the
+            raw model output.  When ``None``, ``json.loads`` is used directly.
 
     Returns:
-        dict: Parsed JSON output from the adapter function.
+        dict: Parsed (and optionally validated) JSON output from the adapter function.
     """
     # Ensure the adapter is registered; resolve_adapter creates it if absent.
     backend.resolve_adapter(intrinsic_name)
@@ -140,4 +149,6 @@ def call_intrinsic(
     result_str = model_output_thunk.value
     if result_str is None:
         raise ValueError("Model output is None.")
+    if io_contract is not None:
+        return io_contract.parse(result_str)
     return json.loads(result_str)

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -1,6 +1,7 @@
 """Adapter functions for core model capabilities."""
 
 import collections.abc
+from typing import cast
 
 from ....backends.adapters import AdapterMixin
 from ...components import Document, Message
@@ -24,7 +25,7 @@ def check_certainty(context: ChatContext, backend: AdapterMixin) -> float:
         Certainty score as a float (higher = more certain).
     """
     result_json = call_intrinsic("uncertainty", context, backend)
-    return result_json["certainty"]
+    return cast(float, result_json["certainty"])
 
 
 def requirement_check(
@@ -48,7 +49,9 @@ def requirement_check(
     result_json = call_intrinsic(
         "requirement-check", context, backend, kwargs={"requirement": requirement}
     )
-    return result_json["requirement_check"]["score"]
+    return cast(
+        float, cast(dict[str, object], result_json["requirement_check"])["score"]
+    )
 
 
 def find_context_attributions(
@@ -95,4 +98,4 @@ def find_context_attributions(
         ),
         backend,
     )
-    return result_json
+    return cast(list[dict], result_json)

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -10,6 +10,7 @@ resolved kwargs through.
 """
 
 import warnings
+from typing import cast
 
 from ....backends.adapters import AdapterMixin
 from ....core.utils import MelleaLogger
@@ -50,9 +51,9 @@ def policy_guardrails(
             "Expected Guardian result to have label xor score, but found neither."
         )
     elif "label" not in result_json.keys() and "score" in result_json.keys():
-        return result_json["score"]
+        return cast(str, result_json["score"])
     elif "label" in result_json.keys() and "score" not in result_json.keys():
-        return result_json["label"]
+        return cast(str, result_json["label"])
     else:
         raise Exception(
             "Expected Guardian result to have label xor score, but found both."
@@ -240,7 +241,7 @@ def guardian_check(
         backend,
         kwargs={"criteria": criteria_text, "scoring_schema": scoring_schema_text},
     )
-    return result_json["guardian"]["score"]
+    return cast(float, cast(dict[str, object], result_json["guardian"])["score"])
 
 
 def factuality_detection(context: ChatContext, backend: AdapterMixin) -> str:
@@ -258,7 +259,7 @@ def factuality_detection(context: ChatContext, backend: AdapterMixin) -> str:
         str: Factuality score as a `"yes"` / `"no"` label (`"yes"` = factually incorrect).
     """
     result_json = call_intrinsic("factuality-detection", context, backend)
-    return result_json["score"]
+    return cast(str, result_json["score"])
 
 
 def factuality_correction(context: ChatContext, backend: AdapterMixin) -> str:
@@ -275,4 +276,4 @@ def factuality_correction(context: ChatContext, backend: AdapterMixin) -> str:
         str: Corrected assistant response.
     """
     result_json = call_intrinsic("factuality-correction", context, backend)
-    return result_json["correction"]
+    return cast(str, result_json["correction"])

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -38,7 +38,7 @@ class _DictContract(IOContract):
 
     def build_prompt(self, **_kwargs: object) -> Component:
         raise NotImplementedError(
-            "build_prompt is not used in Phase 1; implemented in Phase 2 (#1138)."
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
         )
 
     def parse(self, raw: str) -> dict[str, object]:
@@ -51,6 +51,7 @@ class _DictContract(IOContract):
             dict[str, object]: Parsed output dict, unchanged.
 
         Raises:
+            ValueError: When *raw* is not valid JSON.
             AdapterSchemaMismatchError: When a required key is absent.
         """
         data = json.loads(raw)
@@ -84,7 +85,7 @@ class _ListContract(IOContract):
 
     def build_prompt(self, **_kwargs: object) -> Component:
         raise NotImplementedError(
-            "build_prompt is not used in Phase 1; implemented in Phase 2 (#1138)."
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
         )
 
     def parse(self, raw: str) -> dict[str, object]:
@@ -95,8 +96,10 @@ class _ListContract(IOContract):
 
         Returns:
             dict[str, object]: ``{"items": [list of validated dicts]}``.
+                An empty list parses to ``{"items": []}``.
 
         Raises:
+            ValueError: When *raw* is not valid JSON.
             AdapterSchemaMismatchError: When the output is not a list, any item
                 is not a dict, or any item is missing a required key.
         """
@@ -226,6 +229,7 @@ def check_answerability(
         A string value of either ``"answerable"`` or ``"unanswerable"``.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
             ``answerability`` field.
     """
@@ -272,6 +276,7 @@ def rewrite_question(
         Rewritten version of `question`.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
             ``rewritten_question`` field.
     """
@@ -322,6 +327,7 @@ def clarify_query(
         the string ``"CLEAR"`` if no clarification is needed.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
             ``clarification`` field.
     """
@@ -381,6 +387,7 @@ def find_citations(
         character offsets into their respective UTF-8 strings.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When any record in the output is missing a
             required field.
     """
@@ -445,6 +452,7 @@ def check_context_relevance(
         ``"relevant"``, ``"irrelevant"``, or ``"partially relevant"``.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
             ``context_relevance`` field.
     """
@@ -512,6 +520,7 @@ def flag_hallucinated_content(
         ``response_text``, ``faithfulness``, ``explanation``.
 
     Raises:
+        ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When any record in the output is missing a
             required field.
     """

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 import json
+from typing import cast
 
 from ....backends.adapters import (
     Adapter,
@@ -51,13 +52,14 @@ class _DictContract(IOContract):
             dict[str, object]: Parsed output dict, unchanged.
 
         Raises:
-            ValueError: When *raw* is not valid JSON.
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
             AdapterSchemaMismatchError: When a required key is absent.
         """
         data = json.loads(raw)
         if not isinstance(data, dict):
-            raise AdapterSchemaMismatchError(
-                self._name, frozenset(), self._required_keys
+            raise ValueError(
+                f"Adapter '{self._name}' output must be a JSON object, "
+                f"got {type(data).__name__}."
             )
         observed = frozenset(data.keys())
         missing = self._required_keys - observed
@@ -99,19 +101,21 @@ class _ListContract(IOContract):
                 An empty list parses to ``{"items": []}``.
 
         Raises:
-            ValueError: When *raw* is not valid JSON.
-            AdapterSchemaMismatchError: When the output is not a list, any item
-                is not a dict, or any item is missing a required key.
+            ValueError: When *raw* is not valid JSON, is not a JSON array, or
+                contains a non-object element.
+            AdapterSchemaMismatchError: When any item is missing a required key.
         """
         data = json.loads(raw)
         if not isinstance(data, list):
-            raise AdapterSchemaMismatchError(
-                self._name, frozenset(), self._required_item_keys
+            raise ValueError(
+                f"Adapter '{self._name}' output must be a JSON array, "
+                f"got {type(data).__name__}."
             )
         for item in data:
             if not isinstance(item, dict):
-                raise AdapterSchemaMismatchError(
-                    self._name, frozenset(), self._required_item_keys
+                raise ValueError(
+                    f"Adapter '{self._name}' output array must contain only JSON "
+                    f"objects, got a {type(item).__name__} element."
                 )
             observed = frozenset(item.keys())
             missing = self._required_item_keys - observed
@@ -243,7 +247,7 @@ def check_answerability(
         io_contract=_ANSWERABILITY_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["answerability"]  # type: ignore[return-value]
+    return cast(str, result["answerability"])
 
 
 def rewrite_question(
@@ -288,7 +292,7 @@ def rewrite_question(
         io_contract=_QUERY_REWRITE_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["rewritten_question"]  # type: ignore[return-value]
+    return cast(str, result["rewritten_question"])
 
 
 def clarify_query(
@@ -341,7 +345,7 @@ def clarify_query(
         io_contract=_QUERY_CLARIFY_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["clarification"]  # type: ignore[return-value]
+    return cast(str, result["clarification"])
 
 
 def find_citations(
@@ -405,7 +409,7 @@ def find_citations(
         io_contract=_CITATIONS_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["items"]  # type: ignore[return-value]
+    return cast(list[dict], result["items"])
 
 
 def check_context_relevance(
@@ -474,7 +478,7 @@ def check_context_relevance(
         io_contract=_CONTEXT_RELEVANCE_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["context_relevance"]  # type: ignore[return-value]
+    return cast(str, result["context_relevance"])
 
 
 def flag_hallucinated_content(
@@ -534,4 +538,4 @@ def flag_hallucinated_content(
         io_contract=_HALLUCINATION_ADAPTER.io_contract,
         model_options=model_options,
     )
-    return result["items"]  # type: ignore[return-value]
+    return cast(list[dict], result["items"])

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 import json
+import warnings
 from typing import cast
 
 from ....backends.adapters import (

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -1,14 +1,194 @@
 """Adapter functions related to retrieval-augmented generation."""
 
 import collections.abc
-import warnings
+import json
 
-from ....backends.adapters import AdapterMixin
+from ....backends.adapters import (
+    Adapter,
+    AdapterMixin,
+    AdapterSchemaMismatchError,
+    Identity,
+    IOContract,
+    LocalFileBinding,
+)
+from ....core import Component
 from ...components import Document
 from ...context import ChatContext
 from ..chat import Message
 from ..docs.document import _coerce_to_document, _coerce_to_documents
 from ._util import _resolve_question, _resolve_response, call_intrinsic
+
+# ---------------------------------------------------------------------------
+# IOContract implementations
+# ---------------------------------------------------------------------------
+
+
+class _DictContract(IOContract):
+    """Validate dict-shaped adapter output against a fixed set of required keys.
+
+    Args:
+        name: Adapter capability name; included in
+            :class:`~mellea.backends.adapters.AdapterSchemaMismatchError` messages.
+        required_keys: Keys that must be present in the parsed output dict.
+    """
+
+    def __init__(self, name: str, required_keys: frozenset[str]) -> None:
+        self._name = name
+        self._required_keys = required_keys
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2 (#1138)."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate dict-shaped adapter output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict, unchanged.
+
+        Raises:
+            AdapterSchemaMismatchError: When a required key is absent.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise AdapterSchemaMismatchError(
+                self._name, frozenset(), self._required_keys
+            )
+        observed = frozenset(data.keys())
+        missing = self._required_keys - observed
+        if missing:
+            raise AdapterSchemaMismatchError(self._name, observed, self._required_keys)
+        return data
+
+
+class _ListContract(IOContract):
+    """Validate list-of-dicts adapter output and wrap it under key ``"items"``.
+
+    Each item in the list is checked for the declared required keys.  The
+    validated list is returned wrapped in ``{"items": [...]}`` so that
+    :func:`call_intrinsic` can always return a plain ``dict``.
+
+    Args:
+        name: Adapter capability name; included in
+            :class:`~mellea.backends.adapters.AdapterSchemaMismatchError` messages.
+        required_item_keys: Keys that must be present in every item dict.
+    """
+
+    def __init__(self, name: str, required_item_keys: frozenset[str]) -> None:
+        self._name = name
+        self._required_item_keys = required_item_keys
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2 (#1138)."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate a list-of-dicts adapter output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: ``{"items": [list of validated dicts]}``.
+
+        Raises:
+            AdapterSchemaMismatchError: When the output is not a list, any item
+                is not a dict, or any item is missing a required key.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, list):
+            raise AdapterSchemaMismatchError(
+                self._name, frozenset(), self._required_item_keys
+            )
+        for item in data:
+            if not isinstance(item, dict):
+                raise AdapterSchemaMismatchError(
+                    self._name, frozenset(), self._required_item_keys
+                )
+            observed = frozenset(item.keys())
+            missing = self._required_item_keys - observed
+            if missing:
+                raise AdapterSchemaMismatchError(
+                    self._name, observed, self._required_item_keys
+                )
+        return {"items": data}
+
+
+# ---------------------------------------------------------------------------
+# Module-level Adapter constants (one per helper)
+# ---------------------------------------------------------------------------
+
+_ANSWERABILITY_ADAPTER = Adapter(
+    identity=Identity("answerability", "alora", capability="answerability"),
+    io_contract=_DictContract("answerability", frozenset({"answerability"})),
+    weights=LocalFileBinding(),
+)
+
+_QUERY_REWRITE_ADAPTER = Adapter(
+    identity=Identity("query_rewrite", "alora", capability="query_rewrite"),
+    io_contract=_DictContract("query_rewrite", frozenset({"rewritten_question"})),
+    weights=LocalFileBinding(),
+)
+
+_QUERY_CLARIFY_ADAPTER = Adapter(
+    identity=Identity("query_clarification", "alora", capability="query_clarification"),
+    io_contract=_DictContract("query_clarification", frozenset({"clarification"})),
+    weights=LocalFileBinding(),
+)
+
+_CITATIONS_ADAPTER = Adapter(
+    identity=Identity("citations", "alora", capability="citations"),
+    io_contract=_ListContract(
+        "citations",
+        frozenset(
+            {
+                "response_begin",
+                "response_end",
+                "response_text",
+                "citation_doc_id",
+                "citation_begin",
+                "citation_end",
+                "citation_text",
+            }
+        ),
+    ),
+    weights=LocalFileBinding(),
+)
+
+_CONTEXT_RELEVANCE_ADAPTER = Adapter(
+    identity=Identity("context_relevance", "alora", capability="context_relevance"),
+    io_contract=_DictContract("context_relevance", frozenset({"context_relevance"})),
+    weights=LocalFileBinding(),
+)
+
+_HALLUCINATION_ADAPTER = Adapter(
+    identity=Identity(
+        "hallucination_detection", "alora", capability="hallucination_detection"
+    ),
+    io_contract=_ListContract(
+        "hallucination_detection",
+        frozenset(
+            {
+                "response_begin",
+                "response_end",
+                "response_text",
+                "faithfulness",
+                "explanation",
+            }
+        ),
+    ),
+    weights=LocalFileBinding(),
+)
+
+
+# ---------------------------------------------------------------------------
+# High-level helper functions
+# ---------------------------------------------------------------------------
 
 
 def check_answerability(
@@ -16,11 +196,17 @@ def check_answerability(
     documents: collections.abc.Iterable[str | Document],
     context: ChatContext,
     backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> str:
     """Test a user's question for answerability.
 
     Adapter function that checks whether the question in the last user turn of a
     chat can be answered by a provided set of RAG documents.
+
+    Output contract — required key: ``answerability``.  Missing the key raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
+    keys in the model output do not raise (forward-compatible).
 
     Args:
         question: Question that the user has posed in response to the last turn in
@@ -32,28 +218,45 @@ def check_answerability(
         context: Chat context containing the conversation thus far.
         backend: Backend instance that supports adding the LoRA or aLoRA adapters
             for answerability checks.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
-        A string value of either "answerable" or "unanswerable"
+        A string value of either ``"answerable"`` or ``"unanswerable"``.
+
+    Raises:
+        AdapterSchemaMismatchError: When the model output is missing the required
+            ``answerability`` field.
     """
     question, context = _resolve_question(question, context, backend)
-    result_json = call_intrinsic(
+    result = call_intrinsic(
         "answerability",
         context.add(
             Message("user", question, documents=_coerce_to_documents(documents))
         ),
         backend,
+        io_contract=_ANSWERABILITY_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json["answerability"]
+    return result["answerability"]  # type: ignore[return-value]
 
 
 def rewrite_question(
-    question: str | None, context: ChatContext, backend: AdapterMixin
+    question: str | None,
+    context: ChatContext,
+    backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> str:
     """Rewrite a user's question for retrieval.
 
     Adapter function that rewrites the question in the next user turn into a
     self-contained query that can be passed to the retriever.
+
+    Output contract — required key: ``rewritten_question``.  Missing the key
+    raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`;
+    extra optional keys do not raise (forward-compatible).
 
     Args:
         question: Question that the user has posed in response to the last turn in
@@ -61,15 +264,26 @@ def rewrite_question(
             user message in `context`.
         context: Chat context containing the conversation thus far.
         backend: Backend instance that supports adding the LoRA or aLoRA adapters.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
         Rewritten version of `question`.
+
+    Raises:
+        AdapterSchemaMismatchError: When the model output is missing the required
+            ``rewritten_question`` field.
     """
     question, context = _resolve_question(question, context, backend)
-    result_json = call_intrinsic(
-        "query_rewrite", context.add(Message("user", question)), backend
+    result = call_intrinsic(
+        "query_rewrite",
+        context.add(Message("user", question)),
+        backend,
+        io_contract=_QUERY_REWRITE_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json["rewritten_question"]
+    return result["rewritten_question"]  # type: ignore[return-value]
 
 
 def clarify_query(
@@ -77,12 +291,18 @@ def clarify_query(
     documents: collections.abc.Iterable[str | Document],
     context: ChatContext,
     backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> str:
     """Generate clarification for an ambiguous query.
 
     Adapter function that determines if a user's question requires clarification
     based on the retrieved documents and conversation context, and generates an
     appropriate clarification question if needed.
+
+    Output contract — required key: ``clarification``.  Missing the key raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
+    keys do not raise (forward-compatible).
 
     Args:
         question: Question that the user has posed. When `None`, the question
@@ -93,20 +313,29 @@ def clarify_query(
         context: Chat context containing the conversation thus far.
         backend: Backend instance that supports the adapters that implement
             this intrinsic.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
-        Clarification question string (e.g., "Do you mean A or B?"), or
-        the string "CLEAR" if no clarification is needed.
+        Clarification question string (e.g., ``"Do you mean A or B?"``), or
+        the string ``"CLEAR"`` if no clarification is needed.
+
+    Raises:
+        AdapterSchemaMismatchError: When the model output is missing the required
+            ``clarification`` field.
     """
     question, context = _resolve_question(question, context, backend)
-    result_json = call_intrinsic(
+    result = call_intrinsic(
         "query_clarification",
         context.add(
             Message("user", question, documents=_coerce_to_documents(documents))
         ),
         backend,
+        io_contract=_QUERY_CLARIFY_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json["clarification"]
+    return result["clarification"]  # type: ignore[return-value]
 
 
 def find_citations(
@@ -114,11 +343,19 @@ def find_citations(
     documents: collections.abc.Iterable[str | Document],
     context: ChatContext,
     backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> list[dict]:
     """Find information in documents that supports an assistant response.
 
     Adapter function that finds sentences in RAG documents that support sentences
     in a potential assistant response to a user question.
+
+    Output contract — each record must contain: ``response_begin``,
+    ``response_end``, ``response_text``, ``citation_doc_id``, ``citation_begin``,
+    ``citation_end``, ``citation_text``.  A record missing any of these keys
+    raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
+    optional keys do not raise (forward-compatible).
 
     Args:
         response: Potential assistant response. When `None`, the response is
@@ -133,15 +370,22 @@ def find_citations(
             the user has just asked a question that will be answered with RAG documents.
         backend: Backend that supports one of the adapters that implements this
             intrinsic.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
-        List of records with the following fields: `response_begin`,
-        `response_end`, `response_text`, `citation_doc_id`, `citation_begin`,
-        `citation_end`, `citation_text`. Begin and end offsets are character
-        offsets into their respective UTF-8 strings.
+        List of records with fields ``response_begin``, ``response_end``,
+        ``response_text``, ``citation_doc_id``, ``citation_begin``,
+        ``citation_end``, ``citation_text``.  Begin and end offsets are
+        character offsets into their respective UTF-8 strings.
+
+    Raises:
+        AdapterSchemaMismatchError: When any record in the output is missing a
+            required field.
     """
     response, context = _resolve_response(response, context)
-    result_json = call_intrinsic(
+    result = call_intrinsic(
         "citations",
         context.add(
             Message(
@@ -151,8 +395,10 @@ def find_citations(
             )
         ),
         backend,
+        io_contract=_CITATIONS_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json
+    return result["items"]  # type: ignore[return-value]
 
 
 def check_context_relevance(
@@ -160,6 +406,8 @@ def check_context_relevance(
     document: str | Document,
     context: ChatContext,
     backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> str:
     """Test whether a document is relevant to a user's question.
 
@@ -173,6 +421,13 @@ def check_context_relevance(
     the answer to a user's question. Does not consider the context in which the
     question was asked.
 
+    This helper uses a Granite 4.0 adapter (``ibm-granite/granite-4.0-micro``) and
+    is not available for Granite 4.1 models.
+
+    Output contract — required key: ``context_relevance``.  Missing the key raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
+    keys do not raise (forward-compatible).
+
     Args:
         question: Question that the user has posed. When `None`, the question
             is extracted from the last user message in `context`.
@@ -181,12 +436,17 @@ def check_context_relevance(
         context: The chat up to the point where the user asked a question.
         backend: Backend instance that supports the adapters that implement this
             intrinsic.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
         Context relevance judgement as one of the following strings:
-        - "relevant"
-        - "irrelevant"
-        - "partially relevant"
+        ``"relevant"``, ``"irrelevant"``, or ``"partially relevant"``.
+
+    Raises:
+        AdapterSchemaMismatchError: When the model output is missing the required
+            ``context_relevance`` field.
     """
     warnings.warn(
         "check_context_relevance() is deprecated and will be removed in a future "
@@ -198,14 +458,15 @@ def check_context_relevance(
     )
     question, context = _resolve_question(question, context, backend)
     document = _coerce_to_document(document)
-    result_json = call_intrinsic(
+    result = call_intrinsic(
         "context_relevance",
         context.add(Message("user", question)),
         backend,
-        # Target document is passed as an argument
         kwargs={"document_content": document.text},
+        io_contract=_CONTEXT_RELEVANCE_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json["context_relevance"]
+    return result["context_relevance"]  # type: ignore[return-value]
 
 
 def flag_hallucinated_content(
@@ -213,12 +474,24 @@ def flag_hallucinated_content(
     documents: collections.abc.Iterable[str | Document],
     context: ChatContext,
     backend: AdapterMixin,
+    *,
+    model_options: dict | None = None,
 ) -> list[dict]:
     """Flag potentially-hallucinated sentences in an agent's response.
 
     Adapter function that checks whether the sentences in an agent's response to a
-    user question are faithful to the retrieved document snippets. Sentences that do not
-    align with the retrieved snippets are flagged as potential hallucinations.
+    user question are faithful to the retrieved document snippets. Sentences that do
+    not align with the retrieved snippets are flagged as potential hallucinations.
+
+    The ``faithfulness`` field in each record is a string label (e.g.
+    ``"faithful"``, ``"hallucinated"``); coercion to a boolean is the caller's
+    responsibility.
+
+    Output contract — each record must contain: ``response_begin``,
+    ``response_end``, ``response_text``, ``faithfulness``, ``explanation``.  A
+    record missing any of these keys raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
+    keys do not raise (forward-compatible).
 
     Args:
         response: The assistant's response to the user's question in the last turn
@@ -230,18 +503,26 @@ def flag_hallucinated_content(
         context: A chat log that ends with a user asking a question.
         backend: Backend instance that supports the adapters that implement this
             intrinsic.
+        model_options: Optional model-option overrides (e.g.
+            ``{"temperature": 0.1}``).  Merged on top of the adapter default
+            (``temperature=0.0``).
 
     Returns:
-        List of records with the following fields: `response_begin`,
-        `response_end`, `response_text`, `faithfulness`,
-        `explanation`.
+        List of records with fields ``response_begin``, ``response_end``,
+        ``response_text``, ``faithfulness``, ``explanation``.
+
+    Raises:
+        AdapterSchemaMismatchError: When any record in the output is missing a
+            required field.
     """
     response, context = _resolve_response(response, context)
-    result_json = call_intrinsic(
+    result = call_intrinsic(
         "hallucination_detection",
         context.add(
             Message("assistant", response, documents=_coerce_to_documents(documents))
         ),
         backend,
+        io_contract=_HALLUCINATION_ADAPTER.io_contract,
+        model_options=model_options,
     )
-    return result_json
+    return result["items"]  # type: ignore[return-value]

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -317,7 +317,7 @@ def clarify_query(
             `Document`).
         context: Chat context containing the conversation thus far.
         backend: Backend instance that supports the adapters that implement
-            this intrinsic.
+            this adapter function.
         model_options: Optional model-option overrides (e.g.
             ``{"temperature": 0.1}``).  Merged on top of the adapter default
             (``temperature=0.0``).
@@ -371,11 +371,11 @@ def find_citations(
             `Document` with an auto-generated `doc_id` (`"0"`, `"1"`, ...);
             for explicit control, pass `Document` objects with `doc_id` set.
             `Document` objects without `doc_id` trigger a warning because the
-            intrinsic uses `doc_id` to identify citation sources.
+            adapter function uses `doc_id` to identify citation sources.
         context: Context of the dialog between user and assistant at the point where
             the user has just asked a question that will be answered with RAG documents.
         backend: Backend that supports one of the adapters that implements this
-            intrinsic.
+            adapter function.
         model_options: Optional model-option overrides (e.g.
             ``{"temperature": 0.1}``).  Merged on top of the adapter default
             (``temperature=0.0``).
@@ -442,7 +442,7 @@ def check_context_relevance(
             string (automatically wrapped in `Document`).
         context: The chat up to the point where the user asked a question.
         backend: Backend instance that supports the adapters that implement this
-            intrinsic.
+            adapter function.
         model_options: Optional model-option overrides (e.g.
             ``{"temperature": 0.1}``).  Merged on top of the adapter default
             (``temperature=0.0``).
@@ -510,7 +510,7 @@ def flag_hallucinated_content(
             in `Document`).
         context: A chat log that ends with a user asking a question.
         backend: Backend instance that supports the adapters that implement this
-            intrinsic.
+            adapter function.
         model_options: Optional model-option overrides (e.g.
             ``{"temperature": 0.1}``).  Merged on top of the adapter default
             (``temperature=0.0``).

--- a/test/stdlib/components/intrinsic/test_rag_contracts.py
+++ b/test/stdlib/components/intrinsic/test_rag_contracts.py
@@ -176,3 +176,28 @@ def test_find_citations_empty_list() -> None:
 def test_flag_hallucinated_content_empty_list() -> None:
     result = _HALLUCINATION_ADAPTER.io_contract.parse(json.dumps([]))
     assert result == {"items": []}
+
+
+# ---------------------------------------------------------------------------
+# Type-mismatch: ValueError raised when JSON is the wrong shape
+# ---------------------------------------------------------------------------
+
+
+def test_dict_contract_rejects_non_dict() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        _ANSWERABILITY_ADAPTER.io_contract.parse(json.dumps(["not", "a", "dict"]))
+
+
+def test_dict_contract_error_mentions_adapter_name() -> None:
+    with pytest.raises(ValueError, match="answerability"):
+        _ANSWERABILITY_ADAPTER.io_contract.parse(json.dumps(42))
+
+
+def test_list_contract_rejects_non_list() -> None:
+    with pytest.raises(ValueError, match="must be a JSON array"):
+        _CITATIONS_ADAPTER.io_contract.parse(json.dumps({"not": "a list"}))
+
+
+def test_list_contract_rejects_non_dict_element() -> None:
+    with pytest.raises(ValueError, match="must contain only JSON objects"):
+        _CITATIONS_ADAPTER.io_contract.parse(json.dumps(["string_element"]))

--- a/test/stdlib/components/intrinsic/test_rag_contracts.py
+++ b/test/stdlib/components/intrinsic/test_rag_contracts.py
@@ -161,3 +161,18 @@ def test_flag_hallucinated_content_forward_compat() -> None:
     extra_item = {**_GOOD_SPAN, "extra_field": "ignored"}
     result = _HALLUCINATION_ADAPTER.io_contract.parse(json.dumps([extra_item]))
     assert result["items"][0]["faithfulness"] == "faithful"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Empty-list edge cases for list-shaped contracts
+# ---------------------------------------------------------------------------
+
+
+def test_find_citations_empty_list() -> None:
+    result = _CITATIONS_ADAPTER.io_contract.parse(json.dumps([]))
+    assert result == {"items": []}
+
+
+def test_flag_hallucinated_content_empty_list() -> None:
+    result = _HALLUCINATION_ADAPTER.io_contract.parse(json.dumps([]))
+    assert result == {"items": []}

--- a/test/stdlib/components/intrinsic/test_rag_contracts.py
+++ b/test/stdlib/components/intrinsic/test_rag_contracts.py
@@ -201,3 +201,10 @@ def test_list_contract_rejects_non_list() -> None:
 def test_list_contract_rejects_non_dict_element() -> None:
     with pytest.raises(ValueError, match="must contain only JSON objects"):
         _CITATIONS_ADAPTER.io_contract.parse(json.dumps(["string_element"]))
+
+
+def test_list_contract_rejects_non_dict_element_after_valid_item() -> None:
+    with pytest.raises(ValueError, match="must contain only JSON objects"):
+        _CITATIONS_ADAPTER.io_contract.parse(
+            json.dumps([_GOOD_CITATION, "string_element"])
+        )

--- a/test/stdlib/components/intrinsic/test_rag_contracts.py
+++ b/test/stdlib/components/intrinsic/test_rag_contracts.py
@@ -1,0 +1,163 @@
+"""Unit tests for IOContract validation in rag.py (Epic #929 Phase 1).
+
+Tests the ``parse()`` method of each IOContract subclass directly — no backend,
+no GPU, no model download required.  Two tests per helper:
+
+- ``test_<helper>_contract_enforced`` — output missing a required field raises
+  :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`.
+- ``test_<helper>_forward_compat`` — output containing an extra optional field
+  does *not* raise.
+"""
+
+import json
+
+import pytest
+
+from mellea.backends.adapters import AdapterSchemaMismatchError
+from mellea.stdlib.components.intrinsic.rag import (
+    _ANSWERABILITY_ADAPTER,
+    _CITATIONS_ADAPTER,
+    _CONTEXT_RELEVANCE_ADAPTER,
+    _HALLUCINATION_ADAPTER,
+    _QUERY_CLARIFY_ADAPTER,
+    _QUERY_REWRITE_ADAPTER,
+)
+
+# ---------------------------------------------------------------------------
+# check_answerability
+# ---------------------------------------------------------------------------
+
+
+def test_check_answerability_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _ANSWERABILITY_ADAPTER.io_contract.parse(json.dumps({"wrong_key": "value"}))
+    err = exc_info.value
+    assert err.name == "answerability"
+    assert "answerability" in err.expected_keys
+
+
+def test_check_answerability_forward_compat() -> None:
+    result = _ANSWERABILITY_ADAPTER.io_contract.parse(
+        json.dumps({"answerability": "answerable", "extra": "ignored"})
+    )
+    assert result["answerability"] == "answerable"
+
+
+# ---------------------------------------------------------------------------
+# rewrite_question
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_question_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _QUERY_REWRITE_ADAPTER.io_contract.parse(json.dumps({"wrong_key": "value"}))
+    err = exc_info.value
+    assert err.name == "query_rewrite"
+    assert "rewritten_question" in err.expected_keys
+
+
+def test_rewrite_question_forward_compat() -> None:
+    result = _QUERY_REWRITE_ADAPTER.io_contract.parse(
+        json.dumps({"rewritten_question": "new query?", "confidence": 0.9})
+    )
+    assert result["rewritten_question"] == "new query?"
+
+
+# ---------------------------------------------------------------------------
+# clarify_query
+# ---------------------------------------------------------------------------
+
+
+def test_clarify_query_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _QUERY_CLARIFY_ADAPTER.io_contract.parse(json.dumps({"wrong_key": "value"}))
+    err = exc_info.value
+    assert err.name == "query_clarification"
+    assert "clarification" in err.expected_keys
+
+
+def test_clarify_query_forward_compat() -> None:
+    result = _QUERY_CLARIFY_ADAPTER.io_contract.parse(
+        json.dumps({"clarification": "CLEAR", "score": 1.0})
+    )
+    assert result["clarification"] == "CLEAR"
+
+
+# ---------------------------------------------------------------------------
+# find_citations
+# ---------------------------------------------------------------------------
+
+
+_GOOD_CITATION = {
+    "response_begin": 0,
+    "response_end": 10,
+    "response_text": "some text",
+    "citation_doc_id": "0",
+    "citation_begin": 5,
+    "citation_end": 20,
+    "citation_text": "source",
+}
+
+
+def test_find_citations_contract_enforced() -> None:
+    bad_item = {k: v for k, v in _GOOD_CITATION.items() if k != "citation_doc_id"}
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _CITATIONS_ADAPTER.io_contract.parse(json.dumps([bad_item]))
+    err = exc_info.value
+    assert err.name == "citations"
+    assert "citation_doc_id" in err.expected_keys
+
+
+def test_find_citations_forward_compat() -> None:
+    extra_item = {**_GOOD_CITATION, "extra_field": "ignored"}
+    result = _CITATIONS_ADAPTER.io_contract.parse(json.dumps([extra_item]))
+    assert result["items"][0]["citation_doc_id"] == "0"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# check_context_relevance
+# ---------------------------------------------------------------------------
+
+
+def test_check_context_relevance_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _CONTEXT_RELEVANCE_ADAPTER.io_contract.parse(json.dumps({"wrong_key": "value"}))
+    err = exc_info.value
+    assert err.name == "context_relevance"
+    assert "context_relevance" in err.expected_keys
+
+
+def test_check_context_relevance_forward_compat() -> None:
+    result = _CONTEXT_RELEVANCE_ADAPTER.io_contract.parse(
+        json.dumps({"context_relevance": "relevant", "score": 0.8})
+    )
+    assert result["context_relevance"] == "relevant"
+
+
+# ---------------------------------------------------------------------------
+# flag_hallucinated_content
+# ---------------------------------------------------------------------------
+
+
+_GOOD_SPAN = {
+    "response_begin": 0,
+    "response_end": 10,
+    "response_text": "some text",
+    "faithfulness": "faithful",
+    "explanation": "supported by document",
+}
+
+
+def test_flag_hallucinated_content_contract_enforced() -> None:
+    bad_item = {k: v for k, v in _GOOD_SPAN.items() if k != "explanation"}
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _HALLUCINATION_ADAPTER.io_contract.parse(json.dumps([bad_item]))
+    err = exc_info.value
+    assert err.name == "hallucination_detection"
+    assert "explanation" in err.expected_keys
+
+
+def test_flag_hallucinated_content_forward_compat() -> None:
+    extra_item = {**_GOOD_SPAN, "extra_field": "ignored"}
+    result = _HALLUCINATION_ADAPTER.io_contract.parse(json.dumps([extra_item]))
+    assert result["items"][0]["faithfulness"] == "faithful"  # type: ignore[index]


### PR DESCRIPTION
<!-- pr-template-marker -->

## Summary

This is **Epic #929 Phase 1 Wave 3** — whole-file migration of `mellea/stdlib/components/intrinsic/rag.py` to the new `Adapter(identity, io_contract, weights)` dataclass system introduced in Phase 1.A (PR #1269, merged 2026-06-23).

Epic #929 is a multi-phase effort to fix Adapter Function Lifecycle & Consistency in Mellea. The phases are:
- **Phase 0 (#1134)** — scaffolding: `Adapter` dataclass, `IOContract` ABC, `Identity`, `WeightsBinding` types
- **Phase 1.A (#1136)** — `call_intrinsic` refactor + `_ShimIOContract` shims; merged ✅
- **Phase 1 Wave 3 (this PR, #1137)** — full IOContract migration for all 6 RAG adapter functions
- **Phase 2 (#1138)** — `build_prompt` implementation (currently stubs raising `NotImplementedError`)

### What this PR changes

**`rag.py`** — all six RAG adapter functions fully migrated:

- Two new `IOContract` subclasses: `_DictContract` (single-dict output) and `_ListContract` (list-of-dicts output).
- `_ListContract.parse()` wraps the validated list in `{"items": [...]}` to satisfy the `dict[str, object]` return type of `IOContract.parse()`; helper functions unwrap it before returning — public return types are unchanged.
- `parse()` raises `AdapterSchemaMismatchError` when a required field is missing; raises `ValueError` when the JSON output is the wrong type entirely (not a dict / not a list). This replaces the previous silent `KeyError`; **callers that catch `KeyError` should update to `AdapterSchemaMismatchError`**.
- Extra fields in the model output do NOT raise (forward-compatible).
- `parse()` propagates `ValueError` / `json.JSONDecodeError` from `json.loads` when the model output is not valid JSON.
- Six module-level `Adapter` constants, one per helper, each with `Identity`, `_*Contract`, and `LocalFileBinding()`.
- `model_options: dict | None = None` added as a keyword-only argument to all six helpers (previously absent).
- Prose updated to agreed Granite Switch glossary (issue #1192): "intrinsic" → "adapter function" in `backend:` parameter descriptions.
- All six call sites use `cast(str, ...)` / `cast(list[dict], ...)` rather than `# type: ignore[return-value]`.

**`_util.py`** — `call_intrinsic` extended with `io_contract: IOContract | None = None` (keyword-only, defaulted `None`). When provided, replaces the raw `json.loads` call with `io_contract.parse()` for combined parse+validate. All existing callers (`core.py`, `guardian.py`) pass no `io_contract` and are unaffected. The function now carries an explicit `-> dict[str, object]` return annotation.

**`test_rag_contracts.py`** (new) — 18 pure unit tests (no GPU, no backend):
- Two per helper: `contract_enforced` (missing required field → `AdapterSchemaMismatchError`) and `forward_compat` (extra field → no raise)
- Two empty-list edge cases for the list-shaped contracts (`find_citations`, `flag_hallucinated_content`)
- Four type-mismatch cases: `ValueError` when JSON is not a dict, not a list, or contains a non-dict list element

### Output contract verification

Each contract was verified against the current `granitelib-rag-r1.0` weights README before writing the tests:

| Helper | Required output keys |
|--------|---------------------|
| `check_answerability` | `answerability` |
| `rewrite_question` | `rewritten_question` |
| `clarify_query` | `clarification` |
| `find_citations` | `response_begin`, `response_end`, `response_text`, `citation_doc_id`, `citation_begin`, `citation_end`, `citation_text` |
| `check_context_relevance` | `context_relevance` |
| `flag_hallucinated_content` | `response_begin`, `response_end`, `response_text`, `faithfulness`, `explanation` |

### Examples review

All six `docs/examples/intrinsics/` examples that call these helpers (`answerability.py`, `citations.py`, `context_relevance.py`, `hallucination_detection.py`, `query_clarification.py`, `query_rewrite.py`) were reviewed. All existing calls pass the migrated parameters positionally or by name, and none rely on a `model_options` position — the keyword-only addition is non-breaking. All examples are gated with `# pytest: huggingface, e2e` (or have no pytest marker and are silently skipped) and therefore do not run in unit CI.

### Relationship to other open PRs

- **#1320** (`requirement_check_to_bool`, `core.py` — #1138): Wave 3 parallel sibling; touches different file, no conflict.
- **#1323** (`guardian.py` — #1139): Wave 3 parallel sibling; touches different file, no conflict.
- **#1322** (`docs/examples` terminology sweep — #1279): touches `docs/examples/intrinsics/README.md` and Python docstring files, but NOT `rag.py` or `_util.py`. No conflict.
- **#1284** (`.parsed` property / `format=` overloads — #1273/#1274): unrelated to this file.

Ordering: this PR has no blocking relationship to #1320 or #1323 — all three Wave 3 PRs are independent and can merge in any order.

### Related issues

- Closes #1137
- Part of Epic #929
- Prerequisite: #1136 / PR #1269 (merged — `Adapter`, `IOContract`, `LocalFileBinding` API)
- Next wave: #1138 (core.py, PR #1320), #1139 (guardian.py, PR #1323)
- Related open issues noted but out of scope: #1301 (context_relevance JSONDecodeError — separate bug), #937 (empty-context crash — separate bug), #1316 (groundedness nested citations — different helper)

### Test plan

- [x] `uv run pytest test/stdlib/components/intrinsic/test_rag_contracts.py -v` — 18/18 pass
- [x] `uv run pytest test/stdlib/components/intrinsic/ -m "not qualitative"` — all pass
- [x] `uv run pytest test/ -m "not qualitative"` (full local suite) — 1837 passed, 0 failures (1 pre-existing error: #1344)
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] Docstring quality gate: 0 issues
- [x] `docs/examples/intrinsics/` examples reviewed — backward-compatible, no changes required
- [x] GPU integration tests — BlueVela LSF (job 1691399, single A100): 274 passed, 0 failures
- [x] CI (`code-checks` 3.11/3.12/3.13) — all pass (3.13 rerun needed: `httpx.ReadTimeout` flake, tracked #1318)