### PR TITLE
refactor(core): split MOT internal state into _call / _gen sub-objects

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -105,7 +105,7 @@ def _install_cancel_stopping_criteria(
     `**streaming_kwargs`), prepends an :class:`_EventStoppingCriteria` backed
     by a fresh `threading.Event`, and stores the merged list in
     *streaming_kwargs*.  Returns the event so the caller can arm
-    `output._cancel_hook = event.set`.
+    `output._gen.cancel_hook = event.set`.
     """
     cancel_event = threading.Event()
     user_sc = generate_options.pop("stopping_criteria", None)
@@ -702,10 +702,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = ctx.view_for_generation()
-        output._action = action
-        output._model_options = model_options
+        output._gen.start = datetime.datetime.now()
+        output._call.context = ctx.view_for_generation()
+        output._call.action = action
+        output._call.model_options = model_options
 
         # Add another step to the processing function.
         async def granite_formatters_processing(
@@ -740,7 +740,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 mot, res.choices[0].message.content, input_ids=input_ids
             )
 
-        output._process = functools.partial(
+        output._gen.process = functools.partial(
             granite_formatters_processing,
             rewritten=rewritten,
             result_processor=result_processor,
@@ -748,7 +748,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         # TODO: Post-processing should release the lock for this generation.
-        output._post_process = functools.partial(
+        output._gen.post_process = functools.partial(
             self.post_processing,
             conversation=conversation,
             input_ids=generate_input["input_tokens"],
@@ -764,20 +764,20 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         try:
             # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-            # We can also support synchronous calls by adding a flag and changing this ._generate function.
+            # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_options.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )  # type: ignore
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present.
             raise e
@@ -956,7 +956,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 try:
                     # Hugging Face uses a streaming interface that you pass to the generate call.
                     # Must be called from a running event loop. This should always be the case given the same
-                    # requirement of the ._generate function below.
+                    # requirement of the ._gen.generate function below.
                     streamer = AsyncTextIteratorStreamer(
                         self._tokenizer,  # type: ignore
                         skip_prompt=True,
@@ -1028,16 +1028,18 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
                 # through stream_with_chunking; direct avalue()/astream() callers do not,
                 # so the worker thread leaks on STREAM_TIMEOUT for those paths.
-                output._cancel_hook = _cancel_event.set
-            output._start = datetime.datetime.now()
-            output._context = ctx.view_for_generation()
-            output._action = action
-            output._model_options = model_options
+                output._gen.cancel_hook = _cancel_event.set
+            output._gen.start = datetime.datetime.now()
+            output._call.context = ctx.view_for_generation()
+            output._call.action = action
+            output._call.model_options = model_options
 
             # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
             # each processing step.
-            output._process = functools.partial(self.processing, input_ids=input_ids)
-            output._post_process = functools.partial(
+            output._gen.process = functools.partial(
+                self.processing, input_ids=input_ids
+            )
+            output._gen.post_process = functools.partial(
                 self.post_processing,
                 conversation=ctx_as_chat,
                 input_ids=input_ids,
@@ -1053,7 +1055,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             try:
                 # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-                # We can also support synchronous calls by adding a flag and changing this ._generate function.
+                # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
                 response: AsyncTextIteratorStreamer | Coroutine = chat_response
                 if stream and streamer is not None:
@@ -1063,20 +1065,20 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
                     # Since the async iterator isn't returned by the chat_response coroutine, we have to create a separate
                     # task for it here so that it runs in the background. Attach it to the ModelOutputThunk.
-                    output._generate_extra = asyncio.create_task(chat_response)
+                    output._gen.generate_extra = asyncio.create_task(chat_response)
 
                 # This function should always be called from a running event loop so we don't have to worry about
                 # scheduling the task to a specific event loop here.
-                output._generate = asyncio.create_task(
+                output._gen.generate = asyncio.create_task(
                     send_to_queue(
                         response,
-                        output._async_queue,
+                        output._gen.queue,
                         chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore
                 )
-                output._generate_type = GenerateType.ASYNC
+                output._gen.generate_type = GenerateType.ASYNC
             except RuntimeError as e:
                 # Most likely cause is running this function without an event loop present.
                 raise e
@@ -1153,7 +1155,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 try:
                     # Hugging Face uses a streaming interface that you pass to the generate call.
                     # Must be called from a running event loop. This should always be the case given the same
-                    # requirement of the ._generate function below.
+                    # requirement of the ._gen.generate function below.
                     streamer = AsyncTextIteratorStreamer(
                         self._tokenizer,  # type: ignore
                         skip_prompt=True,
@@ -1213,16 +1215,18 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
                 # through stream_with_chunking; direct avalue()/astream() callers do not,
                 # so the worker thread leaks on STREAM_TIMEOUT for those paths.
-                output._cancel_hook = _cancel_event.set
-            output._start = datetime.datetime.now()
-            output._context = ctx.view_for_generation()
-            output._action = action
-            output._model_options = model_options
+                output._gen.cancel_hook = _cancel_event.set
+            output._gen.start = datetime.datetime.now()
+            output._call.context = ctx.view_for_generation()
+            output._call.action = action
+            output._call.model_options = model_options
 
             # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
             # each processing step.
-            output._process = functools.partial(self.processing, input_ids=input_ids)
-            output._post_process = functools.partial(
+            output._gen.process = functools.partial(
+                self.processing, input_ids=input_ids
+            )
+            output._gen.post_process = functools.partial(
                 self.post_processing,
                 conversation=ctx_as_chat,
                 input_ids=input_ids,
@@ -1238,7 +1242,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             try:
                 # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-                # We can also support synchronous calls by adding a flag and changing this ._generate function.
+                # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
                 response: AsyncTextIteratorStreamer | Coroutine = chat_response
                 if stream and streamer is not None:
@@ -1248,20 +1252,20 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
                     # Since the async iterator isn't returned by the chat_response coroutine, we have to create a separate
                     # task for it here so that it runs in the background. Attach it to the ModelOutputThunk.
-                    output._generate_extra = asyncio.create_task(chat_response)
+                    output._gen.generate_extra = asyncio.create_task(chat_response)
 
                 # This function should always be called from a running event loop so we don't have to worry about
                 # scheduling the task to a specific event loop here.
-                output._generate = asyncio.create_task(
+                output._gen.generate = asyncio.create_task(
                     send_to_queue(
                         response,
-                        output._async_queue,
+                        output._gen.queue,
                         chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
                     )  # type: ignore
                 )
-                output._generate_type = GenerateType.ASYNC
+                output._gen.generate_type = GenerateType.ASYNC
             except RuntimeError as e:
                 # Most likely cause is running this function without an event loop present.
                 raise e
@@ -1315,7 +1319,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         """Populate mot.generation.logits and/or raw_logits from hf_output when requested.
 
         Checks ModelOption.LOGITS (processed scores) and ModelOption.RAW_LOGITS (raw
-        LM-head logits) in mot._model_options. Skips population when
+        LM-head logits) in mot._call.model_options. Skips population when
         num_return_sequences > 1, logging a warning the first time per backend instance.
 
         Args:
@@ -1327,7 +1331,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             (ModelOption.LOGITS, hf_output.scores, "logits"),
             (ModelOption.RAW_LOGITS, hf_output.logits, "raw_logits"),
         ):
