### PR TITLE
fix(ci): mint release-workflow writes with the mellea-auto-release App token

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -3,9 +3,7 @@ name: "Cut release branch"
 # Creates a release/vX.Y branch from main and bumps main to the next minor's
 # .dev0. See RELEASE.md for the full workflow.
 #
-# Must be dispatched from the GitHub Actions UI. `github-actions[bot]` needs
-# bypass rights on main's branch-protection ruleset to push the main-side
-# dev bump.
+# Must be dispatched from the GitHub Actions UI.
 
 on:
   workflow_dispatch:
@@ -34,10 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: release
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           persist-credentials: true
       - name: Install uv and set the python version
@@ -50,7 +53,7 @@ jobs:
         env:
           CONFIRM_MINOR: ${{ inputs.confirm_minor }}
           # Env vars for the inline rc0 release-publish step:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           CHGLOG_FILE: CHANGELOG.md
           PUBLISH_PRERELEASES: ${{ vars.PUBLISH_PRERELEASES || 'false' }}

--- a/.github/workflows/publish-dev-from-main.yml
+++ b/.github/workflows/publish-dev-from-main.yml
@@ -41,10 +41,15 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: release
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
       - name: Install uv and set the python version
@@ -63,7 +68,7 @@ jobs:
       # the operator sees when inspecting the branch.
       - name: Publish current .devN
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_BRANCH: main
           ALLOW_MAIN_RELEASE: "1"
           CHGLOG_FILE: CHANGELOG.md
@@ -73,7 +78,7 @@ jobs:
         shell: bash
       - name: Advance .devN counter on main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -108,10 +108,15 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: release
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
       - name: Install uv and set the python version
@@ -127,7 +132,7 @@ jobs:
       - name: Bump version on release branch
         if: inputs.bump_type != 'none'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           BUMP_TYPE: ${{ inputs.bump_type }}
           REF_NAME: ${{ github.ref_name }}
@@ -137,7 +142,7 @@ jobs:
           git push origin "${REF_NAME}"
       - name: Run release script
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_BRANCH: ${{ github.ref_name }}
           ALLOW_MAIN_RELEASE: ${{ inputs.allow_main_release && '1' || '0' }}
           CHGLOG_FILE: CHANGELOG.md
@@ -155,10 +160,15 @@ jobs:
       contents: write
       actions: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -187,10 +197,7 @@ jobs:
           git commit -m "docs: snapshot ${VERSION}"
           git push origin main
       - name: Trigger docs deploy from snapshot
-        # A GITHUB_TOKEN push does not trigger workflow runs by design, so we
-        # dispatch docs-publish.yml explicitly. workflow_dispatch is exempt from
-        # the no-re-trigger rule.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.pre-release-check.outputs.TARGET_TAG_V }}
         run: gh workflow run docs-publish.yml --ref main --field release_tag="v${VERSION}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -175,13 +175,15 @@ on the [`PUBLISH_PRERELEASES`](#the-publish_prereleases-flag) flag.
 
 ## Branch protection
 
-All three write-capable workflows authenticate via `secrets.GITHUB_TOKEN`,
-declaring scopes via inline `permissions:` blocks. The `GITHUB_TOKEN`
-identity is `github-actions[bot]`, configured as a bypass actor on the
-`main` and `release/**` rulesets so workflows can push directly:
+All three write-capable workflows authenticate via a token minted from the
+**mellea-auto-release** GitHub App (`vars.CI_APP_ID` / `secrets.CI_PRIVATE_KEY`),
+configured as a bypass actor on the `main` and `release/**` rulesets so
+workflows can push directly:
 
 - `main`: `cut-release-branch` pushes the `X.(Y+1).0.dev0` bump;
-  `publish-dev-from-main` pushes the `.dev(N+1)` advance commit.
+  `publish-dev-from-main` pushes the `.dev(N+1)` advance commit;
+  `publish-release` (snapshot-docs) pushes the versioned docs snapshot for
+  finals.
 - `release/**`: `publish-release` pushes the version-bump commit and (for
   finals) the changelog update.
 
@@ -200,8 +202,7 @@ and break `git checkout v0.4.2` semantics. Old `release/v0.3`,
 For finals and patch-finals, the `snapshot-docs` job in `publish-release.yml`
 commits a versioned snapshot of `main`'s docs to `main` immediately after the
 GitHub Release is created, then explicitly dispatches `docs-publish.yml` via
-`workflow_dispatch`. (A `GITHUB_TOKEN` push cannot trigger a new workflow run,
-so the dispatch is explicit.) This deploys production with the new version as
+`workflow_dispatch`. This deploys production with the new version as
 the default. Visitors see the released docs by default; a version dropdown in the
 navbar lets them switch to `main` (unreleased) or any prior snapshot.
 


### PR DESCRIPTION
## Issue
Fixes #

## Description

The release-branch workflows authored their writes with the default
`GITHUB_TOKEN`. That fails in two ways this org enforces:

- **Pushes to protected branches** — `cut-release-branch` and
  `publish-dev-from-main` push to `main`, and `publish-release` pushes to
  `release/**`. `github-actions[bot]` cannot be added as a branch-protection
  bypass actor, so these pushes are rejected.
- **Opening the changelog-sync PR** — the org blocks Actions from creating
  PRs under `GITHUB_TOKEN`.

The write jobs now mint a token from the **mellea-auto-release** GitHub App
(`vars.CI_APP_ID` / `secrets.CI_PRIVATE_KEY`), which is a bypass actor on the
protected rulesets — the same app `mellea-contribs` already uses. Read-only
jobs (`guard`, `code-checks`, `pre-release-check`) stay on `GITHUB_TOKEN`.
`RELEASE.md` is updated to match.

Requires (repo settings, no code): the mellea-auto-release app installed with
`main` + `release/**` bypass, and `CI_APP_ID` / `CI_PRIVATE_KEY` available.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
