### PR TITLE
docs: clarify format= value contract and model_validate_json pattern

### DIFF
--- a/docs/docs/how-to/act-and-aact.md
+++ b/docs/docs/how-to/act-and-aact.md
@@ -143,7 +143,8 @@ and validation.
 
 ## Structured output
 
-Pass a Pydantic `BaseModel` as the `format` parameter for constrained decoding:
+Pass a Pydantic `BaseModel` as the `format` parameter for constrained decoding.
+The backend restricts generation to tokens that produce valid JSON matching the schema:
 
 ```python
 # Requires: mellea, pydantic
@@ -160,10 +161,29 @@ class Planet(BaseModel):
 m = start_session()
 instruction = Instruction(description="Describe Saturn.")
 result = m.act(instruction, format=Planet)
-print(result.value)  # A JSON string like '{"name": "Saturn", ...}'
-# Parse with: Planet.model_validate_json(str(result))
+
+# result.value is a JSON string — not a Planet instance
+print(result.value)
+# -> '{"name": "Saturn", "diameter_km": 120536.0, "has_rings": true}'
+
+# Validate to get a typed Planet instance:
+planet = Planet.model_validate_json(str(result))
+print(planet.name, planet.has_rings)
 # Output will vary — LLM responses depend on model and temperature.
 ```
+
+> **`format=` constrains generation, not the return type.**
+> The schema controls the JSON the model produces; the thunk still holds that
+> JSON as a string. `result.value` is always a `str`.
+>
+> A common mistake is `cast(Planet, result.value)`: the type checker accepts it
+> and the code runs, but accessing `.name` or `.has_rings` raises `AttributeError`
+> at runtime. When `return_sampling_results=True`, unwrap before parsing:
+> `Planet.model_validate_json(str(result.result))`.
+>
+> For structured output without a manual parse step, prefer `@generative` — it
+> returns the Pydantic instance directly. See
+> [Enforce Structured Output](./enforce-structured-output.md).
 
 ## The functional API
 
@@ -197,7 +217,9 @@ simpler.
 
 ## Async with `aact()`
 
