### PR TITLE
chore(terminology): sweep docs/examples and Python docstrings (#1192 follow-up)

### DIFF
--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -80,7 +80,7 @@ to run.
 | -------- | ------------- |
 | `aLora/` | Training aLoRA adapters for fast constraint checking; performance optimisation |
 | `intrinsics/` | *(Non-Guardian)* Answer relevance, hallucination detection, citation validation, context relevance — specialised adapter-backed checks. For Guardian safety functions see [Safety and validation](#safety-and-validation) above |
-| `granite-switch/` | Running intrinsics via OpenAI backend with Granite Switch embedded adapters |
+| `granite-switch/` | Running adapter functions via OpenAI backend with Granite Switch embedded adapters |
 | `sofai/` | Two-tier sampling: fast-model iteration with escalation to a slow model; cost optimisation |
 
 ### Multimodal

--- a/docs/docs/how-to/backends-and-configuration.md
+++ b/docs/docs/how-to/backends-and-configuration.md
@@ -33,7 +33,7 @@ The following table shows all available backends, their class names, import path
 | [Ollama](../integrations/ollama) | `OllamaModelBackend` | `mellea.backends.ollama` | base | `backend_name="ollama"` |
 | [OpenAI](../integrations/openai) | `OpenAIBackend` | `mellea.backends.openai` | base | `backend_name="openai"` |
 | [LiteLLM](../integrations/bedrock) | `LiteLLMBackend` | `mellea.backends.litellm` | `mellea[litellm]` | `backend_name="litellm"` |
-| [HuggingFace](../integrations/huggingface) | `LocalHFBackend` | `mellea.backends.huggingface` | `mellea[hf]` | `backend_name="hf"` |
+| [Hugging Face](../integrations/huggingface) | `LocalHFBackend` | `mellea.backends.huggingface` | `mellea[hf]` | `backend_name="hf"` |
 | [WatsonX](../integrations/watsonx) | `WatsonxAIBackend` | `mellea.backends.watsonx` | `mellea[watsonx]` | `backend_name="watsonx"` (deprecated) |
 
 > **Note:** Vertex AI uses the LiteLLM backend with appropriate model IDs. See the [Vertex AI integration](../integrations/vertex-ai) for details. For detailed setup instructions, click the backend name in the table above.

--- a/docs/docs/how-to/safety-guardrails.md
+++ b/docs/docs/how-to/safety-guardrails.md
@@ -5,7 +5,7 @@ description: "Use Guardian adapter functions to detect harmful, biased, unground
 ---
 
 **Prerequisites:** `pip install "mellea[hf]"` for local inference; Apple Silicon or CUDA GPU recommended.
-Guardian adapter functions work via `LocalHFBackend` (local HuggingFace inference) or `OpenAIBackend`
+Guardian adapter functions work via `LocalHFBackend` (local Hugging Face inference) or `OpenAIBackend`
 pointed at a Granite Switch endpoint.
 
 Guardian adapter functions evaluate LLM outputs for safety and quality using LoRA adapters

--- a/docs/docs/how-to/safety-guardrails.md
+++ b/docs/docs/how-to/safety-guardrails.md
@@ -320,7 +320,7 @@ Guardian adapter functions return a numeric score (or label string) rather than 
 [`Requirement`](../reference/glossary#requirement) instance, so they cannot be
 passed to `m.validate()` or wired into `RepairTemplateStrategy` the way the
 deprecated `GuardianCheck` could. The practical workaround is to call
-`guardian_check()` (or another Intrinsic) manually after generation and
+`guardian_check()` (or another adapter function) manually after generation and
 re-invoke `m.instruct()` with an additional requirement when the score crosses
 your threshold. A `Requirement`-backed wrapper is tracked in
 [#1071](https://github.com/generative-computing/mellea/issues/1071).

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -32,7 +32,7 @@ m alora train \
 
 ## Upload Models
 
-If model training succeeds, you will need to upload your model as an intrinsic:
+If model training succeeds, you will need to upload your model as an adapter function:
 
 ```bash
 # WARNING: running this command will upload your model weights to huggingface.co !!!
@@ -63,7 +63,7 @@ m alora upload \
 
 ## Generate a README
 
-After uploading your adapter, you can auto-generate a README for the HuggingFace model repository using `m alora add-readme`. This command uses Mellea to analyze your training dataset and produce documentation with a description, data examples, and integration code:
+After uploading your adapter, you can auto-generate a README for the Hugging Face model repository using `m alora add-readme`. This command uses Mellea to analyze your training dataset and produce documentation with a description, data examples, and integration code:
 
 ```bash
 m alora add-readme \
@@ -84,9 +84,9 @@ m alora add-readme \
     stembolt_failure_dataset.jsonl
 ```
 
-The generator will display the README and ask for confirmation before uploading it to your HuggingFace repo. You can also call the generator programmatically from Python -- see `test_readme_generator.py` for an example.
+The generator will display the README and ask for confirmation before uploading it to your Hugging Face repo. You can also call the generator programmatically from Python -- see `test_readme_generator.py` for an example.
 
-## Using Intrinsics
+## Using Adapter Functions
 
 You can now create a new adapter class for this model somewhere in your python project:
 
@@ -141,7 +141,7 @@ Demonstrates:
 - Preprocessing for training
 
 ### stembolts_intrinsic.py
-Example custom intrinsic adapter implementation.
+Example custom adapter function implementation.
 
 Demonstrates:
 - Custom adapter class definition

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -37,7 +37,7 @@ If model training succeeds, you will need to upload your model as an adapter fun
 ```bash
 # WARNING: running this command will upload your model weights to huggingface.co !!!
 # The model will be private.
-# replace $HF_USERNAME with your huggingface username.
+# replace $HF_USERNAME with your Hugging Face username.
 m alora upload \
    --intrinsic \
    --name "$HF_USERNAME/stembolts" \
@@ -96,7 +96,7 @@ from mellea.backends.adapters.adapter import CustomIntrinsicAdapter
 class StemboltAdapter(CustomIntrinsicAdapter):
     def __init__(self, base_model_name:str="granite-4.1-3b"):
         super().__init__(
-            model_id="$USERNAME/stembolts", # REPLACE $USERNAME WITH YOUR HUGGINGFACE USERNAME
+            model_id="$USERNAME/stembolts", # REPLACE $USERNAME WITH YOUR HUGGING FACE USERNAME
             intrinsic_name="stembolts",
             base_model_name=base_model_name,
         )

--- a/docs/examples/granite-switch/README.md
+++ b/docs/examples/granite-switch/README.md
@@ -1,6 +1,6 @@
 # Granite Switch Examples
 
-This directory contains examples for running Mellea intrinsics through an
+This directory contains examples for running Mellea adapter functions through an
 OpenAI-compatible backend using Granite Switch models.
 
 ## What is Granite Switch?
@@ -26,14 +26,14 @@ python -m vllm.entrypoints.openai.api_server \
 
 ## Available adapters
 
-Not all intrinsics are embedded in every Granite Switch model. You should check the model's `adapter_index.json` file for a definitive list. For granite switch models pre-built by IBM, we include a list of models in the Mellea `model_id`.
+Not all adapter functions are embedded in every Granite Switch model. You should check the model's `adapter_index.json` file for a definitive list. For granite switch models pre-built by IBM, we include a list of models in the Mellea `model_id`.
 
 ## Files
 
 ### answerability_openai.py
 
 Demonstrates `rag.check_answerability()` using `OpenAIBackend` with
-`load_embedded_adapters=True` — the simplest way to use intrinsics with Granite
+`load_embedded_adapters=True` — the simplest way to use adapter functions with Granite
 Switch.
 
 ### hallucination_detection_openai.py
@@ -53,6 +53,6 @@ registration.
 
 ## Related
 
-- [`../intrinsics/`](../intrinsics/) — the same intrinsics using `LocalHFBackend`
-- [Intrinsics Documentation](../../docs/docs/advanced/intrinsics.md)
+- [`../intrinsics/`](../intrinsics/) — the same adapter functions using `LocalHFBackend`
+- [Adapter Functions Documentation](../../docs/docs/advanced/intrinsics.md)
 - [Official Granite Switch Documentation](https://github.com/generative-computing/granite-switch) 

--- a/docs/examples/granite-switch/answerability_openai.py
+++ b/docs/examples/granite-switch/answerability_openai.py
@@ -1,6 +1,6 @@
 # pytest: e2e, vllm, skip
 
-"""Example: running the answerability intrinsic via OpenAI backend with Granite Switch.
+"""Example: running the answerability adapter function via OpenAI backend with Granite Switch.
 
 Requires a vLLM server hosting a Granite Switch model.
 

--- a/docs/examples/granite-switch/manual_adapter_loading.py
+++ b/docs/examples/granite-switch/manual_adapter_loading.py
@@ -9,7 +9,7 @@ the model repo at init), this example shows how to create an OpenAIBackend with
 
 This is useful when:
 - You only need a subset of the model's embedded adapters.
-- You want to load adapters from a local directory rather than HuggingFace Hub.
+- You want to load adapters from a local directory rather than Hugging Face Hub.
 - You want more control over adapter registration.
 
 Requires a vLLM server hosting a Granite Switch model.
@@ -55,7 +55,7 @@ backend = OpenAIBackend(
     load_embedded_adapters=False,
 )
 
-# --- Option A: Load a single adapter from HuggingFace Hub ---
+# --- Option A: Load a single adapter from Hugging Face Hub ---
 adapters = EmbeddedIntrinsicAdapter.from_hub(
     SWITCH_MODEL_ID, intrinsic_name="answerability"
 )
@@ -72,7 +72,7 @@ for adapter in adapters:
 
 print(f"Registered adapters: {backend.list_adapters()}")
 
-# Now use the intrinsic as usual.
+# Now use the adapter function as usual.
 context = ChatContext().add(Message("assistant", "Hello there, how can I help you?"))
 question = "What is the square root of 4?"
 documents = [Document("The square root of 4 is 2.")]

--- a/docs/examples/groundedness_requirement_example.py
+++ b/docs/examples/groundedness_requirement_example.py
@@ -5,13 +5,13 @@ This example shows how to use GroundednessRequirement to validate that
 assistant responses are fully grounded by citations to retrieved documents.
 
 The validator implements a sophisticated 4-step pipeline:
-1. Citation Generation - Generate citations using the citations intrinsic
+1. Citation Generation - Generate citations using the citations adapter function
 2. Citation Necessity - Identify which spans need citations (LLM judgment)
 3. Citation Support - Assess support level for each span (LLM judgment)
 4. Groundedness Output - Declare response grounded iff all spans needing
    citations are fully supported
 
-Note: This example requires HuggingFace backend with GPU (8GB+ VRAM recommended)
+Note: This example requires Hugging Face backend with GPU (8GB+ VRAM recommended)
 and access to the ibm-granite/granite-4.0-micro model.
 """
 
@@ -29,8 +29,8 @@ async def main():
     print("GroundednessRequirement Example")
     print("=" * 70)
 
-    # Initialize HuggingFace backend
-    print("\nInitializing HuggingFace backend...")
+    # Initialize Hugging Face backend
+    print("\nInitializing Hugging Face backend...")
     backend = LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
 
     # Create documents about Rupert Murdoch

--- a/docs/examples/intrinsics/README.md
+++ b/docs/examples/intrinsics/README.md
@@ -1,10 +1,10 @@
-# Intrinsics Examples
+# Adapter Functions Examples
 
-This directory contains examples for using Mellea's intrinsic functions - specialized model capabilities accessed through adapters.
+This directory contains examples for using Mellea's adapter functions - specialized model capabilities accessed through adapters.
 
 ## Concepts Demonstrated
 
-- **Intrinsic Functions**: Specialized model capabilities beyond text generation
+- **Adapter Functions**: Specialized model capabilities beyond text generation
 - **Adapter System**: Using LoRA/aLoRA adapters for specific tasks
 - **RAG Evaluation**: Assessing retrieval-augmented generation quality
 - **Quality Metrics**: Measuring relevance, groundedness, and accuracy
@@ -24,7 +24,7 @@ ctx, backend = start_backend(
 response, ctx = mfuncs.chat("What is 2 + 2?", ctx, backend)
 print(f"Response: {response.content}")
 
-# NOTE: There are additional functions for other intrinsics as well.
+# NOTE: There are additional functions for other adapter functions as well.
 result = core.check_certainty(ctx, backend)
 print(f"Certainty score: {result}")
 ```
@@ -38,7 +38,7 @@ backend = OpenAIBackend(
 )
 ```
 
-The underlying intrinsics can also be utilized directly when generating:
+The underlying adapter functions can also be utilized directly when generating:
 ```python
 from mellea.stdlib.components import Intrinsic
 import mellea.stdlib.functional as mfuncs
@@ -57,11 +57,11 @@ out, new_ctx = mfuncs.act(
 For complete runnable examples using the OpenAI backend with Granite Switch,
 see [`../granite-switch/`](../granite-switch/).
 
-> **Note:** Not all intrinsics are embedded in every Granite Switch model. You should check
+> **Note:** Not all adapter functions are embedded in every Granite Switch model. You should check
 > the model's `adapter_index.json` file for a definitive list. For granite switch models
 > pre-built by IBM, we include a list of models in the Mellea `model_id`.
 
-## Available Intrinsics
+## Available Adapter Functions
 
 - **answerability**: Determine if question is answerable
 - **citations**: Extract and validate citations
@@ -79,7 +79,7 @@ see [`../granite-switch/`](../granite-switch/).
 
 ## Example Files
 
-### RAG Intrinsics
+### RAG Adapter Functions
 
 ```bash
 uv run answerability.py
@@ -116,7 +116,7 @@ uv run query_rewrite.py
 ```
 Demonstrates rewriting queries for better retrieval.
 
-### Core Intrinsics
+### Core Adapter Functions
 
 ```bash
 uv run requirement_check.py
@@ -128,7 +128,7 @@ uv run uncertainty.py
 ```
 Demonstrates assessing model certainty about its response.
 
-### Guardian Intrinsics
+### Guardian Adapter Functions
 
 ```bash
 uv run factuality_detection.py
@@ -155,14 +155,14 @@ Demonstrates checking compliance with policies.
 ```bash
 uv run intrinsics.py
 ```
-Full example showing multiple intrinsics working together in a RAG pipeline.
+Full example showing multiple adapter functions working together in a RAG pipeline.
 
 ## Architecture
 ![Granite Libraries Software Stack Architecture in Mellea](../../docs/images/granite-libraries-mellea-architecture.png)
 
 ## Related Documentation
 
-- See `mellea/stdlib/components/intrinsic/` for intrinsic implementations
+- See `mellea/stdlib/components/intrinsic/` for adapter function implementations
 - See `mellea/backends/adapters/` for adapter system
 - See `docs/dev/intrinsics_and_adapters.md` for architecture details
 - See `docs/docs/examples/granite-switch/README.md` for more about granite-switch

--- a/docs/examples/intrinsics/README.md
+++ b/docs/examples/intrinsics/README.md
@@ -33,7 +33,7 @@ OpenAIBackends also support a type of embedded adapter for Granite Switch models
 ```python
 backend = OpenAIBackend(
         model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
-        load_embedded_adapters=True,  # Auto-loads adapters from huggingface repo.
+        load_embedded_adapters=True,  # Auto-loads adapters from Hugging Face repo.
         ...
 )
 ```

--- a/docs/examples/rag/README.md
+++ b/docs/examples/rag/README.md
@@ -98,6 +98,6 @@ uv pip install faiss-cpu sentence-transformers
 
 ## Related Documentation
 
-- See `intrinsics/` for RAG evaluation intrinsics
+- See `intrinsics/` for RAG evaluation adapter functions
 - See `mini_researcher/` for a complete RAG application
 - See `mellea/stdlib/components/intrinsic/rag.py` for RAG helpers

--- a/docs/examples/sessions/README.md
+++ b/docs/examples/sessions/README.md
@@ -88,7 +88,7 @@ backend = OllamaModelBackend(model_id="llama2")
 from mellea.backends.openai import OpenAIBackend
 backend = OpenAIBackend(model_id="gpt-4")
 
-# HuggingFace
+# Hugging Face
 from mellea.backends.huggingface import LocalHFBackend
 backend = LocalHFBackend(model_id="ibm-granite/granite-3.2-8b-instruct")
 

--- a/docs/examples/tools/README.md
+++ b/docs/examples/tools/README.md
@@ -15,12 +15,12 @@ Comprehensive examples of using the code interpreter tool with LLMs.
 - Local vs. sandboxed execution
 
 ### smolagents_example.py
-Shows how to use pre-built tools from HuggingFace's smolagents library.
+Shows how to use pre-built tools from Hugging Face's smolagents library.
 
 **Key Features:**
 - Loading existing smolagents tools (PythonInterpreterTool, WikipediaSearchTool, etc.)
 - Converting to Mellea tools with `MelleaTool.from_smolagents()`
-- Using tools from the HuggingFace ecosystem
+- Using tools from the Hugging Face ecosystem
 
 ### python_tool_example.py
 Demonstrates creating and using custom Python tools with Mellea.

--- a/docs/examples/tools/smolagents_example.py
+++ b/docs/examples/tools/smolagents_example.py
@@ -1,5 +1,5 @@
 # pytest: ollama, e2e
-"""Example showing how to use pre-built HuggingFace smolagents tools with Mellea.
+"""Example showing how to use pre-built Hugging Face smolagents tools with Mellea.
 
 This demonstrates loading existing tools from the smolagents ecosystem,
 similar to how you can use langchain tools with MelleaTool.from_langchain().
@@ -8,7 +8,7 @@ The smolagents library provides various pre-built tools like:
 - PythonInterpreterTool for code execution
 - DuckDuckGoSearchTool for web search (requires ddgs package)
 - WikipediaSearchTool for Wikipedia queries
-- And many others from the HuggingFace ecosystem
+- And many others from the Hugging Face ecosystem
 """
 
 from mellea import start_session

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -273,7 +273,7 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
         """Download the required adapter function files if necessary and return the path to them.
 
         Args:
-            base_model_name: the base model; typically the last part of the huggingface
+            base_model_name: the base model; typically the last part of the Hugging Face
                 model id like "granite-3.3-8b-instruct"
 
         Returns:
@@ -772,7 +772,7 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
             stacklevel=2,
         )
         assert re.match(".*/.*", model_id), (
-            "expected a huggingface model id with format <user-id>/<repo-name>"
+            "expected a Hugging Face model id with format <user-id>/<repo-name>"
         )
         intrinsic_name = (
             intrinsic_name if intrinsic_name is not None else model_id.split("/")[1]

--- a/mellea/backends/backend.py
+++ b/mellea/backends/backend.py
@@ -3,7 +3,7 @@
 `FormatterBackend` extends the abstract `Backend` with a `ChatFormatter` and
 a `ModelIdentifier`, bridging mellea's generative programming primitives to models
 that do not yet natively support spans or structured fine-tuning. Concrete backend
-implementations (e.g. Ollama, HuggingFace, OpenAI) subclass `FormatterBackend` and
+implementations (e.g. Ollama, Hugging Face, OpenAI) subclass `FormatterBackend` and
 supply the model-specific `generate_from_context` logic.
 """
 

--- a/mellea/backends/cache.py
+++ b/mellea/backends/cache.py
@@ -3,7 +3,7 @@
 Defines the abstract `Cache` interface with `put`, `get`, and
 `current_size` methods, and provides a concrete `SimpleLRUCache` that evicts
 the least-recently-used entry when capacity is exceeded — optionally calling an
-`on_evict` callback (e.g. to free GPU memory). Used by local HuggingFace backends
+`on_evict` callback (e.g. to free GPU memory). Used by local Hugging Face backends
 to store and reuse KV cache state across requests.
 """
 
@@ -59,7 +59,7 @@ class SimpleLRUCache(Cache):
 
     Evicts the least-recently-used entry when capacity is exceeded, optionally
     invoking an `on_evict` callback (e.g. to free GPU memory). Used by local
-    HuggingFace backends to store and reuse KV cache state across requests.
+    Hugging Face backends to store and reuse KV cache state across requests.
 
     Args:
         capacity (int): Maximum number of items to store in the cache.

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -262,7 +262,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             HF-specific option names.
 
     Raises:
-        OSError: If the model cannot be loaded from HuggingFace Hub (bad ID,
+        OSError: If the model cannot be loaded from Hugging Face Hub (bad ID,
             missing access, or local filesystem/cache error).
     """
 
@@ -339,7 +339,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     )
                 except OSError as e:
                     raise OSError(
-                        f"Model '{self._model_id}' could not be loaded from HuggingFace Hub. "
+                        f"Model '{self._model_id}' could not be loaded from Hugging Face Hub. "
                         "Check that the model ID is correct and that you have access to it. "
                         "If the model is gated, set the HF_TOKEN environment variable. "
                         "To browse available models, visit https://huggingface.co/models "

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1,6 +1,6 @@
-"""A backend that uses the Huggingface Transformers library.
+"""A backend that uses the Hugging Face Transformers library.
 
-The purpose of the Hugginface backend is to provide a setting for implementing experimental features. If you want a performance local backend, and do not need experimental features such as Span-based context or aLoRA adapters, consider using Ollama backends instead.
+The purpose of the Hugging Face backend is to provide a setting for implementing experimental features. If you want a performance local backend, and do not need experimental features such as Span-based context or aLoRA adapters, consider using Ollama backends instead.
 """
 
 from __future__ import annotations
@@ -118,7 +118,7 @@ def _install_cancel_stopping_criteria(
 
 """A configuration type for the unhappy path: Tokenizer * Model * torch device string
 
-Huggingface backends can initialize themselves from a model string if the transformers `Auto*` classes can be used. Therefore, a TransformersTorchConfig usually isn't required. However, sometimes a model needs special care to instantiate properly, or a custom device type needs to bse used. Instead of trying to do a lot of partial magic, we basically have two modaliites: either the constructor can figure out everything from the model_id, or the user has to provide an entire config.
+Hugging Face backends can initialize themselves from a model string if the transformers `Auto*` classes can be used. Therefore, a TransformersTorchConfig usually isn't required. However, sometimes a model needs special care to instantiate properly, or a custom device type needs to bse used. Instead of trying to do a lot of partial magic, we basically have two modaliites: either the constructor can figure out everything from the model_id, or the user has to provide an entire config.
 """
 TransformersTorchConfig = tuple[PreTrainedTokenizerBase, PreTrainedModel, torch.device]
 
@@ -234,7 +234,7 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 
 
 class LocalHFBackend(FormatterBackend, AdapterMixin):
-    """The LocalHFBackend uses Huggingface's transformers library for inference, and uses a Formatter to convert `Component`s into prompts. This backend also supports [aLoRA adapters](https://arxiv.org/pdf/2504.12397).
+    """The LocalHFBackend uses Hugging Face's transformers library for inference, and uses a Formatter to convert `Component`s into prompts. This backend also supports [aLoRA adapters](https://arxiv.org/pdf/2504.12397).
 
     This backend is designed for running an HF model for small-scale inference locally on your machine.
 
@@ -358,7 +358,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         assert (
             self._llguidance_tokenizer.vocab_size
             == self._tokenizer._tokenizer.get_vocab_size(with_added_tokens=True)
-        ), "vocab size mismatch between llguidance and huggingface tokenizers"
+        ), "vocab size mismatch between llguidance and Hugging Face tokenizers"
 
         self._use_caches = use_caches
         self._cache = (
@@ -1067,7 +1067,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             input_ids = self._tokenizer.apply_chat_template(  # type: ignore
                 ctx_as_chat,
                 tools=convert_tools_to_json(tools),  # type: ignore
-                add_generation_prompt=True,  # If we change this, must modify huggingface granite guardian.
+                add_generation_prompt=True,  # If we change this, must modify Hugging Face granite guardian.
                 return_tensors="pt",
                 return_dict=True,
                 **self._filter_for_chat_template(model_options),
@@ -1451,7 +1451,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             #       Test this by ensuring all outputs from this call are populated when running on mps.
             #       https://github.com/pytorch/pytorch/pull/157727
             MelleaLogger.get_logger().warning(
-                "utilizing device mps with a `generate_from_raw` request; you may see issues when submitting batches of prompts to a huggingface backend; ensure all ModelOutputThunks have non-empty values."
+                "utilizing device mps with a `generate_from_raw` request; you may see issues when submitting batches of prompts to a Hugging Face backend; ensure all ModelOutputThunks have non-empty values."
             )
 
         model_opts = self._simplify_and_merge(model_options)
@@ -1854,7 +1854,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
 
 def _assert_correct_adapters(expected_state: str, model: PreTrainedModel):
-    """When generating with a huggingface model, this can be used to ensure the correct adapters are active.
+    """When generating with a Hugging Face model, this can be used to ensure the correct adapters are active.
 
     Args:
         expected_state: the current state of the lock

--- a/mellea/backends/kv_block_helpers.py
+++ b/mellea/backends/kv_block_helpers.py
@@ -3,7 +3,7 @@
 Provides ``prefill_cache_v5`` for converting a tokenized prompt into a prefilled
 ``DynamicCache``, ``merge_dynamic_caches_v5`` for concatenating multiple
 ``DynamicCache`` objects along the time axis, and ``merge_v5`` which composes
-the two. These helpers are used internally by local HuggingFace backends
+the two. These helpers are used internally by local Hugging Face backends
 (transformers v5+) that reuse cached prefix computations across multiple
 generation calls.
 """
@@ -19,7 +19,7 @@ try:
     from transformers.tokenization_utils_base import BatchEncoding
 except ImportError as e:
     raise ImportError(
-        "The HuggingFace backend requires extra dependencies. "
+        "The Hugging Face backend requires extra dependencies. "
         'Please install them with: pip install "mellea[hf]"'
     ) from e
 

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -1,7 +1,7 @@
 """`ModelIdentifier` dataclass and a catalog of pre-defined model IDs.
 
 `ModelIdentifier` is a frozen dataclass that groups the platform-specific name
-variants for a model (HuggingFace, Ollama, WatsonX, MLX, OpenAI, Bedrock) so that
+variants for a model (Hugging Face, Ollama, WatsonX, MLX, OpenAI, Bedrock) so that
 a single constant can be passed to any backend without manual string translation.
 The module also ships a curated catalog of ready-to-use constants for popular
 open-weight models including IBM Granite 4, Meta Llama 4, Mistral, and Qwen families.
@@ -19,13 +19,13 @@ class ModelIdentifier:
         2. Using raw strings is annoying because: no autocomplete, typos, hallucinated names, mismatched model and tokenizer names, etc.
 
     Args:
-        hf_model_name (str | None): HuggingFace Hub model repository ID (e.g. `"ibm-granite/granite-3.3-8b-instruct"`).
+        hf_model_name (str | None): Hugging Face Hub model repository ID (e.g. `"ibm-granite/granite-3.3-8b-instruct"`).
         ollama_name (str | None): Ollama model tag (e.g. `"granite3.3:8b"`).
         watsonx_name (str | None): WatsonX AI model ID (e.g. `"ibm/granite-3-2b-instruct"`).
         mlx_name (str | None): MLX model identifier for Apple Silicon inference.
         openai_name (str | None): OpenAI API model name (e.g. `"gpt-5.1"`).
         bedrock_name (str | None): AWS Bedrock model ID (e.g. `"openai.gpt-oss-20b"`).
-        hf_tokenizer_name (str | None): HuggingFace tokenizer ID; defaults to `hf_model_name` if `None`.
+        hf_tokenizer_name (str | None): Hugging Face tokenizer ID; defaults to `hf_model_name` if `None`.
 
     """
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -73,7 +73,7 @@ class ModelOption:
     """Must be a `list[str]`. Generation halts when the model emits any of these strings.
 
     Backends translate this to their native parameter (`stop` for OpenAI/Ollama/LiteLLM
-    chat backends, `stop_strings` for HuggingFace, `stop_sequences` for the WatsonX
+    chat backends, `stop_strings` for Hugging Face, `stop_sequences` for the WatsonX
     text-generation endpoint).
     """
 

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -401,7 +401,7 @@ class OllamaModelBackend(FormatterBackend):
                 messages.extend(self.formatter.to_chat_messages([action]))
         # construct the conversation from our messages, adding a system prompt at the first message if one was provided.
         conversation: list[dict] = []
-        # We use system prompt None/empty-string semantics in a way that is consistent with huggingface and other libraries.
+        # We use system prompt None/empty-string semantics in a way that is consistent with Hugging Face and other libraries.
         # If the system prompt is None, the the default system prompt gets used.
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":

--- a/mellea/backends/tools.py
+++ b/mellea/backends/tools.py
@@ -391,7 +391,7 @@ def convert_tools_to_json(tools: dict[str, AbstractMelleaTool]) -> list[dict]:
         List of OpenAI-compatible JSON tool schema dicts, one per tool.
 
     Notes:
-    - Huggingface transformers library lets you pass in an array of functions but doesn't like methods.
+    - Hugging Face transformers library lets you pass in an array of functions but doesn't like methods.
     - WatsonxAI uses `from langchain_ibm.chat_models import convert_to_openai_tool` in their demos, but it gives the same values.
     - OpenAI uses the same format / schema.
     """

--- a/mellea/backends/tools.py
+++ b/mellea/backends/tools.py
@@ -32,7 +32,7 @@ class MelleaTool(AbstractMelleaTool[P, R]):
     """Tool class to represent a callable tool with an OpenAI-compatible JSON schema.
 
     Wraps a Python callable alongside its JSON schema representation so it can be
-    registered with backends that support tool calling (OpenAI, Ollama, HuggingFace, etc.).
+    registered with backends that support tool calling (OpenAI, Ollama, Hugging Face, etc.).
 
     Type parameters:
         P: Parameter specification for the underlying callable
@@ -127,7 +127,7 @@ class MelleaTool(AbstractMelleaTool[P, R]):
 
     @classmethod
     def from_smolagents(cls, tool: Any) -> "MelleaTool[..., Any]":
-        """Create a Tool from a HuggingFace smolagents tool object.
+        """Create a Tool from a Hugging Face smolagents tool object.
 
         Args:
             tool: A smolagents.Tool instance

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -416,7 +416,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
             None  # Currently only used by hf.
         )
         # Optional cooperative-cancel hook called before asyncio task cancellation.
-        # Backends that run generation in a thread (e.g. HuggingFace via
+        # Backends that run generation in a thread (e.g. Hugging Face via
         # asyncio.to_thread) set this to a non-blocking callable (e.g.
         # threading.Event.set) so the thread receives a stop signal before the
         # task wrapper is cancelled. Must be non-blocking; exceptions are logged

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -96,7 +96,7 @@ def load_transformers_lora(local_or_remote_path: str) -> tuple:
 
     Returns:
         Tuple of `(model, tokenizer)` where `model` is the loaded LoRA model placed on
-        the best available device, and `tokenizer` is the corresponding HuggingFace
+        the best available device, and `tokenizer` is the corresponding Hugging Face
         tokenizer.
 
     Raises:
@@ -135,7 +135,7 @@ def load_transformers_lora(local_or_remote_path: str) -> tuple:
 
 
 class _GuidanceLogitsProcessor:
-    """A HuggingFace logits processor that enforces an llguidance grammar."""
+    """A Hugging Face logits processor that enforces an llguidance grammar."""
 
     # Modified from VLLM v0.9.2 code base
     # https://github.com/vllm-project/vllm/blob/v0.9.2/vllm/model_executor/guided_decoding/guidance_logits_processors.py
@@ -213,8 +213,8 @@ def chat_completion_request_to_transformers_inputs(
 
     Args:
         request: Request as parsed JSON or equivalent dataclass.
-        tokenizer: HuggingFace tokenizer.
-        model: HuggingFace model object. Used for `model.device` placement and
+        tokenizer: Hugging Face tokenizer.
+        model: Hugging Face model object. Used for `model.device` placement and
             when `constrained_decoding_prefix` is set.
         constrained_decoding_prefix: Optional generation prefix to append to the prompt.
         ll_tokenizer: Pre-built `llguidance.LLTokenizer`. Only used when the request
@@ -391,9 +391,9 @@ def generate_with_transformers(
     There are quite a few extra steps.
 
     Args:
-        tokenizer: HuggingFace tokenizer for the model, required at several stages
+        tokenizer: Hugging Face tokenizer for the model, required at several stages
             of generation.
-        model: Initialized HuggingFace model object.
+        model: Initialized Hugging Face model object.
         generate_input: Parameters to pass to the `generate()` method, usually
             produced by `chat_completion_request_to_transformers_inputs()`.
         other_input: Additional kwargs produced by

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -113,7 +113,7 @@ def load_transformers_lora(local_or_remote_path: str) -> tuple:
         import transformers
     local_model_dir = local_or_remote_path
     if not os.path.exists(local_model_dir):
-        raise NotImplementedError("TODO: Talk to hugging face hub")
+        raise NotImplementedError("TODO: Talk to Hugging Face Hub")
     with open(f"{local_model_dir}/adapter_config.json", encoding="utf-8") as f:
         adapter_config = json.load(f)
     base_model_name = adapter_config["base_model_name_or_path"]

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -144,7 +144,7 @@ class Message(Component["Message"]):
                     ),
                 )
             else:
-                # HuggingFace (or others). There are no guarantees on how the model represented the function calls.
+                # Hugging Face (or others). There are no guarantees on how the model represented the function calls.
                 # Output it in the same format we received the tool call request.
                 assert computed.value is not None
                 return Message(role="assistant", content=computed.value)

--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -34,7 +34,7 @@ class GroundednessRequirement(Requirement):
     4. **Groundedness Output**: Declare response grounded iff all spans needing
        citations are fully supported.
 
-    **Important**: This requirement requires a HuggingFace backend (LocalHFBackend)
+    **Important**: This requirement requires a Hugging Face backend (LocalHFBackend)
     as it uses both the find_citations adapter function and LLM-as-Judge for assessment.
 
     Args:

--- a/mellea/stdlib/requirements/safety/guardian.py
+++ b/mellea/stdlib/requirements/safety/guardian.py
@@ -342,7 +342,7 @@ class GuardianCheck(Requirement):
                     "think": True if self._thinking else None,
                 }
             )
-        else:  # huggingface
+        else:  # Hugging Face
             # HF chat template for Guardian expects guardian_config and (optionally) documents
             guardian_cfg: dict[str, object] = {"criteria_id": effective_risk}
             if self._custom_criteria:
@@ -353,7 +353,7 @@ class GuardianCheck(Requirement):
                 {
                     "guardian_config": guardian_cfg,
                     "think": self._thinking,  # Passed to apply_chat_template
-                    # "add_generation_prompt": True,  # Guardian template requires a generation prompt. Mellea always does this for hugging face generation.
+                    # "add_generation_prompt": True,  # Guardian template requires a generation prompt. Mellea always does this for Hugging Face generation.
                     "max_new_tokens": 4000 if self._thinking else 50,
                     "stream": False,
                 }

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -107,7 +107,7 @@ def start_session(
     Args:
         backend_name: The backend to use. Options are:
             - "ollama": Use Ollama backend for local models
-            - "hf" or "huggingface": Use HuggingFace transformers backend
+            - "hf" or "huggingface": Use Hugging Face transformers backend
             - "openai": Use OpenAI API backend
             - "watsonx": Use IBM WatsonX backend, WARNING: this defaults to the IBM_GRANITE_4_HYBRID_SMALL model for now.
             - "litellm": Use the LiteLLM backend


### PR DESCRIPTION
<!-- pr-template-v1 -->

## Summary

Part of the terminology sweep epic (#1192, Epic #929). This is the second and final wave, completing the sweep across `docs/examples/`, `docs/docs/`, and Python docstrings, comments, and user-visible strings. The first wave was #1256 (core source identifiers).

- `HuggingFace` / `Huggingface` / `huggingface` (prose) → `Hugging Face` (official two-word branding) in all docstrings, comments, and user-visible strings
- `intrinsic` / `intrinsics` prose → `adapter function` / `adapter functions` in docs and examples

**Exclusions (intentionally unchanged):** `HuggingFaceTB/` org names in model IDs, Python identifiers (`CustomIntrinsicAdapter`, `intrinsic_name`, `call_intrinsic`), import paths (`from mellea.backends.huggingface import`), `--intrinsic` CLI flags, `'huggingface'` provider string literals, filenames/directory paths, URL path segments, glossary entries documenting both terms.

## Files changed (30)

**`mellea/backends/`** — `huggingface.py`, `ollama.py`, `tools.py`, `backend.py`, `cache.py`, `kv_block_helpers.py`, `model_ids.py`, `model_options.py`, `adapters/adapter.py`

**`mellea/core/`** — `base.py`

**`mellea/formatters/`** — `granite/base/util.py`

**`mellea/stdlib/`** — `session.py`, `components/chat.py`, `requirements/rag.py`, `requirements/safety/guardian.py`

**`docs/examples/`** — `intrinsics/README.md`, `aLora/README.md`, `rag/README.md`, `sessions/README.md`, `granite-switch/README.md` + 2 `.py`, `groundedness_requirement_example.py`, `tools/README.md` + `.py`

**`docs/docs/`** — `examples/index.md`, `how-to/backends-and-configuration.md`, `how-to/safety-guardrails.md`

## Test plan

- [x] `uv run pytest test/ -m "not qualitative"` — 2898 passed, 0 new failures (3 pre-existing failures in HF transformer integration tests unaffected by text changes)
- [x] `ruff format` + `ruff check` — clean
- [x] Pre-commit hooks pass (codespell, markdownlint, mypy)
- [x] Opus code review — found and fixed additional `Huggingface`/`huggingface` case variants missed by initial camelCase-only grep; also fixed two prose `intrinsic` occurrences and three code-block comments
- [x] Case-insensitive final grep confirms zero remaining in-scope occurrences

## Relationship to other open PRs

- **#1328** (`@akihikokuroda` — `docs/examples/tools/README.md`): that PR restores `HuggingFace` spelling on two lines already fixed here. Comment posted on #1328 to coordinate.
- **#1284** (`.parsed` overloads): touches `core/base.py` and `session.py` — same files, different lines; simple rebase on merge.

---

Closes #1279
Part of #1192
Part of #929