### PR TITLE
docs: complete RST to Google-style docstring sweep

### DIFF
--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -10,7 +10,7 @@ Also provides three stub :class:`WeightsBinding` subclasses
 (:class:`LocalFileBinding`, :class:`EmbeddedBinding`,
 :class:`ServerMediatedBinding`) and :class:`AdapterSchemaMismatchError`.
 
-.. note::
+Note:
     The existing :class:`~mellea.backends.adapters.adapter.Adapter` ABC in
     ``adapter.py`` is not modified here.  This module introduces a new
     ``Adapter`` *dataclass* that is re-exported from

--- a/mellea/formatters/template_formatter.py
+++ b/mellea/formatters/template_formatter.py
@@ -49,10 +49,11 @@ class TemplateFormatter(ChatFormatter):
             if you plan to change `model_id` or `template_path` after construction.
             Defaults to `True`.
 
-    Example::
-
+    Example:
+        ```python
         formatter = TemplateFormatter(model_id="my-model", template_path="/path/to/templates")
         text = formatter.print(my_component)
+        ```
     """
 
     def __init__(

--- a/mellea/stdlib/components/docs/richdocument.py
+++ b/mellea/stdlib/components/docs/richdocument.py
@@ -36,9 +36,9 @@ class RichDocument(Component[str]):
     The two canonical ways to create a ``RichDocument``:
 
     * **From a file** — use :meth:`from_document_file` to convert a PDF,
-      Markdown, DOCX, or other `Docling-supported format`_ into a
-      ``RichDocument``.  Set ``do_ocr=False`` for text-based PDFs to skip
-      downloading OCR model weights.
+      Markdown, DOCX, or other [Docling-supported format](https://ds4sd.github.io/docling/)
+      into a ``RichDocument``.  Set ``do_ocr=False`` for text-based PDFs to
+      skip downloading OCR model weights.
     * **From a saved JSON** — use :meth:`load` to restore a document previously
       saved with :meth:`save`.
 
@@ -46,8 +46,6 @@ class RichDocument(Component[str]):
     advanced use (e.g. when you already hold a ``DoclingDocument`` produced by
     your own Docling pipeline).  If you pass any other type a ``TypeError`` is
     raised immediately.
-
-    .. _Docling-supported format: https://ds4sd.github.io/docling/
 
     Args:
         doc (DoclingDocument): The underlying Docling document to wrap.
@@ -57,11 +55,7 @@ class RichDocument(Component[str]):
     """
 
     def __init__(self, doc: DoclingDocument):
-        """Initialize RichDocument by wrapping the provided DoclingDocument.
-
-        Raises:
-            TypeError: If *doc* is not a ``DoclingDocument`` instance.
-        """
+        """Initialize RichDocument by wrapping the provided DoclingDocument."""
         if not isinstance(doc, DoclingDocument):
             raise TypeError(
                 f"RichDocument expects a DoclingDocument, got {type(doc).__name__!r}. "

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -317,8 +317,7 @@ class StreamChunkingResult:
         Each yielded object is a :class:`StreamEvent` subclass describing a
         point in the orchestration lifecycle.  Consumers can dispatch on type:
 
-        .. code-block:: python
-
+        ```python
             async for event in result.events():
                 match event:
                     case ChunkEvent():
@@ -327,6 +326,7 @@ class StreamChunkingResult:
                         print(f"chunk {event.chunk_index} failed validation")
                     case CompletedEvent():
                         print(f"done — success={event.success}")
+        ```
 
         Typical event order (natural completion with requirements):
 

--- a/mellea/telemetry/context.py
+++ b/mellea/telemetry/context.py
@@ -5,8 +5,8 @@ through async call chains via :mod:`contextvars`.  Values automatically appear
 in log records (via :class:`MelleaContextFilter`) and can be attached to
 OpenTelemetry spans.
 
-Example::
-
+Example:
+    ```python
     from mellea.telemetry.context import with_context, async_with_context, get_current_context
 
     # Synchronous (also works inside async functions):
@@ -17,6 +17,7 @@ Example::
     async with async_with_context(session_id="s-1", model_id="granite"):
         result = await backend.generate(...)
         # logs emitted here carry session_id and model_id automatically
+    ```
 """
 
 import contextlib
@@ -164,10 +165,11 @@ def with_context(**kwargs: Any) -> Generator[None, None, None]:
     Raises:
         ValueError: If an unknown context field name is passed.
 
-    Example::
-
+    Example:
+        ```python
         with with_context(session_id="s-1", model_id="granite-4.0"):
             logger.info("generating")   # log record includes both fields
+        ```
     """
     tokens = _apply_context(kwargs)
     try:


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1336

## Description
Completes the RST to Google-style docstring sweep tracked in #1336. The remaining reStructuredText artifacts in the docstrings were converted to Google-style sections:

- `Example::`, `.. code-block::`, and `.. note::` blocks converted to Google-style sections with fenced code.
- A Docling named reference replaced with a Markdown link.
- Removed a duplicate `RichDocument.__init__` `Raises:` block while keeping the class-level entry.

`capabilities.py` was already compliant and `docs-publish.yml` needed validation only, so neither was changed.

### Testing
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Docstring-only change with no new code paths. `ruff format --check` and `ruff check` pass on the touched files, and targeted greps confirm no remaining `Example::` / `.. code-block::` / `.. note::` artifacts.

### Attribution
- [x] AI coding assistants used

AI was used for assistance.
- Type of assistance: drafting the docstring conversions and reviewing the diff.
- Scope: limited to the docstring changes in this PR.
- Tools: an AI coding assistant.
- Level of modification: AI-drafted, then reviewed and verified before submission.

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION - managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
