### PR TITLE
fix: plugin scope to handle list parameters

### DIFF
--- a/mellea/plugins/registry.py
+++ b/mellea/plugins/registry.py
@@ -511,12 +511,20 @@ def unregister(
             _unregister_single(pm, item)
 
 
-def plugin_scope(*items: Callable | Any | PluginSet) -> _PluginScope:
+def plugin_scope(
+    *items: Callable | Any | PluginSet | list[Callable | Any | PluginSet],
+) -> _PluginScope:
     """Return a context manager that temporarily registers plugins for a block of code.
 
     Accepts the same items as `register()`: standalone `@hook`-decorated
     functions, `@plugin`-decorated class instances, `MelleaPlugin` instances,
-    and `PluginSet` instances — or any mix thereof.
+    `PluginSet` instances, or a list of any combination — passed either as
+    varargs or as a single list, mirroring `register()`:
+
+        with plugin_scope(log_hook, audit_plugin):  # varargs
+            ...
+        with plugin_scope([log_hook, audit_plugin]):  # single list
+            ...
 
     Supports both synchronous and asynchronous `with` statements::
 
@@ -529,10 +537,16 @@ def plugin_scope(*items: Callable | Any | PluginSet) -> _PluginScope:
             result, ctx = await ainstruct("Generate code", ctx, backend)
 
     Args:
-        *items: One or more plugins to register for the duration of the block.
+        *items: One or more plugins to register for the duration of the block —
+            standalone `@hook` functions, `@plugin`-decorated class instances,
+            `MelleaPlugin` instances, `PluginSet` instances, or a list of any
+            combination.
 
     Returns:
         A context manager that registers the given plugins on entry and
         deregisters them on exit.
     """
+    # Accept both plugin_scope(a, b) and plugin_scope([a, b]).
+    if len(items) == 1 and isinstance(items[0], list):
+        return _PluginScope(list(items[0]))
     return _PluginScope(list(items))

--- a/test/plugins/test_scoping.py
+++ b/test/plugins/test_scoping.py
@@ -447,6 +447,90 @@ class TestPluginScopeContextManager:
         await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
         assert len(invocations) == count_before  # All deregistered
 
+    async def test_accepts_single_list(self) -> None:
+        """plugin_scope([a, b]) unwraps the lone list, like max()/min().
+
+        Regression test: passing a single list used to wrap it as
+        [[a, b]] and raise during registration.
+        """
+        invocations = []
+
+        @hook("session_pre_init")
+        async def hook_a(payload, ctx):
+            invocations.append("a")
+            return None
+
+        @hook("session_pre_init")
+        async def hook_b(payload, ctx):
+            invocations.append("b")
+            return None
+
+        with plugin_scope([hook_a, hook_b]):
+            await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+
+        assert "a" in invocations
+        assert "b" in invocations
+
+        count_before = len(invocations)
+        await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+        assert len(invocations) == count_before  # Both deregistered
+
+    async def test_varargs_still_works(self) -> None:
+        """plugin_scope(a, b) varargs path is unaffected by the list unwrap."""
+        invocations = []
+
+        @hook("session_pre_init")
+        async def hook_a(payload, ctx):
+            invocations.append("a")
+            return None
+
+        @hook("session_pre_init")
+        async def hook_b(payload, ctx):
+            invocations.append("b")
+            return None
+
+        with plugin_scope(hook_a, hook_b):
+            await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+
+        assert "a" in invocations
+        assert "b" in invocations
+
+        count_before = len(invocations)
+        await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+        assert len(invocations) == count_before  # Both deregistered
+
+    async def test_single_list_with_mixed_items(self) -> None:
+        """A single list mixing a hook, a class plugin, and a PluginSet works."""
+        invocations = []
+
+        @hook("session_pre_init")
+        async def standalone(payload, ctx):
+            invocations.append("standalone")
+            return None
+
+        class ClassPlugin(Plugin, name="scope-list-mixed-cls"):
+            @hook("session_pre_init")
+            async def on_pre_init(self, payload, ctx):
+                invocations.append("class")
+                return None
+
+        @hook("session_pre_init")
+        async def in_set(payload, ctx):
+            invocations.append("in_set")
+            return None
+
+        ps = PluginSet("scope-list-inner-set", [in_set])
+        with plugin_scope([standalone, ClassPlugin(), ps]):
+            await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+
+        assert "standalone" in invocations
+        assert "class" in invocations
+        assert "in_set" in invocations
+
+        count_before = len(invocations)
+        await invoke_hook(HookType.SESSION_PRE_INIT, _payload())
+        assert len(invocations) == count_before  # All deregistered
+
     async def test_async_with_fires_inside_block(self) -> None:
         invocations = []
 


### PR DESCRIPTION

# Pull Request

## Issue
Fixes # N/A; nightlies failing for the new builtin plugin hook examples 

## Description
Lets the plugin scope function utilize a list just like register.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
