### PR TITLE
feat: carry reasoning across turns with per-backend replay policy

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -613,6 +613,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         conversation: list[dict] = []
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
+        # Intrinsic/adapter calls are single-shot evaluations over a rewritten
+        # conversation, not multi-turn generation, so reasoning is never replayed
+        # here (no `replay_reasoning=`). The HF chat path serializes via
+        # `to_chat`/`apply_chat_template`, not this helper.
         conversation.extend([message_to_openai_message(m) for m in ctx_as_message_list])
 
         docs = messages_to_docs(ctx_as_message_list)

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -41,6 +41,7 @@ from ..helpers import (
     get_current_event_loop,
     message_to_openai_message,
     send_to_queue,
+    should_replay_reasoning,
 )
 from ..stdlib.components import Message
 from ..stdlib.requirements import ALoraRequirement
@@ -355,8 +356,12 @@ class LiteLLMBackend(FormatterBackend):
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
+        replay_flags = should_replay_reasoning(messages, self._provider)
         conversation.extend(
-            [message_to_openai_message(m, self.formatter) for m in messages]
+            [
+                message_to_openai_message(m, self.formatter, replay_reasoning=replay)
+                for m, replay in zip(messages, replay_flags)
+            ]
         )
 
         extra_params: dict[str, Any] = {}

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -32,6 +32,7 @@ from ..helpers import (
     ClientCache,
     get_current_event_loop,
     send_to_queue,
+    should_replay_reasoning,
 )
 from ..stdlib.components import Message
 from ..stdlib.requirements import ALoraRequirement
@@ -422,7 +423,8 @@ class OllamaModelBackend(FormatterBackend):
 
         # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
         # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
-        for m in messages:
+        replay_flags = should_replay_reasoning(messages, self._provider)
+        for m, replay in zip(messages, replay_flags):
             if m.images is not None:
                 for img in m.images:
                     if isinstance(img, ImageUrlBlock):
@@ -435,17 +437,20 @@ class OllamaModelBackend(FormatterBackend):
                     "OllamaModelBackend does not support audio (AudioBlock/AudioUrlBlock). "
                     "Remove audio blocks before passing messages to Ollama."
                 )
-            conversation.append(
-                {
-                    "role": m.role,
-                    "content": self.formatter.print(m),
-                    "images": (
-                        _strip_data_uri_prefix([str(img.value) for img in m.images])
-                        if m.images
-                        else None
-                    ),
-                }
-            )
+            message_dict: dict[str, Any] = {
+                "role": m.role,
+                "content": self.formatter.print(m),
+                "images": (
+                    _strip_data_uri_prefix([str(img.value) for img in m.images])
+                    if m.images
+                    else None
+                ),
+            }
+            # Ollama's native SDK carries reasoning under the `thinking` key (see
+            # `chunk.message.thinking` on capture), not `reasoning_content`.
+            if replay and m.thinking:
+                message_dict["thinking"] = m.thinking
+            conversation.append(message_dict)
 
         # Append tool call information if applicable.
         tools: dict[str, AbstractMelleaTool] = dict()

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -43,6 +43,7 @@ from ..helpers import (
     message_to_openai_message,
     messages_to_docs,
     send_to_queue,
+    should_replay_reasoning,
 )
 from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import LLMaJRequirement
@@ -633,6 +634,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         conversation: list[dict] = []
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
+        # Intrinsic/adapter calls are single-shot evaluations over a rewritten
+        # conversation, not multi-turn generation, so reasoning is never replayed
+        # here (no `replay_reasoning=`) — unlike the chat path in
+        # `_generate_from_context`, which applies `should_replay_reasoning`.
         conversation.extend([message_to_openai_message(m) for m in messages])
 
         docs = messages_to_docs(messages)
@@ -859,8 +864,12 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         system_prompt = model_opts.get(ModelOption.SYSTEM_PROMPT, "")
         if system_prompt != "":
             conversation.append({"role": "system", "content": system_prompt})
+        replay_flags = should_replay_reasoning(messages, self._provider)
         conversation.extend(
-            [message_to_openai_message(m, self.formatter) for m in messages]
+            [
+                message_to_openai_message(m, self.formatter, replay_reasoning=replay)
+                for m, replay in zip(messages, replay_flags)
+            ]
         )
 
         extra_params: dict[str, Any] = {}

