### PR TITLE
fix: add Python code extraction from tool_calls in PythonCodeExtraction validator 

### DIFF
--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -1,6 +1,7 @@
 """Requirements for Python code generation validation."""
 
 import dataclasses
+import re
 import warnings
 from collections.abc import Callable
 from typing import Literal
@@ -68,7 +69,7 @@ def _score_code_block(code: str) -> int:
 def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
     """Extract Python code from a tool call's arguments using heuristic field lookup.
 
-    Matches tools with "python" in their name, including: standalone "python", "python_tool",
+    Matches tools with "python" in their name, including: standalone "python"
     or "python" paired with execution keywords (executor, interpreter, runner).
     This conservative approach avoids extracting unrelated data from arbitrary tools.
 
@@ -82,17 +83,9 @@ def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
         str | None: Extracted code string, or None if not found, not a string, or tool
             name doesn't suggest it handles Python code execution.
     """
-    # Only attempt extraction from tools that explicitly handle Python
-    if not hasattr(tool_call, "name"):
-        logger.debug("Tool call missing 'name' attribute, skipping extraction")
-        return None
-
     tool_name_lower = tool_call.name.lower()
     if tool_name_lower == "python":
         # Standalone "python" tool is a strong match
-        pass
-    elif tool_name_lower == "python_tool":
-        # "python_tool" from mellea is a strong match
         pass
     elif "python" in tool_name_lower and any(
         keyword in tool_name_lower for keyword in ["executor", "interpreter", "runner"]
@@ -103,19 +96,6 @@ def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
         logger.debug(
             "Tool name '%s' does not match python execution pattern, skipping extraction",
             tool_call.name,
-        )
-        return None
-
-    if not hasattr(tool_call, "args"):
-        logger.debug(
-            "Tool call '%s' missing 'args' attribute, skipping extraction",
-            tool_call.name,
-        )
-        return None
-
-    if tool_call.args is None:
-        logger.debug(
-            "Tool call '%s' has None args, skipping extraction", tool_call.name
         )
         return None
 
@@ -173,8 +153,6 @@ def _has_python_code_listing(ctx: Context) -> ValidationResult:
         content = last_output.value
 
         # Look for code blocks with python specifier
-        import re
-
         # Pattern for ```python / `python blocks (Markdown and RST)
         python_blocks = re.findall(r"```?python\s*\n(.*?)\n```?", content, re.DOTALL)
 
@@ -196,7 +174,7 @@ def _has_python_code_listing(ctx: Context) -> ValidationResult:
 
     # Step 2: Fallback to tool_calls if no text code found
     if not all_blocks and last_output.tool_calls:
-        for tool_name, tool_call in last_output.tool_calls.items():
+        for tool_call in last_output.tool_calls.values():
             extracted = _extract_code_from_tool_call(tool_call)
             if extracted:
                 # Score tool_call code with +5 bonus (vs +10 for text python blocks).

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -177,9 +177,10 @@ def _has_python_code_listing(ctx: Context) -> ValidationResult:
         for tool_call in last_output.tool_calls.values():
             extracted = _extract_code_from_tool_call(tool_call)
             if extracted:
-                # Score tool_call code with +5 bonus (vs +10 for text python blocks).
-                # This keeps tool_calls below text-visible code in priority, while above
-                # generic text blocks. Text blocks are preferred since they're visible to users.
+                # Tool_calls are a fallback: only reached when text yields no code blocks
+                # (see the `if not all_blocks` guard above). The +5 here only orders
+                # multiple tool_calls relative to each other; it never competes with text
+                # scores. Text is always preferred since it's visible to users.
                 all_blocks.append((extracted, _score_code_block(extracted) + 5))
 
     if not all_blocks:

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -16,7 +16,7 @@ from mellea.stdlib.tools.interpreter import (
     make_execution_environment,
 )
 
-from ...core import Context, MelleaLogger, Requirement, ValidationResult
+from ...core import Context, MelleaLogger, ModelToolCall, Requirement, ValidationResult
 
 logger = MelleaLogger.get_logger()
 
@@ -65,37 +65,96 @@ def _score_code_block(code: str) -> int:
     return score
 
 
+def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
+    """Extract Python code from a tool call's arguments using heuristic field lookup.
+
+    Only attempts extraction from tools with "python" in their name (case-insensitive).
+    This conservative approach avoids extracting unrelated data from arbitrary tools.
+
+    Tries common code field names in order: 'code', 'script', 'command', 'source'.
+    Returns the first string value found, or None if no code-like field exists.
+
+    Args:
+        tool_call: The ModelToolCall to extract code from.
+
+    Returns:
+        str | None: Extracted code string, or None if not found, not a string, or tool
+            name doesn't suggest it handles Python.
+    """
+    # Only attempt extraction from tools that explicitly handle Python
+    if not hasattr(tool_call, "name") or "python" not in tool_call.name.lower():
+        return None
+
+    if not hasattr(tool_call, "args") or tool_call.args is None:
+        return None
+
+    # Try common field names in priority order
+    field_names = ["code", "script", "command", "source"]
+    for field in field_names:
+        if field in tool_call.args:
+            value = tool_call.args[field]
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    return None
+
+
 def _has_python_code_listing(ctx: Context) -> ValidationResult:
-    """Extract Python code from context."""
+    """Extract Python code from context, checking both text blocks and tool_calls.
+
+    First attempts to extract code from text output (markdown/rst code blocks).
+    If no text code is found, falls back to tool_calls (if present), using a
+    heuristic search for code-like argument fields in Python-capable tools.
+
+    Text-based extraction has higher priority than tool_calls to preserve
+    user-visible code in the response. Tool extraction only targets tools with
+    "python" in their name (case-insensitive).
+
+    Args:
+        ctx: Context containing model output.
+
+    Returns:
+        ValidationResult with extracted code or failure reason.
+    """
     last_output = ctx.last_output()
-    if last_output is None or last_output.value is None:
+    if last_output is None:
         return ValidationResult(result=False, reason="No output found in context")
 
-    content = last_output.value
+    all_blocks: list[tuple[str, int]] = []
 
-    # Look for code blocks with python specifier
-    import re
+    # Step 1: Try extracting from text content (highest priority)
+    if last_output.value is not None:
+        content = last_output.value
 
-    # Pattern for ``python / ```python blocks (RST and Markdown)
-    python_blocks = re.findall(r"```?python\s*\n(.*?)\n```?", content, re.DOTALL)
+        # Look for code blocks with python specifier
+        import re
 
-    # Pattern for generic `` / ``` blocks (RST and Markdown)
-    generic_blocks = re.findall(r"```?\s*\n(.*?)\n```?", content, re.DOTALL)
+        # Pattern for ```python / `python blocks (Markdown and RST)
+        python_blocks = re.findall(r"```?python\s*\n(.*?)\n```?", content, re.DOTALL)
 
-    all_blocks = []
+        # Pattern for generic ``` / ` blocks (Markdown and RST)
+        generic_blocks = re.findall(r"```?\s*\n(.*?)\n```?", content, re.DOTALL)
 
-    # Add python blocks with high priority
-    for block in python_blocks:
-        all_blocks.append((block.strip(), _score_code_block(block.strip()) + 10))
+        # Add python blocks with high priority
+        for block in python_blocks:
+            all_blocks.append((block.strip(), _score_code_block(block.strip()) + 10))
 
-    # Add generic blocks if they look like Python
-    for block in generic_blocks:
-        block = block.strip()
-        if block and any(
-            keyword in block
-            for keyword in ["def ", "class ", "import ", "print(", "if __name__"]
-        ):
-            all_blocks.append((block, _score_code_block(block)))
+        # Add generic blocks if they look like Python
+        for block in generic_blocks:
+            block = block.strip()
+            if block and any(
+                keyword in block
+                for keyword in ["def ", "class ", "import ", "print(", "if __name__"]
+            ):
+                all_blocks.append((block, _score_code_block(block)))
+
+    # Step 2: Fallback to tool_calls if no text code found
+    if not all_blocks and last_output.tool_calls:
+        for tool_name, tool_call in last_output.tool_calls.items():
+            extracted = _extract_code_from_tool_call(tool_call)
+            if extracted:
+                # Score tool_call code slightly lower than text blocks to preserve priority
+                all_blocks.append((extracted, _score_code_block(extracted) + 5))
 
     if not all_blocks:
         return ValidationResult(result=False, reason="No Python code blocks found")

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -68,7 +68,8 @@ def _score_code_block(code: str) -> int:
 def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
     """Extract Python code from a tool call's arguments using heuristic field lookup.
 
-    Only attempts extraction from tools with "python" in their name (case-insensitive).
+    Matches tools with "python" in their name, including: standalone "python", "python_tool",
+    or "python" paired with execution keywords (executor, interpreter, runner).
     This conservative approach avoids extracting unrelated data from arbitrary tools.
 
     Tries common code field names in order: 'code', 'script', 'command', 'source'.
@@ -79,13 +80,43 @@ def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
 
     Returns:
         str | None: Extracted code string, or None if not found, not a string, or tool
-            name doesn't suggest it handles Python.
+            name doesn't suggest it handles Python code execution.
     """
     # Only attempt extraction from tools that explicitly handle Python
-    if not hasattr(tool_call, "name") or "python" not in tool_call.name.lower():
+    if not hasattr(tool_call, "name"):
+        logger.debug("Tool call missing 'name' attribute, skipping extraction")
         return None
 
-    if not hasattr(tool_call, "args") or tool_call.args is None:
+    tool_name_lower = tool_call.name.lower()
+    if tool_name_lower == "python":
+        # Standalone "python" tool is a strong match
+        pass
+    elif tool_name_lower == "python_tool":
+        # "python_tool" from mellea is a strong match
+        pass
+    elif "python" in tool_name_lower and any(
+        keyword in tool_name_lower for keyword in ["executor", "interpreter", "runner"]
+    ):
+        # "python" paired with execution keywords is a strong match
+        pass
+    else:
+        logger.debug(
+            "Tool name '%s' does not match python execution pattern, skipping extraction",
+            tool_call.name,
+        )
+        return None
+
+    if not hasattr(tool_call, "args"):
+        logger.debug(
+            "Tool call '%s' missing 'args' attribute, skipping extraction",
+            tool_call.name,
+        )
+        return None
+
+    if tool_call.args is None:
+        logger.debug(
+            "Tool call '%s' has None args, skipping extraction", tool_call.name
+        )
         return None
 
     # Try common field names in priority order
@@ -94,8 +125,23 @@ def _extract_code_from_tool_call(tool_call: ModelToolCall) -> str | None:
         if field in tool_call.args:
             value = tool_call.args[field]
             if isinstance(value, str) and value.strip():
+                logger.debug(
+                    "Extracted code from tool '%s' field '%s'", tool_call.name, field
+                )
                 return value.strip()
+            if not isinstance(value, str):
+                logger.debug(
+                    "Tool '%s' field '%s' is not a string (type: %s), skipping",
+                    tool_call.name,
+                    field,
+                    type(value).__name__,
+                )
 
+    logger.debug(
+        "No code-like fields found in tool '%s' args (available fields: %s)",
+        tool_call.name,
+        list(tool_call.args.keys()),
+    )
     return None
 
 
@@ -153,7 +199,9 @@ def _has_python_code_listing(ctx: Context) -> ValidationResult:
         for tool_name, tool_call in last_output.tool_calls.items():
             extracted = _extract_code_from_tool_call(tool_call)
             if extracted:
-                # Score tool_call code slightly lower than text blocks to preserve priority
+                # Score tool_call code with +5 bonus (vs +10 for text python blocks).
+                # This keeps tool_calls below text-visible code in priority, while above
+                # generic text blocks. Text blocks are preferred since they're visible to users.
                 all_blocks.append((extracted, _score_code_block(extracted) + 5))
 
     if not all_blocks:

--- a/test/stdlib/requirements/test_python_tools.py
+++ b/test/stdlib/requirements/test_python_tools.py
@@ -648,31 +648,41 @@ class TestToolCallsCodeExtraction:
         result = _extract_code_from_tool_call(tool_call)
         assert result == "print('case-insensitive')"
 
+    def test_extract_code_python_runner_keyword(self):
+        """Test extraction from tool with 'python' + 'runner' keyword."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_runner", func=python_tool, args={"code": "print('runner')"}
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result == "print('runner')"
+
     def test_extract_code_tries_field_names_in_order(self):
         """Test that common field names are tried in priority order."""
         python_tool = MockPythonTool()
 
         # Test 'code' field (highest priority)
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"code": "print('code')"}
+            name="python", func=python_tool, args={"code": "print('code')"}
         )
         assert _extract_code_from_tool_call(tool_call) == "print('code')"
 
         # Test 'script' field (second priority)
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"script": "print('script')"}
+            name="python", func=python_tool, args={"script": "print('script')"}
         )
         assert _extract_code_from_tool_call(tool_call) == "print('script')"
 
         # Test 'command' field (third priority)
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"command": "print('command')"}
+            name="python", func=python_tool, args={"command": "print('command')"}
         )
         assert _extract_code_from_tool_call(tool_call) == "print('command')"
 
         # Test 'source' field (fourth priority)
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"source": "print('source')"}
+            name="python", func=python_tool, args={"source": "print('source')"}
         )
         assert _extract_code_from_tool_call(tool_call) == "print('source')"
 
@@ -680,7 +690,7 @@ class TestToolCallsCodeExtraction:
         """Test extraction returns None when no code fields are present."""
         python_tool = MockPythonTool()
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"other_field": "value"}
+            name="python", func=python_tool, args={"other_field": "value"}
         )
 
         result = _extract_code_from_tool_call(tool_call)
@@ -690,7 +700,7 @@ class TestToolCallsCodeExtraction:
         """Test extraction ignores non-string field values."""
         python_tool = MockPythonTool()
         tool_call = ModelToolCall(
-            name="python_tool",
+            name="python",
             func=python_tool,
             args={"code": 123, "script": None, "command": ["list"]},
         )
@@ -714,13 +724,11 @@ class TestToolCallsCodeExtraction:
         """Test extraction ignores empty or whitespace-only strings."""
         python_tool = MockPythonTool()
 
-        tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"code": ""}
-        )
+        tool_call = ModelToolCall(name="python", func=python_tool, args={"code": ""})
         assert _extract_code_from_tool_call(tool_call) is None
 
         tool_call = ModelToolCall(
-            name="python_tool", func=python_tool, args={"code": "   \n  \t  "}
+            name="python", func=python_tool, args={"code": "   \n  \t  "}
         )
         assert _extract_code_from_tool_call(tool_call) is None
 
@@ -786,6 +794,88 @@ class TestToolCallsCodeExtraction:
 
         assert result.as_bool() is True
         assert "factorial" in (result.reason or "")
+
+    def test_code_priority_ordering(self):
+        """Test that code blocks are prioritized: python_text > tool_call > generic_text.
+
+        Scoring breakdown:
+        - ```python block: base_score + 10 (highest)
+        - tool_call code: base_score + 5 (middle)
+        - generic ``` block: base_score + 0 (lowest)
+
+        This test verifies the ordering by providing multiple code sources
+        with similar complexity, ensuring the highest-priority source wins.
+        """
+        python_tool = MockPythonTool()
+
+        # Generic text block (lowest priority): simple one-liner
+        # Score: min(1, 10) + 0 = 1
+        generic_code = "x = 1"
+
+        # Tool call code (middle priority): similar complexity
+        # Score: min(1, 10) + 5 = 6
+        tool_call = ModelToolCall(
+            name="python_executor", func=python_tool, args={"code": "y = 2"}
+        )
+
+        # Python text block (highest priority): similar complexity
+        # Score: min(1, 10) + 10 = 11
+        python_text = "```python\nz = 3\n```"
+
+        text_content = f"{generic_code}\n\n{python_text}"
+        ctx = from_model_with_tool_calls(
+            text_content=text_content, tool_calls_dict={"python_executor": tool_call}
+        )
+
+        req = PythonCodeExtraction()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+        # Should extract the python_text block (z = 3), not generic_code or tool_call
+        assert "z = 3" in (result.reason or "")
+        assert "x = 1" not in (result.reason or "")
+        assert "y = 2" not in (result.reason or "")
+
+    def test_generic_text_blocks_fallback_tier(self):
+        """Test that generic text blocks (score + 0) are extracted when available.
+
+        The code extraction hierarchy is:
+        1. Text blocks marked ```python (score + 10)
+        2. Generic text blocks that look like Python (score + 0) - patterns: def/class/import/print
+        3. Tool call code (score + 5) - only used if both 1 and 2 are absent
+
+        When both generic text blocks and tool_calls are present, generic blocks
+        take priority because they're extracted as part of text processing before
+        tool_calls are considered. Tool calls are only checked if all_blocks is empty.
+        """
+        python_tool = MockPythonTool()
+
+        # Generic text block (looks like Python): contains "import" keyword
+        text_content = """
+Some explanation text
+```
+import os
+```
+More text here
+"""
+
+        # Tool call code (would score +5 if used)
+        tool_call = ModelToolCall(
+            name="python_executor", func=python_tool, args={"code": "import sys"}
+        )
+
+        ctx = from_model_with_tool_calls(
+            text_content=text_content, tool_calls_dict={"python_executor": tool_call}
+        )
+
+        req = PythonCodeExtraction()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+        # Generic text block is extracted (it's detected as Python-like)
+        assert "import os" in (result.reason or "")
+        # Tool call is NOT used because generic text block was found
+        assert "import sys" not in (result.reason or "")
 
     def test_syntax_validation_with_tool_calls_code(self):
         """Test syntax validation works with code from tool_calls."""

--- a/test/stdlib/requirements/test_python_tools.py
+++ b/test/stdlib/requirements/test_python_tools.py
@@ -25,14 +25,14 @@ def from_model(content: str) -> Context:
 class MockPythonTool(AbstractMelleaTool):
     """Mock Python tool for testing."""
 
-    name = "python_executor"
+    name: str = "python_executor"
 
     def run(self, code: str) -> str:
         """Mock execution."""
         return f"executed: {code}"
 
     @property
-    def as_json_tool(self) -> dict:
+    def as_json_tool(self) -> dict[str, str]:
         """Return tool schema."""
         return {"name": self.name, "description": "Mock Python tool"}
 
@@ -40,22 +40,31 @@ class MockPythonTool(AbstractMelleaTool):
 class MockBashTool(AbstractMelleaTool):
     """Mock Bash tool for testing."""
 
-    name = "bash_executor"
+    name: str = "bash_executor"
 
     def run(self, command: str) -> str:
         """Mock execution."""
         return f"executed: {command}"
 
     @property
-    def as_json_tool(self) -> dict:
+    def as_json_tool(self) -> dict[str, str]:
         """Return tool schema."""
         return {"name": self.name, "description": "Mock Bash tool"}
 
 
 def from_model_with_tool_calls(
-    text_content: str | None = None, tool_calls_dict: dict | None = None
+    text_content: str | None = None,
+    tool_calls_dict: dict[str, ModelToolCall] | None = None,
 ) -> Context:
-    """Helper to create context with both text and tool_calls."""
+    """Helper to create context with both text and tool_calls.
+
+    Args:
+        text_content: Optional text content for the model output.
+        tool_calls_dict: Optional dict mapping tool names to ModelToolCall objects.
+
+    Returns:
+        Context with ModelOutputThunk containing both text and tool_calls.
+    """
     ctx = ChatContext()
     ctx = ctx.add(ModelOutputThunk(value=text_content, tool_calls=tool_calls_dict))
     return ctx
@@ -693,7 +702,7 @@ class TestToolCallsCodeExtraction:
         """Test extracted code is stripped of leading/trailing whitespace."""
         python_tool = MockPythonTool()
         tool_call = ModelToolCall(
-            name="python_tool",
+            name="python_executor",
             func=python_tool,
             args={"code": "  \n  print('hello')  \n  "},
         )
@@ -819,11 +828,11 @@ class TestToolCallsCodeExtraction:
         """Test import restrictions work with code from tool_calls."""
         python_tool = MockPythonTool()
         tool_call = ModelToolCall(
-            name="python_tool",
+            name="python_executor",
             func=python_tool,
             args={"code": "import os\nimport sys\nprint(os.getcwd())"},
         )
-        tool_calls_dict = {"python_tool": tool_call}
+        tool_calls_dict = {"python_executor": tool_call}
 
         ctx = from_model_with_tool_calls(
             text_content=None, tool_calls_dict=tool_calls_dict
@@ -837,11 +846,11 @@ class TestToolCallsCodeExtraction:
         """Test import restrictions catch forbidden imports in tool_calls code."""
         python_tool = MockPythonTool()
         tool_call = ModelToolCall(
-            name="python_tool",
+            name="python_executor",
             func=python_tool,
             args={"code": "import subprocess\nprint('dangerous')"},
         )
-        tool_calls_dict = {"python_tool": tool_call}
+        tool_calls_dict = {"python_executor": tool_call}
 
         ctx = from_model_with_tool_calls(
             text_content=None, tool_calls_dict=tool_calls_dict

--- a/test/stdlib/requirements/test_python_tools.py
+++ b/test/stdlib/requirements/test_python_tools.py
@@ -2,8 +2,10 @@
 
 import pytest
 
-from mellea.core import Context, ModelOutputThunk
+from mellea.core import Context, ModelOutputThunk, ModelToolCall
+from mellea.core.base import AbstractMelleaTool
 from mellea.stdlib.context import ChatContext
+from mellea.stdlib.requirements.python_reqs import _extract_code_from_tool_call
 from mellea.stdlib.requirements.python_tools import (
     ImportRestrictions,
     OutputSizeLimit,
@@ -17,6 +19,45 @@ def from_model(content: str) -> Context:
     """Helper to create context from model output."""
     ctx = ChatContext()
     ctx = ctx.add(ModelOutputThunk(value=content))
+    return ctx
+
+
+class MockPythonTool(AbstractMelleaTool):
+    """Mock Python tool for testing."""
+
+    name = "python_executor"
+
+    def run(self, code: str) -> str:
+        """Mock execution."""
+        return f"executed: {code}"
+
+    @property
+    def as_json_tool(self) -> dict:
+        """Return tool schema."""
+        return {"name": self.name, "description": "Mock Python tool"}
+
+
+class MockBashTool(AbstractMelleaTool):
+    """Mock Bash tool for testing."""
+
+    name = "bash_executor"
+
+    def run(self, command: str) -> str:
+        """Mock execution."""
+        return f"executed: {command}"
+
+    @property
+    def as_json_tool(self) -> dict:
+        """Return tool schema."""
+        return {"name": self.name, "description": "Mock Bash tool"}
+
+
+def from_model_with_tool_calls(
+    text_content: str | None = None, tool_calls_dict: dict | None = None
+) -> Context:
+    """Helper to create context with both text and tool_calls."""
+    ctx = ChatContext()
+    ctx = ctx.add(ModelOutputThunk(value=text_content, tool_calls=tool_calls_dict))
     return ctx
 
 
@@ -561,3 +602,252 @@ class TestPythonToolRequirementsFactory:
         # Description should reflect the allowed list
         assert "os" in import_req.description
         assert "sys" in import_req.description
+
+
+class TestToolCallsCodeExtraction:
+    """Tests for Python code extraction from tool_calls."""
+
+    def test_extract_code_from_python_tool_by_name(self):
+        """Test extraction from tool with 'python' in name."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_executor", func=python_tool, args={"code": "print('hello')"}
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result == "print('hello')"
+
+    def test_extract_code_ignores_non_python_tools(self):
+        """Test extraction ignores tools without 'python' in name."""
+        bash_tool = MockBashTool()
+        tool_call = ModelToolCall(
+            name="bash_executor", func=bash_tool, args={"command": "echo hello"}
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result is None
+
+    def test_extract_code_case_insensitive_python_match(self):
+        """Test tool name matching is case-insensitive."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="PYTHON_Interpreter",
+            func=python_tool,
+            args={"code": "print('case-insensitive')"},
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result == "print('case-insensitive')"
+
+    def test_extract_code_tries_field_names_in_order(self):
+        """Test that common field names are tried in priority order."""
+        python_tool = MockPythonTool()
+
+        # Test 'code' field (highest priority)
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"code": "print('code')"}
+        )
+        assert _extract_code_from_tool_call(tool_call) == "print('code')"
+
+        # Test 'script' field (second priority)
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"script": "print('script')"}
+        )
+        assert _extract_code_from_tool_call(tool_call) == "print('script')"
+
+        # Test 'command' field (third priority)
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"command": "print('command')"}
+        )
+        assert _extract_code_from_tool_call(tool_call) == "print('command')"
+
+        # Test 'source' field (fourth priority)
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"source": "print('source')"}
+        )
+        assert _extract_code_from_tool_call(tool_call) == "print('source')"
+
+    def test_extract_code_returns_none_for_missing_fields(self):
+        """Test extraction returns None when no code fields are present."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"other_field": "value"}
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result is None
+
+    def test_extract_code_returns_none_for_non_string_values(self):
+        """Test extraction ignores non-string field values."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_tool",
+            func=python_tool,
+            args={"code": 123, "script": None, "command": ["list"]},
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result is None
+
+    def test_extract_code_strips_whitespace(self):
+        """Test extracted code is stripped of leading/trailing whitespace."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_tool",
+            func=python_tool,
+            args={"code": "  \n  print('hello')  \n  "},
+        )
+
+        result = _extract_code_from_tool_call(tool_call)
+        assert result == "print('hello')"
+
+    def test_extract_code_ignores_empty_strings(self):
+        """Test extraction ignores empty or whitespace-only strings."""
+        python_tool = MockPythonTool()
+
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"code": ""}
+        )
+        assert _extract_code_from_tool_call(tool_call) is None
+
+        tool_call = ModelToolCall(
+            name="python_tool", func=python_tool, args={"code": "   \n  \t  "}
+        )
+        assert _extract_code_from_tool_call(tool_call) is None
+
+    def test_extraction_from_tool_calls_in_context(self):
+        """Test extraction of code from tool_calls in ModelOutputThunk."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_executor",
+            func=python_tool,
+            args={"code": "x = 1 + 1\nprint(x)"},
+        )
+        tool_calls_dict = {"python_executor": tool_call}
+
+        ctx = from_model_with_tool_calls(
+            text_content=None, tool_calls_dict=tool_calls_dict
+        )
+        req = PythonCodeExtraction()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+        assert "x = 1 + 1" in (result.reason or "")
+
+    def test_text_code_takes_priority_over_tool_calls(self):
+        """Test that text code blocks are prioritized over tool_calls."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_executor",
+            func=python_tool,
+            args={"code": "print('from tool')"},
+        )
+        tool_calls_dict = {"python_executor": tool_call}
+
+        text_content = "```python\nprint('from text')\n```"
+        ctx = from_model_with_tool_calls(
+            text_content=text_content, tool_calls_dict=tool_calls_dict
+        )
+        req = PythonCodeExtraction()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+        # Should extract text code, not tool_calls code
+        assert "from text" in (result.reason or "")
+        assert "from tool" not in (result.reason or "")
+
+    def test_tool_calls_fallback_when_no_text_code(self):
+        """Test that tool_calls are used when no text code blocks exist."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_interpreter",
+            func=python_tool,
+            args={
+                "code": "def factorial(n):\n    return n * factorial(n-1) if n > 1 else 1"
+            },
+        )
+        tool_calls_dict = {"python_interpreter": tool_call}
+
+        text_content = "Here's a function to compute factorials:"
+        ctx = from_model_with_tool_calls(
+            text_content=text_content, tool_calls_dict=tool_calls_dict
+        )
+        req = PythonCodeExtraction()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+        assert "factorial" in (result.reason or "")
+
+    def test_syntax_validation_with_tool_calls_code(self):
+        """Test syntax validation works with code from tool_calls."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_executor",
+            func=python_tool,
+            args={"code": "def valid_func():\n    return 42"},
+        )
+        tool_calls_dict = {"python_executor": tool_call}
+
+        ctx = from_model_with_tool_calls(
+            text_content=None, tool_calls_dict=tool_calls_dict
+        )
+        req = PythonSyntaxValid()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+
+    def test_syntax_validation_catches_errors_in_tool_calls_code(self):
+        """Test syntax validation catches errors in tool_calls code."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_executor",
+            func=python_tool,
+            args={"code": "def invalid_func(\n    return 42"},
+        )
+        tool_calls_dict = {"python_executor": tool_call}
+
+        ctx = from_model_with_tool_calls(
+            text_content=None, tool_calls_dict=tool_calls_dict
+        )
+        req = PythonSyntaxValid()
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is False
+        assert "syntax error" in (result.reason or "").lower()
+
+    def test_import_validation_with_tool_calls_code(self):
+        """Test import restrictions work with code from tool_calls."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_tool",
+            func=python_tool,
+            args={"code": "import os\nimport sys\nprint(os.getcwd())"},
+        )
+        tool_calls_dict = {"python_tool": tool_call}
+
+        ctx = from_model_with_tool_calls(
+            text_content=None, tool_calls_dict=tool_calls_dict
+        )
+        req = ImportRestrictions(allowed_imports=["os", "sys"])
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is True
+
+    def test_import_validation_catches_forbidden_in_tool_calls(self):
+        """Test import restrictions catch forbidden imports in tool_calls code."""
+        python_tool = MockPythonTool()
+        tool_call = ModelToolCall(
+            name="python_tool",
+            func=python_tool,
+            args={"code": "import subprocess\nprint('dangerous')"},
+        )
+        tool_calls_dict = {"python_tool": tool_call}
+
+        ctx = from_model_with_tool_calls(
+            text_content=None, tool_calls_dict=tool_calls_dict
+        )
+        req = ImportRestrictions(allowed_imports=["os"])
+        result = req.validation_fn(ctx)
+
+        assert result.as_bool() is False
+        assert "subprocess" in (result.reason or "")


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1352 

## Description
<!-- What does this PR do and why? -->
Extends the PythonCodeExtraction validator to extract and analyze Python code from LLM tool_calls, not just response body text. When tool_use=True is enabled in model requests, Python code is often placed in tool arguments—this change ensures such code is captured and validated.

Changes

- New function _extract_code_from_tool_call() in mellea/stdlib/requirements/python_reqs.py
  - Extracts Python code from ModelToolCall objects with intelligent tool name matching
  - Supports tools named "python", "python_tool", or "python" + execution keywords (executor, interpreter, runner)
  - Tries common code field names in priority order: code, script, command, source
  - Includes detailed debug logging for filtering and extraction diagnostics
- Enhanced _has_python_code_listing() to check both text blocks and tool_calls
  - Collects code from both sources with priority scoring (+10 for text, +5 for tool_calls)
  - Improves clarity in docstring and comments about scoring rationale


### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

- Comprehensive test coverage in test/stdlib/requirements/test_python_tools.py
  - Tests for tool name pattern matching (Python, python_tool, python_executor, etc.)
  - Tests for field extraction (code, script, command, source)
  - Tests for whitespace handling and non-string field rejection
  - Tests for integration with ImportRestrictions and OutputSizeLimit validators
  - Tests for cross-requirement validation scenarios
   
### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
