### PR TITLE
docs: fix stale 'main (unreleased)' reference in CONTRIBUTING_DOCS.md

### DIFF
--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -293,7 +293,7 @@ Docusaurus renders previous/next page links automatically from the sidebar order
 
 ## Versioning
 
-Docusaurus versioning is integrated into the release pipeline (closes #557). On each final release, `publish-release.yml` automatically snapshots the current docs as a numbered version. A version dropdown in the navbar lets readers switch between the latest release, prior releases, and `main (unreleased)`.
+Docusaurus versioning is integrated into the release pipeline (closes #557). On each final release, `publish-release.yml` automatically snapshots the current docs as a numbered version. A version dropdown in the navbar lets readers switch between the latest release, prior releases, and `Next`.
 
 For pages documenting features that don't yet exist in any released version, use a callout:
 


### PR DESCRIPTION
Closes #1334.

## What

PR #1238 renamed the Docusaurus version label from `main (unreleased)` to `Next` (the Docusaurus default) and updated `docs/PUBLISHING.md` throughout, but one reference in `docs/CONTRIBUTING_DOCS.md` was missed.

**File:** `docs/CONTRIBUTING_DOCS.md`, line 296
**Change:** `` `main (unreleased)` `` → `` `Next` ``

## Why

Keeps the version label consistent across both docs files so contributors reading `CONTRIBUTING_DOCS.md` see the same label they encounter in the live site's version dropdown.

<!-- pr-template-marker -->