### PR TITLE
fix(test): enable openai intrinsic e2e tests in nightlies

### DIFF
--- a/test/backends/test_openai_intrinsics.py
+++ b/test/backends/test_openai_intrinsics.py
@@ -29,9 +29,6 @@ pytestmark = [
         int(os.environ.get("CICD", 0)) == 1,
         reason="Skipping OpenAI intrinsics tests in CI",
     ),
-    pytest.mark.skip(
-        reason="Requires additional VLLM setup that isn't yet streamlined. Re-enable once nightlies can run this."
-    ),
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue
Fixes #931

## Description

Drops the module-level \`pytest.mark.skip\` from \`test/backends/test_openai_intrinsics.py\` that was blocking the file from collecting since PR #881. The infrastructure these tests need (a vLLM serving \`ibm-granite/granite-switch-4.1-3b-preview\`) is now provided by the nightly.

The remaining markers (\`e2e\`, \`openai\`, \`vllm\`, \`require_gpu\`, CICD-skipif) keep the file gated for laptops and GitHub Actions; only the nightly satisfies all of them simultaneously, so CI here will continue to skip the file under \`CICD=1\`.

### Testing
- [x] Tests added to the respective file if code was changed (no new tests — re-enabling existing ones)
- [x] New code has 100% coverage if code was added (n/a — pure deletion)
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

🤖 Assisted-by: Claude Code