### PR TITLE
chore: remove review guard on intrinsics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,3 @@
 
 # Mellea Core requires special review
 /mellea/core/ @nrfulton @jakelorocco
-
-# Mellea Intrinsics
-/mellea/formatters/granite @generative-computing/mellea-intrinsics
-/test/formatters/granite @generative-computing/mellea-intrinsics


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #

## Description
Drop review guard on intrinsics (`/mellea/formatters/granite` and `/test/formatters/granite`)

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
