### PR TITLE
feat: surface container artifacts via executionresult artifacts

### DIFF
--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -31,7 +31,7 @@ import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from ...backends.tools import MelleaTool
@@ -469,6 +469,12 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             `None` infers the tier from policy presence (`"docker"` when a policy
             is set, `"docker_unsafe"` otherwise).  Prefer passing an explicit value;
             `make_execution_environment` always supplies one.
+        export_dir (Path | None): Host directory under which exported artifacts are
+            placed.  When set, each copied-out file lands in a randomized `0o700`
+            subdirectory of this directory and is left in place for the caller to
+            read.  When `None`, artifacts land in a randomized subdirectory of the
+            system temp directory that is removed once the returned
+            `ExecutionResult` is garbage collected.
     """
 
     def __init__(
@@ -479,8 +485,9 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
         installed_packages: set[str] | None = None,
         failed_packages: set[str] | None = None,
         tier: str | None = None,
+        export_dir: Path | None = None,
     ):
-        """Initialize the Docker sandbox environment with optional install caches and tier override."""
+        """Initialize the Docker sandbox environment with optional install caches, tier override, and artifact export directory."""
         super().__init__(
             allowed_imports=allowed_imports,
             policy=policy,
@@ -495,6 +502,7 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             failed_packages if failed_packages is not None else set()
         )
         self._tier: str | None = tier
+        self._export_dir: Path | None = export_dir
 
     def _mode(self) -> str:
         if self._tier is not None:
@@ -745,26 +753,47 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
 
             artifacts: list[Artifact] = []
             export_dirs: list[Path] = []
+            # When a host export_dir is configured, artifacts persist there for
+            # the caller and are NOT auto-cleaned; otherwise they land in a
+            # randomized system-tempdir subdir removed once the result is GC'd.
+            caller_owns_exports = self._export_dir is not None
+            # Only surface artifacts from a successful run, consistent with the
+            # local tier (see UnsafeEnvironment.execute).  A failed run must not
+            # leak partial or stale container output.
             if (
                 self.policy
                 and self.policy.artifact_export_paths
                 and self._session is not None
+                and result.exit_code == 0
             ):
+                if caller_owns_exports:
+                    self._export_dir.mkdir(parents=True, exist_ok=True)  # type: ignore[union-attr]
                 for container_path in self.policy.artifact_export_paths:
                     with tempfile.TemporaryDirectory() as tmp_dir:
                         staging = Path(tmp_dir) / container_path.name
                         try:
                             self.copy_out(str(container_path), staging)
-                            export_dir = Path(tempfile.mkdtemp())
+                            export_dir = Path(
+                                tempfile.mkdtemp(dir=self._export_dir)
+                                if caller_owns_exports
+                                else tempfile.mkdtemp()
+                            )
                             os.chmod(export_dir, 0o700)
-                            export_dirs.append(export_dir)
+                            if not caller_owns_exports:
+                                export_dirs.append(export_dir)
                             dest = export_dir / container_path.name
-                            shutil.copy2(staging, dest)
+                            # copy_out may bring back a directory tree (e.g. an
+                            # artifact_export_path pointing at a folder); handle
+                            # both files and directories.
+                            if staging.is_dir():
+                                shutil.copytree(staging, dest)
+                            else:
+                                shutil.copy2(staging, dest)
                             artifacts.append(
                                 Artifact(
                                     path=dest,
                                     size_bytes=dest.stat().st_size
-                                    if dest.exists()
+                                    if dest.is_file()
                                     else None,
                                 )
                             )
@@ -840,6 +869,7 @@ def make_execution_environment(
     working_directory: str | None = None,
     _install_cache: set[str] | None = None,
     _failed_cache: set[str] | None = None,
+    export_dir: Path | None = None,
 ) -> ExecutionEnvironment:
     """Create an :class:`ExecutionEnvironment` for the given tier.
 
