### PR TITLE
fix: repair release/v0.7 full-suite test failures (telemetry plugin registration + broken aLora example)

### DIFF
--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -1,4 +1,5 @@
-# pytest: huggingface, e2e
+# pytest: skip, huggingface, e2e
+# SKIP REASON: broken stembolts adapter/example, pending rewrite to new intrinsics API (#385).
 
 import time
 

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -142,10 +142,12 @@ def _register_tracing_plugins() -> None:
     for plugin_cls in _TRACING_PLUGIN_CLASSES:
         try:
             register(plugin_cls())
-        except ValueError:
-            # Already registered in a previous invocation (e.g. after a
-            # state reset in tests). Silent — registry remains correct.
-            pass
+        except ValueError as e:
+            warnings.warn(
+                f"{plugin_cls.__name__} already registered: {e}",
+                UserWarning,
+                stacklevel=2,
+            )
     _plugins_registered = True
 
 

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -1,8 +1,10 @@
 """Shared test helpers for the `mellea.telemetry` submodules."""
 
+import os
+
 import pytest
 
-_TELEMETRY_DIR = __file__.rsplit("/", 1)[0]
+_TELEMETRY_DIR = os.path.dirname(__file__)
 
 
 def pytest_collection_modifyitems(items):

--- a/test/telemetry/conftest.py
+++ b/test/telemetry/conftest.py
@@ -1,5 +1,20 @@
 """Shared test helpers for the `mellea.telemetry` submodules."""
 
+import pytest
+
+_TELEMETRY_DIR = __file__.rsplit("/", 1)[0]
+
+
+def pytest_collection_modifyitems(items):
+    """Ignore the duplicate-registration warning that the reset helpers provoke.
+
+    The hook receives the whole session's items even from a subdir conftest, so
+    scope the marker to this directory by path.
+    """
+    for item in items:
+        if str(item.fspath).startswith(_TELEMETRY_DIR):
+            item.add_marker(pytest.mark.filterwarnings("ignore:.*already registered"))
+
 
 def reset_metrics_state() -> None:
     """Reset metrics module state and re-run setup so env-var changes take effect."""
@@ -23,7 +38,8 @@ def reset_metrics_state() -> None:
     metrics._requirement_checks_counter = None
     metrics._requirement_failures_counter = None
     metrics._tool_calls_counter = None
-    # _plugins_registered intentionally NOT reset — registry is process-global.
+    # Re-register: another test's shutdown_plugins() may have emptied the manager.
+    metrics._plugins_registered = False
     metrics._setup_metrics()
 
 
@@ -38,6 +54,8 @@ def reset_tracing_state() -> None:
     tracing._backend_tracer = None
     tracing._in_flight_spans.clear()
     tracing._reattached_tokens.clear()
+    # Re-register: another test's shutdown_plugins() may have emptied the manager.
+    tracing._plugins_registered = False
     tracing._setup_tracing()
 
 

--- a/test/telemetry/test_tracing_streaming.py
+++ b/test/telemetry/test_tracing_streaming.py
@@ -460,8 +460,10 @@ async def test_stream_with_chunking_chat_span_nests_under_streaming_span(span_ex
         gen.close()
 
     spans = _finished_spans(span_exporter)
-    streaming_span = next(s for s in spans if s.name == "stream_with_chunking")
-    chat_span = next(s for s in spans if s.name == "chat")
+    streaming_span = next((s for s in spans if s.name == "stream_with_chunking"), None)
+    assert streaming_span is not None, "stream_with_chunking span not emitted"
+    chat_span = next((s for s in spans if s.name == "chat"), None)
+    assert chat_span is not None, "chat span not emitted"
 
     assert streaming_span.parent is None, "streaming span should be a root"
     if _CONTEXT_ATTACH_SUPPORTED:
@@ -489,7 +491,8 @@ async def test_stream_with_chunking_validation_chat_span_is_sibling_of_generatio
         gen.close()
 
     spans = _finished_spans(span_exporter)
-    streaming_span = next(s for s in spans if s.name == "stream_with_chunking")
+    streaming_span = next((s for s in spans if s.name == "stream_with_chunking"), None)
+    assert streaming_span is not None, "stream_with_chunking span not emitted"
     chat_spans = [s for s in spans if s.name == "chat"]
     assert len(chat_spans) == 2, f"expected 2 chat spans, got {len(chat_spans)}"
 
@@ -543,8 +546,10 @@ async def test_stream_with_chunking_span_ends_error_on_early_exit(
         gen.close()
 
     streaming_span = next(
-        s for s in _finished_spans(span_exporter) if s.name == "stream_with_chunking"
+        (s for s in _finished_spans(span_exporter) if s.name == "stream_with_chunking"),
+        None,
     )
+    assert streaming_span is not None, "stream_with_chunking span not emitted"
     assert streaming_span.status.status_code == StatusCode.ERROR
     cross_task = [r for r in caplog.records if "across asyncio tasks" in r.getMessage()]
     assert not cross_task, "early exit should not warn about cross-task detach"


### PR DESCRIPTION
## Issue
Fixes #

## Description
Two unrelated failures surface when running the full test suite with `--group-by-backend` (via `test/scripts/run_tests_with_ollama_and_vllm.sh`) with ollama and huggingface backends available. This PR addresses both.

### 1. Telemetry plugin re-registration (test-order state leakage)
`--group-by-backend` hoists the `@pytest.mark.ollama` tracing tests ahead of the plugin/logger tests. The tracing tests register the telemetry plugins on the process-global plugin manager and set `_plugins_registered = True`. The plugin/logger tests then call `shutdown_plugins()`, which nulls the manager — but that flag stays `True`, so a later `reset_tracing_state()`/`reset_metrics_state()` skips re-registration. The plugin-driven `action`/`chat`/`stream_with_chunking` spans are then never emitted (directly-emitted `session` spans still work), surfacing as "span not emitted" and, for three streaming tests using a bare `next()`, `RuntimeError: coroutine raised StopIteration`. This does not reproduce under the default collection order (GitHub CI), which runs the plugin-wipe tests before any telemetry test.

- Reset `_plugins_registered` in both telemetry reset helpers so setup re-registers against the current manager.
- Make `tracing` warn on duplicate registration (metrics already did); scope a `filterwarnings` for the expected test-provoked duplicate to the telemetry dir only.
- Harden three `stream_with_chunking` span lookups to assert-on-missing instead of raising `StopIteration`.

### 2. Skip broken `101_example.py`
`docs/examples/aLora/101_example.py` fails with `AdapterSchemaMismatchError`: the `stembolts` adapter output no longer satisfies `requirement_check_to_bool`'s contract (tightened in #1320). The example predates the intrinsics refactor and needs rewriting to the new API, tracked in #385. Skipped until then.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.