### PR TITLE
fix: add chmod and umask guard to interpreter

### DIFF
--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ast
 import mimetypes
+import os
 import shutil
 import stat
 import subprocess
@@ -384,6 +385,7 @@ class UnsafeEnvironment(ExecutionEnvironment):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(code)
             temp_file = f.name
+        os.chmod(temp_file, 0o600)
 
         try:
             result = subprocess.run(
@@ -1233,7 +1235,11 @@ def python_tool(
         # No caller-supplied artifact_dir.  Create a per-call tempdir; clean it
         # up immediately when no artifacts were produced, or attach a finalizer
         # so it is removed when the result (and therefore its artifacts) is GC'd.
-        tmp_dir = Path(tempfile.mkdtemp())
+        old_umask = os.umask(0o077)
+        try:
+            tmp_dir = Path(tempfile.mkdtemp())
+        finally:
+            os.umask(old_umask)
         try:
             env = make_execution_environment(
                 resolved_tier,

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -385,7 +385,9 @@ class UnsafeEnvironment(ExecutionEnvironment):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(code)
             temp_file = f.name
-        os.chmod(temp_file, 0o600)
+        os.chmod(
+            temp_file, 0o600
+        )  # defense-in-depth: NamedTemporaryFile is 0o600 on most POSIX, but not guaranteed
 
         try:
             result = subprocess.run(
@@ -636,6 +638,11 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             )
             return False
 
+    @staticmethod
+    def _cleanup_export_dirs(dirs: list[Path]) -> None:
+        for d in dirs:
+            shutil.rmtree(d, True)
+
     def execute(self, code: str, timeout: int | None = None) -> ExecutionResult:
         """Execute code in a Docker container.
 
@@ -737,6 +744,7 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             )
 
             artifacts: list[Artifact] = []
+            export_dirs: list[Path] = []
             if (
                 self.policy
                 and self.policy.artifact_export_paths
@@ -747,7 +755,10 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                         staging = Path(tmp_dir) / container_path.name
                         try:
                             self.copy_out(str(container_path), staging)
-                            dest = Path(tempfile.gettempdir()) / container_path.name
+                            export_dir = Path(tempfile.mkdtemp())
+                            os.chmod(export_dir, 0o700)
+                            export_dirs.append(export_dir)
+                            dest = export_dir / container_path.name
                             shutil.copy2(staging, dest)
                             artifacts.append(
                                 Artifact(
@@ -762,7 +773,7 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                                 "Failed to export artifact %s: %s", container_path, e
                             )
 
-            return ExecutionResult(
+            execution_result = ExecutionResult(
                 success=result.exit_code == 0,
                 stdout=stdout,
                 stderr=stderr,
@@ -770,6 +781,11 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
                 artifacts=artifacts,
                 execution_mode=self._mode(),
             )
+            if export_dirs:
+                weakref.finalize(
+                    execution_result, self._cleanup_export_dirs, export_dirs
+                )
+            return execution_result
         except Exception as e:
             return ExecutionResult(
                 success=False,
@@ -1235,11 +1251,10 @@ def python_tool(
         # No caller-supplied artifact_dir.  Create a per-call tempdir; clean it
         # up immediately when no artifacts were produced, or attach a finalizer
         # so it is removed when the result (and therefore its artifacts) is GC'd.
-        old_umask = os.umask(0o077)
-        try:
-            tmp_dir = Path(tempfile.mkdtemp())
-        finally:
-            os.umask(old_umask)
+        tmp_dir = Path(tempfile.mkdtemp())
+        os.chmod(
+            tmp_dir, 0o700
+        )  # defense-in-depth: mkdtemp is already 0o700, but explicit is safer if stdlib behavior ever changes
         try:
             env = make_execution_environment(
                 resolved_tier,

--- a/test/stdlib/tools/test_python_tool.py
+++ b/test/stdlib/tools/test_python_tool.py
@@ -1,5 +1,7 @@
 """Tests for python_tool() factory and related helpers."""
 
+import os
+import stat
 import subprocess
 import warnings
 from pathlib import Path
@@ -10,6 +12,7 @@ import pytest
 import mellea.stdlib.tools.interpreter as _interpreter_mod
 from mellea.stdlib.tools import CapabilityPolicy, ExecutionResult, python_tool
 from mellea.stdlib.tools.interpreter import (
+    LLMSandboxEnvironment,
     _needs_matplotlib_preamble,
     _scan_artifacts,
     _validate_package_names,
@@ -714,6 +717,104 @@ def test_docker_oneshot_reinstalls_per_container():
     # Second call: fresh container — packages must be reinstalled, not skipped.
     result2 = tool.run(code="import cowsay; print('call2')")
     assert result2.success, result2.stderr
+
+
+# endregion
+
+
+# region security tests
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_temp_script_file_is_owner_only():
+    """_execute_subprocess temp script must be mode 0o600 on POSIX systems."""
+    captured_modes: list[int] = []
+    original_chmod = os.chmod
+
+    def capturing_chmod(path: str, mode: int) -> None:
+        original_chmod(path, mode)
+        if str(path).endswith(".py"):
+            captured_modes.append(stat.S_IMODE(os.stat(path).st_mode))
+
+    with patch("mellea.stdlib.tools.interpreter.os.chmod", side_effect=capturing_chmod):
+        tool = python_tool(tier="local_unsafe")
+        tool.run(code="print('ok')")
+
+    assert captured_modes, "os.chmod was not called on the temp script file"
+    assert captured_modes[0] == 0o600, f"expected 0o600, got {oct(captured_modes[0])}"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_artifact_tmpdir_is_owner_only():
+    """mkdtemp artifact dir must be mode 0o700 on POSIX systems."""
+    captured_modes: list[int] = []
+    original_chmod = os.chmod
+
+    def capturing_chmod(path: str, mode: int) -> None:
+        original_chmod(path, mode)
+        if os.path.isdir(path):
+            captured_modes.append(stat.S_IMODE(os.stat(path).st_mode))
+
+    with patch("mellea.stdlib.tools.interpreter.os.chmod", side_effect=capturing_chmod):
+        tool = python_tool(tier="local_unsafe")
+        tool.run(code="print('ok')")
+
+    assert captured_modes, "os.chmod was not called on the artifact tmpdir"
+    assert captured_modes[0] == 0o700, f"expected 0o700, got {oct(captured_modes[0])}"
+
+
+def _make_llm_sandbox_env_with_export(export_filename: str) -> LLMSandboxEnvironment:
+    """Return an LLMSandboxEnvironment with a fake session and copy_out that writes a real file."""
+    from unittest.mock import MagicMock
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path(f"/out/{export_filename}")])
+    env = LLMSandboxEnvironment(policy=policy)
+
+    fake_result = MagicMock()
+    fake_result.stdout = "ok"
+    fake_result.stderr = ""
+    fake_result.exit_code = 0
+
+    fake_session = MagicMock()
+    fake_session.run.return_value = fake_result
+    env._session = fake_session
+
+    def fake_copy_out(container_path: str, host_path: Path) -> None:
+        host_path.write_text("data")
+
+    env.copy_out = fake_copy_out  # type: ignore[method-assign]
+    return env
+
+
+def test_artifact_export_path_is_randomized():
+    """Exported artifact must land in a randomized subdirectory, not directly in gettempdir()."""
+    import tempfile
+
+    env = _make_llm_sandbox_env_with_export("output.csv")
+    result = env.execute("print('ok')")
+
+    assert result.artifacts, "no artifacts returned"
+    artifact_path = result.artifacts[0].path
+    # Must be inside a subdirectory of gettempdir(), not gettempdir() itself.
+    assert artifact_path.parent != Path(tempfile.gettempdir()), (
+        f"artifact landed directly in gettempdir(): {artifact_path}"
+    )
+    # The parent directory name must not be predictable from the filename alone.
+    assert artifact_path.parent.name != "output.csv"
+    assert artifact_path.name == "output.csv"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_artifact_export_dir_is_owner_only():
+    """Each per-artifact export directory must be mode 0o700 on POSIX systems."""
+    env = _make_llm_sandbox_env_with_export("output.csv")
+    result = env.execute("print('ok')")
+
+    assert result.artifacts, "no artifacts returned"
+    export_dir = result.artifacts[0].path.parent
+    assert export_dir.exists(), "export dir was removed before stat"
+    mode = stat.S_IMODE(os.stat(export_dir).st_mode)
+    assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
 
 
 # endregion


### PR DESCRIPTION
# Pull Request

## Issue
Fixes # Partial for #1246 

## Description
<!-- What does this PR do and why? -->
add chmod to named temporary file and umask guard around mkdtemp in interpreter.py to be cautious per security findings

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
