### PR TITLE
fix: remove granite 3 vision from warmup pin

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -595,7 +595,18 @@ def pytest_runtest_setup(item):
             logger.info(
                 "Warming up ollama models before ollama group (keep_alive=-1)..."
             )
-            for model in ["granite4.1:3b", "granite3.2-vision"]:
+            # Only pin models that CI actually exercises. granite3.2-vision was
+            # removed: no CI-collected test uses it (Ollama vision e2e is skipped
+            # until granite-vision-4.1 lands in the Ollama library, and the
+            # OpenAI vision test uses granite4.1:3b under gh_run==1), and pinning
+            # a second model with keep_alive=-1 alongside concurrent-request
+            # tests inflated resident memory enough to segfault llama-server on
+            # memory-limited runners.
+            # WHEN REACTIVATING VISION (see #1187): pin the vision model
+            # *sequentially* — evict granite4.1:3b first, then pin the vision
+            # model for the vision tests — do NOT add it back to this list to be
+            # pinned in parallel, or the segfault cascade returns.
+            for model in ["granite4.1:3b"]:
                 try:
                     requests.post(
                         f"{ollama_base}/api/generate",
@@ -621,7 +632,9 @@ def pytest_runtest_setup(item):
                 port = os.environ.get("OLLAMA_PORT", "11434")
                 ollama_base = f"http://{host_str}:{port}"
             logger.info("Evicting ollama models from VRAM after ollama group...")
-            for model in ["granite4.1:3b", "granite3.2-vision"]:
+            # Keep in sync with the warmup pin list above. granite3.2-vision
+            # dropped — see the warmup comment and #1187 for reactivation.
+            for model in ["granite4.1:3b"]:
                 try:
                     requests.post(
                         f"{ollama_base}/api/generate",


### PR DESCRIPTION
# Pull Request

## Issue
Originally was for #1388 but after further investigation this is not currently contributing to that.

## Description
<!-- What does this PR do and why? -->
test/conftest.py — dropped granite3.2-vision from both the warmup-pin list and the evict list (each now ["granite4.1:3b"]), with breadcrumb comments explaining the removal and instructing that reactivation (per #1187) must pin the vision model sequentially (evict granite4 first), not in parallel. Verified the file still parses.  Currently this is unused, **and was never actually called via the quality CI check as --group-by-backend was never passed**.

### Where `granite3.2-vision` is referenced, and why none of it runs in CI

**Currently pinned in CI:** `test/conftest.py` warms & pins `granite3.2-vision` with `keep_alive=-1` in the Ollama-group warmup (`pytest_runtest_setup`, ~L598) and evicts it in the matching teardown (~L624). This was the **only** thing keeping the model resident in CI and it's not run in the quality check.

| Reference | CI-collected? | Reason it's not collected / not run in CI |
|---|---|---|
| `test/conftest.py` (warmup pin, ~L598 + evict ~L624) | N/A (fixture) | **This is the pin.** Warms/pins the model for the whole Ollama group even though nothing collected in CI uses it. Now removed. |
| `test/backends/test_vision_ollama.py` (live e2e) | Collected | Hard-`skip`: availability probe hits `/api/tags`, and `granite-vision-4.1` is **not in the Ollama library** (all name variants 404). Reactivation gated on #1187. |
| `test/backends/test_vision_openai.py` | Collected | Uses `granite3.2-vision` **only** in the `gh_run != 1` (local) branch; under `gh_run == 1` (CI) it points at `granite4.1:3b`. So CI never touches the vision model. |
| `docs/examples/image_text_models/vision_ollama_chat.py` | **No** | Has `# pytest: ollama, e2e`, but the quality CI job runs `pytest ... test` — an explicit path that **overrides `testpaths = ["test","docs"]`**, so `docs/` is never collected in CI. |
| `docs/examples/image_text_models/vision_litellm_backend.py` | **No** | Same as above (`docs/` not collected by the `pytest ... test` invocation). |
| `docs/examples/m_serve/m_serve_example_multimodal_image.py` | **No** | Same as above. |
| `docs/examples/image_text_models/README.md` | **No** | Docs prose; no `# pytest:` marker, so never collected anywhere. |
| `docs/docs/how-to/use-images-and-vision.md` | **No** | Docs prose; no `# pytest:` marker. |
| `docs/versioned_docs/version-0.7.0/how-to/use-images-and-vision.md` | **No** | Versioned docs snapshot; not collected. |

**Net:** every CI-collected test that touches vision either self-skips (no Ollama vision model) or uses `granite4.1:3b` under CI. The doc examples that reference the vision model are not collected by CI at all.

I have added a [comment](https://github.com/generative-computing/mellea/issues/1187#issuecomment-4973153805) to the issue for activating granite-vision-4.1 when available on ollama to avoid the dual model resource constraint we appear to be running into when re adding the vision tests in CI (that are currently skipped anyway awaiting granite-vision-4.1).

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