-            if not (mot._model_options and mot._model_options.get(opt)):
+            if not (mot._call.model_options and mot._call.model_options.get(opt)):
                 continue
             if tensors is None:
                 MelleaLogger.get_logger().debug(
@@ -1381,8 +1385,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 KV cache bookkeeping.
         """
         if mot.raw.response is None:
-            if mot._generate_extra is not None:
-                full_output = await mot._generate_extra
+            if mot._gen.generate_extra is not None:
+                full_output = await mot._gen.generate_extra
                 assert isinstance(full_output, GenerateDecoderOnlyOutput)
                 mot.raw.response = full_output
 
@@ -1394,7 +1398,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         hf_output = mot.raw.response
 
         # Surface logits before the caching branch clears hf_output.scores/logits.
-        if isinstance(hf_output, GenerateDecoderOnlyOutput) and mot._model_options:
+        if isinstance(hf_output, GenerateDecoderOnlyOutput) and mot._call.model_options:
             self._surface_logits(mot, hf_output)
 
         if (
@@ -1432,10 +1436,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if _format is None and tool_calls:
             mot.tool_calls = to_tool_calls(tools, mot.value)
 
-        assert mot._action is not None, (
+        assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
         )
-        assert mot._model_options is not None, (
+        assert mot._call.model_options is not None, (
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
@@ -1474,8 +1478,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 last_token = hf_output.sequences[0][-1].item()
                 eos = self._tokenizer.eos_token_id
                 eos_set = set(eos) if isinstance(eos, list) else {eos}
-                max_new_tokens = mot._model_options.get(ModelOption.MAX_NEW_TOKENS)
-                stop_strings = mot._model_options.get(ModelOption.STOP_SEQUENCES) or []
+                max_new_tokens = mot._call.model_options.get(ModelOption.MAX_NEW_TOKENS)
+                stop_strings = (
+                    mot._call.model_options.get(ModelOption.STOP_SEQUENCES) or []
+                )
                 ends_with_stop_string = isinstance(mot.value, str) and any(
                     mot.value.endswith(s) for s in stop_strings
                 )
@@ -1521,7 +1527,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         generate_log = GenerateLog()
         generate_log.prompt = conversation
         generate_log.backend = f"hf::{self.model_id!s}"
-        generate_log.model_options = mot._model_options
+        generate_log.model_options = mot._call.model_options
         generate_log.date = datetime.datetime.now()
         generate_log.model_output = mot.value
         generate_log.extra = {
@@ -1530,7 +1536,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "tools_called": mot.tool_calls,
             "seed": seed,
         }
-        generate_log.action = mot._action
+        generate_log.action = mot._call.action
         generate_log.result = mot
 
         mot._generate_log = generate_log

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -440,15 +440,15 @@ class LiteLLMBackend(FormatterBackend):
         )
 
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = linearized_context
-        output._action = action
-        output._model_options = model_opts
+        output._gen.start = datetime.datetime.now()
+        output._call.context = linearized_context
+        output._call.action = action
+        output._call.model_options = model_opts
 
         # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
         # each processing step.
-        output._process = self.processing
-        output._post_process = functools.partial(
+        output._gen.process = self.processing
+        output._gen.post_process = functools.partial(
             self.post_processing,
             conversation=conversation,
             tools=tools,
@@ -462,20 +462,20 @@ class LiteLLMBackend(FormatterBackend):
 
         try:
             # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-            # We can also support synchronous calls by adding a flag and changing this ._generate function.
+            # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present
             raise e
@@ -597,10 +597,10 @@ class LiteLLMBackend(FormatterBackend):
                 mot.raw.streamed_chunks, force_all_tool_calls_separate=separate_tools
             )
 
-        assert mot._action is not None, (
+        assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
         )
-        assert mot._model_options is not None, (
+        assert mot._call.model_options is not None, (
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
@@ -628,7 +628,7 @@ class LiteLLMBackend(FormatterBackend):
         generate_log = GenerateLog()
         generate_log.prompt = conversation
         generate_log.backend = f"litellm::{self.model_id!s}"
-        generate_log.model_options = mot._model_options
+        generate_log.model_options = mot._call.model_options
         generate_log.date = datetime.datetime.now()
         generate_log.model_output = response
         generate_log.extra = {
@@ -637,7 +637,7 @@ class LiteLLMBackend(FormatterBackend):
             "tools_called": mot.tool_calls,
             "thinking": thinking,
         }
-        generate_log.action = mot._action
+        generate_log.action = mot._call.action
         generate_log.result = mot
 
         mot._generate_log = generate_log
@@ -758,9 +758,10 @@ class LiteLLMBackend(FormatterBackend):
 
         for res, action, prompt in zip(responses, actions, prompts):
             output = ModelOutputThunk(res.text)  # type: ignore
-            output._context = None  # There is no context for generate_from_raw for now
-            output._action = action
-            output._model_options = model_opts
+            # There is no context for generate_from_raw for now
+            output._call.context = None
+            output._call.action = action
+            output._call.model_options = model_opts
             output.raw = RawProviderResponse(
                 provider=self._provider, response=res.model_dump()
             )

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -475,15 +475,15 @@ class OllamaModelBackend(FormatterBackend):
         )  # type: ignore
 
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = linearized_context
-        output._action = action
-        output._model_options = model_opts
+        output._gen.start = datetime.datetime.now()
+        output._call.context = linearized_context
+        output._call.action = action
+        output._call.model_options = model_opts
 
         # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
         # each processing step.
-        output._process = functools.partial(self.processing, tools=tools)
-        output._post_process = functools.partial(
+        output._gen.process = functools.partial(self.processing, tools=tools)
+        output._gen.post_process = functools.partial(
             self.post_processing,
             conversation=conversation,
             tools=tools,
@@ -496,22 +496,22 @@ class OllamaModelBackend(FormatterBackend):
 
         try:
             # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-            # We can also support synchronous calls by adding a flag and changing this ._generate function.
+            # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
 
             # Use `create_task` so that we don't have to specifically await this task before it starts executing.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present
             raise e
@@ -754,10 +754,10 @@ class OllamaModelBackend(FormatterBackend):
             tools (dict[str, AbstractMelleaTool]): Available tools, keyed by name.
             _format: The structured output format class used during generation, if any.
         """
-        assert mot._action is not None, (
+        assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
         )
-        assert mot._model_options is not None, (
+        assert mot._call.model_options is not None, (
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
@@ -765,21 +765,21 @@ class OllamaModelBackend(FormatterBackend):
         generate_log = GenerateLog()
         generate_log.prompt = conversation
         generate_log.backend = f"ollama::{self._model_id}"
-        generate_log.model_options = mot._model_options
+        generate_log.model_options = mot._call.model_options
         generate_log.date = datetime.datetime.now()
         generate_log.model_output = mot.raw.response
         generate_log.extra = {
             "format": _format,
-            "thinking": mot._model_options.get(ModelOption.THINKING, None),
+            "thinking": mot._call.model_options.get(ModelOption.THINKING, None),
             "tools_available": tools,
             "tools_called": mot.tool_calls,
-            "seed": mot._model_options.get(ModelOption.SEED, None),
+            "seed": mot._call.model_options.get(ModelOption.SEED, None),
         }
-        generate_log.action = mot._action
+        generate_log.action = mot._call.action
         generate_log.result = mot
 
         mot._generate_log = generate_log
-        mot._generate = None
+        mot._gen.generate = None
 
         # Extract token counts from response
         response = mot.raw.response

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -719,10 +719,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
         # --- wire up ModelOutputThunk with intrinsic post-processing ------
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = linearized_context
-        output._action = action
-        output._model_options = model_options
+        output._gen.start = datetime.datetime.now()
+        output._call.context = linearized_context
+        output._call.action = action
+        output._call.model_options = model_options
 
         async def granite_formatters_processing(
             mot: ModelOutputThunk,
@@ -752,13 +752,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
         # Processing functions only pass the ModelOutputThunk (and current chunk
         # of response). Bind the other vars necessary for each processing step.
-        output._process = functools.partial(
+        output._gen.process = functools.partial(
             granite_formatters_processing,
             rewritten=rewritten,
             result_processor=result_processor,
         )
 
-        output._post_process = functools.partial(
+        output._gen.post_process = functools.partial(
             self.post_processing,
             tools=tools,
             conversation=conversation,
@@ -771,21 +771,21 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # To support lazy computation, will need to remove this create_task
             # and store just the unexecuted coroutine.
             # We can also support synchronous calls by adding a flag and changing
-            # this ._generate function.
+            # this ._gen.generate function.
 
             # This function should always be called from a running event loop so
             # we don't have to worry about scheduling the task to a specific
             # event loop here.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_options.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present.
             raise e
@@ -976,15 +976,15 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         )  # type: ignore
 
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = linearized_context
-        output._action = action
-        output._model_options = model_opts
+        output._gen.start = datetime.datetime.now()
+        output._call.context = linearized_context
+        output._call.action = action
+        output._call.model_options = model_opts
 
         # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
         # each processing step.
-        output._process = self.processing
-        output._post_process = functools.partial(
+        output._gen.process = self.processing
+        output._gen.post_process = functools.partial(
             self.post_processing,
             tools=tools,
             conversation=conversation,
@@ -999,20 +999,20 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
         try:
             # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-            # We can also support synchronous calls by adding a flag and changing this ._generate function.
+            # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present
             raise e
@@ -1110,10 +1110,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         if mot.raw.streamed_chunks is not None:
             mot.raw.response = chat_completion_delta_merge(mot.raw.streamed_chunks)
 
-        assert mot._action is not None, (
+        assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
         )
-        assert mot._model_options is not None, (
+        assert mot._call.model_options is not None, (
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
@@ -1141,7 +1141,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         generate_log = GenerateLog()
         generate_log.prompt = conversation
         generate_log.backend = f"openai::{self.model_id!s}"
-        generate_log.model_options = mot._model_options
+        generate_log.model_options = mot._call.model_options
         generate_log.date = datetime.datetime.now()
         # Store the full response (includes usage info)
         generate_log.model_output = response
@@ -1152,7 +1152,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             "tools_called": mot.tool_calls,
             "seed": seed,
         }
-        generate_log.action = mot._action
+        generate_log.action = mot._call.action
         generate_log.result = mot
         mot._generate_log = generate_log
 
@@ -1258,9 +1258,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             completion_response.choices, actions, prompts
         ):
             output = ModelOutputThunk(response.text)
-            output._context = None  # There is no context for generate_from_raw for now
-            output._action = action
-            output._model_options = model_opts
+            # There is no context for generate_from_raw for now
+            output._call.context = None
+            output._call.action = action
+            output._call.model_options = model_opts
             output.raw = RawProviderResponse(
                 provider=self._provider, response=response.model_dump()
             )

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -449,15 +449,15 @@ class WatsonxAIBackend(FormatterBackend):
             )
 
         output = ModelOutputThunk(None)
-        output._start = datetime.datetime.now()
-        output._context = linearized_context
-        output._action = action
-        output._model_options = model_opts
+        output._gen.start = datetime.datetime.now()
+        output._call.context = linearized_context
+        output._call.action = action
+        output._call.model_options = model_opts
 
         # Processing functions only pass the ModelOutputThunk (and current chunk of response). Bind the other vars necessary for
         # each processing step.
-        output._process = self.processing
-        output._post_process = functools.partial(
+        output._gen.process = self.processing
+        output._gen.post_process = functools.partial(
             self.post_processing,
             conversation=conversation,
             tools=tools,
@@ -471,20 +471,20 @@ class WatsonxAIBackend(FormatterBackend):
 
         try:
             # To support lazy computation, will need to remove this create_task and store just the unexecuted coroutine.
-            # We can also support synchronous calls by adding a flag and changing this ._generate function.
+            # We can also support synchronous calls by adding a flag and changing this ._gen.generate function.
 
             # This function should always be called from a running event loop so we don't have to worry about
             # scheduling the task to a specific event loop here.
-            output._generate = asyncio.create_task(
+            output._gen.generate = asyncio.create_task(
                 send_to_queue(
                     chat_response,
-                    output._async_queue,
+                    output._gen.queue,
                     chunk_timeout=model_opts.get(
                         ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                     ),
                 )
             )
-            output._generate_type = GenerateType.ASYNC
+            output._gen.generate_type = GenerateType.ASYNC
         except RuntimeError as e:
             # Most likely cause is running this function without an event loop present
             raise e
@@ -567,10 +567,10 @@ class WatsonxAIBackend(FormatterBackend):
         if mot.raw.streamed_chunks is not None:
             mot.raw.response = chat_completion_delta_merge(mot.raw.streamed_chunks)
 
-        assert mot._action is not None, (
+        assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
         )
-        assert mot._model_options is not None, (
+        assert mot._call.model_options is not None, (
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
@@ -610,7 +610,7 @@ class WatsonxAIBackend(FormatterBackend):
         generate_log = GenerateLog()
         generate_log.prompt = conversation
         generate_log.backend = f"watsonx::{self.model_id!s}"
-        generate_log.model_options = mot._model_options
+        generate_log.model_options = mot._call.model_options
         generate_log.date = datetime.datetime.now()
         generate_log.model_output = response
         generate_log.extra = {
@@ -620,7 +620,7 @@ class WatsonxAIBackend(FormatterBackend):
             "seed": seed,
         }
         generate_log.result = mot
-        generate_log.action = mot._action
+        generate_log.action = mot._call.action
         mot._generate_log = generate_log
 
     async def _generate_from_raw(

--- a/mellea/core/backend.py
+++ b/mellea/core/backend.py
@@ -124,7 +124,7 @@ class Backend(abc.ABC):
                 )
             raise
         # Save the ID for the post_call / error hooks.
-        mot._generation_id = generation_id
+        mot._call.generation_id = generation_id
         return mot, new_ctx
 
     @abc.abstractmethod

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -581,7 +581,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 self._gen.cancel_hook()
             except Exception as hook_exc:
                 logging.getLogger(__name__).warning(
-                    "cancel_generation: _cancel_hook raised (suppressed): %r", hook_exc
+                    "cancel_generation: cancel_hook raised (suppressed): %r", hook_exc
                 )
 
         if self._gen.generate is not None and not self._gen.generate.done():
@@ -858,7 +858,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                     self.parsed_repr = self.value  # type: ignore
                 case _:
                     raise ValueError(
-                        "attempted to astream from a model output thunk with no ._call.action set"
+                        "attempted to astream from a model output thunk with no originating action set"
                     )
             assert self.parsed_repr is not None, (
                 "enforce constraint that a computed ModelOutputThunk has a non-None parsed_repr"

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -20,7 +20,7 @@ import enum
 import logging
 from collections.abc import Callable, Coroutine, Iterable, Mapping
 from copy import copy, deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import BytesIO
 from typing import (
     TYPE_CHECKING,
@@ -414,6 +414,69 @@ class RawProviderResponse:
     streamed_chunks: list[Any] | None = None
 
 
+@dataclass
+class _CallInfo:
+    """Originating-call data for a `ModelOutputThunk`.
+
+    Preserved across `__copy__` / `__deepcopy__` because retries and sampling
+    routinely need to re-issue or inspect the call that produced a thunk.
+
+    Args:
+        action: The component or block whose generation produced this thunk.
+        context: The context passed to the originating generate call.
+        model_options: Model options passed to the originating generate call.
+        generation_id: Mellea-side hook correlation ID; distinct from the
+            provider-assigned `GenerationMetadata.response_id`.
+    """
+
+    action: Component | CBlock | None = None
+    context: list[Component | CBlock] | None = None
+    model_options: dict[str, Any] | None = None
+    generation_id: str | None = None
+
+
+@dataclass
+class _GenerationState:
+    """In-flight computation machinery for a `ModelOutputThunk`.
+
+    Reset to a fresh empty instance on `__copy__` / `__deepcopy__` — a copied
+    thunk is a distinct (non-generating) object and must not share queues,
+    tasks, or thread signals with the original.
+
+    Args:
+        queue: Single-consumer queue feeding `astream()` during generation.
+        chunk_size: Minimum number of chunks to stream at a single time.
+        first_chunk_received: Whether the first streamed chunk has arrived
+            (gates time-to-first-byte recording).
+        generate: The task driving generation. Linked to `generate_type`.
+        generate_type: Determines which functions can resolve the thunk's value.
+        generate_extra: Auxiliary generation task; currently only used by hf.
+        cancel_hook: Optional cooperative-cancel hook called before asyncio task
+            cancellation. Backends that run generation in a thread (e.g. Hugging
+            Face via `asyncio.to_thread`) set this to a non-blocking callable
+            (e.g. `threading.Event.set`) so the thread receives a stop signal
+            before the task wrapper is cancelled. Must be non-blocking;
+            exceptions are logged and suppressed. Copied thunks reset this to
+            `None` — each computation owns its own thread signal.
+        process: Backend coroutine that folds a streamed chunk into the thunk.
+        post_process: Backend coroutine run once after the value is complete.
+        on_computed: Coroutine run when the thunk becomes computed.
+        start: Wall-clock start time of generation, for latency metrics.
+    """
+
+    queue: asyncio.Queue = field(default_factory=lambda: asyncio.Queue(maxsize=20))
+    chunk_size: int = 3
+    first_chunk_received: bool = False
+    generate: asyncio.Task[None] | None = None
+    generate_type: GenerateType = GenerateType.NONE
+    generate_extra: asyncio.Task[Any] | None = None
+    cancel_hook: Callable[[], None] | None = None
+    process: Callable[[ModelOutputThunk, Any], Coroutine] | None = None
+    post_process: Callable[[ModelOutputThunk], Coroutine] | None = None
+    on_computed: Callable[[ModelOutputThunk], Coroutine] | None = None
+    start: datetime.datetime | None = None
+
+
 class ModelOutputThunk(CBlock, Generic[S]):
     """A `ModelOutputThunk` is a special type of `CBlock` that we know came from a model's output. It is possible to instantiate one without the output being computed yet.
 
@@ -451,56 +514,28 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self.raw: RawProviderResponse = RawProviderResponse()
         """Backend-native provider response populated during generation."""
 
-        # Used for tracking generation.
-        self._context: list[Component | CBlock] | None = None
-        self._action: Component | CBlock | None = None
-        self._model_options: dict[str, Any] | None = None
+        # Originating-call data, preserved across copies. See `_CallInfo`.
+        self._call = _CallInfo()
 
-        # Used for async and async streaming.
-        self._async_queue: asyncio.Queue = asyncio.Queue(maxsize=20)
-        self._chunk_size = 3  # Minimum number of chunks to stream at a single time.
+        # In-flight computation machinery, reset on copy. See `_GenerationState`.
+        self._gen = _GenerationState()
 
-        # _generate and _generate_type are linked. _generate will determine
-        # what gets set for _generate_type. _generate_type determines what
-        # function(s) can be used to get the value of the ModelOutputThunk.
-        self._generate: asyncio.Task[None] | None = None
-        self._generate_type: GenerateType = GenerateType.NONE
-        self._generate_extra: asyncio.Task[Any] | None = (
-            None  # Currently only used by hf.
-        )
-        # Optional cooperative-cancel hook called before asyncio task cancellation.
-        # Backends that run generation in a thread (e.g. Hugging Face via
-        # asyncio.to_thread) set this to a non-blocking callable (e.g.
-        # threading.Event.set) so the thread receives a stop signal before the
-        # task wrapper is cancelled. Must be non-blocking; exceptions are logged
-        # and suppressed. Copied MOTs reset this to None — each computation owns
-        # its own thread signal.
-        self._cancel_hook: Callable[[], None] | None = None
-        self._process: Callable[[ModelOutputThunk, Any], Coroutine] | None = None
-        self._post_process: Callable[[ModelOutputThunk], Coroutine] | None = None
-        self._on_computed: Callable[[ModelOutputThunk], Coroutine] | None = None
-
-        self._start: datetime.datetime | None = None
-        self._first_chunk_received: bool = False
         self._generate_log: GenerateLog | None = None
         # Soft-failure cause recorded by backends that return a placeholder
         # MOT instead of raising. Sibling to `_cancelled`.
         self._error: Exception | None = None
-        # Mellea-side hook correlation ID; distinct from the provider-assigned
-        # `GenerationMetadata.response_id`.
-        self._generation_id: str | None = None
 
     def _record_ttfb(self) -> None:
         """Record time-to-first-byte if streaming and not yet recorded."""
         if (
             self.generation.streaming
-            and not self._first_chunk_received
-            and self._start is not None
+            and not self._gen.first_chunk_received
+            and self._gen.start is not None
         ):
             self.generation.ttfb_ms = (
-                datetime.datetime.now() - self._start
+                datetime.datetime.now() - self._gen.start
             ).total_seconds() * 1000
-            self._first_chunk_received = True
+            self._gen.first_chunk_received = True
 
     async def cancel_generation(self, error: Exception | None = None) -> None:
         """Cancel an in-progress streaming generation, drain the queue, and fire the `generation_error` hook.
@@ -533,34 +568,34 @@ class ModelOutputThunk(CBlock, Generic[S]):
             return
 
         def _drain() -> None:
-            while not self._async_queue.empty():
+            while not self._gen.queue.empty():
                 try:
-                    self._async_queue.get_nowait()
+                    self._gen.queue.get_nowait()
                 except asyncio.QueueEmpty:
                     break
 
         # Signal any backend thread before cancelling the asyncio task wrapper
         # so the thread can stop cooperatively instead of running to completion.
-        if self._cancel_hook is not None:
+        if self._gen.cancel_hook is not None:
             try:
-                self._cancel_hook()
+                self._gen.cancel_hook()
             except Exception as hook_exc:
                 logging.getLogger(__name__).warning(
                     "cancel_generation: _cancel_hook raised (suppressed): %r", hook_exc
                 )
 
-        if self._generate is not None and not self._generate.done():
-            self._generate.cancel()
+        if self._gen.generate is not None and not self._gen.generate.done():
+            self._gen.generate.cancel()
 
-        if self._generate_extra is not None and not self._generate_extra.done():
-            self._generate_extra.cancel()
+        if self._gen.generate_extra is not None and not self._gen.generate_extra.done():
+            self._gen.generate_extra.cancel()
 
         # Drain before awaiting — unblocks any put() the task is stuck on.
         _drain()
 
-        if self._generate is not None:
+        if self._gen.generate is not None:
             try:
-                await self._generate
+                await self._gen.generate
             except asyncio.CancelledError:
                 # Re-raise if the *outer* task is being cancelled (Python 3.11+
                 # task.cancelling() > 0) so we don't silently absorb external
@@ -572,9 +607,9 @@ class ModelOutputThunk(CBlock, Generic[S]):
             except Exception:
                 pass
 
-        if self._generate_extra is not None:
+        if self._gen.generate_extra is not None:
             try:
-                await self._generate_extra
+                await self._gen.generate_extra
             except asyncio.CancelledError:
                 cur = asyncio.current_task()
                 if cur is not None and cur.cancelling() > 0:
@@ -596,7 +631,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 GenerationErrorPayload(
                     exception=recorded,
                     model_output=self,
-                    generation_id=self._generation_id,
+                    generation_id=self._call.generation_id,
                 ),
             )
 
@@ -653,9 +688,10 @@ class ModelOutputThunk(CBlock, Generic[S]):
         self._generate_log = other._generate_log
         self._cancelled = other._cancelled
         self._error = other._error
-        # _cancel_hook is deliberately not copied: _copy_from swaps output state,
-        # not backend-thread plumbing, which is tied to the original computation.
-        self._cancel_hook = None
+        # _gen.cancel_hook is deliberately not copied: _copy_from swaps output
+        # state, not backend-thread plumbing, which is tied to the original
+        # computation.
+        self._gen.cancel_hook = None
 
     def is_computed(self) -> bool:
         """Returns true only if this Thunk has already been filled.
@@ -694,9 +730,9 @@ class ModelOutputThunk(CBlock, Generic[S]):
             assert self.value is not None  # If computed, the value cannot be None.
             return self.value
 
-        if not self._generate_type == GenerateType.ASYNC:
+        if not self._gen.generate_type == GenerateType.ASYNC:
             raise RuntimeError(
-                f"Cannot use `ModelOutputThunk.avalue()` when the generate function is using `{self._generate_type.name}`"
+                f"Cannot use `ModelOutputThunk.avalue()` when the generate function is using `{self._gen.generate_type.name}`"
             )
 
         while not self._computed:
@@ -735,12 +771,12 @@ class ModelOutputThunk(CBlock, Generic[S]):
         # Use string directly to avoid importing ModelOption from backends into core (circular import).
         # ModelOption.STREAM is defined in mellea/backends/model_options.py.
         self.generation.streaming = bool(
-            (self._model_options or {}).get("@@@stream@@@", False)
+            (self._call.model_options or {}).get("@@@stream@@@", False)
         )
 
-        if not self._generate_type == GenerateType.ASYNC:
+        if not self._gen.generate_type == GenerateType.ASYNC:
             raise RuntimeError(
-                f"Cannot use `ModelOutputThunk.astream()` when the generate function is using `{self._generate_type.name}`"
+                f"Cannot use `ModelOutputThunk.astream()` when the generate function is using `{self._gen.generate_type.name}`"
             )
         # Beginning value
         beginning_length = (
@@ -751,7 +787,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
         chunks: list[Any | None] = []
         while True:
             try:
-                item = self._async_queue.get_nowait()
+                item = self._gen.queue.get_nowait()
                 chunks.append(item)
                 self._record_ttfb()
             except asyncio.QueueEmpty:
@@ -759,7 +795,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 break
 
         # Make sure we always get the minimum chunk size.
-        while len(chunks) <= self._chunk_size:
+        while len(chunks) <= self._gen.chunk_size:
             if len(chunks) > 0:
                 if chunks[-1] is None or isinstance(chunks[-1], Exception):
                     break  # Hit sentinel value or an error.
@@ -767,7 +803,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 # but that forces us to know about the chunk type here. Prefer sentinel values
                 # for now.
 
-            item = await self._async_queue.get()
+            item = await self._gen.queue.get()
             chunks.append(item)
             self._record_ttfb()
 
@@ -777,12 +813,12 @@ class ModelOutputThunk(CBlock, Generic[S]):
             do_set_computed = True
 
             # Shouldn't be needed, but cancel the Tasks this ModelOutputThunk relied on.
-            if self._generate is not None:
-                self._generate.cancel()
-            if self._generate_extra is not None:
+            if self._gen.generate is not None:
+                self._gen.generate.cancel()
+            if self._gen.generate_extra is not None:
                 # Covers an hf edge case. The task is done generating anything useful but isn't `done` yet.
-                await self._generate_extra
-                self._generate_extra.cancel()
+                await self._gen.generate_extra
+                self._gen.generate_extra.cancel()
 
             # If ModelOutputThunks get too bulky, we can do additional cleanup here
             # and set fields to None.
@@ -795,26 +831,26 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 err_payload = GenerationErrorPayload(
                     exception=chunks[-1],
                     model_output=self,
-                    generation_id=self._generation_id,
+                    generation_id=self._call.generation_id,
                 )
                 await invoke_hook(HookType.GENERATION_ERROR, err_payload)
 
             raise chunks[-1]
 
         for chunk in chunks:
-            assert self._process is not None
-            await self._process(self, chunk)
+            assert self._gen.process is not None
+            await self._gen.process(self, chunk)
 
         if do_set_computed:
             assert self._underlying_value is not None
             self._computed = True
 
-            assert self._post_process is not None
-            await self._post_process(self)
+            assert self._gen.post_process is not None
+            await self._gen.post_process(self)
 
-            match self._action:
+            match self._call.action:
                 case Component():
-                    self.parsed_repr = self._action._parse(self)
+                    self.parsed_repr = self._call.action._parse(self)
                 case CBlock():
                     assert self.value is not None, (
                         "value must be non-None since this thunk is computed"
@@ -822,7 +858,7 @@ class ModelOutputThunk(CBlock, Generic[S]):
                     self.parsed_repr = self.value  # type: ignore
                 case _:
                     raise ValueError(
-                        "attempted to astream from a model output thunk with no ._action set"
+                        "attempted to astream from a model output thunk with no ._call.action set"
                     )
             assert self.parsed_repr is not None, (
                 "enforce constraint that a computed ModelOutputThunk has a non-None parsed_repr"
@@ -835,15 +871,15 @@ class ModelOutputThunk(CBlock, Generic[S]):
                 glog = self._generate_log
                 prompt = glog.prompt if glog and glog.prompt else ""
                 latency_ms = (
-                    (datetime.datetime.now() - self._start).total_seconds() * 1000
-                    if self._start
+                    (datetime.datetime.now() - self._gen.start).total_seconds() * 1000
+                    if self._gen.start
                     else -1
                 )
                 post_payload = GenerationPostCallPayload(
                     prompt=prompt,
                     model_output=self,
                     latency_ms=latency_ms,
-                    generation_id=self._generation_id,
+                    generation_id=self._call.generation_id,
                 )
                 await invoke_hook(HookType.GENERATION_POST_CALL, post_payload)
                 # NOTE: If we allow generation_post_call to modify the model output thunk, we need to
@@ -866,7 +902,19 @@ class ModelOutputThunk(CBlock, Generic[S]):
         return f"ModelOutputThunk({self.value})"
 
     def __copy__(self) -> ModelOutputThunk:
-        """Returns a shallow copy of the ModelOutputThunk. A copied ModelOutputThunk cannot be used for generation; don't copy over fields associated with generating."""
+        """Returns a shallow copy of the ModelOutputThunk.
+
+        Copies are post-generation: `_call` (originating-call data) is preserved
+        while `_gen` (in-flight machinery) is left as the fresh instance from
+        `__init__`. Copying an uncomputed thunk raises.
+
+        Raises:
+            RuntimeError: If the thunk has not been computed.
+        """
+        if not self._computed:
+            raise RuntimeError(
+                "Cannot copy an uncomputed ModelOutputThunk; copies are post-generation."
+            )
         copied = ModelOutputThunk(
             self._underlying_value, self._meta, self.parsed_repr, self.tool_calls
         )
@@ -880,20 +928,29 @@ class ModelOutputThunk(CBlock, Generic[S]):
         copied._computed = self._computed
         copied._cancelled = self._cancelled
         copied._error = self._error
-        # _cancel_hook is not forwarded: a copied MOT is a distinct computation
-        # and must not share the original's backend thread signal.
-        copied._cancel_hook = None
         copied._thinking = self._thinking
-        copied._action = self._action
-        copied._context = self._context
         copied._generate_log = self._generate_log
-        copied._model_options = self._model_options
+        # _call is preserved; _gen is left as the fresh _GenerationState() from
+        # __init__ so the copy shares no queues, tasks, or thread signals.
+        copied._call = copy(self._call)
         copied.generation = copy(self.generation)
         copied.raw = copy(self.raw)
         return copied
 
     def __deepcopy__(self, memo: dict) -> ModelOutputThunk:
-        """Returns a deep copy of the ModelOutputThunk. A copied ModelOutputThunk cannot be used for generation; don't copy over fields associated with generation. Similar to __copy__ but creates deepcopies of _meta, parsed_repr, and most other fields that are objects."""
+        """Returns a deep copy of the ModelOutputThunk.
+
+        Like `__copy__` but deep-copies `_meta`, `parsed_repr`, and the
+        originating-call data. `_gen` is left as the fresh instance from
+        `__init__`. Copying an uncomputed thunk raises.
+
+        Raises:
+            RuntimeError: If the thunk has not been computed.
+        """
+        if not self._computed:
+            raise RuntimeError(
+                "Cannot deepcopy an uncomputed ModelOutputThunk; copies are post-generation."
+            )
         # Use __init__ to initialize all fields. Modify the fields that need to be copied/deepcopied below.
         deepcopied = ModelOutputThunk(self._underlying_value)
         memo[id(self)] = deepcopied
@@ -914,16 +971,17 @@ class ModelOutputThunk(CBlock, Generic[S]):
         deepcopied._computed = self._computed
         deepcopied._cancelled = self._cancelled
         deepcopied._error = self._error
-        # _cancel_hook is not forwarded: a deepcopied MOT is a distinct computation
-        # and must not share the original's backend thread signal.
-        deepcopied._cancel_hook = None
         deepcopied._thinking = self._thinking
-        deepcopied._action = deepcopy(self._action)
-        deepcopied._context = copy(
-            self._context
-        )  # The items in a context should be immutable.
         deepcopied._generate_log = copy(self._generate_log)
-        deepcopied._model_options = copy(self._model_options)
+        # action is deep-copied; context and model_options are shallow-copied
+        # (their items are immutable). _gen is left as the fresh instance from
+        # __init__ so the copy shares no queues, tasks, or thread signals.
+        deepcopied._call = _CallInfo(
+            action=deepcopy(self._call.action),
+            context=copy(self._call.context),
+            model_options=copy(self._call.model_options),
+            generation_id=self._call.generation_id,
+        )
         deepcopied.generation = deepcopy(self.generation)
         deepcopied.raw = deepcopy(self.raw)
         return deepcopied

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -833,7 +833,7 @@ async def stream_with_chunking(
 
     # Clone requirements before starting backend generation so that a raising
     # __copy__ (an advertised extension point on Requirement) cannot leave the
-    # backend feeder task wedged against a full _async_queue with no consumer.
+    # backend feeder task wedged against a full streaming queue with no consumer.
     cloned_reqs = [copy(req) for req in (requirements or [])]
     val_backend = validation_backend if validation_backend is not None else backend
 

--- a/mellea/telemetry/_tracing_setters.py
+++ b/mellea/telemetry/_tracing_setters.py
@@ -72,11 +72,12 @@ def set_response_attrs(span: Any, gen: GenerationMetadata) -> None:
 
 def set_mellea_attrs(span: Any, mot: Any, gen: GenerationMetadata) -> None:
     """Emit `mellea.*` attributes derivable from the `ModelOutputThunk`."""
-    action = getattr(mot, "_action", None)
+    call = getattr(mot, "_call", None)
+    action = getattr(call, "action", None)
     if action is not None:
         span.set_attribute("mellea.action_type", action.__class__.__name__)
 
-    ctx = getattr(mot, "_context", None)
+    ctx = getattr(call, "context", None)
     span.set_attribute("mellea.context_size", len(ctx) if ctx else 0)
 
     if gen.streaming:

--- a/test/backends/test_huggingface.py
+++ b/test/backends/test_huggingface.py
@@ -674,8 +674,8 @@ async def test_intrinsic_temperature_forwarded(backend) -> None:
         )
         # Don't call avalue() — the canned response lacks logprobs for the
         # answerability result processor.  We only need the generate call.
-        assert _mot._generate is not None
-        await _mot._generate
+        assert _mot._gen.generate is not None
+        await _mot._gen.generate
 
     gi = captured["generate_input"]
     assert gi["temperature"] == 0.7
@@ -707,8 +707,8 @@ async def test_intrinsic_model_options_forwarded(backend) -> None:
                 ModelOption.SYSTEM_PROMPT: "You are helpful",
             },
         )
-        assert _mot._generate is not None
-        await _mot._generate
+        assert _mot._gen.generate is not None
+        await _mot._gen.generate
 
     gi = captured["generate_input"]
     # Temperature is forwarded.
@@ -744,8 +744,8 @@ async def test_intrinsic_temperature_overrides_io_yaml(backend) -> None:
             strategy=None,
             model_options={ModelOption.TEMPERATURE: 0.3},
         )
-        assert _mot._generate is not None
-        await _mot._generate
+        assert _mot._gen.generate is not None
+        await _mot._gen.generate
 
     gi = captured["generate_input"]
     # User value (0.3) must override any io.yaml default.
@@ -787,8 +787,8 @@ async def test_intrinsic_tools_in_generate_input(backend) -> None:
                 ModelOption.TOOLS: [MelleaTool.from_callable(get_temperature)]
             },
         )
-        assert _mot._generate is not None
-        await _mot._generate
+        assert _mot._gen.generate is not None
+        await _mot._gen.generate
 
     # Decode the input tokens and verify the tool name and tool markers are present.
     input_tokens = captured["generate_input"]["input_tokens"]
@@ -855,8 +855,8 @@ async def test_intrinsic_no_system_prompt(backend) -> None:
         _mot, _ = await mfuncs.aact(
             Intrinsic("answerability"), ctx, backend, strategy=None
         )
-        assert _mot._generate is not None
-        await _mot._generate
+        assert _mot._gen.generate is not None
+        await _mot._gen.generate
 
     # Verify generation completed without error.
     assert "generate_input" in captured

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -80,8 +80,8 @@ async def test_finish_reasons_derivation(
     sequences = torch.tensor([[*range(n_completion), last_token]])
 
     mot = ModelOutputThunk(value=value)
-    mot._action = Message("user", "noop")
-    mot._model_options = model_options
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = model_options
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=None,
@@ -262,8 +262,8 @@ async def test_intrinsic_seed_with_zero_temperature_keeps_greedy(stub_backend):
             ChatContext().add(Message("user", "Is the sky blue?")),
             model_options={ModelOption.SEED: 42, ModelOption.TEMPERATURE: 0.0},
         )
-        assert output._generate is not None
-        await output._generate
+        assert output._gen.generate is not None
+        await output._gen.generate
 
     assert captured["generate_input"]["do_sample"] is False
     assert "temperature" not in captured["generate_input"]
@@ -279,8 +279,8 @@ async def test_logits_populated_when_option_set():
     fake_scores = (torch.zeros(1, 32000), torch.zeros(1, 32000))
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {ModelOption.LOGITS: True}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {ModelOption.LOGITS: True}
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=fake_scores,
@@ -307,8 +307,8 @@ async def test_raw_logits_populated_when_option_set():
     fake_raw_logits = (torch.ones(1, vocab_size), torch.ones(1, vocab_size))
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {ModelOption.RAW_LOGITS: True}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {ModelOption.RAW_LOGITS: True}
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=None,
@@ -337,8 +337,8 @@ async def test_raw_logits_and_logits_both_populated_when_both_options_set():
     fake_raw_logits = (torch.ones(1, vocab_size), torch.ones(1, vocab_size))
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {ModelOption.LOGITS: True, ModelOption.RAW_LOGITS: True}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {ModelOption.LOGITS: True, ModelOption.RAW_LOGITS: True}
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=fake_scores,
@@ -366,8 +366,8 @@ async def test_logits_populated_when_option_set_caching_enabled():
     fake_scores = (torch.zeros(1, 32000), torch.zeros(1, 32000))
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {ModelOption.LOGITS: True}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {ModelOption.LOGITS: True}
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=fake_scores,
@@ -394,8 +394,8 @@ async def test_logits_not_populated_when_option_not_set():
     fake_scores = (torch.zeros(1, 32000), torch.zeros(1, 32000))
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {}
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
         scores=fake_scores,
@@ -539,8 +539,8 @@ async def test_logits_none_when_stream_and_logits_both_set():
     sequences = torch.tensor([[0, 0]])
 
     mot = ModelOutputThunk(value="hi")
-    mot._action = Message("user", "noop")
-    mot._model_options = {ModelOption.LOGITS: True, ModelOption.STREAM: True}
+    mot._call.action = Message("user", "noop")
+    mot._call.model_options = {ModelOption.LOGITS: True, ModelOption.STREAM: True}
     # Streaming output carries no scores — hf_output.scores is None.
     mot.raw.response = GenerateDecoderOnlyOutput(
         sequences=sequences,
@@ -647,15 +647,15 @@ async def test_intrinsic_logits_populated_when_option_set(stub_backend):
             ChatContext().add(Message("user", "Is the sky blue?")),
             model_options={ModelOption.LOGITS: True},
         )
-        assert output._generate is not None
-        await output._generate
+        assert output._gen.generate is not None
+        await output._gen.generate
 
         # Drain the queue to trigger _process (granite_formatters_processing), which
         # stashes the intercepted hf_output in mot._meta["hf_output"].
-        while not output._async_queue.empty():
-            item = output._async_queue.get_nowait()
+        while not output._gen.queue.empty():
+            item = output._gen.queue.get_nowait()
             if item is not None:
-                await output._process(output, item)
+                await output._gen.process(output, item)
 
         # Simulate the sentinel-driven completion that astream() performs before
         # calling _post_process, so post_processing's assertion mot.value is not None passes.

--- a/test/cli/test_serve_streaming.py
+++ b/test/cli/test_serve_streaming.py
@@ -91,7 +91,7 @@ class TestStreamingHelpers:
         """Test helper emits only incremental content fragments."""
         output = ModelOutputThunk(None)
         output._computed = False
-        output._generate_type = output._generate_type.ASYNC
+        output._gen.generate_type = output._gen.generate_type.ASYNC
 
         chunks = ["Hello", " there", "!"]
 
@@ -181,7 +181,7 @@ class TestStreamingHelpers:
         """Test helper emits an error payload and [DONE] when streaming fails."""
         output = ModelOutputThunk(None)
         output._computed = False
-        output._generate_type = output._generate_type.ASYNC
+        output._gen.generate_type = output._gen.generate_type.ASYNC
 
         async def mock_astream():
             raise RuntimeError("boom")
@@ -219,7 +219,7 @@ class TestStreamingEndpoint:
         # Create a mock output that simulates streaming
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         # Simulate streaming chunks (deltas, not accumulated)
         chunks = ["Hello", " there", "!"]
@@ -318,7 +318,7 @@ class TestStreamingEndpoint:
 
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
         mock_output.astream = AsyncMock(
             side_effect=lambda: setattr(mock_output, "_computed", True) or "done"
         )
@@ -348,7 +348,7 @@ class TestStreamingEndpoint:
         """Test streaming handles empty content chunks gracefully."""
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         # Simulate streaming with some empty incremental chunks
         chunks = ["", "Hello", "", " world", ""]
@@ -399,7 +399,7 @@ class TestStreamingEndpoint:
         """Test that completion ID is consistent across all chunks."""
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         chunks = ["A", "B"]
 
@@ -445,7 +445,7 @@ class TestStreamingEndpoint:
         """Test that streaming response ends with [DONE] marker."""
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         async def mock_astream():
             mock_output._computed = True
@@ -474,7 +474,7 @@ class TestStreamingEndpoint:
         """Test that model field is correctly set in streaming chunks."""
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         async def mock_astream():
             mock_output._computed = True
@@ -514,7 +514,7 @@ class TestStreamingEndpoint:
 
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         async def mock_astream():
             mock_output._computed = True
@@ -567,7 +567,7 @@ class TestStreamingEndpoint:
 
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         async def mock_astream():
             mock_output._computed = True
@@ -619,7 +619,7 @@ class TestStreamingEndpoint:
 
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         async def mock_astream():
             mock_output._computed = True
@@ -671,7 +671,7 @@ class TestStreamingEndpoint:
         """
         mock_output = ModelOutputThunk(None)
         mock_output._computed = False
-        mock_output._generate_type = mock_output._generate_type.ASYNC
+        mock_output._gen.generate_type = mock_output._gen.generate_type.ASYNC
 
         chunks = ["Hello", " world"]
 

--- a/test/core/test_astream_exception_propagation.py
+++ b/test/core/test_astream_exception_propagation.py
@@ -24,12 +24,12 @@ async def _failing_post_process(mot):
 
 def _make_thunk(post_process=_failing_post_process):
     mot = ModelOutputThunk(value=None)
-    mot._generate_type = GenerateType.ASYNC
-    mot._process = _noop_process
-    mot._post_process = post_process
-    mot._action = CBlock("test")
-    mot._chunk_size = 0
-    mot._start = datetime.datetime.now()
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.process = _noop_process
+    mot._gen.post_process = post_process
+    mot._call.action = CBlock("test")
+    mot._gen.chunk_size = 0
+    mot._gen.start = datetime.datetime.now()
     return mot
 
 
@@ -40,7 +40,7 @@ def _make_thunk(post_process=_failing_post_process):
 async def test_astream_propagates_generation_exception(error):
     """The original generation error must propagate, not a secondary error from post_process."""
     mot = _make_thunk()
-    await mot._async_queue.put(error)
+    await mot._gen.queue.put(error)
 
     with pytest.raises(type(error), match=str(error)):
         await mot.astream()
@@ -56,7 +56,7 @@ async def test_astream_post_process_only_called_on_success():
 
     # Error path: post_process should NOT be called
     mot = _make_thunk(post_process=_tracking_post_process)
-    await mot._async_queue.put(RuntimeError("generation failed"))
+    await mot._gen.queue.put(RuntimeError("generation failed"))
 
     with pytest.raises(RuntimeError, match="generation failed"):
         await mot.astream()
@@ -68,8 +68,8 @@ async def test_astream_post_process_only_called_on_success():
     # Success path: post_process SHOULD be called
     post_process_called = False
     mot = _make_thunk(post_process=_tracking_post_process)
-    await mot._async_queue.put("hello")
-    await mot._async_queue.put(None)  # sentinel for completion
+    await mot._gen.queue.put("hello")
+    await mot._gen.queue.put(None)  # sentinel for completion
 
     await mot.astream()
 

--- a/test/core/test_astream_mock.py
+++ b/test/core/test_astream_mock.py
@@ -29,11 +29,11 @@ async def mock_post_process(mot: ModelOutputThunk) -> None:
 def create_manual_mock_thunk() -> ModelOutputThunk:
     """Helper to create a mock ModelOutputThunk where we manually populate the queue."""
     mot = ModelOutputThunk(value=None)
-    mot._action = CBlock("mock_action")
-    mot._generate_type = GenerateType.ASYNC
-    mot._process = mock_process
-    mot._post_process = mock_post_process
-    mot._chunk_size = 0  # Read exactly what is available
+    mot._call.action = CBlock("mock_action")
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.process = mock_process
+    mot._gen.post_process = mock_post_process
+    mot._gen.chunk_size = 0  # Read exactly what is available
     return mot
 
 
@@ -43,22 +43,22 @@ async def test_astream_returns_incremental_chunks():
     mot = create_manual_mock_thunk()
 
     # Drop the first chunk and pull it
-    mot._async_queue.put_nowait("chunk1 ")
+    mot._gen.queue.put_nowait("chunk1 ")
     chunk1 = await mot.astream()
     assert chunk1 == "chunk1 "
 
     # Drop the second chunk and pull it
-    mot._async_queue.put_nowait("chunk2 ")
+    mot._gen.queue.put_nowait("chunk2 ")
     chunk2 = await mot.astream()
     assert chunk2 == "chunk2 "
 
     # Drop the third chunk and pull it
-    mot._async_queue.put_nowait("chunk3 ")
+    mot._gen.queue.put_nowait("chunk3 ")
     chunk3 = await mot.astream()
     assert chunk3 == "chunk3 "
 
     # Send completion sentinel
-    mot._async_queue.put_nowait(None)
+    mot._gen.queue.put_nowait(None)
 
     # Wait until fully consumed
     while not mot.is_computed():
@@ -75,17 +75,17 @@ async def test_astream_multiple_calls_accumulate_correctly():
     mot = create_manual_mock_thunk()
 
     # Drop multiple items at once to simulate fast network
-    mot._async_queue.put_nowait("c")
-    mot._async_queue.put_nowait("h")
-    mot._async_queue.put_nowait("u")
+    mot._gen.queue.put_nowait("c")
+    mot._gen.queue.put_nowait("h")
+    mot._gen.queue.put_nowait("u")
 
     # Calling astream should drain all currently queued items ("chu")
     chunk1 = await mot.astream()
     assert chunk1 == "chu"
 
-    mot._async_queue.put_nowait("n")
-    mot._async_queue.put_nowait("k")
-    mot._async_queue.put_nowait(None)
+    mot._gen.queue.put_nowait("n")
+    mot._gen.queue.put_nowait("k")
+    mot._gen.queue.put_nowait(None)
 
     chunk2 = await mot.astream()
     # astream() returns only the incremental content added during this call
@@ -102,11 +102,11 @@ async def test_astream_beginning_length_tracking():
     """Test that beginning_length is correctly tracked across astream calls."""
     mot = create_manual_mock_thunk()
 
-    mot._async_queue.put_nowait("AAA")
+    mot._gen.queue.put_nowait("AAA")
     chunk1 = await mot.astream()
     assert chunk1 == "AAA"
 
-    mot._async_queue.put_nowait("BBB")
+    mot._gen.queue.put_nowait("BBB")
     chunk2 = await mot.astream()
     # verify incremental length tracking works
     assert not chunk2.startswith(chunk1)
@@ -118,7 +118,7 @@ async def test_astream_empty_beginning():
     """Test astream when _underlying_value starts as None."""
     mot = create_manual_mock_thunk()
 
-    mot._async_queue.put_nowait("First")
+    mot._gen.queue.put_nowait("First")
     # At the start, _underlying_value is None, beginning_length is 0
     chunk = await mot.astream()
 
@@ -143,16 +143,16 @@ async def test_astream_final_call_returns_full_value():
     """Test that the final astream call returns the full value when computed."""
     mot = create_manual_mock_thunk()
 
-    mot._async_queue.put_nowait("part1")
+    mot._gen.queue.put_nowait("part1")
     chunk1 = await mot.astream()
     assert chunk1 == "part1"
 
-    mot._async_queue.put_nowait("part2")
+    mot._gen.queue.put_nowait("part2")
     chunk2 = await mot.astream()
     assert chunk2 == "part2"
 
-    mot._async_queue.put_nowait("part3")
-    mot._async_queue.put_nowait(None)
+    mot._gen.queue.put_nowait("part3")
+    mot._gen.queue.put_nowait(None)
 
     # Calling astream here processes "part3" and `None`, flagging it as done
     chunk3 = await mot.astream()

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -447,6 +447,33 @@ def test_deepcopy_resets_gen_and_preserves_call() -> None:
     assert isinstance(deep._call.action, Message)
 
 
+def test_copy_resets_gen_and_preserves_call() -> None:
+    """Shallow-copying a computed MOT yields a fresh _gen but preserves _call."""
+    mot = ModelOutputThunk(value="done")
+    mot._call.action = Message("user", "hi")
+    mot._call.context = []
+    mot._call.model_options = {"temperature": 0.5}
+    mot._call.generation_id = "gen-123"
+    # Dirty the in-flight machinery so a shared _gen would be observable.
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.chunk_size = 99
+
+    shallow = copy.copy(mot)
+
+    # _gen is a distinct, fresh instance — not shared with the original.
+    assert shallow._gen is not mot._gen
+    assert shallow._gen.queue is not mot._gen.queue
+    assert shallow._gen.generate is None
+    assert shallow._gen.generate_type is GenerateType.NONE
+    assert shallow._gen.chunk_size == 3
+
+    # _call is preserved.
+    assert shallow._call.model_options == {"temperature": 0.5}
+    assert shallow._call.generation_id == "gen-123"
+    assert shallow._call.context == []
+    assert isinstance(shallow._call.action, Message)
+
+
 @pytest.mark.asyncio
 async def test_cancel_generation_hook_exception_is_suppressed() -> None:
     """Fix 2: a faulty _cancel_hook must not mask cancel_generation itself."""

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -9,6 +9,7 @@ from PIL import Image as PILImage
 from mellea.core import (
     CBlock,
     Component,
+    GenerateType,
     ImageBlock,
     ImageUrlBlock,
     ModelOutputThunk,
@@ -364,13 +365,13 @@ async def test_cancel_generation_invokes_cancel_hook_before_task_cancel() -> Non
         thread_released.set()
 
     mot = ModelOutputThunk(value=None)
-    mot._cancel_hook = hook  # type: ignore[attr-defined]
+    mot._gen.cancel_hook = hook  # type: ignore[attr-defined]
 
     # Task that blocks in a thread until thread_released is set.
     async def spin() -> None:
         await asyncio.to_thread(thread_released.wait, 5.0)
 
-    mot._generate = asyncio.create_task(spin())  # type: ignore[attr-defined]
+    mot._gen.generate = asyncio.create_task(spin())  # type: ignore[attr-defined]
     await asyncio.sleep(0)  # let the task reach to_thread
 
     # Must return within 1 s; without the hook it would hang ~5 s.
@@ -388,17 +389,56 @@ def test_cancel_hook_not_forwarded_by_copy_methods() -> None:
         pass
 
     mot = ModelOutputThunk(value="x")
-    mot._cancel_hook = _hook  # type: ignore[attr-defined]
+    mot._gen.cancel_hook = _hook  # type: ignore[attr-defined]
 
     shallow = copy_mod.copy(mot)
-    assert shallow._cancel_hook is None, "__copy__ must reset _cancel_hook to None"  # type: ignore[attr-defined]
+    assert shallow._gen.cancel_hook is None, "__copy__ must reset _cancel_hook to None"  # type: ignore[attr-defined]
 
     deep = copy_mod.deepcopy(mot)
-    assert deep._cancel_hook is None, "__deepcopy__ must reset _cancel_hook to None"  # type: ignore[attr-defined]
+    assert deep._gen.cancel_hook is None, "__deepcopy__ must reset _cancel_hook to None"  # type: ignore[attr-defined]
 
     target = ModelOutputThunk(value="original")
     target._copy_from(mot)  # type: ignore[attr-defined]
-    assert target._cancel_hook is None, "_copy_from must reset _cancel_hook to None"  # type: ignore[attr-defined]
+    assert target._gen.cancel_hook is None, "_copy_from must reset _cancel_hook to None"  # type: ignore[attr-defined]
+
+
+def test_copy_of_uncomputed_mot_raises() -> None:
+    """Copying an uncomputed MOT raises; copies are only valid post-generation."""
+    uncomputed = ModelOutputThunk(value=None)
+    assert not uncomputed.is_computed()
+
+    with pytest.raises(RuntimeError):
+        copy.copy(uncomputed)
+
+    with pytest.raises(RuntimeError):
+        copy.deepcopy(uncomputed)
+
+
+def test_deepcopy_resets_gen_and_preserves_call() -> None:
+    """Deepcopying a computed MOT yields a fresh _gen but preserves _call."""
+    mot = ModelOutputThunk(value="done")
+    mot._call.action = Message("user", "hi")
+    mot._call.context = []
+    mot._call.model_options = {"temperature": 0.5}
+    mot._call.generation_id = "gen-123"
+    # Dirty the in-flight machinery so a shared _gen would be observable.
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.chunk_size = 99
+
+    deep = copy.deepcopy(mot)
+
+    # _gen is a distinct, fresh instance — not shared with the original.
+    assert deep._gen is not mot._gen
+    assert deep._gen.queue is not mot._gen.queue
+    assert deep._gen.generate is None
+    assert deep._gen.generate_type is GenerateType.NONE
+    assert deep._gen.chunk_size == 3
+
+    # _call is preserved.
+    assert deep._call.model_options == {"temperature": 0.5}
+    assert deep._call.generation_id == "gen-123"
+    assert deep._call.context == []
+    assert isinstance(deep._call.action, Message)
 
 
 @pytest.mark.asyncio
@@ -410,7 +450,7 @@ async def test_cancel_generation_hook_exception_is_suppressed() -> None:
         raise RuntimeError("hook exploded")
 
     mot = ModelOutputThunk(value=None)
-    mot._cancel_hook = _bad_hook  # type: ignore[attr-defined]
+    mot._gen.cancel_hook = _bad_hook  # type: ignore[attr-defined]
 
     # No _generate task — cancel_generation still runs the hook path.
     # The hook raises, but cancel_generation must complete without propagating.
@@ -422,7 +462,7 @@ async def test_cancel_generation_hook_exception_is_suppressed() -> None:
 async def test_cancel_generation_propagates_outer_cancellation() -> None:
     """Outer cancellation of the cancel_generation() task must re-raise CancelledError.
 
-    When cancel_generation() is awaiting self._generate and the *cancel_generation*
+    When cancel_generation() is awaiting self._gen.generate and the *cancel_generation*
     task is itself cancelled from outside, cur.cancelling() > 0 and the
     CancelledError must propagate — not be swallowed by the bare ``pass`` path.
     """
@@ -435,18 +475,18 @@ async def test_cancel_generation_propagates_outer_cancellation() -> None:
             await asyncio.sleep(60)
         except asyncio.CancelledError:
             # Signal that cancel_generation() has called .cancel() and is
-            # now blocked at ``await self._generate``.
+            # now blocked at ``await self._gen.generate``.
             inner_cancelled.set()
             # Absorb this cancel so cancel_generation() stays at the await.
             await asyncio.sleep(60)
 
     mot = ModelOutputThunk(value=None)
-    mot._generate = asyncio.create_task(_absorbs_first_cancel())  # type: ignore[attr-defined]
+    mot._gen.generate = asyncio.create_task(_absorbs_first_cancel())  # type: ignore[attr-defined]
     await asyncio.sleep(0)
 
     cg_task = asyncio.create_task(mot.cancel_generation())  # type: ignore[attr-defined]
     # Wait until _generate has absorbed cancel_generation()'s .cancel() call —
-    # at that point cg_task is blocked at ``await self._generate``.
+    # at that point cg_task is blocked at ``await self._gen.generate``.
     await asyncio.wait_for(inner_cancelled.wait(), timeout=2.0)
 
     # Cancel cancel_generation() from outside (simulates asyncio.wait_for timeout
@@ -456,8 +496,8 @@ async def test_cancel_generation_propagates_outer_cancellation() -> None:
         await asyncio.wait_for(cg_task, timeout=2.0)
 
     # Cleanup: stop the still-running _generate task.
-    mot._generate.cancel()  # type: ignore[attr-defined]
+    mot._gen.generate.cancel()  # type: ignore[attr-defined]
     try:
-        await asyncio.wait_for(mot._generate, timeout=1.0)  # type: ignore[attr-defined]
+        await asyncio.wait_for(mot._gen.generate, timeout=1.0)  # type: ignore[attr-defined]
     except (TimeoutError, asyncio.CancelledError):
         pass

--- a/test/core/test_logger_plugin_hooks.py
+++ b/test/core/test_logger_plugin_hooks.py
@@ -35,6 +35,8 @@ from mellea.core.base import (
     GenerateLog,
     GenerateType,
     ModelOutputThunk,
+    _CallInfo,
+    _GenerationState,
 )
 from mellea.core.utils import (
     MelleaLogger,
@@ -56,11 +58,13 @@ class _MockBackend(Backend):
 
     async def _generate_from_context(self, action, ctx, **kwargs):
         mot = MagicMock(spec=ModelOutputThunk)
+        mot._gen = _GenerationState()
+        mot._call = _CallInfo()
         glog = GenerateLog()
         glog.prompt = "mocked prompt"
         mot._generate_log = glog
         mot.parsed_repr = None
-        mot._start = datetime.datetime.now()
+        mot._gen.start = datetime.datetime.now()
 
         async def _avalue():
             return "mocked output"

--- a/test/core/test_model_output_thunk.py
+++ b/test/core/test_model_output_thunk.py
@@ -24,7 +24,7 @@ def test_model_output_thunk_copy(m_session: MelleaSession):
     copied = copy.copy(out)
 
     assert out is not copied
-    assert copied._generate is None
+    assert copied._gen.generate is None
     assert copied._meta is out._meta
 
     empty = ModelOutputThunk("")
@@ -37,7 +37,7 @@ def test_model_output_thunk_deepcopy(m_session: MelleaSession):
     deepcopied = copy.deepcopy(out)
 
     assert out is not deepcopied
-    assert deepcopied._generate is None
+    assert deepcopied._gen.generate is None
     assert deepcopied._meta is not out._meta
 
     empty = ModelOutputThunk("")

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -28,6 +28,8 @@ from mellea.core.base import (
     GenerateLog,
     GenerateType,
     ModelOutputThunk,
+    _CallInfo,
+    _GenerationState,
 )
 from mellea.core.requirement import Requirement, ValidationResult
 from mellea.plugins import HookType, PluginResult, hook, register
@@ -64,11 +66,13 @@ class _MockBackend(Backend):
 
     async def _generate_from_context(self, action, ctx, **kwargs):
         mot = MagicMock(spec=ModelOutputThunk)
+        mot._gen = _GenerationState()
+        mot._call = _CallInfo()
         glog = GenerateLog()
         glog.prompt = "mocked formatted prompt"
         mot._generate_log = glog
         mot.parsed_repr = None
-        mot._start = datetime.datetime.now()
+        mot._gen.start = datetime.datetime.now()
 
         async def _avalue():
             return "mocked output"
@@ -96,12 +100,12 @@ async def _noop_post_process(mot):
 
 def _make_thunk():
     mot = ModelOutputThunk(value=None)
-    mot._generate_type = GenerateType.ASYNC
-    mot._process = _noop_process
-    mot._post_process = _noop_post_process
-    mot._action = CBlock("test")
-    mot._chunk_size = 0
-    mot._start = datetime.datetime.now()
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.process = _noop_process
+    mot._gen.post_process = _noop_post_process
+    mot._call.action = CBlock("test")
+    mot._gen.chunk_size = 0
+    mot._gen.start = datetime.datetime.now()
     return mot
 
 
@@ -162,9 +166,9 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = _make_thunk()
-        await mot._async_queue.put("hello")
-        await mot._async_queue.put("goodbye")
-        await mot._async_queue.put(None)  # sentinel for being done
+        await mot._gen.queue.put("hello")
+        await mot._gen.queue.put("goodbye")
+        await mot._gen.queue.put(None)  # sentinel for being done
 
         await mot.avalue()
         assert len(observed) == 1
@@ -183,9 +187,9 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = _make_thunk()
-        await mot._async_queue.put("hello")
-        await mot._async_queue.put("goodbye")
-        await mot._async_queue.put(None)  # sentinel for being done
+        await mot._gen.queue.put("hello")
+        await mot._gen.queue.put("goodbye")
+        await mot._gen.queue.put(None)  # sentinel for being done
         await mot.avalue()
 
         assert observed[0].model_output is not None
@@ -202,9 +206,9 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = _make_thunk()
-        await mot._async_queue.put("hello")
-        await mot._async_queue.put("goodbye")
-        await mot._async_queue.put(None)  # sentinel for being done
+        await mot._gen.queue.put("hello")
+        await mot._gen.queue.put("goodbye")
+        await mot._gen.queue.put(None)  # sentinel for being done
 
         await asyncio.sleep(1)
         await mot.avalue()
@@ -323,7 +327,7 @@ class TestGenerationHookCallSites:
             CBlock("hi"), MagicMock(spec=Context)
         )
 
-        assert mot._generation_id == observed[0].generation_id
+        assert mot._call.generation_id == observed[0].generation_id
 
     async def test_generation_post_call_carries_generation_id(self) -> None:
         """astream() fires post_call with the MOT's _generation_id."""
@@ -337,9 +341,9 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = _make_thunk()
-        mot._generation_id = "gid-post-1"
-        await mot._async_queue.put("hello")
-        await mot._async_queue.put(None)
+        mot._call.generation_id = "gid-post-1"
+        await mot._gen.queue.put("hello")
+        await mot._gen.queue.put(None)
         await mot.avalue()
 
         assert observed[0].generation_id == "gid-post-1"
@@ -356,9 +360,9 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = _make_thunk()
-        mot._generation_id = "gid-err-1"
+        mot._call.generation_id = "gid-err-1"
         error = ConnectionError("server unavailable")
-        await mot._async_queue.put(error)
+        await mot._gen.queue.put(error)
 
         with pytest.raises(ConnectionError, match="server unavailable"):
             await mot.astream()
@@ -380,7 +384,7 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = ModelOutputThunk(value=None)
-        mot._generation_id = "gid-cancel-1"
+        mot._call.generation_id = "gid-cancel-1"
         cause = ValueError("validator rejected")
 
         await mot.cancel_generation(error=cause)
@@ -405,7 +409,7 @@ class TestGenerationHookCallSites:
         register(recorder)
 
         mot = ModelOutputThunk(value=None)
-        mot._generation_id = "gid-cancel-2"
+        mot._call.generation_id = "gid-cancel-2"
 
         await mot.cancel_generation()
 
@@ -1546,9 +1550,9 @@ class _MockLazyBackend(Backend):
         import asyncio
 
         mot = ModelOutputThunk(value=None)
-        mot._generate_type = GenerateType.ASYNC
-        mot._chunk_size = 0
-        mot._action = action
+        mot._gen.generate_type = GenerateType.ASYNC
+        mot._gen.chunk_size = 0
+        mot._call.action = action
 
         async def _process(thunk, chunk):
             if thunk._underlying_value is None:
@@ -1558,8 +1562,8 @@ class _MockLazyBackend(Backend):
         async def _post_process(thunk):
             pass
 
-        mot._process = _process
-        mot._post_process = _post_process
+        mot._gen.process = _process
+        mot._gen.post_process = _post_process
 
         glog = GenerateLog()
         glog.prompt = "lazy mocked prompt"
@@ -1567,10 +1571,10 @@ class _MockLazyBackend(Backend):
 
         # Simulate async generation: enqueue chunks + sentinel
         async def _generate():
-            await mot._async_queue.put("lazy output")
-            await mot._async_queue.put(None)  # sentinel
+            await mot._gen.queue.put("lazy output")
+            await mot._gen.queue.put(None)  # sentinel
 
-        mot._generate = asyncio.ensure_future(_generate())
+        mot._gen.generate = asyncio.ensure_future(_generate())
 
         return mot, SimpleContext()
 

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -51,11 +51,11 @@ async def _mock_post_process(_mot: ModelOutputThunk) -> None:
 
 def _make_mot() -> ModelOutputThunk:
     mot = ModelOutputThunk(value=None)
-    mot._action = CBlock("mock_action")
-    mot._generate_type = GenerateType.ASYNC
-    mot._process = _mock_process
-    mot._post_process = _mock_post_process
-    mot._chunk_size = 0
+    mot._call.action = CBlock("mock_action")
+    mot._gen.generate_type = GenerateType.ASYNC
+    mot._gen.process = _mock_process
+    mot._gen.post_process = _mock_post_process
+    mot._gen.chunk_size = 0
     return mot
 
 
@@ -63,10 +63,10 @@ async def _feed_tokens(mot: ModelOutputThunk, response: str, token_size: int) ->
     i = 0
     while i < len(response):
         token = response[i : i + token_size]
-        await mot._async_queue.put(token)
+        await mot._gen.queue.put(token)
         await asyncio.sleep(0)
         i += token_size
-    await mot._async_queue.put(None)
+    await mot._gen.queue.put(None)
 
 
 class StreamingMockBackend(Backend):

--- a/test/telemetry/test_tracing_application.py
+++ b/test/telemetry/test_tracing_application.py
@@ -26,7 +26,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from mellea.core.backend import Backend
-from mellea.core.base import GenerateLog, ModelOutputThunk
+from mellea.core.base import GenerateLog, ModelOutputThunk, _CallInfo, _GenerationState
 from mellea.stdlib.components import Message
 from mellea.stdlib.context import SimpleContext
 from mellea.stdlib.session import MelleaSession, start_session
@@ -107,11 +107,13 @@ class _MockBackend(Backend):
 
     async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
         mot = MagicMock(spec=ModelOutputThunk)
+        mot._gen = _GenerationState()
+        mot._call = _CallInfo()
         glog = GenerateLog()
         glog.prompt = "mocked formatted prompt"
         mot._generate_log = glog
         mot.parsed_repr = None
-        mot._start = datetime.datetime.now()
+        mot._gen.start = datetime.datetime.now()
 
         async def _avalue() -> str:
             return "mocked output"

--- a/test/telemetry/test_tracing_setters.py
+++ b/test/telemetry/test_tracing_setters.py
@@ -154,8 +154,8 @@ def test_set_mellea_attrs_action_class_name_from_action():
         pass
 
     mot = MagicMock()
-    mot._action = MyAction()
-    mot._context = None
+    mot._call.action = MyAction()
+    mot._call.context = None
     gen = GenerationMetadata(model="m", provider="p")
     set_mellea_attrs(span, mot, gen)
     attrs = _attrs(span)
@@ -177,13 +177,13 @@ def test_set_mellea_attrs_context_size():
 
     span = MagicMock()
     mot = MagicMock()
-    mot._action = None
-    mot._context = [1, 2, 3]
+    mot._call.action = None
+    mot._call.context = [1, 2, 3]
     set_mellea_attrs(span, mot, gen)
     assert _attrs(span)["mellea.context_size"] == 3
 
     span = MagicMock()
-    mot._context = None
+    mot._call.context = None
     set_mellea_attrs(span, mot, gen)
     assert _attrs(span)["mellea.context_size"] == 0
 
@@ -191,8 +191,8 @@ def test_set_mellea_attrs_context_size():
 def test_set_mellea_attrs_streaming_conditional():
     """`mellea.streaming` is emitted only when streaming is truthy."""
     mot = MagicMock()
-    mot._action = None
-    mot._context = None
+    mot._call.action = None
+    mot._call.context = None
 
     span = MagicMock()
     set_mellea_attrs(


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1216
Fixes #909 (closes the Epic as this is the last sub issue)

## Description
Final area (Area 3) of the ModelOutputThunk structural cleanup epic (#909).

`ModelOutputThunk.__init__` set a flat list of private attributes; `__copy__` and `__deepcopy__` each enumerated them field-by-field, deciding per-field whether to preserve (originating-call data) or reset (in-flight machinery). This made adding a field a multi-method edit governed only by inline comments.

This groups them into two dataclasses:

- **`_CallInfo`** — originating-call data (`action`, `context`, `model_options`, `generation_id`), preserved across copies.
- **`_GenerationState`** — in-flight machinery (`queue`, `chunk_size`, `first_chunk_received`, `generate`, `generate_type`, `generate_extra`, `cancel_hook`, `process`, `post_process`, `on_computed`, `start`), reset on copy.

`__copy__` / `__deepcopy__` collapse to a single `_call` copy plus the fresh `_gen` from `__init__`, and both now raise `RuntimeError` on an uncomputed thunk (copies are only valid post-generation). `_computed`, `_cancelled`, `_error`, `_generate_log`, and `_thinking` stay flat — they back status flags or public properties (`mot.error`, `mot.generate_log`), not call inputs.

All internal access sites migrated across `mellea/` and `test/`. Every renamed symbol is private and read only within `mellea/`, so no public API changes and no deprecation aliases are needed.

> **Note — coordination with other open MOT PRs:** two open PRs restructure the same `ModelOutputThunk`, so whichever merges second will need a rebase:
> - **#1315** (Area 4: `_thinking` → public `mot.thinking`) edits the same `__copy__` / `__deepcopy__` / `_copy_from` methods. This PR leaves `_thinking` flat and unchanged, so the overlap is limited to those `_thinking` lines.
> - **#1348** (MOT as a separate class, #269) reshapes the `ModelOutputThunk` definition itself; it will need to absorb the `_call` / `_gen` split into the new class layout.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

New tests in `test/core/test_base.py`: copy/deepcopy of an uncomputed MOT raises; deepcopy of a computed MOT yields a fresh `_gen` and preserves `_call`.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