--- a/mellea/backends/utils.py
+++ b/mellea/backends/utils.py
@@ -98,6 +98,10 @@ def to_chat(
 
     # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
     # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
+    # NOTE: reasoning is never replayed on the HF chat path — we serialize only `content` and never
+    # consult `should_replay_reasoning` (unlike the OpenAI/LiteLLM/Watsonx/Ollama chat paths). This is
+    # acceptable today because HF has a capture gap (per #1201) and never populates `Message.thinking`
+    # to begin with; when that gap is closed, replay must be wired in here.
     ctx_as_conversation: list = [
         {"role": m.role, "content": formatter.print(m)} for m in ctx_as_message_list
     ]

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -43,6 +43,7 @@ from ..helpers import (
     extract_model_tool_requests,
     get_current_event_loop,
     send_to_queue,
+    should_replay_reasoning,
 )
 from ..stdlib.components import Message
 from ..stdlib.requirements import ALoraRequirement
@@ -402,7 +403,8 @@ class WatsonxAIBackend(FormatterBackend):
 
         # NOTE: `self.formatter.to_chat_messages` explicitly skips `Message` objects. However, we need
         # to print `Message`s to correctly serialize any documents with the message. Do the printing here.
-        for m in messages:
+        replay_flags = should_replay_reasoning(messages, self._provider)
+        for m, replay in zip(messages, replay_flags):
             if m.images:
                 raise ValueError(
                     "WatsonxAIBackend does not support image inputs (ImageBlock/ImageUrlBlock). "
@@ -413,9 +415,13 @@ class WatsonxAIBackend(FormatterBackend):
                     "WatsonxAIBackend does not support audio inputs (AudioBlock/AudioUrlBlock). "
                     "Remove audio blocks before passing messages to Watsonx."
                 )
-        conversation.extend(
-            [{"role": m.role, "content": self.formatter.print(m)} for m in messages]
-        )
+            message_dict: dict[str, Any] = {
+                "role": m.role,
+                "content": self.formatter.print(m),
+            }
+            if replay and m.thinking:
+                message_dict["reasoning_content"] = m.thinking
+            conversation.append(message_dict)
 
         if _format is not None:
             model_opts["response_format"] = {

--- a/mellea/helpers/__init__.py
+++ b/mellea/helpers/__init__.py
@@ -22,6 +22,7 @@ from .openai_compatible_helpers import (
     extract_model_tool_requests,
     message_to_openai_message,
     messages_to_docs,
+    should_replay_reasoning,
 )
 from .server_type import (
     _server_type,
@@ -42,5 +43,6 @@ __all__ = [
     "message_to_openai_message",
     "messages_to_docs",
     "send_to_queue",
+    "should_replay_reasoning",
     "wait_for_all_mots",
 ]

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -184,7 +184,45 @@ def chat_completion_delta_merge(
     return merged
 
 
-def message_to_openai_message(msg: Message, formatter: Formatter | None = None) -> dict:
+def should_replay_reasoning(
+    messages: list[Message], provider: str | None
+) -> list[bool]:
+    """Decide, per message, whether its reasoning trace should be replayed to the provider.
+
+    Implements the cross-provider consensus rule from issue #1201: an assistant
+    message's reasoning is round-tripped only when that turn issued a tool call —
+    detected by a `tool`-role message immediately following it — and stripped on
+    plain follow-up turns. Non-assistant messages and assistant messages without
+    reasoning always return `False`.
+
+    Args:
+        messages: The conversation in order, as it will be serialised.
+        provider: The backend provider name (e.g. `"openai"`, `"ollama"`).
+            Currently unused — every provider follows the consensus rule above.
+            It is a reserved hook for a provider-specific deviation (e.g. a model
+            that must replay reasoning on plain turns, or must not after a tool
+            call); add a keyed branch here once such a case is verified live.
+
+    Returns:
+        A list of booleans, one per message in `messages`, indicating whether that
+        message's reasoning should be included in the serialised payload.
+    """
+    flags: list[bool] = []
+    for i, msg in enumerate(messages):
+        if msg.role != "assistant" or not msg.thinking:
+            flags.append(False)
+            continue
+        # The prior turn "had a tool call" iff the next message is a tool result.
+        prior_turn_had_tool_call = (
+            i + 1 < len(messages) and messages[i + 1].role == "tool"
+        )
+        flags.append(prior_turn_had_tool_call)
+    return flags
+
+
+def message_to_openai_message(
+    msg: Message, formatter: Formatter | None = None, *, replay_reasoning: bool = False
+) -> dict:
     """Serialise a Mellea `Message` to the format required by OpenAI-compatible API providers.
 
     Args:
@@ -192,13 +230,20 @@ def message_to_openai_message(msg: Message, formatter: Formatter | None = None) 
         formatter: Optional formatter used to render the message content (including
             documents) through the template system. When `None`, uses the raw
             `msg.content` string without document rendering.
+        replay_reasoning: When `True` and `msg.thinking` is a non-empty string,
+            the reasoning trace is emitted under the `"reasoning_content"` key so
+            the provider receives the model's prior reasoning. Defaults to `False`
+            (reasoning is stripped), preserving the historical behaviour; callers
+            decide per-turn via their replay policy (see `should_replay_reasoning`).
 
     Returns:
         A dict with `"role"` and `"content"` fields. When the message carries
         images or audio, `"content"` is a list of content-part dicts; otherwise
         is a plain string. For tool-only assistant turns, `"content"` is `None`
         and `"tool_calls"` carries the structured call list. When content is
-        present alongside tool calls, both keys are included.
+        present alongside tool calls, both keys are included. When
+        `replay_reasoning` is `True` and reasoning is present, the dict also
+        carries a `"reasoning_content"` field.
 
     Raises:
         ValueError: If the message contains an `AudioUrlBlock`. The OpenAI Chat
@@ -256,6 +301,9 @@ def message_to_openai_message(msg: Message, formatter: Formatter | None = None) 
         result["tool_calls"] = tool_calls
         if msg.images is None and not content:
             result["content"] = None
+
+    if replay_reasoning and msg.thinking:
+        result["reasoning_content"] = msg.thinking
     return result
 
 

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -191,9 +191,11 @@ def should_replay_reasoning(
 
     Implements the cross-provider consensus rule from issue #1201: an assistant
     message's reasoning is round-tripped only when that turn issued a tool call —
-    detected by a `tool`-role message immediately following it — and stripped on
-    plain follow-up turns. Non-assistant messages and assistant messages without
-    reasoning always return `False`.
+    detected by the message's own `tool_calls` field — and stripped on plain
+    follow-up turns. Keying off `tool_calls` rather than a trailing `tool`-role
+    message means reasoning is still replayed for a turn that requested a tool
+    call even if the tool was never executed. Non-assistant messages and
+    assistant messages without reasoning always return `False`.
 
     Args:
         messages: The conversation in order, as it will be serialised.
@@ -208,15 +210,13 @@ def should_replay_reasoning(
         message's reasoning should be included in the serialised payload.
     """
     flags: list[bool] = []
-    for i, msg in enumerate(messages):
+    for msg in messages:
         if msg.role != "assistant" or not msg.thinking:
             flags.append(False)
             continue
-        # The prior turn "had a tool call" iff the next message is a tool result.
-        prior_turn_had_tool_call = (
-            i + 1 < len(messages) and messages[i + 1].role == "tool"
-        )
-        flags.append(prior_turn_had_tool_call)
+        # The turn "had a tool call" iff the assistant message itself carries
+        # tool calls — independent of whether the tool was later executed.
+        flags.append(bool(msg.tool_calls))
     return flags
 
 

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -48,6 +48,13 @@ class Message(Component["Message"]):
             the message.
         tool_calls (list[dict[str, Any]] | None): Optional OpenAI-compatible
             assistant tool calls associated with the message.
+        thinking (str | None): Optional reasoning trace produced by a thinking
+            model on the turn that generated this message. Populated by `_parse`
+            from `ModelOutputThunk.thinking`; carried through `as_chat_history`
+            so backends can round-trip it on subsequent turns per their replay
+            policy. `None` or empty for messages that carry no reasoning (e.g.
+            user turns, or assistant turns from non-thinking models); the replay
+            policy and serializers treat both falsy cases identically.
 
     Attributes:
         Role (type): Type alias for the allowed role literals: `"system"`,
@@ -65,14 +72,16 @@ class Message(Component["Message"]):
         audio: None | list[AudioBlock | AudioUrlBlock] = None,
         documents: None | Iterable[str | Document] = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        thinking: str | None = None,
     ):
-        """Initialize a Message with a role, text content, and optional images, audio, and documents."""
+        """Initialize a Message with a role, text content, optional images, audio, documents, tool calls, and an optional reasoning trace."""
         if role not in get_args(Message.Role):
             raise ValueError(
                 f"Invalid role {role!r}. Must be one of: {list(get_args(Message.Role))}"
             )
         self.role = role
         self.content = content  # TODO this should be private.
+        self.thinking = thinking
         self._content_cblock = CBlock(self.content)
         self._images = images
         self._audio = audio
@@ -159,35 +168,56 @@ class Message(Component["Message"]):
             # Assistant responses for tool calling differ by backend. Preserve
             # OpenAI-compatible tool calls separately from message content when
             # the provider gives us structured tool-call data.
+            # Carry any captured reasoning onto the tool-issuing assistant Message: this is the
+            # exact turn the replay policy round-trips (see `should_replay_reasoning`), so the
+            # reasoning must survive parsing here or the round-trip has nothing to replay.
             if provider == "ollama" and response is not None:
                 from ...helpers.openai_compatible_helpers import build_tool_calls
 
                 tool_calls = cast(
                     list[dict[str, Any]], build_tool_calls(computed) or []
                 )
+                thinking = (
+                    computed.thinking if response.message.role == "assistant" else None
+                )
                 return Message(
                     role=response.message.role,
                     content=getattr(response.message, "content", "") or "",
                     tool_calls=tool_calls,
+                    thinking=thinking,
                 )
             if provider in ("openai", "watsonx", "litellm") and isinstance(
                 response, dict
             ):
                 choice = response["choices"][0] if "choices" in response else response
                 msg = choice["message"]
+                thinking = computed.thinking if msg["role"] == "assistant" else None
                 return Message(
                     role=msg["role"],
                     content=msg.get("content") or "",
                     tool_calls=msg.get("tool_calls") or None,
+                    thinking=thinking,
                 )
             # Hugging Face (or others). There are no guarantees on how the model represented the function calls.
             # Output it in the same format we received the tool call request.
             assert computed.value is not None
-            return Message(role="assistant", content=computed.value)
+            return Message(
+                role="assistant", content=computed.value, thinking=computed.thinking
+            )
 
+        # No tool call on this turn: carry any captured reasoning onto the parsed
+        # assistant Message so it can round-trip on subsequent turns. `thinking` is
+        # None for non-thinking models and for role="tool" recoveries.
         if provider == "ollama" and response is not None:
             # Ollama can return role="tool"; preserve role recovery from the response.
-            return Message(role=response.message.role, content=response.message.content)
+            thinking = (
+                computed.thinking if response.message.role == "assistant" else None
+            )
+            return Message(
+                role=response.message.role,
+                content=response.message.content,
+                thinking=thinking,
+            )
         if provider in ("openai", "watsonx", "litellm") and isinstance(response, dict):
             choices = response.get("choices") or [{}]
             msg = choices[0].get("message", {})
@@ -197,12 +227,15 @@ class Message(Component["Message"]):
             content = msg.get("content") or response.get("message", {}).get(
                 "content", ""
             )
-            return Message(role=role, content=content)
+            thinking = computed.thinking if role == "assistant" else None
+            return Message(role=role, content=content, thinking=thinking)
 
         # Hugging Face: raw.response is token tensors with no role/content to parse.
         # Unknown provider: nothing to switch on. Both fall back to the decoded text.
         assert computed.value is not None
-        return Message(role="assistant", content=computed.value)
+        return Message(
+            role="assistant", content=computed.value, thinking=computed.thinking
+        )
 
 
 class ToolMessage(Message):

--- a/test/backends/test_reasoning_replay.py
+++ b/test/backends/test_reasoning_replay.py
@@ -5,8 +5,8 @@ follow-up turn, exercising issue #1201's consensus replay rule end-to-end
 through each backend's conversation-construction path:
 
 - reasoning is **stripped** on a plain follow-up turn, and
-- **round-tripped** when the immediately-prior assistant turn issued a tool call
-  (detected by a following ``role="tool"`` message).
+- **round-tripped** when the prior assistant turn issued a tool call
+  (detected by that assistant message's own ``tool_calls`` field).
 
 The provider ``create``/``acompletion`` call is mocked, so no endpoint is
 required. A separate CI-skipped e2e test (``test_reasoning_replay_e2e.py``)
@@ -69,6 +69,13 @@ def _assistant_messages(messages: list[dict]) -> list[dict]:
     return [m for m in messages if m.get("role") == "assistant"]
 
 
+# A tool-issuing assistant turn is detected by its own `tool_calls` field (not a
+# trailing `tool`-role message), matching `should_replay_reasoning`'s policy.
+_TOOL_CALLS = [
+    {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+]
+
+
 # ---------------------------------------------------------------------------
 # OpenAI-compatible path (reasoning_content wire key)
 # ---------------------------------------------------------------------------
@@ -96,7 +103,14 @@ async def test_openai_round_trips_reasoning_after_tool_call(
     ctx = (
         ChatContext()
         .add(Message("user", "use a tool"))
-        .add(Message("assistant", "calling tool", thinking="tool-turn reasoning"))
+        .add(
+            Message(
+                "assistant",
+                "calling tool",
+                thinking="tool-turn reasoning",
+                tool_calls=_TOOL_CALLS,
+            )
+        )
         .add(Message("tool", "tool output"))
     )
     messages = await _capture_messages(openai_backend, ctx)
@@ -109,13 +123,20 @@ async def test_openai_round_trips_reasoning_after_tool_call(
 
 
 async def test_openai_only_tool_turn_reasoning_replayed(openai_backend: OpenAIBackend):
-    """In a mixed history only the tool-preceding assistant turn carries reasoning."""
+    """In a mixed history only the tool-call assistant turn carries reasoning."""
     ctx = (
         ChatContext()
         .add(Message("user", "q1"))
         .add(Message("assistant", "plain answer", thinking="plain reasoning"))
         .add(Message("user", "q2"))
-        .add(Message("assistant", "calling tool", thinking="tool reasoning"))
+        .add(
+            Message(
+                "assistant",
+                "calling tool",
+                thinking="tool reasoning",
+                tool_calls=_TOOL_CALLS,
+            )
+        )
         .add(Message("tool", "tool output"))
     )
     messages = await _capture_messages(openai_backend, ctx)
@@ -125,7 +146,7 @@ async def test_openai_only_tool_turn_reasoning_replayed(openai_backend: OpenAIBa
         if "reasoning_content" in m
     ]
     assert replayed == ["tool reasoning"], (
-        "exactly the tool-preceding assistant turn's reasoning should be replayed"
+        "exactly the tool-call assistant turn's reasoning should be replayed"
     )
 
 
@@ -223,7 +244,14 @@ def _tool_ctx() -> ChatContext:
     return (
         ChatContext()
         .add(Message("user", "use a tool"))
-        .add(Message("assistant", "calling tool", thinking="tool-turn reasoning"))
+        .add(
+            Message(
+                "assistant",
+                "calling tool",
+                thinking="tool-turn reasoning",
+                tool_calls=_TOOL_CALLS,
+            )
+        )
         .add(Message("tool", "tool output"))
     )
 

--- a/test/backends/test_reasoning_replay.py
+++ b/test/backends/test_reasoning_replay.py
@@ -1,0 +1,333 @@
+"""Per-backend multi-turn reasoning-replay policy tests (no live model).
+
+These tests assert the *messages array actually sent to the provider* on a
+follow-up turn, exercising issue #1201's consensus replay rule end-to-end
+through each backend's conversation-construction path:
+
+- reasoning is **stripped** on a plain follow-up turn, and
+- **round-tripped** when the immediately-prior assistant turn issued a tool call
+  (detected by a following ``role="tool"`` message).
+
+The provider ``create``/``acompletion`` call is mocked, so no endpoint is
+required. A separate CI-skipped e2e test (``test_reasoning_replay_e2e.py``)
+verifies the same behaviour against a real reasoning model.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+
+from mellea.backends import ModelOption
+from mellea.backends.openai import OpenAIBackend
+from mellea.core import CBlock
+from mellea.stdlib.components import Message
+from mellea.stdlib.context import ChatContext
+
+
+def _fake_openai_response() -> ChatCompletion:
+    """Minimal real ChatCompletion that survives processing()/post_processing()."""
+    return ChatCompletion(
+        id="test",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="next answer"),
+            )
+        ],
+        created=0,
+        model="qwen3",
+        object="chat.completion",
+    )
+
+
+@pytest.fixture
+def openai_backend() -> OpenAIBackend:
+    """OpenAIBackend with a fake key — the client is never actually contacted."""
+    return OpenAIBackend(
+        model_id="qwen3", api_key="fake-key", base_url="http://localhost:9999/v1"
+    )
+
+
+async def _capture_messages(backend: OpenAIBackend, ctx: ChatContext) -> list[dict]:
+    """Run one generation with the network mocked; return the sent messages array."""
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = _fake_openai_response()
+        mot, _ = await backend.generate_from_chat_context(
+            CBlock(value="follow up"), ctx, model_options={ModelOption.STREAM: False}
+        )
+        await mot.avalue()
+        assert mock_create.called, "create() was never called"
+        return list(mock_create.call_args.kwargs["messages"])
+
+
+def _assistant_messages(messages: list[dict]) -> list[dict]:
+    return [m for m in messages if m.get("role") == "assistant"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible path (reasoning_content wire key)
+# ---------------------------------------------------------------------------
+
+
+async def test_openai_strips_reasoning_on_plain_turn(openai_backend: OpenAIBackend):
+    """A plain prior assistant turn: reasoning must NOT be replayed."""
+    ctx = (
+        ChatContext()
+        .add(Message("user", "first question"))
+        .add(Message("assistant", "first answer", thinking="prior reasoning"))
+    )
+    messages = await _capture_messages(openai_backend, ctx)
+    assistants = _assistant_messages(messages)
+    assert assistants, "expected the prior assistant turn in the payload"
+    assert all("reasoning_content" not in m for m in assistants), (
+        "reasoning must be stripped on a plain follow-up turn"
+    )
+
+
+async def test_openai_round_trips_reasoning_after_tool_call(
+    openai_backend: OpenAIBackend,
+):
+    """Prior assistant turn issued a tool call: reasoning must be replayed."""
+    ctx = (
+        ChatContext()
+        .add(Message("user", "use a tool"))
+        .add(Message("assistant", "calling tool", thinking="tool-turn reasoning"))
+        .add(Message("tool", "tool output"))
+    )
+    messages = await _capture_messages(openai_backend, ctx)
+    tool_turn = next(
+        m
+        for m in _assistant_messages(messages)
+        if m.get("reasoning_content") is not None
+    )
+    assert tool_turn["reasoning_content"] == "tool-turn reasoning"
+
+
+async def test_openai_only_tool_turn_reasoning_replayed(openai_backend: OpenAIBackend):
+    """In a mixed history only the tool-preceding assistant turn carries reasoning."""
+    ctx = (
+        ChatContext()
+        .add(Message("user", "q1"))
+        .add(Message("assistant", "plain answer", thinking="plain reasoning"))
+        .add(Message("user", "q2"))
+        .add(Message("assistant", "calling tool", thinking="tool reasoning"))
+        .add(Message("tool", "tool output"))
+    )
+    messages = await _capture_messages(openai_backend, ctx)
+    replayed = [
+        m["reasoning_content"]
+        for m in _assistant_messages(messages)
+        if "reasoning_content" in m
+    ]
+    assert replayed == ["tool reasoning"], (
+        "exactly the tool-preceding assistant turn's reasoning should be replayed"
+    )
+
+
+async def test_openai_no_thinking_never_replayed(openai_backend: OpenAIBackend):
+    """An assistant turn without reasoning never grows a reasoning_content key."""
+    ctx = (
+        ChatContext()
+        .add(Message("user", "q"))
+        .add(Message("assistant", "answer"))  # no thinking
+        .add(Message("tool", "out"))
+    )
+    messages = await _capture_messages(openai_backend, ctx)
+    assert all("reasoning_content" not in m for m in _assistant_messages(messages))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end seam: a tool-issuing turn parsed by `_parse` must carry reasoning
+# all the way to the wire. The per-turn tests above hand-build the assistant
+# Message; this exercises the real capture -> _parse -> policy -> serialize
+# path, guarding the gap where `_parse`'s tool-call branch dropped `thinking`
+# and left the round-trip with nothing to replay.
+# ---------------------------------------------------------------------------
+
+
+async def test_openai_tool_turn_reasoning_survives_parse_to_wire(
+    openai_backend: OpenAIBackend,
+):
+    """`_parse` of a tool-issuing MOT yields a Message whose reasoning is replayed."""
+    from typing import cast
+
+    from mellea.core import ModelOutputThunk, ModelToolCall, RawProviderResponse
+
+    # Simulate what a backend produces on a tool-calling turn: tool_calls set and
+    # reasoning captured on the MOT. `_parse` only checks `tool_calls is not None`,
+    # never the value — the cast keeps the type checker happy without a real tool.
+    mot = ModelOutputThunk(value="v", tool_calls={"fn": cast(ModelToolCall, None)})
+    mot.thinking = "reasoning that led to the tool call"
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [{"function": {"name": "fn"}}],
+                    }
+                }
+            ]
+        },
+    )
+    assistant_msg = Message("user", "use a tool")._parse(mot)
+    assert assistant_msg.thinking == "reasoning that led to the tool call", (
+        "_parse must carry reasoning onto the tool-issuing assistant Message"
+    )
+
+    ctx = (
+        ChatContext()
+        .add(Message("user", "use a tool"))
+        .add(assistant_msg)
+        .add(Message("tool", "tool output"))
+    )
+    messages = await _capture_messages(openai_backend, ctx)
+    tool_turn = next(
+        m
+        for m in _assistant_messages(messages)
+        if m.get("reasoning_content") is not None
+    )
+    assert tool_turn["reasoning_content"] == "reasoning that led to the tool call"
+
+
+# ---------------------------------------------------------------------------
+# Ollama and WatsonX build the conversation dict INLINE (not via
+# message_to_openai_message) and use DIVERGENT wire keys — Ollama's native SDK
+# carries reasoning under `thinking`, WatsonX under `reasoning_content`. That
+# per-backend divergence is the riskiest part of the change, so it gets direct
+# coverage here. Both backends assemble `conversation` fully before calling the
+# client, so a mock that records the `messages=` kwarg and short-circuits the
+# rest of the async pipeline captures exactly what would go on the wire.
+# ---------------------------------------------------------------------------
+
+
+class _StopBeforeSend(Exception):
+    """Raised by the capturing mock to skip the (unmocked) response machinery."""
+
+
+def _plain_ctx() -> ChatContext:
+    return (
+        ChatContext()
+        .add(Message("user", "first question"))
+        .add(Message("assistant", "first answer", thinking="prior reasoning"))
+    )
+
+
+def _tool_ctx() -> ChatContext:
+    return (
+        ChatContext()
+        .add(Message("user", "use a tool"))
+        .add(Message("assistant", "calling tool", thinking="tool-turn reasoning"))
+        .add(Message("tool", "tool output"))
+    )
+
+
+async def _capture_ollama_conversation(ctx: ChatContext) -> list[dict]:
+    """Return the messages array Ollama would send, without a live server."""
+    from unittest.mock import MagicMock
+
+    from mellea.backends.ollama import OllamaModelBackend
+
+    captured: dict = {}
+
+    def _record(*args, **kwargs):
+        captured["messages"] = kwargs["messages"]
+        raise _StopBeforeSend
+
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client", return_value=MagicMock()),
+        patch("mellea.backends.ollama.ollama.AsyncClient", return_value=MagicMock()),
+    ):
+        backend = OllamaModelBackend(model_id="granite3.3:8b")
+        with patch.object(backend._async_client, "chat", side_effect=_record):
+            try:
+                await backend.generate_from_chat_context(
+                    CBlock(value="follow up"),
+                    ctx,
+                    model_options={ModelOption.STREAM: False},
+                )
+            except _StopBeforeSend:
+                pass
+    assert "messages" in captured, "Ollama never built the conversation"
+    return captured["messages"]
+
+
+async def test_ollama_strips_reasoning_on_plain_turn():
+    """Ollama plain follow-up: no `thinking` key round-tripped."""
+    conversation = await _capture_ollama_conversation(_plain_ctx())
+    assistants = [m for m in conversation if m.get("role") == "assistant"]
+    assert assistants, "expected the prior assistant turn in the payload"
+    assert all("thinking" not in m for m in assistants)
+
+
+async def test_ollama_round_trips_reasoning_after_tool_call():
+    """Ollama tool turn: reasoning round-tripped under the native `thinking` key."""
+    conversation = await _capture_ollama_conversation(_tool_ctx())
+    tool_turn = next(m for m in conversation if m.get("thinking") is not None)
+    assert tool_turn["thinking"] == "tool-turn reasoning"
+    # And it must NOT be emitted under the OpenAI-compat key.
+    assert all("reasoning_content" not in m for m in conversation)
+
+
+async def _capture_watsonx_conversation(ctx: ChatContext) -> list[dict]:
+    """Return the messages array WatsonX would send, without a live endpoint."""
+    pytest.importorskip("ibm_watsonx_ai")
+    from unittest.mock import MagicMock
+
+    from mellea.backends.watsonx import WatsonxAIBackend
+
+    captured: dict = {}
+
+    def _record(*args, **kwargs):
+        captured["messages"] = kwargs["messages"]
+        raise _StopBeforeSend
+
+    with (
+        patch("mellea.backends.watsonx.Credentials", return_value=MagicMock()),
+        patch("mellea.backends.watsonx.APIClient", return_value=MagicMock()),
+        patch("mellea.backends.watsonx.ModelInference", return_value=MagicMock()),
+    ):
+        backend = WatsonxAIBackend(
+            model_id="ibm/granite-3-8b-instruct",
+            api_key="fake-key",
+            base_url="https://example.invalid",
+            project_id="fake-project",
+        )
+        with patch.object(backend._model, "achat", side_effect=_record):
+            try:
+                await backend.generate_from_chat_context(
+                    CBlock(value="follow up"),
+                    ctx,
+                    model_options={ModelOption.STREAM: False},
+                )
+            except _StopBeforeSend:
+                pass
+    assert "messages" in captured, "WatsonX never built the conversation"
+    return captured["messages"]
+
+
+async def test_watsonx_strips_reasoning_on_plain_turn():
+    """WatsonX plain follow-up: no `reasoning_content` round-tripped."""
+    conversation = await _capture_watsonx_conversation(_plain_ctx())
+    assistants = [m for m in conversation if m.get("role") == "assistant"]
+    assert assistants, "expected the prior assistant turn in the payload"
+    assert all("reasoning_content" not in m for m in assistants)
+
+
+async def test_watsonx_round_trips_reasoning_after_tool_call():
+    """WatsonX tool turn: reasoning round-tripped under `reasoning_content`."""
+    conversation = await _capture_watsonx_conversation(_tool_ctx())
+    tool_turn = next(m for m in conversation if m.get("reasoning_content") is not None)
+    assert tool_turn["reasoning_content"] == "tool-turn reasoning"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/backends/test_reasoning_replay_e2e.py
+++ b/test/backends/test_reasoning_replay_e2e.py
@@ -1,0 +1,101 @@
+"""Live multi-turn reasoning-replay verification against a real thinking model.
+
+This is the "quick verification after the fact" for issue #1201: the mechanical
+strip/round-trip plumbing is unit-tested in ``test_reasoning_replay.py`` without
+a model; this module confirms the same behaviour holds against a real reasoning
+endpoint, and pins the one empirical unknown — which side of the tool-call
+contract the served model lands on.
+
+Model-agnostic by design. Configure via environment variables (skipped entirely
+when unset, so it never runs in default CI):
+
+- ``MELLEA_REASONING_TEST_BASE_URL`` — OpenAI-compatible endpoint, e.g.
+  ``http://localhost:8000/v1`` (vLLM) or ``http://localhost:11434/v1`` (Ollama).
+- ``MELLEA_REASONING_TEST_MODEL`` — served model id. Defaults to a Granite
+  reasoning model; point it at Qwen3 / DeepSeek-R1 / etc. to verify those.
+- ``MELLEA_REASONING_TEST_API_KEY`` — optional; defaults to ``"ollama"``.
+
+Run directly (bypasses the default marker filter):
+
+    MELLEA_REASONING_TEST_BASE_URL=http://localhost:8000/v1 \\
+    MELLEA_REASONING_TEST_MODEL=Qwen/Qwen3-8B \\
+    uv run pytest test/backends/test_reasoning_replay_e2e.py -v
+"""
+
+import os
+
+import pytest
+
+from mellea.backends import ModelOption
+from mellea.backends.openai import OpenAIBackend
+from mellea.stdlib.components import Message
+from mellea.stdlib.components.chat import as_chat_history
+from mellea.stdlib.context import ChatContext, Context
+
+pytestmark = [
+    pytest.mark.openai,
+    pytest.mark.e2e,
+    pytest.mark.qualitative,
+    pytest.mark.skipif(
+        not os.environ.get("MELLEA_REASONING_TEST_BASE_URL"),
+        reason="Set MELLEA_REASONING_TEST_BASE_URL to run the live reasoning-replay check",
+    ),
+]
+
+_DEFAULT_MODEL = "granite4:micro-h"
+
+
+@pytest.fixture(scope="module")
+def backend() -> OpenAIBackend:
+    return OpenAIBackend(
+        model_id=os.environ.get("MELLEA_REASONING_TEST_MODEL", _DEFAULT_MODEL),
+        base_url=os.environ["MELLEA_REASONING_TEST_BASE_URL"],
+        api_key=os.environ.get("MELLEA_REASONING_TEST_API_KEY", "ollama"),
+    )
+
+
+async def test_reasoning_captured_and_carried_across_turns(backend: OpenAIBackend):
+    """End-to-end: reasoning is captured on turn 1 and reaches Message.thinking.
+
+    Verifies the capture -> parse -> as_chat_history plumbing against a live
+    reasoning model. The turn-2 replay contract (strip vs. round-trip) is
+    asserted structurally in the unit test; here we confirm the trace survives
+    into the parsed assistant Message so the policy has something to act on.
+    """
+    ctx: Context = ChatContext()
+    mot, ctx = await backend.generate_from_chat_context(
+        Message("user", "What is 17 * 23? Think step by step."),
+        ctx,
+        model_options={ModelOption.THINKING: True},
+    )
+    await mot.avalue()
+
+    if not mot.thinking:
+        pytest.skip(
+            "Model produced no reasoning trace — ensure the configured model is a "
+            "reasoning model and THINKING is honoured by the endpoint."
+        )
+
+    # The captured reasoning must survive parsing into the assistant Message and
+    # the chat-history round-trip.
+    history = as_chat_history(ctx)
+    assistant_turns = [m for m in history if m.role == "assistant"]
+    assert assistant_turns, "expected an assistant turn in the history"
+    assert assistant_turns[-1].thinking, (
+        "reasoning captured on the MOT must carry onto the parsed assistant Message"
+    )
+
+    # A plain follow-up turn should complete without error (consensus rule strips
+    # the prior reasoning; a model that hard-400s here is the DeepSeek-style
+    # exception worth flagging on the issue).
+    mot2, ctx = await backend.generate_from_chat_context(
+        Message("user", "Now double that result."),
+        ctx,
+        model_options={ModelOption.THINKING: True},
+    )
+    value2 = await mot2.avalue()
+    assert value2 is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -15,7 +15,11 @@ from mellea.core import (
 )
 from mellea.formatters.chat_formatter import ChatFormatter
 from mellea.formatters.template_formatter import TemplateFormatter
-from mellea.helpers import message_to_openai_message, messages_to_docs
+from mellea.helpers import (
+    message_to_openai_message,
+    messages_to_docs,
+    should_replay_reasoning,
+)
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.components.chat import (
     ToolMessage,
@@ -67,6 +71,16 @@ def test_message_basic_fields():
     assert msg.content == "hello"
     assert msg._images is None
     assert msg._docs is None
+
+
+def test_message_thinking_defaults_none():
+    msg = Message("assistant", "hello")
+    assert msg.thinking is None
+
+
+def test_message_thinking_stored():
+    msg = Message("assistant", "hello", thinking="step-by-step reasoning")
+    assert msg.thinking == "step-by-step reasoning"
 
 
 def test_message_content_block_created():
@@ -226,6 +240,76 @@ def test_parse_openai_streamed_choice_shape():
     assert result.content == "streamed answer"
 
 
+# --- Message._parse — reasoning (thinking) population ---
+
+
+def test_parse_plain_carries_thinking():
+    """Fallback branch (no provider) copies mot.thinking onto the parsed Message."""
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="answer")
+    mot.thinking = "let me think"
+    result = msg._parse(mot)
+    assert result.content == "answer"
+    assert result.thinking == "let me think"
+
+
+def test_parse_openai_carries_thinking():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v")
+    mot.thinking = "openai reasoning"
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "choices": [{"message": {"role": "assistant", "content": "openai answer"}}]
+        },
+    )
+    result = msg._parse(mot)
+    assert result.content == "openai answer"
+    assert result.thinking == "openai reasoning"
+
+
+def test_parse_ollama_carries_thinking():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v")
+    mot.thinking = "ollama reasoning"
+    fake_response = type(
+        "Resp",
+        (),
+        {
+            "message": type(
+                "Msg", (), {"role": "assistant", "content": "ollama answer"}
+            )()
+        },
+    )()
+    mot.raw = RawProviderResponse(provider="ollama", response=fake_response)
+    result = msg._parse(mot)
+    assert result.content == "ollama answer"
+    assert result.thinking == "ollama reasoning"
+
+
+def test_parse_ollama_tool_role_drops_thinking():
+    """A role='tool' recovery must not carry reasoning onto a tool message."""
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v")
+    mot.thinking = "should not appear"
+    fake_response = type(
+        "Resp",
+        (),
+        {"message": type("Msg", (), {"role": "tool", "content": "tool output"})()},
+    )()
+    mot.raw = RawProviderResponse(provider="ollama", response=fake_response)
+    result = msg._parse(mot)
+    assert result.role == "tool"
+    assert result.thinking is None
+
+
+def test_parse_no_thinking_stays_none():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="answer")  # mot.thinking defaults to None
+    result = msg._parse(mot)
+    assert result.thinking is None
+
+
 # --- Message._parse — with tool calls ---
 
 
@@ -362,6 +446,81 @@ def test_parse_tool_calls_fallback_uses_value():
     assert result.content == "<tool_call>fn()</tool_call>"
 
 
+# --- Message._parse — reasoning on the tool-issuing assistant turn ---
+#
+# The replay policy round-trips reasoning precisely on the turn that issued a
+# tool call, so `_parse` must carry `mot.thinking` onto that assistant Message.
+# These drive the tool-call branch (mirroring the tool-call tests above) and
+# assert `thinking` survives — the round-trip has nothing to replay otherwise.
+
+
+def test_parse_tool_calls_ollama_carries_thinking():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v", tool_calls={"some_fn": None})
+    mot.thinking = "tool-turn reasoning"
+    fake_calls = [{"name": "some_fn"}]
+    fake_response = type(
+        "Resp",
+        (),
+        {"message": type("Msg", (), {"role": "assistant", "tool_calls": fake_calls})()},
+    )()
+    mot.raw = RawProviderResponse(provider="ollama", response=fake_response)
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.thinking == "tool-turn reasoning"
+
+
+def test_parse_tool_calls_openai_carries_thinking():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v", tool_calls={"fn": None})
+    mot.thinking = "tool-turn reasoning"
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [{"function": {"name": "fn"}}],
+                    }
+                }
+            ]
+        },
+    )
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.thinking == "tool-turn reasoning"
+
+
+def test_parse_tool_calls_openai_streamed_carries_thinking():
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v", tool_calls={"fn": None})
+    mot.thinking = "tool-turn reasoning"
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "fn"}}],
+            },
+        },
+    )
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.thinking == "tool-turn reasoning"
+
+
+def test_parse_tool_calls_fallback_carries_thinking():
+    """HF/unknown fallback also carries reasoning onto the tool-issuing turn."""
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="<tool_call>fn()</tool_call>", tool_calls={"fn": None})
+    mot.thinking = "tool-turn reasoning"
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.thinking == "tool-turn reasoning"
+
+
 # --- ToolMessage ---
 
 
@@ -421,6 +580,73 @@ def test_as_chat_history_with_parsed_mot():
     history = as_chat_history(ctx)
     assert len(history) == 2
     assert history[1].content == "reply"
+
+
+def test_as_chat_history_carries_thinking():
+    """Reasoning on a parsed assistant Message survives the chat-history round-trip."""
+    ctx = ChatContext()
+    ctx = ctx.add(Message("user", "hello"))
+    mot = ModelOutputThunk(value="reply")
+    mot.parsed_repr = Message("assistant", "reply", thinking="my reasoning")
+    ctx = ctx.add(mot)
+    history = as_chat_history(ctx)
+    assert history[1].thinking == "my reasoning"
+
+
+# --- should_replay_reasoning policy ---
+
+
+def test_replay_policy_strips_plain_assistant_turn():
+    msgs = [
+        Message("user", "q"),
+        Message("assistant", "a", thinking="t"),
+        Message("user", "q2"),
+    ]
+    assert should_replay_reasoning(msgs, "openai") == [False, False, False]
+
+
+def test_replay_policy_round_trips_after_tool_call():
+    """Assistant turn immediately followed by a tool result is replayed."""
+    msgs = [
+        Message("user", "q"),
+        Message("assistant", "a", thinking="tool reasoning"),
+        Message("tool", "tool output"),
+    ]
+    assert should_replay_reasoning(msgs, "openai") == [False, True, False]
+
+
+def test_replay_policy_assistant_without_thinking_is_false():
+    msgs = [
+        Message("user", "q"),
+        Message("assistant", "a"),  # no thinking
+        Message("tool", "out"),
+    ]
+    assert should_replay_reasoning(msgs, "openai") == [False, False, False]
+
+
+def test_replay_policy_none_provider_uses_consensus():
+    msgs = [Message("assistant", "a", thinking="t"), Message("tool", "out")]
+    assert should_replay_reasoning(msgs, None) == [True, False]
+
+
+def test_replay_policy_mixed_history():
+    """Only the tool-preceding assistant turn is replayed in a multi-turn history."""
+    msgs = [
+        Message("user", "q1"),
+        Message("assistant", "a1", thinking="plain reasoning"),  # plain → strip
+        Message("user", "q2"),
+        Message("assistant", "a2", thinking="tool reasoning"),  # before tool → keep
+        Message("tool", "tool result"),
+        Message("assistant", "a3", thinking="final reasoning"),  # plain → strip
+    ]
+    assert should_replay_reasoning(msgs, "ollama") == [
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
 
 
 # --- as_generic_chat_history ---
@@ -640,6 +866,37 @@ class TestMessageDocumentRendering:
         assert result["role"] == "user"
         assert result["content"] == "main content"
         assert "supporting text" not in result["content"]
+
+    def test_message_to_openai_message_strips_reasoning_by_default(self):
+        """Default (replay_reasoning=False) never emits reasoning — no regression."""
+        msg = Message("assistant", "answer", thinking="secret reasoning")
+        result = message_to_openai_message(msg)
+        assert "reasoning_content" not in result
+
+    def test_message_to_openai_message_emits_reasoning_when_replayed(self):
+        msg = Message("assistant", "answer", thinking="secret reasoning")
+        result = message_to_openai_message(msg, replay_reasoning=True)
+        assert result["reasoning_content"] == "secret reasoning"
+
+    def test_message_to_openai_message_replay_without_thinking_is_noop(self):
+        """replay_reasoning=True but no thinking present emits no key."""
+        msg = Message("assistant", "answer")
+        result = message_to_openai_message(msg, replay_reasoning=True)
+        assert "reasoning_content" not in result
+
+    def test_message_to_openai_message_replay_with_images(self):
+        """Reasoning is emitted alongside multimodal content lists too."""
+        from mellea.core import ImageUrlBlock
+
+        msg = Message(
+            "assistant",
+            "answer",
+            images=[ImageUrlBlock("https://example.com/a.png")],
+            thinking="visual reasoning",
+        )
+        result = message_to_openai_message(msg, replay_reasoning=True)
+        assert isinstance(result["content"], list)
+        assert result["reasoning_content"] == "visual reasoning"
 
     def test_print_message_with_docs_renders_document_format(self, formatter):
         """Verify exact rendered format of documents within a Message."""

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -595,6 +595,10 @@ def test_as_chat_history_carries_thinking():
 
 # --- should_replay_reasoning policy ---
 
+_TOOL_CALLS = [
+    {"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+]
+
 
 def test_replay_policy_strips_plain_assistant_turn():
     msgs = [
@@ -605,37 +609,57 @@ def test_replay_policy_strips_plain_assistant_turn():
     assert should_replay_reasoning(msgs, "openai") == [False, False, False]
 
 
-def test_replay_policy_round_trips_after_tool_call():
-    """Assistant turn immediately followed by a tool result is replayed."""
+def test_replay_policy_round_trips_tool_call_turn():
+    """An assistant turn carrying tool calls is replayed."""
     msgs = [
         Message("user", "q"),
-        Message("assistant", "a", thinking="tool reasoning"),
+        Message("assistant", "a", thinking="tool reasoning", tool_calls=_TOOL_CALLS),
         Message("tool", "tool output"),
     ]
     assert should_replay_reasoning(msgs, "openai") == [False, True, False]
 
 
+def test_replay_policy_round_trips_tool_call_never_executed():
+    """A tool-requesting turn is replayed even when the tool was never executed.
+
+    Regression test (PR #1201 review): keying off the assistant message's own
+    `tool_calls` field rather than a trailing `tool`-role message means reasoning
+    is still replayed when no tool result follows.
+    """
+    msgs = [
+        Message("user", "q"),
+        Message("assistant", "a", thinking="tool reasoning", tool_calls=_TOOL_CALLS),
+        # No tool result follows — the tool was requested but never executed.
+    ]
+    assert should_replay_reasoning(msgs, "openai") == [False, True]
+
+
 def test_replay_policy_assistant_without_thinking_is_false():
     msgs = [
         Message("user", "q"),
-        Message("assistant", "a"),  # no thinking
+        Message("assistant", "a", tool_calls=_TOOL_CALLS),  # no thinking
         Message("tool", "out"),
     ]
     assert should_replay_reasoning(msgs, "openai") == [False, False, False]
 
 
 def test_replay_policy_none_provider_uses_consensus():
-    msgs = [Message("assistant", "a", thinking="t"), Message("tool", "out")]
+    msgs = [
+        Message("assistant", "a", thinking="t", tool_calls=_TOOL_CALLS),
+        Message("tool", "out"),
+    ]
     assert should_replay_reasoning(msgs, None) == [True, False]
 
 
 def test_replay_policy_mixed_history():
-    """Only the tool-preceding assistant turn is replayed in a multi-turn history."""
+    """Only the tool-call assistant turn is replayed in a multi-turn history."""
     msgs = [
         Message("user", "q1"),
         Message("assistant", "a1", thinking="plain reasoning"),  # plain → strip
         Message("user", "q2"),
-        Message("assistant", "a2", thinking="tool reasoning"),  # before tool → keep
+        Message(
+            "assistant", "a2", thinking="tool reasoning", tool_calls=_TOOL_CALLS
+        ),  # tool call → keep
         Message("tool", "tool result"),
         Message("assistant", "a3", thinking="final reasoning"),  # plain → strip
     ]

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -456,7 +456,9 @@ def test_parse_tool_calls_fallback_uses_value():
 
 def test_parse_tool_calls_ollama_carries_thinking():
     msg = Message("user", "q")
-    mot = ModelOutputThunk(value="v", tool_calls={"some_fn": None})
+    mot = ModelOutputThunk(
+        value="v", tool_calls={"some_fn": _make_tool_call("some_fn")}
+    )
     mot.thinking = "tool-turn reasoning"
     fake_calls = [{"name": "some_fn"}]
     fake_response = type(


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1201 

## Description
<!-- What does this PR do and why? -->
Carry reasoning across turns with per-backend replay policy for better thinking handling.

The policy is currently provider-agnostic (provider is unused, documented as a reserved hook). The divergent contracts from https://github.com/generative-computing/mellea/issues/1201's table — DeepSeek hard-400 without tools, Anthropic signed blocks — are not implemented here.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