-`aact()` is the async counterpart. Same signature, same return types:
+`aact()` is the async counterpart. Same signature, same return types.
+`aact(format=...)` follows the same contract as `act(format=...)` — `.value` is
+a JSON string; parse with `model_validate_json`.
 
 ```python
 # Requires: mellea

--- a/docs/docs/how-to/enforce-structured-output.md
+++ b/docs/docs/how-to/enforce-structured-output.md
@@ -12,8 +12,8 @@ into your code:
 
 | Pattern | When to use |
 | ------- | ----------- |
-| `@generative` with return type | You want a named, reusable function. The return type is declared in the signature. |
-| `instruct(format=...)` | You are building the prompt dynamically or combining structured output with `grounding_context` or `user_variables`. |
+| `@generative` with return type | You want a named, reusable function. The return type is declared in the signature. Pydantic instance returned directly — no manual parse needed. |
+| `instruct(format=...)` or `act(format=...)` | Building the prompt dynamically, or combining structured output with `grounding_context` or `user_variables`. The result's `.value` is a JSON string — parse with `model_validate_json`. |
 
 Both paths enforce the declared schema at generation time using constrained decoding
 where the backend supports it, and retry with the IVR loop if parsing fails.
@@ -160,6 +160,14 @@ The `format` parameter triggers constrained decoding. The result is a
 `ModelOutputThunk` whose `.value` is a JSON string matching the schema. Parse it
 with `PydanticModel.model_validate_json(str(result))`.
 
+> **Watch out for `cast()`**: `cast(MyModel, result.value)` passes type checking
+> but fails at runtime — `.value` is always a string, not a model instance. Always
+> parse explicitly with `model_validate_json`. When `return_sampling_results=True`,
+> unwrap first: `MyModel.model_validate_json(str(result.result))`.
+
+`act(format=...)` follows the same contract — see [act() and aact()](./act-and-aact.md)
+for a worked example.
+
 ## Validating structured output content
 
 Constrained decoding enforces schema validity — the output is always parseable JSON
@@ -263,10 +271,11 @@ You receive a `Summary` instance, not a JSON string.
 - You want a clean function signature with IDE type-checking.
 - You prefer direct attribute access (`person.name`) over manual JSON parsing.
 
-**Use `instruct(format=...)`** when:
+**Use `instruct(format=...)` or `act(format=...)`** when:
 
 - The prompt is built dynamically with `user_variables` or `grounding_context`.
 - You are retrofitting structured output onto an existing `instruct()` call.
+- You are passing a custom component to `act()` with `format=` directly.
 - You need fine-grained control over requirements and sampling alongside formatting.
 
 Both patterns support the full IVR loop, requirements, sampling strategies, and

--- a/docs/docs/how-to/enforce-structured-output.md
+++ b/docs/docs/how-to/enforce-structured-output.md
@@ -165,7 +165,7 @@ with `PydanticModel.model_validate_json(str(result))`.
 > parse explicitly with `model_validate_json`. When `return_sampling_results=True`,
 > unwrap first: `MyModel.model_validate_json(str(result.result))`.
 
-`act(format=...)` follows the same contract — see [act() and aact()](./act-and-aact.md)
+`act(format=...)` follows the same JSON-string contract — see [act() and aact()](./act-and-aact.md)
 for a worked example.
 
 ## Validating structured output content

--- a/docs/docs/how-to/enforce-structured-output.md
+++ b/docs/docs/how-to/enforce-structured-output.md
@@ -12,8 +12,12 @@ into your code:
 
 | Pattern | When to use |
 | ------- | ----------- |
-| `@generative` with return type | You want a named, reusable function. The return type is declared in the signature. Pydantic instance returned directly — no manual parse needed. |
-| `instruct(format=...)` or `act(format=...)` | Building the prompt dynamically, or combining structured output with `grounding_context` or `user_variables`. The result's `.value` is a JSON string — parse with `model_validate_json`. |
+| `@generative` with return type | You want a named, reusable function. The return type is declared in the signature. |
+| `instruct(format=...)` or `act(format=...)` | Building the prompt dynamically, or combining structured output with `grounding_context` or `user_variables`. |
+
+`@generative` returns the Pydantic instance directly. `instruct(format=...)` and
+`act(format=...)` return a thunk whose `.value` is a JSON string — parse with
+`MyModel.model_validate_json(str(result))`.
 
 Both paths enforce the declared schema at generation time using constrained decoding
 where the backend supports it, and retry with the IVR loop if parsing fails.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -931,7 +931,12 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
 
     @property
     def value(self) -> str:
-        """Gets the value of the block."""
+        """The raw string value produced by the model.
+
+        When ``format=`` was passed to the generating call, this is a JSON
+        string matching the declared schema — not a parsed model instance.
+        Use ``MyModel.model_validate_json(self.value)`` to get a typed instance.
+        """
         return self._underlying_value  # type: ignore
 
     @value.setter

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -933,9 +933,9 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     def value(self) -> str:
         """The raw string value produced by the model.
 
-        When ``format=`` was passed to the generating call, this is a JSON
+        When `format=` was passed to the generating call, this is a JSON
         string matching the declared schema — not a parsed model instance.
-        Use ``MyModel.model_validate_json(self.value)`` to get a typed instance.
+        Use `MyModel.model_validate_json(str(result))` to get a typed instance.
         """
         return self._underlying_value  # type: ignore
 

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -101,7 +101,10 @@ def act(
         requirements: used as additional requirements when a sampling strategy is provided.
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: if set, the BaseModel to use for constrained decoding.
+        format: If set, constrains generation to JSON matching this Pydantic
+            schema. The result's ``.value`` is always a JSON string — not a
+            parsed model instance. Parse with
+            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tool_calls: if true, tool calling is enabled.
 
@@ -210,7 +213,10 @@ def instruct(
         output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
         strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, the BaseModel to use for constrained decoding.
+        format: If set, constrains generation to JSON matching this Pydantic
+            schema. The result's ``.value`` is always a JSON string — not a
+            parsed model instance. Parse with
+            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
         model_options: Additional model options, which will upsert into the model/backend's defaults.
         tool_calls: If true, tool calling is enabled.
         images: A list of images to be used in the instruction or None if none.
@@ -570,7 +576,10 @@ async def aact(
         requirements: used as additional requirements when a sampling strategy is provided
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: if set, the BaseModel to use for constrained decoding.
+        format: If set, constrains generation to JSON matching this Pydantic
+            schema. The result's ``.value`` is always a JSON string — not a
+            parsed model instance. Parse with
+            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tool_calls: if true, tool calling is enabled.
         silence_context_type_warning: if called directly from an asynchronous function, will log a warning if not using a SimpleContext
@@ -856,7 +865,10 @@ async def ainstruct(
         output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
         strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, the BaseModel to use for constrained decoding.
+        format: If set, constrains generation to JSON matching this Pydantic
+            schema. The result's ``.value`` is always a JSON string — not a
+            parsed model instance. Parse with
+            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
         model_options: Additional model options, which will upsert into the model/backend's defaults.
         tool_calls: If true, tool calling is enabled.
         images: A list of images to be used in the instruction or None if none.

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -101,10 +101,10 @@ def act(
         requirements: used as additional requirements when a sampling strategy is provided.
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, constrains generation to JSON matching this Pydantic
-            schema. The result's ``.value`` is always a JSON string — not a
+        format: Constrains generation to JSON matching this Pydantic
+            schema. The result's `.value` is always a JSON string — not a
             parsed model instance. Parse with
-            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+            `MyModel.model_validate_json(str(result))` to get a typed instance.
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tool_calls: if true, tool calling is enabled.
 
@@ -213,10 +213,10 @@ def instruct(
         output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
         strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, constrains generation to JSON matching this Pydantic
-            schema. The result's ``.value`` is always a JSON string — not a
+        format: Constrains generation to JSON matching this Pydantic
+            schema. The result's `.value` is always a JSON string — not a
             parsed model instance. Parse with
-            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+            `MyModel.model_validate_json(str(result))` to get a typed instance.
         model_options: Additional model options, which will upsert into the model/backend's defaults.
         tool_calls: If true, tool calling is enabled.
         images: A list of images to be used in the instruction or None if none.
@@ -576,10 +576,10 @@ async def aact(
         requirements: used as additional requirements when a sampling strategy is provided
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, constrains generation to JSON matching this Pydantic
-            schema. The result's ``.value`` is always a JSON string — not a
+        format: Constrains generation to JSON matching this Pydantic
+            schema. The result's `.value` is always a JSON string — not a
             parsed model instance. Parse with
-            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+            `MyModel.model_validate_json(str(result))` to get a typed instance.
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tool_calls: if true, tool calling is enabled.
         silence_context_type_warning: if called directly from an asynchronous function, will log a warning if not using a SimpleContext
@@ -865,10 +865,10 @@ async def ainstruct(
         output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
         strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-        format: If set, constrains generation to JSON matching this Pydantic
-            schema. The result's ``.value`` is always a JSON string — not a
+        format: Constrains generation to JSON matching this Pydantic
+            schema. The result's `.value` is always a JSON string — not a
             parsed model instance. Parse with
-            ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+            `MyModel.model_validate_json(str(result))` to get a typed instance.
         model_options: Additional model options, which will upsert into the model/backend's defaults.
         tool_calls: If true, tool calling is enabled.
         images: A list of images to be used in the instruction or None if none.

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -462,10 +462,10 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, constrains generation to JSON matching this Pydantic
-                schema. The result's ``.value`` is always a JSON string — not a
+            format: Constrains generation to JSON matching this Pydantic
+                schema. The result's `.value` is always a JSON string — not a
                 parsed model instance. Parse with
-                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+                `MyModel.model_validate_json(str(result))` to get a typed instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
 
@@ -559,10 +559,10 @@ class MelleaSession:
             output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
             strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, constrains generation to JSON matching this Pydantic
-                schema. The result's ``.value`` is always a JSON string — not a
+            format: Constrains generation to JSON matching this Pydantic
+                schema. The result's `.value` is always a JSON string — not a
                 parsed model instance. Parse with
-                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+                `MyModel.model_validate_json(str(result))` to get a typed instance.
             model_options: Additional model options, which will upsert into the model/backend's defaults.
             tool_calls: If true, tool calling is enabled.
             images: A list of images to be used in the instruction or None if none.
@@ -816,10 +816,10 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, constrains generation to JSON matching this Pydantic
-                schema. The result's ``.value`` is always a JSON string — not a
+            format: Constrains generation to JSON matching this Pydantic
+                schema. The result's `.value` is always a JSON string — not a
                 parsed model instance. Parse with
-                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+                `MyModel.model_validate_json(str(result))` to get a typed instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
             await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. Default is False.
@@ -959,10 +959,10 @@ class MelleaSession:
             output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
             strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, constrains generation to JSON matching this Pydantic
-                schema. The result's ``.value`` is always a JSON string — not a
+            format: Constrains generation to JSON matching this Pydantic
+                schema. The result's `.value` is always a JSON string — not a
                 parsed model instance. Parse with
-                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
+                `MyModel.model_validate_json(str(result))` to get a typed instance.
             model_options: Additional model options, which will upsert into the model/backend's defaults.
             tool_calls: If true, tool calling is enabled.
             images: A list of images to be used in the instruction or None if none.

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -462,7 +462,10 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: if set, the BaseModel to use for constrained decoding.
+            format: If set, constrains generation to JSON matching this Pydantic
+                schema. The result's ``.value`` is always a JSON string — not a
+                parsed model instance. Parse with
+                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
 
@@ -556,7 +559,10 @@ class MelleaSession:
             output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
             strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, the BaseModel to use for constrained decoding.
+            format: If set, constrains generation to JSON matching this Pydantic
+                schema. The result's ``.value`` is always a JSON string — not a
+                parsed model instance. Parse with
+                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
             model_options: Additional model options, which will upsert into the model/backend's defaults.
             tool_calls: If true, tool calling is enabled.
             images: A list of images to be used in the instruction or None if none.
@@ -810,7 +816,10 @@ class MelleaSession:
             requirements: used as additional requirements when a sampling strategy is provided
             strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: if set, the BaseModel to use for constrained decoding.
+            format: If set, constrains generation to JSON matching this Pydantic
+                schema. The result's ``.value`` is always a JSON string — not a
+                parsed model instance. Parse with
+                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
             await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. Default is False.
@@ -950,7 +959,10 @@ class MelleaSession:
             output_prefix: A string or ContentBlock that defines a prefix for the output generation. Usually you do not need this.
             strategy: A SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
-            format: If set, the BaseModel to use for constrained decoding.
+            format: If set, constrains generation to JSON matching this Pydantic
+                schema. The result's ``.value`` is always a JSON string — not a
+                parsed model instance. Parse with
+                ``MyModel.model_validate_json(str(result))`` to get a typed instance.
             model_options: Additional model options, which will upsert into the model/backend's defaults.
             tool_calls: If true, tool calling is enabled.
             images: A list of images to be used in the instruction or None if none.


### PR DESCRIPTION
Closes #1273. Closes #1274.

Supersedes #1284, which attempted a code-level fix. The maintainer decision
is to document the behaviour clearly instead.

## What this PR does

`format=` on `act`/`aact`/`instruct`/`ainstruct` constrains the backend's
token generation to JSON matching the declared Pydantic schema. The thunk's
`.value` is always a `str` — not a parsed model instance. The previous docs
only hinted at this in a terse comment; callers had to guess the parse step
and could silently introduce a cast footgun.

### `docs/how-to/act-and-aact.md`

- Rewrites the Structured output section with a complete working example
  (schema definition → `act()` call → `model_validate_json` parse)
- Adds a callout explaining the design contract, naming the cast footgun
  explicitly (`cast(Planet, result.value)` passes type checking but raises
  `AttributeError` at runtime), and covering the `return_sampling_results`
  unwrap variant
- Adds a one-sentence note to the `aact()` section confirming the same
  contract applies there

### `docs/how-to/enforce-structured-output.md`

- Merges `instruct(format=...)` and `act(format=...)` into a single table
  row (they share the same contract)
- Adds a cast warning callout to Pattern 2 with the `return_sampling_results`
  unwrap note
- Updates the "Choosing between" section to mention `act(format=...)` directly

### Docstrings (`mellea/core/base.py`, `mellea/stdlib/session.py`, `mellea/stdlib/functional.py`)

- `ComputedModelOutputThunk.value` — expanded from "Gets the value of the
  block" to describe the JSON-string contract and the parse step
- `format` parameter — updated in `act`, `aact`, `instruct`, `ainstruct`
  (both `session.py` and `functional.py`) from "BaseModel for constrained
  decoding" to include the `.value`-is-str contract and the
  `model_validate_json` pattern

## Why not a code fix?

A code fix (#1284) was explored and declined in review. The design intent is
that `format=` is a generation hint, not a typing signal: a component
declares the shape of its output (e.g. a `Message` component returns a
`Message`), and `format=` is a separate concern. The clean code-level path
is `@generative`, which returns a typed instance directly. The docs now say
this clearly.

The type-narrowing gap (#1274) remains open as a future improvement,
tracked in #1313.

<!-- pr-template-v1 -->