### PR TITLE
chore: remove review guard on mellea/core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Default: request review from maintainers
 * @generative-computing/mellea-maintainers
 
-# Mellea Core requires special review
-/mellea/core/ @nrfulton @jakelorocco
-
 # Mellea Intrinsics
 /mellea/formatters/granite @generative-computing/mellea-intrinsics
 /test/formatters/granite @generative-computing/mellea-intrinsics


### PR DESCRIPTION
# Pull Request

## Issue
n/a

## Description
Removes the restricted reviewers for /mellea/core, as discussed internally earlier today.

### Testing
n/a

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
