### PR TITLE
fix: ollama releases prior to the pre release today ran into issues with amx runners

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -105,7 +105,17 @@ jobs:
       - name: Download NLTK data
         run: uv run python -m nltk.downloader punkt_tab
       - name: Install Ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        # Pinned to a GCC-13 build to fix a segfault loading granite4.1:3b on
+        # AMX-capable ubuntu-latest runners (#1388). Ollama's Linux builds through
+        # 0.32.1 were compiled with GCC 11, which miscompiles the AMX CPU kernels in
+        # libggml-cpu-sapphirerapids.so -- so ~1/3 of runs (the AMX-capable runner
+        # draws) crashed during model warmup, independent of ollama version and
+        # unreachable by any env var (the code path is correct; the machine code was
+        # not). Ollama PR #17244 ("bump Linux toolchain to GCC 13", Fixes ollama#17006
+        # / #17205) first ships in v0.32.2-rc0. Drop this pin once v0.32.2+ is a
+        # stable release. NB: OLLAMA_VERSION must omit the leading "v" -- install.sh
+        # prepends it (a "v" yields a broken .../download/vv0.32.2-rc0/... path).
+        run: curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.32.2-rc0 sh
       - name: Start serving ollama
         run: nohup ollama serve &
       - name: Pull models


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1388

## Description
<!-- What does this PR do and why? -->
Intermittent CI failures were an ollama segfault while loading granite4.1:3b, hitting ~1/3 of runs. Investigation traced it to the ~1/3 of ubuntu-latest runners that are AMX-capable (Sapphire Rapids+): llama.cpp selects libggml-cpu-sapphirerapids.so, which segfaults during model warmup.

It reproduced identically on ollama 0.31.0 and 0.32.1, so it wasn't a version regression in the recent history; and no env var disabled it (OLLAMA_LLM_LIBRARY=cpu was tried and had no effect). The reason: it's a compiler bug, not a logic bug — ollama's recent Linux builds through were compiled with GCC 11, which miscompiled the AMX kernels. 

Fix upstream pinning to ollama pre release v0.32.2-rc0. Validated on an AMX runner — tests pass. Drop the pin once v0.32.2+ is a stable release or at least swap to a release instead of pre release.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
