### PR TITLE
fix(ci): revert OLLAMA_NUM_PARALLEL serialization (#1381)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,9 +14,6 @@ concurrency:
 env:
   CICD: 1
   OLLAMA_HOST: "127.0.0.1:5000"
-  # Serialize requests server-side so concurrent-request tests don't make Ollama
-  # spawn multiple llama-server slots at once and segfault on memory-limited runners.
-  OLLAMA_NUM_PARALLEL: "1"
 
 jobs:
   actionlint:


### PR DESCRIPTION
## Issue
Reverts #1381

## Description
#1381 set `OLLAMA_NUM_PARALLEL=1` to stop the llama-server segfault cascade on memory-limited runners. In practice it did not prevent the cascade, and serializing every ollama request roughly quadrupled CI runtime by forcing all concurrent-request tests to run sequentially. Reverting to unblock CI; the segfault issue needs a different fix.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