@@ -868,6 +898,10 @@ def make_execution_environment(
             installation has already failed.  Packages in this set are skipped
             on subsequent calls; clear the set to allow a retry.  Pass the same
             set as `_install_cache` to persist failure state across calls.
+        export_dir (Path | None): Host directory under which Docker tiers place
+            exported artifacts.  Ignored by non-Docker tiers.  `None` uses a
+            randomized system-tempdir subdirectory that is cleaned up when the
+            `ExecutionResult` is garbage collected.
 
     Returns:
         ExecutionEnvironment: Configured environment instance.
@@ -908,6 +942,7 @@ def make_execution_environment(
                 installed_packages=_install_cache,
                 failed_packages=_failed_cache,
                 tier="docker_unsafe",
+                export_dir=export_dir,
             )
         case "docker":
             resolved_policy = policy if policy is not None else DOCKER_POLICY
@@ -918,6 +953,7 @@ def make_execution_environment(
                 installed_packages=_install_cache,
                 failed_packages=_failed_cache,
                 tier="docker",
+                export_dir=export_dir,
             )
         case _:
             raise ValueError(
@@ -1075,10 +1111,17 @@ def python_tool(
     files produced by a **successful** execution (exit code 0) are included.
 
     Note:
-        **Docker tiers** (`"docker"`, `"docker_unsafe"`) do not support
-        artifact scanning.  `artifact_dir` is ignored for these tiers and
-        `result.artifacts` is always `[]`.  A `RuntimeWarning` is emitted if
-        `artifact_dir` is passed with a docker tier.
+        **Docker tiers** (`"docker"`, `"docker_unsafe"`) surface artifacts only
+        when the policy's `artifact_export_paths` lists the container paths to
+        copy out — Docker has no host-shared working directory to scan, so
+        `artifact_dir` alone cannot drive export.  When `artifact_export_paths`
+        is set, a persistent container session is opened once for the tool's
+        lifetime, copied-out files are returned on `result.artifacts`, and
+        `artifact_dir` (when provided) is used as the host destination.  As with
+        local tiers, only files from a **successful** execution (exit code 0)
+        are exported.  Passing `artifact_dir` with a docker tier but no
+        `artifact_export_paths` emits a `RuntimeWarning` and yields
+        `result.artifacts == []`.
 
         **Local tiers are always unenforced.** ``CapabilityPolicy`` boolean
         restrictions (``network_access``, ``subprocess_execution``, etc.)
@@ -1115,7 +1158,12 @@ def python_tool(
             write output files.  A per-call tempdir is used when `None`;
             that tempdir is kept alive as long as the returned
             `ExecutionResult` holds artifacts, and cleaned up immediately
-            when no artifacts are produced.  Ignored for docker tiers.
+            when no artifacts are produced.  For docker tiers this is the host
+            destination for files copied out via `artifact_export_paths`; each
+            such file lands in a randomized `0o700` subdirectory of
+            `artifact_dir` (not directly in it) to prevent collisions and
+            preserve owner-only permissions.  It has no effect on docker tiers
+            when `artifact_export_paths` is unset.
         policy (CapabilityPolicy | None): Override the tier's default
             `CapabilityPolicy`.  When `packages` is also provided, those
             packages are merged into this policy.
@@ -1132,8 +1180,19 @@ def python_tool(
 
     Raises:
         ImportError: If `MelleaTool` cannot be imported (should not happen in
-            a normal mellea installation).
+            a normal mellea installation), or, for a docker tier with
+            `artifact_export_paths` set, if `llm-sandbox` is not installed —
+            the persistent container session is opened at construction time.
         ValueError: If any entry in `packages` is empty or begins with `-`.
+        RuntimeError: If a docker tier with `artifact_export_paths` set cannot
+            open its container session at construction time (e.g. the Docker
+            daemon is unreachable).
+
+    Note:
+        For a docker tier with `artifact_export_paths`, the container is opened
+        eagerly when the tool is constructed (so it can be reused across
+        `run_python` calls), so daemon/availability errors surface here rather
+        than on the first `run`.
 
     Example:
         ```python
@@ -1218,15 +1277,49 @@ def python_tool(
     _install_cache: set[str] = set()
     _failed_cache: set[str] = set()
 
-    if resolved_tier in _DOCKER_TIERS and artifact_dir is not None:
+    # Docker tiers export artifacts only via artifact_export_paths (there is no
+    # host-shared cwd to scan).  When those paths are set, open ONE persistent
+    # container session for the tool's lifetime so copy_out runs on a live
+    # container across every run_python() call — one-shot mode closes the
+    # container before export can happen.
+    docker_export = bool(
+        resolved_tier in _DOCKER_TIERS
+        and effective_policy
+        and effective_policy.artifact_export_paths
+    )
+
+    if (
+        resolved_tier in _DOCKER_TIERS
+        and artifact_dir is not None
+        and not docker_export
+    ):
         warnings.warn(
-            f"artifact_dir is ignored for the {resolved_tier!r} tier — "
-            "LLMSandboxEnvironment does not scan the container filesystem for "
-            "artifacts.  result.artifacts will always be [].  "
-            "Use a local tier to surface output files as structured artifacts.",
+            f"artifact_dir was passed with the {resolved_tier!r} tier but no "
+            "artifact_export_paths are set on the policy.  Docker tiers have no "
+            "host-shared working directory to scan, so result.artifacts will be "
+            "[].  Set CapabilityPolicy.artifact_export_paths to the container "
+            "paths to copy out; artifact_dir will then be used as the host "
+            "destination.",
             RuntimeWarning,
             stacklevel=2,
         )
+
+    persistent_env: LLMSandboxEnvironment | None = None
+    if docker_export:
+        # A docker tier always yields an LLMSandboxEnvironment; cast rather than
+        # assert so the invariant survives `python -O` (which strips asserts).
+        persistent_env = cast(
+            LLMSandboxEnvironment,
+            make_execution_environment(
+                resolved_tier,
+                policy=effective_policy,
+                allowed_imports=allowed_imports,
+                _install_cache=_install_cache,
+                _failed_cache=_failed_cache,
+                export_dir=artifact_dir,
+            ),
+        )
+        persistent_env.__enter__()  # open the container; closed by the finalizer below
 
     def run_python(code: str) -> ExecutionResult:
         """Execute Python code and return the result with any output artifacts."""
@@ -1235,6 +1328,10 @@ def python_tool(
             if not suppress_agg
             else ""
         ) + code
+
+        if persistent_env is not None:
+            # Docker tier with artifact export: reuse the open container session.
+            return persistent_env.execute(patched_code)
 
         if artifact_dir is not None:
             artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -1274,7 +1371,13 @@ def python_tool(
             weakref.finalize(result, shutil.rmtree, tmp_dir, True)
         return result
 
-    return MelleaTool.from_callable(run_python, name=name)
+    tool = MelleaTool.from_callable(run_python, name=name)
+    if persistent_env is not None:
+        # Tie the container's lifetime to the tool: close it when the tool is
+        # garbage collected.  The finalizer holds the only strong reference the
+        # callback needs, so it cannot itself keep the tool alive.
+        weakref.finalize(tool, persistent_env.__exit__, None, None, None)
+    return tool
 
 
 def code_interpreter(code: str) -> ExecutionResult:

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -474,7 +474,9 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             subdirectory of this directory and is left in place for the caller to
             read.  When `None`, artifacts land in a randomized subdirectory of the
             system temp directory that is removed once the returned
-            `ExecutionResult` is garbage collected.
+            `ExecutionResult` is garbage collected.  An empty or cwd-equivalent
+            path (`Path("")` or `Path(".")`) is treated as `None` rather than
+            scattering export subdirectories into the current working directory.
     """
 
     def __init__(
@@ -502,7 +504,15 @@ class LLMSandboxEnvironment(ExecutionEnvironment):
             failed_packages if failed_packages is not None else set()
         )
         self._tier: str | None = tier
-        self._export_dir: Path | None = export_dir
+        # Normalize an empty/cwd path (Path("") or Path("."), both str "." ) to
+        # None: such a path is truthy and `is not None`, but resolves to the
+        # current working directory, so mkdtemp(dir=...) would scatter export
+        # subdirs into cwd and mkdir(...) is a silent no-op.  Treat it as "no
+        # export dir" so those artifacts fall through to the auto-cleaned system
+        # temp; a caller who wants cwd should pass an explicit named subdir.
+        self._export_dir: Path | None = (
+            None if export_dir is None or str(export_dir) == "." else export_dir
+        )
 
     def _mode(self) -> str:
         if self._tier is not None:
@@ -1184,15 +1194,24 @@ def python_tool(
             `artifact_export_paths` set, if `llm-sandbox` is not installed —
             the persistent container session is opened at construction time.
         ValueError: If any entry in `packages` is empty or begins with `-`.
-        RuntimeError: If a docker tier with `artifact_export_paths` set cannot
-            open its container session at construction time (e.g. the Docker
-            daemon is unreachable).
+        Exception: If a docker tier with `artifact_export_paths` set cannot
+            open its container session at construction time, the underlying
+            docker/llm-sandbox error (e.g. the Docker daemon is unreachable)
+            propagates unchanged.
 
     Note:
         For a docker tier with `artifact_export_paths`, the container is opened
         eagerly when the tool is constructed (so it can be reused across
         `run_python` calls), so daemon/availability errors surface here rather
         than on the first `run`.
+
+        Because that container persists and `artifact_export_paths` are fixed,
+        a later successful run that does not touch an export path will still
+        `copy_out` a file left there by an earlier run and surface it as the
+        current run's artifact.  This mirrors the persistent-local
+        `artifact_dir` behavior, but the reused container makes it easy to hit
+        in a ReACT loop — callers should treat exported artifacts as
+        potentially stale unless the run wrote to the export path.
 
     Example:
         ```python

--- a/test/stdlib/tools/test_python_tool.py
+++ b/test/stdlib/tools/test_python_tool.py
@@ -445,13 +445,42 @@ open("subdir/nested.csv", "w").write("a,b\\n1,2\\n")
     assert "nested.csv" in names
 
 
-def test_docker_tier_artifact_dir_emits_warning(tmp_path: Path):
-    """Passing artifact_dir with a docker tier must emit a RuntimeWarning."""
+def test_docker_tier_artifact_dir_without_export_paths_warns(tmp_path: Path):
+    """artifact_dir with a docker tier but no artifact_export_paths must warn."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         python_tool(tier="docker_unsafe", artifact_dir=tmp_path)
     assert any(issubclass(warning.category, RuntimeWarning) for warning in w)
-    assert any("artifact_dir" in str(warning.message) for warning in w)
+    assert any(
+        "artifact_export_paths" in str(warning.message)
+        for warning in w
+        if issubclass(warning.category, RuntimeWarning)
+    )
+
+
+def test_docker_tier_artifact_dir_with_export_paths_no_warning(tmp_path: Path):
+    """artifact_dir + artifact_export_paths on a docker tier must NOT warn.
+
+    A persistent container session is opened at construction time; guard the
+    real Docker call behind the skip so this stays a fast unit test by patching
+    LLMSandboxEnvironment.__enter__/__exit__.
+    """
+    from unittest.mock import patch
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/data.csv")])
+    with (
+        patch.object(LLMSandboxEnvironment, "__enter__", lambda self: self),
+        patch.object(LLMSandboxEnvironment, "__exit__", lambda self, *a: None),
+    ):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+    runtime_warnings = [
+        warning for warning in w if issubclass(warning.category, RuntimeWarning)
+    ]
+    assert not runtime_warnings, (
+        f"unexpected RuntimeWarning(s): {[str(x.message) for x in runtime_warnings]}"
+    )
 
 
 def test_packages_empty_list_does_not_create_policy():
@@ -692,7 +721,7 @@ def test_docker_package_install_cache():
     policy = CapabilityPolicy(packages=["cowsay"])
     install_cache: set[str] = set()
 
-    with LLMSandboxEnvironment(policy=policy, _installed_packages=install_cache) as env:
+    with LLMSandboxEnvironment(policy=policy, installed_packages=install_cache) as env:
         result1 = env.execute("import cowsay; print('first')")
         assert result1.success, result1.stderr
         assert "cowsay" in install_cache  # installed and cached
@@ -717,6 +746,22 @@ def test_docker_oneshot_reinstalls_per_container():
     # Second call: fresh container — packages must be reinstalled, not skipped.
     result2 = tool.run(code="import cowsay; print('call2')")
     assert result2.success, result2.stderr
+
+
+@_docker_skip
+@pytest.mark.slow
+def test_docker_export_real_container_surfaces_file(tmp_path: Path):
+    """A file written inside a real container is copied out to artifact_dir."""
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/tmp/out.txt")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+
+    result = tool.run(code="open('/tmp/out.txt', 'w').write('hello from container')")
+    assert result.success, result.stderr
+    assert result.artifacts, "no artifact exported from real container"
+    artifact = result.artifacts[0]
+    assert artifact.path.name == "out.txt"
+    assert tmp_path in artifact.path.parents
+    assert artifact.path.read_text() == "hello from container"
 
 
 # endregion
@@ -815,6 +860,166 @@ def test_artifact_export_dir_is_owner_only():
     assert export_dir.exists(), "export dir was removed before stat"
     mode = stat.S_IMODE(os.stat(export_dir).st_mode)
     assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+
+
+# endregion
+
+
+# region docker persistent-session artifact export (mocked, no real Docker)
+
+
+def _patch_persistent_docker_session(
+    monkeypatch, opened: list, closed: list, exit_code: int = 0, copy_out=None
+):
+    """Patch LLMSandboxEnvironment so python_tool opens a fake persistent session.
+
+    The fake session's run() returns a result with the given exit_code and
+    copy_out() writes a real host file (unless overridden), so the export loop in
+    execute() can produce Artifact objects.  `opened` and `closed` record
+    __enter__/__exit__ calls for assertions.
+    """
+    from unittest.mock import MagicMock
+
+    def default_copy_out(container_path, host_path):
+        host_path.write_text("data")
+
+    effective_copy_out = copy_out if copy_out is not None else default_copy_out
+
+    def fake_enter(self):
+        fake_result = MagicMock()
+        fake_result.stdout = "ok" if exit_code == 0 else "boom"
+        fake_result.stderr = "" if exit_code == 0 else "error"
+        fake_result.exit_code = exit_code
+        fake_session = MagicMock()
+        fake_session.run.return_value = fake_result
+        self._session = fake_session
+        self.copy_out = effective_copy_out
+        opened.append(self)
+        return self
+
+    def fake_exit(self, *_args):
+        self._session = None
+        closed.append(self)
+
+    monkeypatch.setattr(LLMSandboxEnvironment, "__enter__", fake_enter)
+    monkeypatch.setattr(LLMSandboxEnvironment, "__exit__", fake_exit)
+
+
+def test_docker_export_surfaces_artifacts_to_artifact_dir(monkeypatch, tmp_path: Path):
+    """Docker tier + artifact_export_paths exports files under artifact_dir."""
+    opened: list = []
+    closed: list = []
+    _patch_persistent_docker_session(monkeypatch, opened, closed)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/result.csv")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+
+    result = tool.run(code="print('ok')")
+
+    assert result.artifacts, "no artifacts surfaced for docker tier"
+    artifact = result.artifacts[0]
+    assert artifact.path.name == "result.csv"
+    # Artifact must land under the caller-supplied artifact_dir, not a temp dir.
+    assert tmp_path in artifact.path.parents, (
+        f"artifact {artifact.path} not under artifact_dir {tmp_path}"
+    )
+    assert artifact.path.read_text() == "data"
+
+
+def test_docker_export_opens_session_once_and_reuses(monkeypatch, tmp_path: Path):
+    """The persistent container session is opened once and reused across calls."""
+    opened: list = []
+    closed: list = []
+    _patch_persistent_docker_session(monkeypatch, opened, closed)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/result.csv")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+
+    assert len(opened) == 1, "session should open exactly once at construction"
+
+    tool.run(code="print('call1')")
+    tool.run(code="print('call2')")
+
+    # Still only one session — reused, not reopened per call.
+    assert len(opened) == 1, "session must be reused across run_python calls"
+
+
+def test_docker_export_finalizer_closes_session(monkeypatch, tmp_path: Path):
+    """Dropping the tool closes the container session via the finalizer."""
+    import gc
+
+    opened: list = []
+    closed: list = []
+    _patch_persistent_docker_session(monkeypatch, opened, closed)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/result.csv")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+    assert len(opened) == 1
+
+    del tool
+    gc.collect()
+
+    assert len(closed) == 1, "finalizer did not close the persistent session"
+
+
+def test_docker_export_no_artifact_dir_uses_tempdir(monkeypatch):
+    """Docker export without artifact_dir still surfaces artifacts (system tempdir)."""
+    opened: list = []
+    closed: list = []
+    _patch_persistent_docker_session(monkeypatch, opened, closed)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/result.csv")])
+    tool = python_tool(tier="docker", policy=policy)
+
+    result = tool.run(code="print('ok')")
+    assert result.artifacts, "no artifacts surfaced when artifact_dir is None"
+    assert result.artifacts[0].path.name == "result.csv"
+
+
+def test_docker_export_failed_run_surfaces_no_artifacts(monkeypatch, tmp_path: Path):
+    """A failed docker run (non-zero exit) must not export any artifacts.
+
+    This mirrors the local-tier contract (see
+    test_failed_code_does_not_surface_prior_artifacts) so a crashed run cannot
+    leak partial or stale container output.
+    """
+    opened: list = []
+    closed: list = []
+    _patch_persistent_docker_session(monkeypatch, opened, closed, exit_code=1)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/result.csv")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+
+    result = tool.run(code="raise RuntimeError('boom')")
+    assert not result.success
+    assert result.artifacts == [], "failed run must not surface artifacts"
+    # artifact_dir must not be polluted with export subdirs from a failed run.
+    assert list(tmp_path.iterdir()) == [], "failed run left files under artifact_dir"
+
+
+def test_docker_export_directory_artifact(monkeypatch, tmp_path: Path):
+    """A container artifact_export_path pointing at a directory is copied whole."""
+    opened: list = []
+    closed: list = []
+
+    def copy_out_dir(container_path, host_path):
+        # Simulate `docker cp` bringing back a directory tree.
+        host_path.mkdir()
+        (host_path / "a.txt").write_text("one")
+        (host_path / "b.txt").write_text("two")
+
+    _patch_persistent_docker_session(monkeypatch, opened, closed, copy_out=copy_out_dir)
+
+    policy = CapabilityPolicy(artifact_export_paths=[Path("/out/results")])
+    tool = python_tool(tier="docker", policy=policy, artifact_dir=tmp_path)
+
+    result = tool.run(code="print('ok')")
+    assert result.artifacts, "no artifact surfaced for directory export"
+    artifact = result.artifacts[0]
+    assert artifact.path.name == "results"
+    assert artifact.path.is_dir()
+    assert artifact.size_bytes is None, "directory artifact should have size_bytes=None"
+    assert {p.name for p in artifact.path.iterdir()} == {"a.txt", "b.txt"}
 
 
 # endregion

--- a/test/stdlib/tools/test_python_tool.py
+++ b/test/stdlib/tools/test_python_tool.py
@@ -400,6 +400,25 @@ def test_python_tool_rejects_flag_package():
         python_tool(tier="local_unsafe", packages=["-r"])
 
 
+@pytest.mark.parametrize("empty_path", [Path(""), Path(".")])
+def test_export_dir_empty_path_normalized_to_none(empty_path: Path):
+    """An empty/cwd export_dir must normalize to None, not scatter temp dirs into cwd.
+
+    Path("") and Path(".") are both truthy and `is not None`, so neither a
+    falsey nor an `is not None` check catches them; they resolve to cwd, so
+    mkdtemp(dir=...) would litter the working directory.  The constructor must
+    treat them as "no export dir".
+    """
+    env = LLMSandboxEnvironment(export_dir=empty_path)
+    assert env._export_dir is None
+
+
+def test_export_dir_real_path_preserved(tmp_path: Path):
+    """A genuine export_dir must be preserved unchanged."""
+    env = LLMSandboxEnvironment(export_dir=tmp_path)
+    assert env._export_dir == tmp_path
+
+
 # endregion
 
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1340 

## Description
<!-- What does this PR do and why? -->
surface container artifacts via ExecutionResult.artifacts - users should not need to dig into their local container to pull artifacts created during the sandbox use via python tool

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
