### PR TITLE
fix(ci): serialize ollama requests to prevent llama-server segfault cascade

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   CICD: 1
   OLLAMA_HOST: "127.0.0.1:5000"
+  # Serialize requests server-side so concurrent-request tests don't make Ollama
+  # spawn multiple llama-server slots at once and segfault on memory-limited runners.
+  OLLAMA_NUM_PARALLEL: "1"
 
 jobs:
   actionlint:


### PR DESCRIPTION
## Issue
Fixes #

## Description
CI's `quality` job intermittently fails with a cascade of ~56 ollama-dependent
test failures, all tracing to:

`ollama._types.ResponseError: llama-server process has terminated: signal: segmentation fault (core dumped)`

**Root cause:** the concurrent-request tests (`test_async_parallel_requests`,
`test_multiple_asyncio_runs`, etc.) make Ollama allocate multiple `llama-server`
runner slots at once. On memory-limited GitHub-hosted CPU runners this spikes
memory and segfaults llama.cpp. Because the whole job shares one `ollama serve`
(started once via `nohup ollama serve &`) and the only auto-retry is scoped to
`ReadTimeout`, a single segfault cascades across every remaining ollama test for
the rest of the run.

**Fix:** set `OLLAMA_NUM_PARALLEL=1` so Ollama queues concurrent requests instead
of spawning parallel slots. The client still issues concurrent requests, so
mellea's async assertions are unchanged — Ollama just serializes execution
internally. Near-zero runtime cost; no model-reload churn.

**Reviewer notes:**
- Observed on unpinned Ollama `0.31.2` (the installer is unpinned, so CI tracks
  latest — a recent Ollama/llama.cpp build likely explains the ~1–2 week onset).
- Reserve levers if this doesn't fully resolve it: `OLLAMA_MAX_LOADED_MODELS=1`
  (adds model-reload cost) or pinning the Ollama version.

### Testing
- [ ] Tests added to the respective file if code was changed — N/A, CI config only
- [ ] New code has 100% coverage if code was added — N/A
- [x] Ensure existing tests and github automation passes

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
