### PR TITLE
chore: add PEP 484 return-type annotations to mellea.stdlib public methods

### DIFF
--- a/mellea/stdlib/components/docs/richdocument.py
+++ b/mellea/stdlib/components/docs/richdocument.py
@@ -80,7 +80,7 @@ class RichDocument(Component[str]):
         """
         return self._doc
 
-    def to_markdown(self):
+    def to_markdown(self) -> str:
         """Get the full text of the document as markdown."""
         return self._doc.export_to_markdown()
 
@@ -282,7 +282,7 @@ class Table(MObject):
         else:
             return None
 
-    def parts(self):
+    def parts(self) -> list[Component | CBlock]:
         """Return the constituent parts of this table component.
 
         The current implementation always returns an empty list because the

--- a/mellea/stdlib/components/instruction.py
+++ b/mellea/stdlib/components/instruction.py
@@ -142,8 +142,15 @@ class Instruction(Component[str]):
         self._images = images
         self._repair_string: str | None = None
 
-    def parts(self):
-        """Returns all of the constituent parts of an Instruction."""
+    def parts(self) -> list[Component | CBlock]:
+        """Returns all of the constituent parts of an Instruction.
+
+        Returns:
+            list[Component | CBlock]: All non-None constituent blocks and
+            components making up this instruction, including description,
+            prefix, grounding context, requirements, and in-context-learning
+            examples.
+        """
         # Add all of the optionally defined CBlocks/Components then filter Nones at the end.
         cs = [self._description, self._prefix, self._output_prefix]
         match self._grounding_context:

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -355,7 +355,7 @@ class MelleaSession:
         """
         return copy(self)
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the context state to a fresh, empty context of the same type.
 
         Fires the `SESSION_RESET` plugin hook if any plugins are registered, then
@@ -1132,7 +1132,7 @@ class MelleaSession:
         return result
 
     @classmethod
-    def powerup(cls, powerup_cls: type):
+    def powerup(cls, powerup_cls: type) -> None:
         """Appends methods in a class object `powerup_cls` to MelleaSession.
 
         Iterates over all functions defined on `powerup_cls` and attaches each


### PR DESCRIPTION
# Pull Request

## Issue
Related to #1177 (not "Fixes" — this covers only the `mellea.stdlib` portion of that issue, not the full scope)

## Description
Addresses part of #1177 — specifically the five `mellea.stdlib` griffe warnings named in the issue: `MelleaSession.reset`, `MelleaSession.powerup`, `Instruction.parts`, `RichDocument.to_markdown`, and `Table.parts`. All five now have return-type annotations, and `Instruction.parts` also got a fuller docstring since the return type alone didn't explain what's actually in the returned list.

This does not cover the larger backend-protocol portion of #1177 (huggingface, ollama, openai, litellm, watsonx, adapters, tools, formatters.granite, telemetry — 58 more warnings) or the broader `__all__`/public-API question the issue raises. Both felt like separate, larger decisions — happy to take on the backend annotations as a follow-up if that's useful, but wanted to land the stdlib piece on its own rather than bundle everything into one large diff.

No logic changes — purely additive type metadata, matched exactly to griffe's reported warnings.

### Testing
- [ ] Tests added to the respective file if code was changed — none added; no behavior changed, only return-type annotations on existing methods
- [ ] New code has 100% coverage if code was added — not applicable, no new code paths introduced
- [ ] Ensure existing tests and github automation passes — haven't run the full suite locally against this specific change; given it's metadata-only I'd expect it to pass, but flagging that as an expectation, not a verified result

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?
- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool