### PR TITLE
fix(adapters): correct typo from IntriniscsCatalogEntry to IntrinsicsCatalogEntry

### DIFF
--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -151,7 +151,7 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
 
     Attributes:
         intrinsic_name (str): Name of the adapter function this adapter implements.
-        intrinsic_metadata (IntriniscsCatalogEntry): Catalog metadata for the adapter function.
+        intrinsic_metadata (IntrinsicsCatalogEntry): Catalog metadata for the adapter function.
         base_model_name (str | None): Base model name provided at construction, if any.
         adapter_type (AdapterType): The adapter type (``LORA`` or ``ALORA``).
         config (dict): Parsed I/O transformation configuration for the adapter function.
@@ -790,7 +790,7 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
 
         if intrinsic_name not in catalog._INTRINSICS_CATALOG:
             catalog._INTRINSICS_CATALOG_ENTRIES.append(
-                catalog.IntriniscsCatalogEntry(
+                catalog.IntrinsicsCatalogEntry(
                     name=intrinsic_name, repo_id=model_id, revision="main"
                 )
             )

--- a/mellea/backends/adapters/capabilities.py
+++ b/mellea/backends/adapters/capabilities.py
@@ -7,7 +7,7 @@ adapter functions are not blocked.
 
 Deriving from the catalog (rather than hand-copying) keeps the two registries in
 sync automatically — adding a new entry to ``catalog.py`` automatically registers
-its :attr:`~mellea.backends.adapters.catalog.IntriniscsCatalogEntry.effective_capability`
+its :attr:`~mellea.backends.adapters.catalog.IntrinsicsCatalogEntry.effective_capability`
 as a known capability.
 """
 

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -48,7 +48,7 @@ class AdapterType(enum.Enum):
     ALORA = "alora"
 
 
-class IntriniscsCatalogEntry(pydantic.BaseModel):
+class IntrinsicsCatalogEntry(pydantic.BaseModel):
     """A single row in the main adapter function catalog table.
 
     We use Pydantic for this dataclass because the rest of Mellea also uses Pydantic.
@@ -161,60 +161,60 @@ _INTRINSICS_CATALOG_ENTRIES = [
     ############################################
     # Core adapter functions
     ############################################
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="context-attribution",
         capability="context_attribution",
         repo_id=_CORE_R1_REPO,
         revision=_CORE_R1_SHA,
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="requirement-check",
         capability="requirement_check",
         repo_id=_CORE_R1_REPO,
         revision=_CORE_R1_SHA,
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="uncertainty", repo_id=_CORE_R1_REPO, revision=_CORE_R1_SHA
     ),
     ############################################
     # RAG adapter functions
     ############################################
-    IntriniscsCatalogEntry(name="answerability", repo_id=_RAG_REPO, revision=_RAG_SHA),
-    IntriniscsCatalogEntry(name="citations", repo_id=_RAG_REPO, revision=_RAG_SHA),
+    IntrinsicsCatalogEntry(name="answerability", repo_id=_RAG_REPO, revision=_RAG_SHA),
+    IntrinsicsCatalogEntry(name="citations", repo_id=_RAG_REPO, revision=_RAG_SHA),
     # Deprecated: Granite 4.0 only; no Granite 4.1 adapter planned.
     # Removal tracked alongside check_context_relevance() in rag.py.
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="context_relevance", repo_id=_RAG_REPO, revision=_RAG_SHA
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="hallucination_detection", repo_id=_RAG_REPO, revision=_RAG_SHA
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="query_clarification", repo_id=_RAG_REPO, revision=_RAG_SHA
     ),
-    IntriniscsCatalogEntry(name="query_rewrite", repo_id=_RAG_REPO, revision=_RAG_SHA),
+    IntrinsicsCatalogEntry(name="query_rewrite", repo_id=_RAG_REPO, revision=_RAG_SHA),
     ############################################
     # Guardian adapter functions
     ############################################
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="policy-guardrails",
         capability="policy_guardrails",
         repo_id=_GUARDIAN_REPO,
         revision=_GUARDIAN_SHA,
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="guardian-core",
         capability="guardian_core",
         repo_id=_GUARDIAN_REPO,
         revision=_GUARDIAN_SHA,
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="factuality-detection",
         capability="factuality_detection",
         repo_id=_GUARDIAN_REPO,
         revision=_GUARDIAN_SHA,
     ),
-    IntriniscsCatalogEntry(
+    IntrinsicsCatalogEntry(
         name="factuality-correction",
         capability="factuality_correction",
         repo_id=_GUARDIAN_REPO,
@@ -245,14 +245,14 @@ def known_intrinsic_names() -> list[str]:
     return list(_INTRINSICS_CATALOG.keys())
 
 
-def fetch_intrinsic_metadata(intrinsic_name: str) -> IntriniscsCatalogEntry:
+def fetch_intrinsic_metadata(intrinsic_name: str) -> IntrinsicsCatalogEntry:
     """Retrieve catalog metadata for the adapter that implements an adapter function.
 
     Args:
         intrinsic_name (str): User-visible name of the adapter function.
 
     Returns:
-        IntriniscsCatalogEntry: Metadata about the adapter(s) that implement the
+        IntrinsicsCatalogEntry: Metadata about the adapter(s) that implement the
             adapter function.
 
     Raises:

--- a/test/backends/test_adapters/test_catalog.py
+++ b/test/backends/test_adapters/test_catalog.py
@@ -5,7 +5,7 @@ import pytest
 from mellea.backends.adapters.catalog import (
     _INTRINSICS_CATALOG_ENTRIES,
     AdapterType,
-    IntriniscsCatalogEntry,
+    IntrinsicsCatalogEntry,
     fetch_intrinsic_metadata,
     known_intrinsic_names,
 )
@@ -59,7 +59,7 @@ def test_default_adapter_types():
 def test_lora_only_entry(monkeypatch):
     from mellea.backends.adapters import catalog
 
-    fake_entry = catalog.IntriniscsCatalogEntry(
+    fake_entry = catalog.IntrinsicsCatalogEntry(
         name="query_clarification",
         repo_id="ibm-granite/granitelib-rag-r1.0",
         revision="main",
@@ -130,7 +130,7 @@ def test_effective_capability_not_in_model_dump():
 
 
 def test_capability_field_used_when_constructing_directly():
-    entry = IntriniscsCatalogEntry(
+    entry = IntrinsicsCatalogEntry(
         name="my-custom-adapter",
         capability="my_custom_adapter",
         repo_id="org/repo",
@@ -140,7 +140,7 @@ def test_capability_field_used_when_constructing_directly():
 
 
 def test_capability_none_means_effective_capability_equals_name():
-    entry = IntriniscsCatalogEntry(
+    entry = IntrinsicsCatalogEntry(
         name="plain_name", repo_id="org/repo", revision="abc123def456"
     )
     assert entry.capability is None
@@ -156,35 +156,35 @@ def test_all_catalog_effective_capabilities_are_nonempty():
 
 def test_name_empty_string_rejected():
     with pytest.raises(ValueError, match="non-empty"):
-        IntriniscsCatalogEntry(name="", repo_id="org/repo", revision="abc123")
+        IntrinsicsCatalogEntry(name="", repo_id="org/repo", revision="abc123")
 
 
 def test_name_whitespace_only_rejected():
     with pytest.raises(ValueError, match="non-empty"):
-        IntriniscsCatalogEntry(name="   ", repo_id="org/repo", revision="abc123")
+        IntrinsicsCatalogEntry(name="   ", repo_id="org/repo", revision="abc123")
 
 
 def test_name_leading_trailing_whitespace_rejected():
     with pytest.raises(ValueError, match="leading or trailing whitespace"):
-        IntriniscsCatalogEntry(name="  foo  ", repo_id="org/repo", revision="abc123")
+        IntrinsicsCatalogEntry(name="  foo  ", repo_id="org/repo", revision="abc123")
 
 
 def test_capability_empty_string_rejected():
     with pytest.raises(ValueError, match="non-empty"):
-        IntriniscsCatalogEntry(
+        IntrinsicsCatalogEntry(
             name="x", capability="", repo_id="org/repo", revision="abc123"
         )
 
 
 def test_capability_whitespace_only_rejected():
     with pytest.raises(ValueError, match="non-empty"):
-        IntriniscsCatalogEntry(
+        IntrinsicsCatalogEntry(
             name="x", capability="   ", repo_id="org/repo", revision="abc123"
         )
 
 
 def test_capability_leading_trailing_whitespace_rejected():
     with pytest.raises(ValueError, match="leading or trailing whitespace"):
-        IntriniscsCatalogEntry(
+        IntrinsicsCatalogEntry(
             name="x", capability="  foo  ", repo_id="org/repo", revision="abc123"
         )

--- a/test/backends/test_adapters/test_catalog_revision.py
+++ b/test/backends/test_adapters/test_catalog_revision.py
@@ -1,10 +1,10 @@
-"""Tests for IntriniscsCatalogEntry revision field and requirement-check deduplication."""
+"""Tests for IntrinsicsCatalogEntry revision field and requirement-check deduplication."""
 
 import pydantic
 import pytest
 
 from mellea.backends.adapters.catalog import (
-    IntriniscsCatalogEntry,
+    IntrinsicsCatalogEntry,
     fetch_intrinsic_metadata,
     known_intrinsic_names,
     validate_revision,
@@ -48,19 +48,19 @@ def test_revision_validation_accepts_branch_and_tag():
 
 def test_revision_field_rejects_empty_via_pydantic():
     with pytest.raises(pydantic.ValidationError):
-        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision="")
+        IntrinsicsCatalogEntry(name="x", repo_id="org/repo", revision="")
 
 
 def test_revision_field_rejects_none_via_pydantic():
     with pytest.raises(pydantic.ValidationError):
-        IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=None)  # type: ignore[arg-type]
+        IntrinsicsCatalogEntry(name="x", repo_id="org/repo", revision=None)  # type: ignore[arg-type]
 
 
 def test_revision_round_trip():
-    entry = IntriniscsCatalogEntry(name="x", repo_id="org/repo", revision=_VALID_SHA)
+    entry = IntrinsicsCatalogEntry(name="x", repo_id="org/repo", revision=_VALID_SHA)
     assert entry.revision == _VALID_SHA
 
-    entry_main = IntriniscsCatalogEntry(name="y", repo_id="org/repo", revision="main")
+    entry_main = IntrinsicsCatalogEntry(name="y", repo_id="org/repo", revision="main")
     assert entry_main.revision == "main"
 
 

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -15,13 +15,13 @@ import pytest
 from mellea.backends.adapters import Adapter, EmbeddedIntrinsicAdapter, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
 from mellea.backends.adapters.adapter import AdapterMixin
-from mellea.backends.adapters.catalog import AdapterType, IntriniscsCatalogEntry
+from mellea.backends.adapters.catalog import AdapterType, IntrinsicsCatalogEntry
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-_MOCK_CATALOG_ENTRY = IntriniscsCatalogEntry(
+_MOCK_CATALOG_ENTRY = IntrinsicsCatalogEntry(
     name="answerability",
     repo_id="ibm-granite/granitelib-rag-r1.0",
     revision="abc123deadbeef",
@@ -34,7 +34,7 @@ def _make_intrinsic_adapter(intrinsic_name: str = "answerability") -> IntrinsicA
     with (
         patch(
             "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
-            return_value=IntriniscsCatalogEntry(
+            return_value=IntrinsicsCatalogEntry(
                 name=intrinsic_name,
                 repo_id="ibm-granite/granitelib-rag-r1.0",
                 revision="abc123",
@@ -171,7 +171,7 @@ def test_intrinsic_identity_lora_adapter_type():
     with (
         patch(
             "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
-            return_value=IntriniscsCatalogEntry(
+            return_value=IntrinsicsCatalogEntry(
                 name="answerability",
                 repo_id="ibm-granite/granitelib-rag-r1.0",
                 revision="abc123",
@@ -273,7 +273,7 @@ def test_resolve_adapter_raises_without_base_model():
 
 def test_resolve_adapter_lazy_creates_and_returns():
     """resolve_adapter must create an IntrinsicAdapter when none is registered."""
-    mock_catalog_entry = IntriniscsCatalogEntry(
+    mock_catalog_entry = IntrinsicsCatalogEntry(
         name="answerability",
         repo_id="ibm-granite/granitelib-rag-r1.0",
         revision="abc123",


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1268 

## Description
Refactored code to fix the typo in the class name `IntriniscsCatalogEntry`. Corrected "Intriniscs" to "Intrinsics".
Below 5 files have been edited as mentioned in scope of #1268 

- `mellea/backends/adapters/catalog.py`
- `mellea/backends/adapters/adapter.py`
- `mellea/backends/adapters/capabilities.py `
- `test/backends/test_adapters/test_catalog.py `
- `test/backends/test_adapters/test_catalog_revision.py`

However, `IntriniscsCatalogEntry` was also used in `test/backends/test_adapters/test_shims.py` which was not part of the scope mentioned in #1268 . But this PR covers this additional file as well to replace all instance of `IntriniscsCatalogEntry ` with `IntrinsicsCatalogEntry`

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
