### PR TITLE
feat: first pass at guardian io contract subclasses

### DIFF
--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -256,8 +256,7 @@ def policy_guardrails(
     `policy_text`.
 
     Output contract — exactly one of `label` or `score` must be present.
-    Missing both or having both raises
-    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`.
+    Missing both or having both raises `AdapterSchemaMismatchError`.
 
     Args:
         context: Chat context containing the conversation to evaluate.
@@ -267,7 +266,7 @@ def policy_guardrails(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        str: Compliance as a `"Yes"` / `"No"` / `"Ambiguous"` label (`"Yes"` = compliant).
+        Compliance label as `"Yes"`, `"No"`, or `"Ambiguous"` (`"Yes"` = compliant).
 
     Raises:
         ValueError: When the model output is not valid JSON.
@@ -510,8 +509,7 @@ def factuality_detection(
     not affected.
 
     Output contract — required key: `score`.  Missing the key raises
-    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
-    optional keys do not raise (forward-compatible).
+    `AdapterSchemaMismatchError`; extra optional keys do not raise (forward-compatible).
 
     Args:
         context: Chat context ending with a user question and an assistant
@@ -525,7 +523,7 @@ def factuality_detection(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        str: Factuality score as a `"yes"` / `"no"` label (`"yes"` = factually incorrect).
+        Factuality score: `"yes"` / `"no"` label (`"yes"` = factually incorrect).
 
     Raises:
         ValueError: If `documents` is provided but the last assistant response
@@ -572,8 +570,7 @@ def factuality_correction(
     not affected.
 
     Output contract — required key: `correction`.  Missing the key raises
-    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
-    optional keys do not raise (forward-compatible).
+    `AdapterSchemaMismatchError`; extra optional keys do not raise (forward-compatible).
 
     Args:
         context: Chat context ending with a user question and an assistant
@@ -587,7 +584,7 @@ def factuality_correction(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        str: Corrected assistant response.
+        Corrected assistant response as a plain string.
 
     Raises:
         ValueError: If `documents` is provided but the last assistant response

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -10,10 +10,19 @@ resolved kwargs through.
 """
 
 import collections.abc
+import json
 import warnings
 from typing import cast
 
-from ....backends.adapters import AdapterMixin
+from ....backends.adapters import (
+    Adapter,
+    AdapterMixin,
+    AdapterSchemaMismatchError,
+    Identity,
+    IOContract,
+    LocalFileBinding,
+)
+from ....core import Component
 from ....core.utils import MelleaLogger
 from ...components import Document
 from ...context import ChatContext
@@ -29,6 +38,210 @@ _TARGET_ROLE_TO_SCHEMA = {"user": "user_prompt", "assistant": "assistant_respons
 """Mapping used by the deprecated `target_role` path of `guardian_check`."""
 
 
+# ---------------------------------------------------------------------------
+# IOContract implementations
+# ---------------------------------------------------------------------------
+
+
+class _PolicyGuardrailsContract(IOContract):
+    """Validate policy-guardrails adapter output: exactly one of `label` or `score`.
+
+    The adapter returns either `{"label": "Yes"|"No"|"Ambiguous"}` or
+    `{"score": "Yes"|"No"|"Ambiguous"}` — never both, never neither.
+    """
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate policy-guardrails output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict with exactly one of `label` or `score`.
+
+        Raises:
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
+            AdapterSchemaMismatchError: When neither or both of `label` / `score` are present.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Adapter 'policy-guardrails' output must be a JSON object, "
+                f"got {type(data).__name__}."
+            )
+        has_label = "label" in data
+        has_score = "score" in data
+        if not has_label and not has_score:
+            raise AdapterSchemaMismatchError(
+                "policy-guardrails",
+                frozenset(data.keys()),
+                frozenset({"label", "score"}),
+            )
+        if has_label and has_score:
+            raise AdapterSchemaMismatchError(
+                "policy-guardrails",
+                frozenset(data.keys()),
+                frozenset({"label", "score"}),
+            )
+        return data
+
+
+class _GuardianCheckContract(IOContract):
+    """Validate guardian-core adapter output: `{"guardian": {"score": <float>}}`.
+
+    Checks that the outer `guardian` key is present and that it contains
+    a nested `score` key.
+    """
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate guardian-core output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict containing `{"guardian": {"score": ...}}`.
+
+        Raises:
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
+            AdapterSchemaMismatchError: When `guardian` key is absent or `guardian.score`
+                is absent.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Adapter 'guardian-core' output must be a JSON object, "
+                f"got {type(data).__name__}."
+            )
+        if "guardian" not in data:
+            raise AdapterSchemaMismatchError(
+                "guardian-core", frozenset(data.keys()), frozenset({"guardian"})
+            )
+        guardian_val = data["guardian"]
+        if not isinstance(guardian_val, dict) or "score" not in guardian_val:
+            raise AdapterSchemaMismatchError(
+                "guardian-core",
+                frozenset(guardian_val.keys())
+                if isinstance(guardian_val, dict)
+                else frozenset(),
+                frozenset({"score"}),
+            )
+        return data
+
+
+class _FactualityDetectionContract(IOContract):
+    """Validate factuality-detection output: required key `score`."""
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate factuality-detection output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict with `score` key.
+
+        Raises:
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
+            AdapterSchemaMismatchError: When `score` key is absent.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Adapter 'factuality-detection' output must be a JSON object, "
+                f"got {type(data).__name__}."
+            )
+        if "score" not in data:
+            raise AdapterSchemaMismatchError(
+                "factuality-detection", frozenset(data.keys()), frozenset({"score"})
+            )
+        return data
+
+
+class _FactualityCorrectionContract(IOContract):
+    """Validate factuality-correction output: required key `correction`."""
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate factuality-correction output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict with `correction` key.
+
+        Raises:
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
+            AdapterSchemaMismatchError: When `correction` key is absent.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Adapter 'factuality-correction' output must be a JSON object, "
+                f"got {type(data).__name__}."
+            )
+        if "correction" not in data:
+            raise AdapterSchemaMismatchError(
+                "factuality-correction",
+                frozenset(data.keys()),
+                frozenset({"correction"}),
+            )
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Module-level Adapter constants (one per helper)
+# ---------------------------------------------------------------------------
+
+_POLICY_GUARDRAILS_ADAPTER = Adapter(
+    identity=Identity("policy-guardrails", "lora", capability="policy_guardrails"),
+    io_contract=_PolicyGuardrailsContract(),
+    weights=LocalFileBinding(),
+)
+
+_GUARDIAN_CHECK_ADAPTER = Adapter(
+    identity=Identity("guardian-core", "lora", capability="guardian_core"),
+    io_contract=_GuardianCheckContract(),
+    weights=LocalFileBinding(),
+)
+
+_FACTUALITY_DETECTION_ADAPTER = Adapter(
+    identity=Identity(
+        "factuality-detection", "lora", capability="factuality_detection"
+    ),
+    io_contract=_FactualityDetectionContract(),
+    weights=LocalFileBinding(),
+)
+
+_FACTUALITY_CORRECTION_ADAPTER = Adapter(
+    identity=Identity(
+        "factuality-correction", "lora", capability="factuality_correction"
+    ),
+    io_contract=_FactualityCorrectionContract(),
+    weights=LocalFileBinding(),
+)
+
+
 def policy_guardrails(
     context: ChatContext,
     backend: AdapterMixin,
@@ -42,6 +255,10 @@ def policy_guardrails(
     described in the last message in `context` is compliant with the given
     `policy_text`.
 
+    Output contract — exactly one of `label` or `score` must be present.
+    Missing both or having both raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`.
+
     Args:
         context: Chat context containing the conversation to evaluate.
         backend: Backend instance that supports LoRA adapters.
@@ -50,11 +267,11 @@ def policy_guardrails(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        Compliance label as `"Yes"`, `"No"`, or `"Ambiguous"` (Yes = compliant).
+        str: Compliance as a `"Yes"` / `"No"` / `"Ambiguous"` label (`"Yes"` = compliant).
 
     Raises:
-        ValueError: If the adapter returns a result with neither or both of
-            `"label"` and `"score"` fields.
+        ValueError: When the model output is not valid JSON.
+        AdapterSchemaMismatchError: When neither or both of `label` / `score` are present.
     """
     result_json = call_intrinsic(
         "policy-guardrails",
@@ -62,19 +279,12 @@ def policy_guardrails(
         backend,
         kwargs={"policy_text": policy_text},
         model_options=model_options,
+        io_contract=_POLICY_GUARDRAILS_ADAPTER.io_contract,
     )
 
-    has_label = "label" in result_json
-    has_score = "score" in result_json
-    if has_label == has_score:
-        if has_label:
-            raise ValueError(
-                "Expected Guardian result to have label xor score, but found both."
-            )
-        raise ValueError(
-            "Expected Guardian result to have label xor score, but found neither."
-        )
-    return cast(str, result_json["label"] if has_label else result_json["score"])
+    if "label" in result_json:
+        return cast(str, result_json["label"])
+    return cast(str, result_json["score"])
 
 
 SCORING_SCHEMA_BANK = {
@@ -219,6 +429,13 @@ def guardian_check(
 
     Returns:
         Risk score as a float between 0.0 (no risk) and 1.0 (risk detected).
+
+    Raises:
+        TypeError: When both `scoring_schema` and `target_role` are provided.
+        ValueError: When `target_role` is not `"user"` or `"assistant"`, or
+            when the model output is not valid JSON.
+        AdapterSchemaMismatchError: When the model output is missing the required
+            `guardian` key or its nested `score` key.
     """
     if target_role is not None:
         warnings.warn(
@@ -262,6 +479,7 @@ def guardian_check(
         backend,
         kwargs={"criteria": criteria_text, "scoring_schema": scoring_schema_text},
         model_options=model_options,
+        io_contract=_GUARDIAN_CHECK_ADAPTER.io_contract,
     )
     return cast(float, cast(dict[str, object], result_json["guardian"])["score"])
 
@@ -291,6 +509,10 @@ def factuality_detection(
     last assistant turn; documents on other messages in `context` are
     not affected.
 
+    Output contract — required key: `score`.  Missing the key raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
+    optional keys do not raise (forward-compatible).
+
     Args:
         context: Chat context ending with a user question and an assistant
             answer.
@@ -303,18 +525,23 @@ def factuality_detection(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        Factuality label: `"yes"` if the response is factually incorrect,
-        `"no"` if it is correct.
+        str: Factuality score as a `"yes"` / `"no"` label (`"yes"` = factually incorrect).
 
     Raises:
         ValueError: If `documents` is provided but the last assistant response
             cannot be extracted (empty context, non-assistant last turn, or
-            uncomputed response).
+            uncomputed response). Also raised when the model output is not valid JSON.
+        AdapterSchemaMismatchError: When the model output is missing the required
+            `score` field.
     """
     if documents is not None:
         context = _inject_documents(context, documents)
     result_json = call_intrinsic(
-        "factuality-detection", context, backend, model_options=model_options
+        "factuality-detection",
+        context,
+        backend,
+        model_options=model_options,
+        io_contract=_FACTUALITY_DETECTION_ADAPTER.io_contract,
     )
     return cast(str, result_json["score"])
 
@@ -344,6 +571,10 @@ def factuality_correction(
     last assistant turn; documents on other messages in `context` are
     not affected.
 
+    Output contract — required key: `correction`.  Missing the key raises
+    :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
+    optional keys do not raise (forward-compatible).
+
     Args:
         context: Chat context ending with a user question and an assistant
             answer.
@@ -356,17 +587,23 @@ def factuality_correction(
             backend (e.g. `{"temperature": 0}`).
 
     Returns:
-        Corrected assistant response as a plain string.
+        str: Corrected assistant response.
 
     Raises:
         ValueError: If `documents` is provided but the last assistant response
             cannot be extracted (empty context, non-assistant last turn, or
-            uncomputed response).
+            uncomputed response). Also raised when the model output is not valid JSON.
+        AdapterSchemaMismatchError: When the model output is missing the required
+            `correction` field.
     """
     if documents is not None:
         context = _inject_documents(context, documents)
     result_json = call_intrinsic(
-        "factuality-correction", context, backend, model_options=model_options
+        "factuality-correction",
+        context,
+        backend,
+        model_options=model_options,
+        io_contract=_FACTUALITY_CORRECTION_ADAPTER.io_contract,
     )
     return cast(str, result_json["correction"])
 

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -133,7 +133,7 @@ class _GuardianCheckContract(IOContract):
                 "guardian-core",
                 frozenset(guardian_val.keys())
                 if isinstance(guardian_val, dict)
-                else frozenset(),
+                else frozenset(data.keys()),
                 frozenset({"score"}),
             )
         return data
@@ -214,20 +214,20 @@ class _FactualityCorrectionContract(IOContract):
 # ---------------------------------------------------------------------------
 
 _POLICY_GUARDRAILS_ADAPTER = Adapter(
-    identity=Identity("policy-guardrails", "lora", capability="policy_guardrails"),
+    identity=Identity("policy-guardrails", "alora", capability="policy_guardrails"),
     io_contract=_PolicyGuardrailsContract(),
     weights=LocalFileBinding(),
 )
 
 _GUARDIAN_CHECK_ADAPTER = Adapter(
-    identity=Identity("guardian-core", "lora", capability="guardian_core"),
+    identity=Identity("guardian-core", "alora", capability="guardian_core"),
     io_contract=_GuardianCheckContract(),
     weights=LocalFileBinding(),
 )
 
 _FACTUALITY_DETECTION_ADAPTER = Adapter(
     identity=Identity(
-        "factuality-detection", "lora", capability="factuality_detection"
+        "factuality-detection", "alora", capability="factuality_detection"
     ),
     io_contract=_FactualityDetectionContract(),
     weights=LocalFileBinding(),
@@ -235,7 +235,7 @@ _FACTUALITY_DETECTION_ADAPTER = Adapter(
 
 _FACTUALITY_CORRECTION_ADAPTER = Adapter(
     identity=Identity(
-        "factuality-correction", "lora", capability="factuality_correction"
+        "factuality-correction", "alora", capability="factuality_correction"
     ),
     io_contract=_FactualityCorrectionContract(),
     weights=LocalFileBinding(),

--- a/test/stdlib/components/intrinsic/test_guardian_deprecation.py
+++ b/test/stdlib/components/intrinsic/test_guardian_deprecation.py
@@ -1,7 +1,7 @@
-"""Unit tests for the deprecated ``target_role`` path of ``guardian_check``.
+"""Unit tests for the deprecated `target_role` path of `guardian_check`.
 
 Exercises the sentinel/mapping logic without touching a model. We monkeypatch
-``call_intrinsic`` and assert on (a) the ``kwargs["scoring_schema"]`` that
+`call_intrinsic` and assert on (a) the `kwargs["scoring_schema"]` that
 reaches the adapter boundary and (b) the warnings/errors the caller sees.
 """
 
@@ -18,7 +18,9 @@ def capture_kwargs(monkeypatch):
     """Replace call_intrinsic with a spy that returns a stub yes=1.0 result."""
     captured: dict = {}
 
-    def fake_call_intrinsic(name, context, backend, /, kwargs=None, model_options=None):
+    def fake_call_intrinsic(
+        name, context, backend, /, kwargs=None, model_options=None, io_contract=None
+    ):
         captured["name"] = name
         captured["kwargs"] = kwargs
         return {"guardian": {"score": 1.0}}

--- a/test/stdlib/components/intrinsic/test_guardian_documents.py
+++ b/test/stdlib/components/intrinsic/test_guardian_documents.py
@@ -17,7 +17,9 @@ def capture_intrinsic(monkeypatch):
     """Spy that replaces call_intrinsic and captures what it receives."""
     captured: dict = {}
 
-    def fake_call_intrinsic(name, context, backend, /, kwargs=None, model_options=None, io_contract=None):
+    def fake_call_intrinsic(
+        name, context, backend, /, kwargs=None, model_options=None, io_contract=None
+    ):
         captured["name"] = name
         captured["context"] = context
         return {"score": "yes", "correction": "corrected"}
@@ -199,39 +201,6 @@ def test_factuality_detection_thunk_attaches_doc_to_assistant_turn(capture_intri
     doc_parts = [p for p in last.parts() if isinstance(p, Document)]
     assert len(doc_parts) == 1
     assert doc_parts[0].text == "Ozzy Osbourne passed away."
-
-
-# ---------------------------------------------------------------------------
-# policy_guardrails: XOR validation error paths
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def capture_policy(monkeypatch):
-    """Return a factory that makes call_intrinsic return a controlled result dict."""
-
-    def _make(result: dict):
-        monkeypatch.setattr(
-            guardian,
-            "call_intrinsic",
-            lambda name, ctx, backend, /, kwargs=None, model_options=None, io_contract=None: result,
-        )
-
-    return _make
-
-
-def test_policy_guardrails_raises_when_both_label_and_score_present(capture_policy):
-    capture_policy({"label": "Yes", "score": 0.9})
-    ctx = ChatContext().add(Message("user", "Hello"))
-    with pytest.raises(Exception):
-        guardian.policy_guardrails(ctx, object(), policy_text="no hate speech")
-
-
-def test_policy_guardrails_raises_when_neither_label_nor_score_present(capture_policy):
-    capture_policy({})
-    ctx = ChatContext().add(Message("user", "Hello"))
-    with pytest.raises(Exception):
-        guardian.policy_guardrails(ctx, object(), policy_text="no hate speech")
 
 
 # ---------------------------------------------------------------------------

--- a/test/stdlib/components/intrinsic/test_guardian_documents.py
+++ b/test/stdlib/components/intrinsic/test_guardian_documents.py
@@ -17,7 +17,7 @@ def capture_intrinsic(monkeypatch):
     """Spy that replaces call_intrinsic and captures what it receives."""
     captured: dict = {}
 
-    def fake_call_intrinsic(name, context, backend, /, kwargs=None, model_options=None):
+    def fake_call_intrinsic(name, context, backend, /, kwargs=None, model_options=None, io_contract=None):
         captured["name"] = name
         captured["context"] = context
         return {"score": "yes", "correction": "corrected"}
@@ -214,7 +214,7 @@ def capture_policy(monkeypatch):
         monkeypatch.setattr(
             guardian,
             "call_intrinsic",
-            lambda name, ctx, backend, /, kwargs=None, model_options=None: result,
+            lambda name, ctx, backend, /, kwargs=None, model_options=None, io_contract=None: result,
         )
 
     return _make
@@ -223,14 +223,14 @@ def capture_policy(monkeypatch):
 def test_policy_guardrails_raises_when_both_label_and_score_present(capture_policy):
     capture_policy({"label": "Yes", "score": 0.9})
     ctx = ChatContext().add(Message("user", "Hello"))
-    with pytest.raises(ValueError, match="found both"):
+    with pytest.raises(Exception):
         guardian.policy_guardrails(ctx, object(), policy_text="no hate speech")
 
 
 def test_policy_guardrails_raises_when_neither_label_nor_score_present(capture_policy):
     capture_policy({})
     ctx = ChatContext().add(Message("user", "Hello"))
-    with pytest.raises(ValueError, match="found neither"):
+    with pytest.raises(Exception):
         guardian.policy_guardrails(ctx, object(), policy_text="no hate speech")
 
 
@@ -243,7 +243,7 @@ def _make_capture(monkeypatch, result: dict):
     """Patch call_intrinsic to capture (name, model_options) and return result."""
     calls: list[tuple] = []
 
-    def _fake(name, ctx, backend, /, kwargs=None, model_options=None):
+    def _fake(name, ctx, backend, /, kwargs=None, model_options=None, io_contract=None):
         calls.append((name, model_options))
         return result
 

--- a/test/stdlib/components/intrinsic/test_guardian_io_contract.py
+++ b/test/stdlib/components/intrinsic/test_guardian_io_contract.py
@@ -1,0 +1,192 @@
+"""Unit tests for IOContract validation in guardian.py (Epic #929 Phase 1).
+
+Tests the `parse()` method of each IOContract subclass directly — no backend,
+no GPU, no model download required.  Two tests per helper:
+
+- `test_<helper>_contract_enforced` — output missing a required field raises
+  :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`.
+- `test_<helper>_forward_compat` — output containing an extra optional field
+  does *not* raise.
+"""
+
+import json
+
+import pytest
+
+from mellea.backends.adapters import AdapterSchemaMismatchError
+from mellea.stdlib.components.intrinsic.guardian import (
+    _FACTUALITY_CORRECTION_ADAPTER,
+    _FACTUALITY_DETECTION_ADAPTER,
+    _GUARDIAN_CHECK_ADAPTER,
+    _POLICY_GUARDRAILS_ADAPTER,
+)
+
+# ---------------------------------------------------------------------------
+# policy_guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_policy_guardrails_contract_enforced_neither_key() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(json.dumps({"wrong_key": "value"}))
+    err = exc_info.value
+    assert err.name == "policy-guardrails"
+    assert "label" in err.expected_keys
+    assert "score" in err.expected_keys
+
+
+def test_policy_guardrails_contract_enforced_both_keys() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(
+            json.dumps({"label": "Yes", "score": "Yes"})
+        )
+    err = exc_info.value
+    assert err.name == "policy-guardrails"
+
+
+def test_policy_guardrails_forward_compat_label() -> None:
+    result = _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(
+        json.dumps({"label": "Yes", "extra": "ignored"})
+    )
+    assert result["label"] == "Yes"
+
+
+def test_policy_guardrails_forward_compat_score() -> None:
+    result = _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(
+        json.dumps({"score": "No", "extra": "ignored"})
+    )
+    assert result["score"] == "No"
+
+
+def test_policy_guardrails_rejects_non_dict() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(json.dumps(["not", "a", "dict"]))
+
+
+# ---------------------------------------------------------------------------
+# guardian_check
+# ---------------------------------------------------------------------------
+
+
+def test_guardian_check_contract_enforced_missing_guardian_key() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _GUARDIAN_CHECK_ADAPTER.io_contract.parse(json.dumps({"wrong_key": 0.5}))
+    err = exc_info.value
+    assert err.name == "guardian-core"
+    assert "guardian" in err.expected_keys
+
+
+def test_guardian_check_contract_enforced_missing_score_in_guardian() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _GUARDIAN_CHECK_ADAPTER.io_contract.parse(
+            json.dumps({"guardian": {"wrong_key": 0.5}})
+        )
+    err = exc_info.value
+    assert err.name == "guardian-core"
+    assert "score" in err.expected_keys
+
+
+def test_guardian_check_contract_enforced_guardian_not_dict() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _GUARDIAN_CHECK_ADAPTER.io_contract.parse(json.dumps({"guardian": 0.8}))
+    err = exc_info.value
+    assert err.name == "guardian-core"
+    assert "score" in err.expected_keys
+
+
+def test_guardian_check_forward_compat() -> None:
+    result = _GUARDIAN_CHECK_ADAPTER.io_contract.parse(
+        json.dumps({"guardian": {"score": 0.9}, "extra": "ignored"})
+    )
+    assert isinstance(result["guardian"], dict)
+    assert result["guardian"]["score"] == 0.9  # type: ignore[index]
+
+
+def test_guardian_check_rejects_non_dict() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        _GUARDIAN_CHECK_ADAPTER.io_contract.parse(json.dumps([0.5]))
+
+
+# ---------------------------------------------------------------------------
+# factuality_detection
+# ---------------------------------------------------------------------------
+
+
+def test_factuality_detection_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _FACTUALITY_DETECTION_ADAPTER.io_contract.parse(
+            json.dumps({"wrong_key": "yes"})
+        )
+    err = exc_info.value
+    assert err.name == "factuality-detection"
+    assert "score" in err.expected_keys
+
+
+def test_factuality_detection_forward_compat() -> None:
+    result = _FACTUALITY_DETECTION_ADAPTER.io_contract.parse(
+        json.dumps({"score": "yes", "confidence": 0.9})
+    )
+    assert result["score"] == "yes"
+
+
+def test_factuality_detection_rejects_non_dict() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        _FACTUALITY_DETECTION_ADAPTER.io_contract.parse(json.dumps("yes"))
+
+
+# ---------------------------------------------------------------------------
+# factuality_correction
+# ---------------------------------------------------------------------------
+
+
+def test_factuality_correction_contract_enforced() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _FACTUALITY_CORRECTION_ADAPTER.io_contract.parse(
+            json.dumps({"wrong_key": "corrected text"})
+        )
+    err = exc_info.value
+    assert err.name == "factuality-correction"
+    assert "correction" in err.expected_keys
+
+
+def test_factuality_correction_forward_compat() -> None:
+    result = _FACTUALITY_CORRECTION_ADAPTER.io_contract.parse(
+        json.dumps({"correction": "The correct answer is 42.", "score": 0.95})
+    )
+    assert result["correction"] == "The correct answer is 42."
+
+
+def test_factuality_correction_rejects_non_dict() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        _FACTUALITY_CORRECTION_ADAPTER.io_contract.parse(
+            json.dumps(["not", "a", "dict"])
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error message includes adapter name for debuggability
+# ---------------------------------------------------------------------------
+
+
+def test_policy_guardrails_error_mentions_adapter_name() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _POLICY_GUARDRAILS_ADAPTER.io_contract.parse(json.dumps({}))
+    assert exc_info.value.name == "policy-guardrails"
+
+
+def test_guardian_check_error_mentions_adapter_name() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _GUARDIAN_CHECK_ADAPTER.io_contract.parse(json.dumps({}))
+    assert exc_info.value.name == "guardian-core"
+
+
+def test_factuality_detection_error_mentions_adapter_name() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _FACTUALITY_DETECTION_ADAPTER.io_contract.parse(json.dumps({}))
+    assert exc_info.value.name == "factuality-detection"
+
+
+def test_factuality_correction_error_mentions_adapter_name() -> None:
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        _FACTUALITY_CORRECTION_ADAPTER.io_contract.parse(json.dumps({}))
+    assert exc_info.value.name == "factuality-correction"

--- a/test/stdlib/components/intrinsic/test_guardian_io_contract.py
+++ b/test/stdlib/components/intrinsic/test_guardian_io_contract.py
@@ -10,16 +10,19 @@ no GPU, no model download required.  Two tests per helper:
 """
 
 import json
+import unittest.mock
 
 import pytest
 
-from mellea.backends.adapters import AdapterSchemaMismatchError
+from mellea.backends.adapters import AdapterMixin, AdapterSchemaMismatchError
+from mellea.stdlib.components.intrinsic import guardian
 from mellea.stdlib.components.intrinsic.guardian import (
     _FACTUALITY_CORRECTION_ADAPTER,
     _FACTUALITY_DETECTION_ADAPTER,
     _GUARDIAN_CHECK_ADAPTER,
     _POLICY_GUARDRAILS_ADAPTER,
 )
+from mellea.stdlib.context import ChatContext
 
 # ---------------------------------------------------------------------------
 # policy_guardrails
@@ -92,6 +95,7 @@ def test_guardian_check_contract_enforced_guardian_not_dict() -> None:
     err = exc_info.value
     assert err.name == "guardian-core"
     assert "score" in err.expected_keys
+    assert "guardian" in err.observed_keys
 
 
 def test_guardian_check_forward_compat() -> None:
@@ -190,3 +194,25 @@ def test_factuality_correction_error_mentions_adapter_name() -> None:
     with pytest.raises(AdapterSchemaMismatchError) as exc_info:
         _FACTUALITY_CORRECTION_ADAPTER.io_contract.parse(json.dumps({}))
     assert exc_info.value.name == "factuality-correction"
+
+
+# ---------------------------------------------------------------------------
+# policy_guardrails helper — score branch
+# ---------------------------------------------------------------------------
+
+
+def test_policy_guardrails_score_branch(monkeypatch) -> None:
+    """policy_guardrails returns the `score` value when the adapter omits `label`."""
+
+    def fake_call_intrinsic(
+        name, context, backend, /, kwargs=None, model_options=None, io_contract=None
+    ):
+        return {"score": "No"}
+
+    monkeypatch.setattr(guardian, "call_intrinsic", fake_call_intrinsic)
+    result = guardian.policy_guardrails(
+        ChatContext(),
+        unittest.mock.create_autospec(AdapterMixin, instance=True),
+        policy_text="any policy",
+    )
+    assert result == "No"


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1332 

## Description
<!-- What does this PR do and why? -->
Adds io contract subclasses, adapter constants, and utilizes these via existing call sites in guardian.py

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
