### PR TITLE
experiment: decouple the openai-compatible server from the m cli

### DIFF
--- a/cli/serve/commands.py
+++ b/cli/serve/commands.py
@@ -38,6 +38,6 @@ def serve(
         guide: integrations/m-serve
     """
 
-    from cli.serve.app import run_server
+    from mellea.serve.app import run_server
 
     run_server(script_path=script_path, host=host, port=port)

--- a/mellea/serve/__init__.py
+++ b/mellea/serve/__init__.py
@@ -1,7 +1,16 @@
-"""Public API for m serve types.
+"""Public API for Mellea's OpenAI-compatible server.
 
-This module provides the types that users need when writing serve() functions
-for use with the `m serve` command.
+Provides types for writing ``serve()`` functions and the ``run_server()``
+entry point for starting the server programmatically.
+
+``run_server`` requires the ``mellea[server]`` extra and is imported lazily:
+
+Example:
+    ```python
+    from mellea.serve.app import run_server
+
+    run_server("my_app.py", host="0.0.0.0", port=8080)
+    ```
 """
 
 from .models import ChatMessage, ImageUrlContent, MessageContent, TextContent

--- a/mellea/serve/app.py
+++ b/mellea/serve/app.py
@@ -1,0 +1,321 @@
+"""A simple app that runs an OpenAI compatible server wrapped around a Mellea program."""
+
+import asyncio
+import importlib.util
+import inspect
+import os
+import sys
+import time
+import uuid
+from typing import Any, cast
+
+try:
+    import uvicorn
+    from fastapi import FastAPI, Request
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse, StreamingResponse
+    from pydantic import BaseModel
+except ImportError as e:
+    raise ImportError(
+        "mellea.serve requires extra dependencies. "
+        'Please install them with: pip install "mellea[server]"'
+    ) from e
+
+from mellea.backends.model_options import ModelOption
+from mellea.core import MelleaLogger
+from mellea.helpers.openai_compatible_helpers import (
+    build_completion_usage,
+    build_tool_calls,
+)
+
+from .models import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+    ChatCompletionRequest,
+    Choice,
+    JsonSchemaFormat,
+    OpenAIError,
+    OpenAIErrorResponse,
+)
+from .schema_converter import json_schema_to_pydantic
+from .streaming import stream_chat_completion_chunks
+from .utils import extract_finish_reason
+
+logger = MelleaLogger.get_logger()
+
+app = FastAPI(
+    title="Mellea OpenAI API Compatible Server",
+    description="Mellea programs that run as a simple OpenAI API-compatible server",
+    version="0.1.0",
+)
+
+
+@app.get("/health")
+async def health_check() -> dict[str, str]:
+    """Basic liveness check endpoint.
+
+    Returns a 200 OK status to signal that the Python process is alive and responding.
+
+    Returns:
+        dict: A dictionary with status "pass".
+    """
+    return {"status": "pass"}
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Convert FastAPI validation errors to OpenAI-compatible format.
+
+    FastAPI returns 422 with a 'detail' array by default. OpenAI API uses
+    400 with an 'error' object containing message, type, and param fields.
+    """
+    # Extract the first validation error
+    errors = exc.errors()
+    if errors:
+        first_error = errors[0]
+        # Get the field name from the location tuple (e.g., ('body', 'n') -> 'n')
+        param = first_error["loc"][-1] if first_error["loc"] else None
+        message = first_error["msg"]
+    else:
+        param = None
+        message = "Invalid request parameters"
+
+    return create_openai_error_response(
+        status_code=400,
+        message=message,
+        error_type="invalid_request_error",
+        param=str(param) if param else None,
+    )
+
+
+def load_module_from_path(path: str):
+    """Load the module with Mellea program in it."""
+    module_name = os.path.splitext(os.path.basename(path))[0]
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def create_openai_error_response(
+    status_code: int, message: str, error_type: str, param: str | None = None
+) -> JSONResponse:
+    """Create an OpenAI-compatible error response."""
+    error_response = OpenAIErrorResponse(
+        error=OpenAIError(message=message, type=error_type, param=param)
+    )
+    return JSONResponse(
+        status_code=status_code, content=error_response.model_dump(mode="json")
+    )
+
+
+def _build_model_options(request: ChatCompletionRequest) -> dict:
+    """Build model_options dict from OpenAI-compatible request parameters."""
+    excluded_fields = {
+        # Request structure fields (handled separately)
+        "messages",  # Chat messages - passed separately to serve()
+        "requirements",  # Mellea requirements - passed separately to serve()
+        # Routing/metadata fields (not generation parameters)
+        "model",  # Model identifier - used for routing, not generation
+        "n",  # Number of completions - not supported in Mellea's model_options
+        "user",  # User tracking ID - metadata, not a generation parameter
+        "extra",  # Pydantic's extra fields dict - unused (see model_config)
+        "stream_options",  # Streaming options - handled separately in streaming response
+        # Not-yet-implemented OpenAI parameters (silently ignored)
+        "stop",  # Stop sequences - not yet implemented
+        "top_p",  # Nucleus sampling - not yet implemented
+        "presence_penalty",  # Presence penalty - not yet implemented
+        "frequency_penalty",  # Frequency penalty - not yet implemented
+        "logit_bias",  # Logit bias - not yet implemented
+        "response_format",  # Response format - handled separately
+        "functions",  # Legacy function calling - not yet implemented
+        "function_call",  # Legacy function calling - not yet implemented
+    }
+    openai_to_model_option = {
+        "temperature": ModelOption.TEMPERATURE,
+        "max_tokens": ModelOption.MAX_NEW_TOKENS,
+        "seed": ModelOption.SEED,
+        "stream": ModelOption.STREAM,
+        "tools": ModelOption.TOOLS,
+        "tool_choice": ModelOption.TOOL_CHOICE,
+    }
+
+    # Get all non-None fields
+    filtered_options = {
+        key: value
+        for key, value in request.model_dump(exclude_none=True).items()
+        if key not in excluded_fields
+    }
+
+    # Special handling for stream: only include if True (don't forward False)
+    if "stream" in filtered_options and not filtered_options["stream"]:
+        del filtered_options["stream"]
+
+    return ModelOption.replace_keys(filtered_options, openai_to_model_option)
+
+
+def make_chat_endpoint(module):
+    """Makes a chat endpoint using a custom module."""
+    # Inspect serve function once at endpoint creation time
+    serve_sig = inspect.signature(module.serve)
+    accepts_format = "format" in serve_sig.parameters
+    is_async = inspect.iscoroutinefunction(module.serve)
+
+    async def endpoint(request: ChatCompletionRequest):
+        try:
+            # Validate that n=1 (we don't support multiple completions)
+            if request.n is not None and request.n > 1:
+                return create_openai_error_response(
+                    status_code=400,
+                    message=f"Multiple completions (n={request.n}) are not supported. Please set n=1 or omit the parameter.",
+                    error_type="invalid_request_error",
+                    param="n",
+                )
+
+            completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
+            created_timestamp = int(time.time())
+
+            model_options = _build_model_options(request)
+
+            # Handle response_format
+            format_model: type[BaseModel] | None = None
+            if request.response_format is not None:
+                if request.response_format.type == "json_schema":
+                    # json_schema presence is validated by ResponseFormat.model_validator
+                    json_schema = cast(
+                        JsonSchemaFormat, request.response_format.json_schema
+                    )
+                    try:
+                        format_model = json_schema_to_pydantic(
+                            json_schema.schema_, json_schema.name
+                        )
+                    except (ValueError, TypeError, RecursionError) as e:
+                        message = (
+                            "Invalid JSON schema: recursive $ref is not supported"
+                            if isinstance(e, RecursionError)
+                            else f"Invalid JSON schema: {e!s}"
+                        )
+                        return create_openai_error_response(
+                            status_code=400,
+                            message=message,
+                            error_type="invalid_request_error",
+                            param="response_format.json_schema.schema",
+                        )
+                # For "json_object" and "text", format_model remains None
+                # Note: "json_object" mode is not yet implemented - the backend
+                # receives no signal to produce JSON output (same as "text" mode)
+
+            # Build kwargs for serve call
+            serve_kwargs: dict[str, Any] = {
+                "input": request.messages,
+                "requirements": request.requirements,
+                "model_options": model_options,
+            }
+            if accepts_format:
+                serve_kwargs["format"] = format_model
+
+            # Detect if serve is async or sync and handle accordingly
+            if is_async:
+                # It's async, await it directly
+                output = await module.serve(**serve_kwargs)
+            else:
+                # It's sync, run in thread pool to avoid blocking event loop
+                output = await asyncio.to_thread(module.serve, **serve_kwargs)
+
+            # Leave as None since we don't track backend config fingerprints yet
+            system_fingerprint = None
+
+            # Handle streaming response
+            if request.stream:
+                return StreamingResponse(
+                    stream_chat_completion_chunks(
+                        output=output,
+                        completion_id=completion_id,
+                        model=request.model,
+                        created=created_timestamp,
+                        stream_options=request.stream_options,
+                        system_fingerprint=system_fingerprint,
+                    ),
+                    media_type="text/event-stream",
+                )
+
+            tool_calls_list = build_tool_calls(output)
+            tool_calls = (
+                [
+                    ChatCompletionMessageToolCall.model_validate(tc)
+                    for tc in tool_calls_list
+                ]
+                if tool_calls_list
+                else None
+            )
+
+            return ChatCompletion(
+                id=completion_id,
+                model=request.model,
+                created=created_timestamp,
+                choices=[
+                    Choice(
+                        index=0,
+                        message=ChatCompletionMessage(
+                            content=output.value,
+                            role="assistant",
+                            tool_calls=tool_calls,
+                        ),
+                        finish_reason=extract_finish_reason(output),
+                    )
+                ],
+                object="chat.completion",  # type: ignore
+                system_fingerprint=system_fingerprint,
+                usage=build_completion_usage(output),
+            )  # type: ignore
+        except ValueError as e:
+            # Handle validation errors or invalid input
+            return create_openai_error_response(
+                status_code=400,
+                message=f"Invalid request: {e!s}",
+                error_type="invalid_request_error",
+            )
+        except Exception:
+            logger.exception("Unhandled error in chat-completion handler")
+            return create_openai_error_response(
+                status_code=500,
+                message="Internal server error",
+                error_type="server_error",
+            )
+
+    endpoint.__name__ = f"chat_{module.__name__}_endpoint"
+    return endpoint
+
+
+def run_server(
+    script_path: str = "docs/examples/m_serve/example.py",
+    host: str = "0.0.0.0",
+    port: int = 8080,
+) -> None:
+    """Serve a Mellea program as an OpenAI-compatible HTTP endpoint.
+
+    Loads a Python file containing a `serve` function and exposes it via a
+    FastAPI server implementing the OpenAI chat completions API. The server
+    accepts `POST /v1/chat/completions` requests.
+
+    Args:
+        script_path: Path to the Python script to import and serve. The script
+            must define a `serve` function.
+        host: Host address to bind the server to.
+        port: Port number to bind the server to.
+    """
+    module = load_module_from_path(script_path)
+    route_path = "/v1/chat/completions"
+
+    app.add_api_route(
+        route_path,
+        make_chat_endpoint(module),
+        methods=["POST"],
+        response_model=ChatCompletion | OpenAIErrorResponse,
+    )
+    print(f"Serving {route_path} at http://{host}:{port}")
+    uvicorn.run(app, host=host, port=port)

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -1,10 +1,20 @@
-"""User-facing types for `m serve`."""
+"""Types for Mellea's OpenAI-compatible server.
+
+User-facing types (``ChatMessage``, ``MessageContent``, etc.) are used when
+writing ``serve()`` functions.  Request/response types are used internally by
+the FastAPI application and are also importable for testing.
+"""
 
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, RootModel, model_validator
 
 from mellea.core import ImageBlock, ImageUrlBlock
+from mellea.helpers.openai_compatible_helpers import CompletionUsage
+
+# ---------------------------------------------------------------------------
+# User-facing message types (used when authoring a serve() function)
+# ---------------------------------------------------------------------------
 
 
 class TextContent(BaseModel):
@@ -108,3 +118,330 @@ class ChatMessage(BaseModel):
                     "Expected an http/https URL or a data: URI."
                 )
         return image_blocks
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible request / response types (used by the FastAPI app)
+# ---------------------------------------------------------------------------
+
+
+class FunctionParameters(RootModel[dict[str, Any]]):
+    """OpenAI-compatible function parameters as a bare JSON Schema object.
+
+    Accepts a standard JSON Schema dict directly without wrapping.
+    Example: {"type": "object", "properties": {...}, "required": [...]}
+    """
+
+    root: dict[str, Any]
+
+    @model_validator(mode="after")
+    def _reject_legacy_envelope(self) -> "FunctionParameters":
+        """Reject legacy RootModel envelope pattern.
+
+        Ensures parameters are sent as a bare JSON Schema object, not wrapped
+        in a {"RootModel": {...}} envelope which would be invalid.
+        """
+        if set(self.root.keys()) == {"RootModel"}:
+            raise ValueError(
+                "Legacy {'RootModel': {...}} envelope is no longer accepted. "
+                "Send parameters as a bare JSON Schema object."
+            )
+        return self
+
+
+class FunctionDefinition(BaseModel):
+    """OpenAI-compatible function definition."""
+
+    name: str
+    description: str | None = None
+    parameters: FunctionParameters
+
+
+class ToolFunction(BaseModel):
+    """OpenAI-compatible tool (function) definition."""
+
+    type: Literal["function"]
+    function: FunctionDefinition
+
+
+class JsonSchemaFormat(BaseModel):
+    """JSON Schema definition for structured output."""
+
+    name: str
+    """Name of the schema."""
+
+    schema_: dict[str, Any] = Field(alias="schema")
+    """JSON Schema definition."""
+
+    strict: bool | None = None
+    """Accepted for OpenAI compatibility; currently ignored by `m serve`."""
+
+    model_config = {"populate_by_name": True, "serialize_by_alias": True}
+
+
+class ResponseFormat(BaseModel):
+    """OpenAI-compatible response format specifier."""
+
+    type: Literal["text", "json_object", "json_schema"]
+
+    json_schema: JsonSchemaFormat | None = None
+    """JSON Schema definition when type is 'json_schema'."""
+
+    @model_validator(mode="after")
+    def validate_json_schema_required(self) -> "ResponseFormat":
+        """Validate that json_schema is provided when type is 'json_schema'."""
+        if self.type == "json_schema" and self.json_schema is None:
+            raise ValueError("json_schema field is required when type is 'json_schema'")
+        return self
+
+
+class StreamOptions(BaseModel):
+    """OpenAI-compatible streaming options.
+
+    Controls behavior of streaming responses. Only applies when stream=True.
+    """
+
+    include_usage: bool = False
+    """Whether to include usage statistics in the final streaming chunk.
+
+    When True, the final chunk will include token usage information.
+    When False (default), usage is excluded from streaming responses.
+    For non-streaming requests, usage is always included regardless of this setting.
+    """
+
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI-compatible chat completion request."""
+
+    model_config = {"extra": "allow"}
+
+    model: str
+    messages: list[ChatMessage]
+    requirements: list[str | None] | None = Field(default_factory=list)
+    functions: list[FunctionDefinition] | None = None
+    function_call: Literal["none", "auto"] | dict[str, str] | None = None
+    tools: list[ToolFunction] | None = None
+    tool_choice: Literal["none", "auto"] | dict[str, Any] | None = None
+    temperature: float | None = Field(default=1.0, ge=0, le=2)
+    top_p: float | None = Field(default=1.0, ge=0, le=1)
+    n: int | None = Field(default=1, ge=1)
+    stream: bool | None = False
+    stop: str | list[str] | None = None
+    max_tokens: int | None = None
+    presence_penalty: float | None = Field(default=0, ge=-2, le=2)
+    frequency_penalty: float | None = Field(default=0, ge=-2, le=2)
+    logit_bias: dict[str, float] | None = None
+    user: str | None = None
+    seed: int | None = None
+    response_format: ResponseFormat | None = None
+    stream_options: StreamOptions | None = None
+
+    # For future/undocumented fields
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolCallFunction(BaseModel):
+    """Function details for a tool call."""
+
+    name: str
+    """The name of the function to call."""
+
+    arguments: str
+    """The arguments to call the function with, as a JSON string."""
+
+
+class ChatCompletionMessageToolCall(BaseModel):
+    """A tool call generated by the model (non-streaming)."""
+
+    id: str
+    """The ID of the tool call."""
+
+    type: Literal["function"]
+    """The type of the tool. Currently, only 'function' is supported."""
+
+    function: ToolCallFunction
+    """The function that the model called."""
+
+
+class ToolCallFunctionDelta(BaseModel):
+    """Function details for a streaming tool call delta.
+
+    In streaming responses, function name and arguments may arrive across
+    multiple chunks, so both fields are optional.
+    """
+
+    name: str | None = None
+    """The name of the function to call (may be None in delta chunks)."""
+
+    arguments: str | None = None
+    """The arguments fragment for this delta (may be None in delta chunks)."""
+
+
+class ChatCompletionMessageToolCallDelta(BaseModel):
+    """A tool call delta in a streaming response.
+
+    Per OpenAI streaming spec, each delta must include an index field that
+    clients use to reassemble tool calls across chunks. The id, type, and
+    function fields are optional since they may arrive incrementally.
+    """
+
+    index: int
+    """The index of this tool call in the tool_calls array.
+
+    Required for delta reassembly in OpenAI SDK and compatible clients.
+    """
+
+    id: str | None = None
+    """The ID of the tool call (may be None in subsequent delta chunks)."""
+
+    type: Literal["function"] | None = None
+    """The type of the tool (may be None in subsequent delta chunks)."""
+
+    function: ToolCallFunctionDelta | None = None
+    """The function delta for this chunk (may be None in some chunks)."""
+
+
+# Taking this from OpenAI types https://github.com/openai/openai-python/blob/main/src/openai/types/chat/chat_completion.py,
+class ChatCompletionMessage(BaseModel):
+    """A chat completion message generated by the model."""
+
+    content: str | None = None
+    """The contents of the message."""
+
+    refusal: str | None = None
+    """The refusal message generated by the model."""
+
+    role: Literal["assistant"]
+    """The role of the author of this message."""
+
+    tool_calls: list[ChatCompletionMessageToolCall] | None = None
+    """The tool calls generated by the model, such as function calls."""
+
+
+class Choice(BaseModel):
+    """A single completion choice."""
+
+    index: int
+    """The index of the choice in the list of choices."""
+
+    message: ChatCompletionMessage
+    """A chat completion message generated by the model."""
+
+    finish_reason: (
+        Literal["stop", "length", "content_filter", "tool_calls", "function_call"]
+        | None
+    ) = "stop"
+    """The reason the model stopped generating tokens."""
+
+
+class ChatCompletion(BaseModel):
+    """An OpenAI-compatible chat completion response."""
+
+    id: str
+    """A unique identifier for the chat completion."""
+
+    choices: list[Choice]
+    """A list of chat completion choices.
+
+    Can be more than one if `n` is greater than 1.
+    """
+
+    created: int
+    """The Unix timestamp (in seconds) of when the chat completion was created."""
+
+    model: str
+    """The model used for the chat completion."""
+
+    object: Literal["chat.completion"]
+    """The object type, which is always `chat.completion`."""
+
+    system_fingerprint: str | None = None
+    """This fingerprint represents the backend configuration that the model runs with."""
+
+    usage: CompletionUsage | None = None
+    """Usage statistics for the completion request."""
+
+
+class ChatCompletionChunkDelta(BaseModel):
+    """Delta content in a streaming chunk."""
+
+    content: str | None = None
+    """The content fragment in this chunk."""
+
+    role: Literal["assistant"] | None = None
+    """The role (only present in first chunk)."""
+
+    refusal: str | None = None
+    """The refusal message fragment, if any."""
+
+    tool_calls: list[ChatCompletionMessageToolCallDelta] | None = None
+    """The tool call deltas in this chunk.
+
+    Each delta includes a required index field for reassembly by OpenAI SDK
+    and compatible clients. The id, type, and function fields are optional
+    since they may arrive incrementally across multiple chunks.
+    """
+
+
+class ChatCompletionChunkChoice(BaseModel):
+    """A choice in a streaming chunk."""
+
+    index: int
+    """The index of the choice in the list of choices."""
+
+    delta: ChatCompletionChunkDelta
+    """The delta content for this chunk."""
+
+    finish_reason: (
+        Literal["stop", "length", "content_filter", "tool_calls", "function_call"]
+        | None
+    ) = None
+    """The reason the model stopped generating tokens (only in final chunk)."""
+
+
+class ChatCompletionChunk(BaseModel):
+    """A chunk in a streaming chat completion response."""
+
+    id: str
+    """A unique identifier for the chat completion."""
+
+    choices: list[ChatCompletionChunkChoice]
+    """A list of chat completion choices."""
+
+    created: int
+    """The Unix timestamp (in seconds) of when the chat completion was created."""
+
+    model: str
+    """The model used for the chat completion."""
+
+    object: Literal["chat.completion.chunk"]
+    """The object type, which is always `chat.completion.chunk`."""
+
+    system_fingerprint: str | None = None
+    """This fingerprint represents the backend configuration that the model runs with."""
+
+    usage: CompletionUsage | None = None
+    """Usage statistics for the final streaming chunk when available from the backend."""
+
+
+class OpenAIError(BaseModel):
+    """OpenAI API error object."""
+
+    message: str
+    """A human-readable error message."""
+
+    type: str
+    """The type of error (e.g., 'invalid_request_error', 'server_error')."""
+
+    param: str | None = None
+    """The parameter that caused the error, if applicable."""
+
+    code: str | None = None
+    """An error code, if applicable."""
+
+
+class OpenAIErrorResponse(BaseModel):
+    """OpenAI API error response wrapper."""
+
+    error: OpenAIError
+    """The error object."""

--- a/mellea/serve/schema_converter.py
+++ b/mellea/serve/schema_converter.py
@@ -1,0 +1,420 @@
+"""Helpers for converting OpenAI-style JSON Schema response formats."""
+
+from typing import Annotated, Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Strict, create_model
+
+
+def json_schema_to_pydantic(
+    schema: dict[str, Any], model_name: str = "DynamicModel"
+) -> type[BaseModel]:
+    """Convert a practical subset of JSON Schema to a Pydantic model dynamically.
+
+    This converter targets the OpenAI-style structured output schemas used by
+    `m serve`. It intentionally maps JSON Schema features into Python typing
+    and Pydantic model semantics rather than attempting to preserve every JSON
+    Schema validation rule exactly.
+
+    Supported features:
+    - top-level and nested `object` schemas with `properties` and `required`
+    - primitive types: `string`, `integer`, `number`, `boolean`
+    - arrays via `type: "array"` with supported `items`
+    - string or primitive enums via `enum`
+    - nullable fields via `type: ["<type>", "null"]`
+    - local `$ref` into `$defs` / `definitions`
+    - simple `allOf` merging for object-like schemas
+    - simple `anyOf` / `oneOf` unions when each branch is representable
+    - boolean and schema-valued `additionalProperties`
+
+    Behavior notes:
+    - `additionalProperties: false` maps to `extra="forbid"`
+    - `additionalProperties: true` maps to `extra="ignore"`
+    - schema-valued `additionalProperties` maps to `dict[str, ValueType]`
+      only for open-ended object maps. It cannot be combined with named
+      `properties` because that is not representable as a single standard
+      Pydantic field shape without custom validators.
+    - sibling keywords next to `$ref` are merged over the resolved target,
+      matching common JSON Schema practice for OpenAI-compatible schemas
+
+    Still unsupported and will raise `ValueError`:
+    - non-local refs
+    - recursive `$ref` cycles
+    - tuple-style array schemas
+    - object schemas without `properties` unless they are pure
+      `additionalProperties` maps
+    - schema constraints beyond representable typing/extra handling
+
+    Args:
+        schema: JSON Schema definition (must have top-level `type: "object"`).
+        model_name: Name for the generated Pydantic model.
+
+    Returns:
+        A dynamically created Pydantic model class.
+
+    Raises:
+        ValueError: If the schema is invalid or unsupported.
+    """
+    defs = schema.get("$defs")
+    if defs is None:
+        defs = schema.get("definitions", {})
+    if defs is None:
+        defs = {}
+    if not isinstance(defs, dict):
+        raise ValueError("Schema '$defs' must be an object")
+
+    ref_cache: dict[str, Any] = {}
+    model_cache: dict[str, type[BaseModel]] = {}
+    in_flight_refs: set[str] = set()
+    ref_name_by_schema_id: dict[int, str] = {}
+
+    def _sanitize_model_name(name: str) -> str:
+        sanitized = "".join(ch if ch.isalnum() else "_" for ch in name).strip("_")
+        return sanitized or "DynamicModel"
+
+    def _format_path(path: str) -> str:
+        return path or "<root>"
+
+    def _resolve_ref(ref: str) -> tuple[str, dict[str, Any]]:
+        if ref in ref_cache:
+            resolved = ref_cache[ref]
+            if not isinstance(resolved, dict):
+                raise ValueError(f"Resolved ref is invalid: {ref}")
+
+            for prefix in ("#/$defs/", "#/definitions/"):
+                if ref.startswith(prefix):
+                    return ref[len(prefix) :], resolved
+            raise ValueError(
+                f"Only local $ref values into $defs/definitions are supported: {ref}"
+            )
+
+        prefixes = ("#/$defs/", "#/definitions/")
+        for prefix in prefixes:
+            if ref.startswith(prefix):
+                key = ref[len(prefix) :]
+                if key not in defs:
+                    raise ValueError(f"Unresolved local ref: {ref}")
+                target = defs[key]
+                if not isinstance(target, dict):
+                    raise ValueError(f"Ref target must be an object: {ref}")
+                ref_cache[ref] = target
+                ref_name_by_schema_id[id(target)] = key
+                return key, target
+
+        raise ValueError(
+            f"Only local $ref values into $defs/definitions are supported: {ref}"
+        )
+
+    def _merge_nullable(annotation: Any, is_nullable: bool) -> Any:
+        """Wrap an annotation in `None` when the source schema is nullable."""
+        if is_nullable:
+            return annotation | None
+        return annotation
+
+    def _enum_annotation(enum_values: list[Any], path: str) -> Any:
+        """Convert JSON Schema enum values into a Python typing annotation."""
+        if not enum_values:
+            raise ValueError(f"{_format_path(path)} enum must not be empty")
+
+        value_types = {type(value) for value in enum_values}
+        if len(value_types) != 1:
+            raise ValueError(
+                f"{_format_path(path)} enum values must all have the same primitive type"
+            )
+
+        value_type = value_types.pop()
+        allowed_types = {str, int, float, bool}
+        if value_type not in allowed_types:
+            raise ValueError(
+                f"{_format_path(path)} enum values must be string, integer, number, or boolean"
+            )
+
+        return Literal[tuple(enum_values)]
+
+    def _merge_object_schemas(
+        schemas: list[dict[str, Any]], path: str
+    ) -> dict[str, Any]:
+        """Merge simple object schemas for `allOf`.
+
+        This supports the common OpenAI-compatible case where `allOf` is used
+        to compose object fragments. Conflicting keywords are rejected rather
+        than silently guessed.
+        """
+        merged: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+        merged_required: set[str] = set()
+        merged_additional_properties: bool | dict[str, Any] = True
+
+        for index, branch in enumerate(schemas):
+            resolved_branch = _normalize_schema(branch, f"{path}.allOf[{index}]")
+            branch_type = resolved_branch.get("type", "object")
+            if branch_type != "object":
+                raise ValueError(
+                    f"{_format_path(path)} allOf only supports object branches"
+                )
+
+            branch_properties = resolved_branch.get("properties", {})
+            if not isinstance(branch_properties, dict):
+                raise ValueError(
+                    f"{_format_path(path)} allOf branch properties must be an object"
+                )
+
+            for property_name, property_schema in branch_properties.items():
+                if property_name in merged["properties"]:
+                    raise ValueError(
+                        f"{_format_path(path)} allOf has conflicting property "
+                        f"definitions for '{property_name}'"
+                    )
+                cast(dict[str, Any], merged["properties"])[property_name] = (
+                    property_schema
+                )
+
+            branch_required = resolved_branch.get("required", [])
+            if not isinstance(branch_required, list):
+                raise ValueError(
+                    f"{_format_path(path)} allOf branch 'required' must be an array"
+                )
+            merged_required.update(
+                field_name
+                for field_name in branch_required
+                if isinstance(field_name, str)
+            )
+
+            branch_additional_properties = resolved_branch.get(
+                "additionalProperties", True
+            )
+            if branch_additional_properties is False:
+                merged_additional_properties = False
+            elif isinstance(branch_additional_properties, dict):
+                if merged_additional_properties is True:
+                    merged_additional_properties = branch_additional_properties
+                elif merged_additional_properties is False:
+                    continue
+                elif merged_additional_properties != branch_additional_properties:
+                    raise ValueError(
+                        f"{_format_path(path)} allOf has conflicting "
+                        "additionalProperties schemas"
+                    )
+
+        merged["required"] = sorted(merged_required)
+        merged["additionalProperties"] = merged_additional_properties
+        return merged
+
+    def _union_annotation(
+        keyword: str, union_schemas: list[dict[str, Any]], path: str
+    ) -> Any:
+        """Convert `anyOf`/`oneOf` branches into a Python union annotation."""
+        if not union_schemas:
+            raise ValueError(f"{_format_path(path)} {keyword} must not be empty")
+
+        annotations: list[Any] = []
+        for index, branch in enumerate(union_schemas):
+            annotations.append(
+                _schema_to_type(branch, f"{path}.{keyword}[{index}]", in_union=True)
+            )
+
+        annotation = annotations[0]
+        for branch_annotation in annotations[1:]:
+            annotation = annotation | branch_annotation
+        return annotation
+
+    def _normalize_schema(field_schema: dict[str, Any], path: str) -> dict[str, Any]:
+        """Resolve refs and simple combinators into a normalized schema object."""
+        if not isinstance(field_schema, dict):
+            raise ValueError(f"{_format_path(path)} schema must be an object")
+
+        normalized = dict(field_schema)
+
+        if "$ref" in normalized:
+            ref = normalized["$ref"]
+            if not isinstance(ref, str):
+                raise ValueError(f"{_format_path(path)} $ref must be a string")
+            _, resolved = _resolve_ref(ref)
+            sibling_keywords = {k: v for k, v in normalized.items() if k != "$ref"}
+            if sibling_keywords:
+                merged = dict(resolved)
+                merged.update(sibling_keywords)
+                normalized = merged
+            else:
+                normalized = dict(resolved)
+
+        if "allOf" in normalized:
+            all_of = normalized.pop("allOf")
+            if not isinstance(all_of, list):
+                raise ValueError(f"{_format_path(path)} allOf must be an array")
+            merged = _merge_object_schemas(all_of, path)
+            merged.update(normalized)
+            normalized = merged
+
+        return normalized
+
+    def _schema_to_type(
+        field_schema: dict[str, Any], path: str, in_union: bool = False
+    ) -> Any:
+        """Convert a JSON Schema node into a Python typing annotation."""
+        normalized_schema = _normalize_schema(field_schema, path)
+
+        for keyword in ("anyOf", "oneOf"):
+            if keyword in normalized_schema:
+                union_schemas = normalized_schema[keyword]
+                if not isinstance(union_schemas, list):
+                    raise ValueError(f"{_format_path(path)} {keyword} must be an array")
+                sibling_keywords = {
+                    key: value
+                    for key, value in normalized_schema.items()
+                    if key != keyword
+                }
+                branch_schemas: list[dict[str, Any]] = []
+                for branch in union_schemas:
+                    if not isinstance(branch, dict):
+                        raise ValueError(
+                            f"{_format_path(path)} {keyword} branches must be objects"
+                        )
+                    merged_branch = dict(branch)
+                    for sibling_key, sibling_value in sibling_keywords.items():
+                        merged_branch.setdefault(sibling_key, sibling_value)
+                    branch_schemas.append(merged_branch)
+                return _union_annotation(keyword, branch_schemas, path)
+
+        if "enum" in normalized_schema:
+            enum_values = normalized_schema["enum"]
+            if not isinstance(enum_values, list):
+                raise ValueError(f"{_format_path(path)} enum must be an array")
+            return _enum_annotation(enum_values, path)
+
+        field_type = normalized_schema.get("type")
+        if field_type is None:
+            raise ValueError(
+                f"{_format_path(path)} schema must have a 'type' keyword. "
+                "JSON Schema without 'type' is valid but not supported by this converter. "
+                "Please add an explicit type (e.g., 'string', 'integer', 'object', 'array')."
+            )
+        is_nullable = False
+        if isinstance(field_type, list):
+            non_null_types = [item for item in field_type if item != "null"]
+            null_count = len(field_type) - len(non_null_types)
+            if null_count > 1 or len(non_null_types) != 1:
+                raise ValueError(
+                    f"{_format_path(path)} uses unsupported multi-type schema: {field_type}"
+                )
+            if null_count == 1:
+                is_nullable = True
+            field_type = non_null_types[0]
+
+        primitive_type_mapping = {
+            "string": str,
+            "integer": int,
+            "number": float,
+            "boolean": bool,
+        }
+
+        if field_type in primitive_type_mapping:
+            base_type = primitive_type_mapping[field_type]
+            if in_union:
+                annotated_type = Annotated[base_type, Strict()]  # type: ignore[valid-type]
+                return _merge_nullable(annotated_type, is_nullable)
+            return _merge_nullable(base_type, is_nullable)
+
+        if field_type == "object":
+            properties = normalized_schema.get("properties")
+            additional_properties = normalized_schema.get("additionalProperties", True)
+
+            if properties is None and isinstance(additional_properties, dict):
+                value_annotation = _schema_to_type(additional_properties, f"{path}.*")
+                dict_type = dict[str, value_annotation]  # type: ignore[valid-type]
+                return _merge_nullable(dict_type, is_nullable)
+
+            nested_name = _sanitize_model_name(f"{model_name}_{path.replace('.', '_')}")
+            nested_model = _object_schema_to_model(normalized_schema, nested_name, path)
+            return _merge_nullable(nested_model, is_nullable)
+
+        if field_type == "array":
+            items_schema = normalized_schema.get("items")
+            item_annotation: Any
+            if items_schema is None:
+                item_annotation = Any
+            elif isinstance(items_schema, list):
+                raise ValueError(
+                    f"{_format_path(path)} uses unsupported tuple-style array schema"
+                )
+            elif isinstance(items_schema, dict):
+                item_annotation = _schema_to_type(items_schema, f"{path}[]")
+            else:
+                raise ValueError(f"{_format_path(path)} items must be an object")
+            # Construct list type at runtime to avoid mypy subscript error.
+            list_type = list[item_annotation]  # type: ignore[valid-type]
+            return _merge_nullable(list_type, is_nullable)
+
+        raise ValueError(
+            f"{_format_path(path)} uses unsupported JSON schema type: {field_type}"
+        )
+
+    def _object_schema_to_model(
+        object_schema: dict[str, Any], current_model_name: str, path: str
+    ) -> type[BaseModel]:
+        current_ref_name = ref_name_by_schema_id.get(id(object_schema))
+        if current_ref_name is not None:
+            if current_ref_name in in_flight_refs:
+                raise ValueError("recursive $ref is not supported")
+            in_flight_refs.add(current_ref_name)
+
+        try:
+            normalized_schema = _normalize_schema(object_schema, path)
+            if normalized_schema.get("type") != "object":
+                raise ValueError(f"{_format_path(path)} must be an object schema")
+
+            cache_key = f"{current_model_name}:{id(object_schema)}"
+            cached = model_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+            properties = normalized_schema.get("properties", {})
+            required = normalized_schema.get("required", [])
+            additional_properties = normalized_schema.get("additionalProperties", True)
+
+            if not isinstance(required, list):
+                raise ValueError(f"{_format_path(path)} 'required' must be an array")
+
+            if not isinstance(properties, dict):
+                raise ValueError(f"{_format_path(path)} 'properties' must be an object")
+
+            if not properties:
+                if isinstance(additional_properties, dict):
+                    raise ValueError(
+                        f"{_format_path(path)} is a pure additionalProperties map and should "
+                        "be used as a field type, not as a model root"
+                    )
+                raise ValueError(
+                    f"{_format_path(path)} must have a non-empty 'properties' object"
+                )
+
+            field_definitions: dict[str, Any] = {}
+            for field_name, field_schema in properties.items():
+                child_path = f"{path}.{field_name}" if path else field_name
+                annotation = _schema_to_type(field_schema, child_path)
+                if field_name in required:
+                    field_definitions[field_name] = (annotation, ...)
+                else:
+                    field_definitions[field_name] = (annotation | None, None)
+
+            if additional_properties not in (True, False):
+                raise ValueError(
+                    f"{_format_path(path)} only supports boolean additionalProperties "
+                    "when combined with named properties"
+                )
+
+            model_config = ConfigDict(
+                extra="forbid" if additional_properties is False else "ignore",
+                use_enum_values=True,
+            )
+            dynamic_model = create_model(
+                current_model_name, __config__=model_config, **field_definitions
+            )
+            model_cache[cache_key] = dynamic_model
+            return dynamic_model
+        finally:
+            if current_ref_name is not None:
+                in_flight_refs.remove(current_ref_name)
+
+    if not isinstance(schema, dict):
+        raise ValueError("Schema must be a dictionary")
+
+    return _object_schema_to_model(schema, _sanitize_model_name(model_name), "")

--- a/mellea/serve/streaming.py
+++ b/mellea/serve/streaming.py
@@ -1,0 +1,168 @@
+"""Streaming utilities for OpenAI-compatible server responses."""
+
+from collections.abc import AsyncGenerator
+from typing import Literal
+
+from mellea.core.base import ModelOutputThunk
+from mellea.core.utils import MelleaLogger
+from mellea.helpers.openai_compatible_helpers import (
+    build_completion_usage,
+    build_tool_calls,
+)
+
+from .models import (
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionChunkDelta,
+    ChatCompletionMessageToolCallDelta,
+    OpenAIError,
+    OpenAIErrorResponse,
+    StreamOptions,
+)
+from .utils import extract_finish_reason
+
+
+async def stream_chat_completion_chunks(
+    output: ModelOutputThunk,
+    completion_id: str,
+    model: str,
+    created: int,
+    stream_options: StreamOptions | None = None,
+    system_fingerprint: str | None = None,
+) -> AsyncGenerator[str, None]:
+    """Generate OpenAI-compatible SSE chat completion chunks from a model output.
+
+    This function acts as a pass-through streaming layer, forwarding chunks directly
+    from the backend to the client without buffering or validation. Format validation
+    for structured outputs happens at the module level (in the serve function) and
+    client side, not in this streaming layer.
+
+    Args:
+        output: The model output object to stream.
+        completion_id: Unique identifier for this completion.
+        model: Model name to include in chunks.
+        created: Unix timestamp of when the completion was created.
+        stream_options: OpenAI-compatible streaming options. Controls whether
+            usage statistics are included in the final chunk via the
+            `include_usage` field.
+        system_fingerprint: Backend configuration fingerprint to include in chunks.
+            Defaults to `None`.
+
+    Yields:
+        Server-sent event payload strings representing OpenAI-compatible chat
+        completion chunks, including the terminating `[DONE]` event.
+    """
+    try:
+        initial_chunk = ChatCompletionChunk(
+            id=completion_id,
+            model=model,
+            created=created,
+            choices=[
+                ChatCompletionChunkChoice(
+                    index=0,
+                    delta=ChatCompletionChunkDelta(role="assistant", content=None),
+                    finish_reason=None,
+                )
+            ],
+            object="chat.completion.chunk",
+            system_fingerprint=system_fingerprint,
+        )
+        yield f"data: {initial_chunk.model_dump_json()}\n\n"
+
+        # Handle pre-computed output: emit value as a single content chunk
+        if output.is_computed():
+            if output.value is not None:
+                chunk = ChatCompletionChunk(
+                    id=completion_id,
+                    model=model,
+                    created=created,
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            index=0,
+                            delta=ChatCompletionChunkDelta(content=output.value),
+                            finish_reason=None,
+                        )
+                    ],
+                    object="chat.completion.chunk",
+                    system_fingerprint=system_fingerprint,
+                )
+                yield f"data: {chunk.model_dump_json()}\n\n"
+        else:
+            # Stream incremental chunks for uncomputed output
+            while not output.is_computed():
+                delta_content = await output.astream()
+
+                if delta_content:
+                    chunk = ChatCompletionChunk(
+                        id=completion_id,
+                        model=model,
+                        created=created,
+                        choices=[
+                            ChatCompletionChunkChoice(
+                                index=0,
+                                delta=ChatCompletionChunkDelta(content=delta_content),
+                                finish_reason=None,
+                            )
+                        ],
+                        object="chat.completion.chunk",
+                        system_fingerprint=system_fingerprint,
+                    )
+                    yield f"data: {chunk.model_dump_json()}\n\n"
+
+        tool_calls_list = build_tool_calls(output)
+
+        if tool_calls_list:
+            # Convert to ChatCompletionMessageToolCallDelta objects with required index
+            tool_calls = [
+                ChatCompletionMessageToolCallDelta.model_validate({**tc, "index": idx})
+                for idx, tc in enumerate(tool_calls_list)
+            ]
+
+            # Emit tool calls in a separate chunk before the final chunk
+            tool_call_chunk = ChatCompletionChunk(
+                id=completion_id,
+                model=model,
+                created=created,
+                choices=[
+                    ChatCompletionChunkChoice(
+                        index=0,
+                        delta=ChatCompletionChunkDelta(tool_calls=tool_calls),
+                        finish_reason=None,
+                    )
+                ],
+                object="chat.completion.chunk",
+                system_fingerprint=system_fingerprint,
+            )
+            yield f"data: {tool_call_chunk.model_dump_json()}\n\n"
+
+        # Include usage in final chunk only if explicitly requested via stream_options
+        # Per OpenAI spec: usage is only included when stream_options.include_usage=True
+        include_usage = stream_options is not None and stream_options.include_usage
+
+        usage = build_completion_usage(output) if include_usage else None
+
+        final_chunk = ChatCompletionChunk(
+            id=completion_id,
+            model=model,
+            created=created,
+            choices=[
+                ChatCompletionChunkChoice(
+                    index=0,
+                    delta=ChatCompletionChunkDelta(content=None),
+                    finish_reason=extract_finish_reason(output),
+                )
+            ],
+            object="chat.completion.chunk",
+            system_fingerprint=system_fingerprint,
+            usage=usage,
+        )
+        yield f"data: {final_chunk.model_dump_json()}\n\n"
+        yield "data: [DONE]\n\n"
+
+    except Exception as e:
+        MelleaLogger.get_logger().exception("Streaming error")
+        error_response = OpenAIErrorResponse(
+            error=OpenAIError(message=f"Streaming error: {e!s}", type="server_error")
+        )
+        yield f"data: {error_response.model_dump_json()}\n\n"
+        yield "data: [DONE]\n\n"

--- a/mellea/serve/utils.py
+++ b/mellea/serve/utils.py
@@ -1,0 +1,68 @@
+"""Utilities for extracting finish reason from model output metadata."""
+
+from typing import Any, Literal
+
+from mellea.helpers.openai_compatible_helpers import has_tool_calls
+
+FinishReason = Literal[
+    "stop", "length", "content_filter", "tool_calls", "function_call"
+]
+
+
+def extract_finish_reason(output: Any) -> FinishReason:
+    """Extract finish_reason from ModelOutputThunk metadata.
+
+    First checks if tool_calls are present (returns "tool_calls" if so).
+    Then checks backend-specific metadata fields in order: Ollama, OpenAI, LiteLLM.
+    Backends without finish_reason metadata (e.g., HuggingFace) fall through to
+    the default "stop" value.
+
+    Args:
+        output: The model output thunk containing response metadata.
+
+    Returns:
+        The finish_reason from the backend response, defaulting to "stop" if unavailable.
+        Possible values: "stop", "length", "content_filter", "tool_calls", "function_call".
+    """
+    # If tool calls are present, finish_reason is always "tool_calls"
+    if has_tool_calls(output):
+        return "tool_calls"
+
+    # Valid finish_reason values per OpenAI spec
+    valid_reasons: set[FinishReason] = {
+        "stop",
+        "length",
+        "content_filter",
+        "tool_calls",
+        "function_call",
+    }
+
+    # Try to get finish_reason from the backend-native response on mot.raw.
+    # Different backends store this in different places; switch on mot.raw.provider.
+    raw = getattr(output, "raw", None)
+    if raw is not None:
+        provider = raw.provider
+        response = raw.response
+
+        if provider == "ollama" and response is not None:
+            # ollama.ChatResponse object with done_reason attribute.
+            done_reason = getattr(response, "done_reason", None)
+            if done_reason in valid_reasons:
+                return done_reason
+
+        elif provider in ("openai", "watsonx", "litellm") and isinstance(
+            response, dict
+        ):
+            # Chat path: full response dict, finish_reason nested under choices[0].
+            choices = response.get("choices", [])
+            if choices and len(choices) > 0:
+                finish_reason = choices[0].get("finish_reason")
+                if finish_reason in valid_reasons:
+                    return finish_reason
+            # Raw-completion path: single choice dict, finish_reason at top level.
+            finish_reason = response.get("finish_reason")
+            if finish_reason in valid_reasons:
+                return finish_reason
+
+    # Default to "stop" per OpenAI spec
+    return "stop"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ cli = [
 server = [
     "uvicorn",
     "fastapi",
-    "mellea[cli]",
 ]
 
 sandbox = [

--- a/test/cli/test_build_model_options.py
+++ b/test/cli/test_build_model_options.py
@@ -1,8 +1,8 @@
 """Unit tests for _build_model_options function."""
 
-from cli.serve.app import _build_model_options
-from cli.serve.models import ChatCompletionRequest, ChatMessage
 from mellea.backends.model_options import ModelOption
+from mellea.serve.app import _build_model_options
+from mellea.serve.models import ChatCompletionRequest, ChatMessage
 
 
 class TestBuildModelOptions:

--- a/test/cli/test_schema_converter.py
+++ b/test/cli/test_schema_converter.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from cli.serve.schema_converter import json_schema_to_pydantic
+from mellea.serve.schema_converter import json_schema_to_pydantic
 
 
 def test_json_schema_supports_enum_field():

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -10,8 +10,10 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
 
-from cli.serve.app import app, make_chat_endpoint, validation_exception_handler
-from cli.serve.models import (
+from mellea.backends.model_options import ModelOption
+from mellea.core.base import ModelOutputThunk, ModelToolCall
+from mellea.serve.app import app, make_chat_endpoint, validation_exception_handler
+from mellea.serve.models import (
     ChatCompletion,
     ChatCompletionRequest,
     ChatMessage,
@@ -22,8 +24,6 @@ from cli.serve.models import (
     ResponseFormat,
     ToolFunction,
 )
-from mellea.backends.model_options import ModelOption
-from mellea.core.base import ModelOutputThunk, ModelToolCall
 
 
 @pytest.fixture

--- a/test/cli/test_serve_errors.py
+++ b/test/cli/test_serve_errors.py
@@ -6,8 +6,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import ChatCompletionRequest, ChatMessage
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import ChatCompletionRequest, ChatMessage
 
 
 @pytest.fixture

--- a/test/cli/test_serve_integration.py
+++ b/test/cli/test_serve_integration.py
@@ -15,9 +15,9 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 
-from cli.serve.app import make_chat_endpoint, validation_exception_handler
-from cli.serve.models import FunctionDefinition, FunctionParameters, ToolFunction
 from mellea.core.base import AbstractMelleaTool, ModelOutputThunk, ModelToolCall
+from mellea.serve.app import make_chat_endpoint, validation_exception_handler
+from mellea.serve.models import FunctionDefinition, FunctionParameters, ToolFunction
 
 # Mark all tests in this module as integration tests
 pytestmark = pytest.mark.integration

--- a/test/cli/test_serve_integration_multimodal.py
+++ b/test/cli/test_serve_integration_multimodal.py
@@ -9,14 +9,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import (
+from mellea.core import ModelOutputThunk
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import (
     ChatCompletionRequest,
     ChatMessage,
     ImageUrlContent,
     TextContent,
 )
-from mellea.core import ModelOutputThunk
 
 # --- Helper functions ---
 

--- a/test/cli/test_serve_models.py
+++ b/test/cli/test_serve_models.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from cli.serve.models import FunctionParameters, JsonSchemaFormat, StreamOptions
+from mellea.serve.models import FunctionParameters, JsonSchemaFormat, StreamOptions
 
 
 class TestStreamOptions:

--- a/test/cli/test_serve_streaming.py
+++ b/test/cli/test_serve_streaming.py
@@ -7,11 +7,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import ChatCompletionRequest, ChatMessage, StreamOptions
-from cli.serve.streaming import stream_chat_completion_chunks
 from mellea.core.base import ModelOutputThunk
 from mellea.helpers.openai_compatible_helpers import build_completion_usage
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import ChatCompletionRequest, ChatMessage, StreamOptions
+from mellea.serve.streaming import stream_chat_completion_chunks
 
 
 @pytest.fixture

--- a/test/cli/test_serve_streaming_tool_calls.py
+++ b/test/cli/test_serve_streaming_tool_calls.py
@@ -9,9 +9,9 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from cli.serve.models import StreamOptions
-from cli.serve.streaming import stream_chat_completion_chunks
 from mellea.core.base import ModelOutputThunk, ModelToolCall
+from mellea.serve.models import StreamOptions
+from mellea.serve.streaming import stream_chat_completion_chunks
 
 
 class TestStreamingToolCalls:

--- a/test/cli/test_serve_sync_async.py
+++ b/test/cli/test_serve_sync_async.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import ChatCompletionRequest, ChatMessage
 from mellea.backends.model_options import ModelOption
 from mellea.core import ModelOutputThunk
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import ChatCompletionRequest, ChatMessage
 
 
 @pytest.fixture

--- a/test/cli/test_serve_tool_calling.py
+++ b/test/cli/test_serve_tool_calling.py
@@ -6,8 +6,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import (
+from mellea.backends import ModelOption
+from mellea.core.base import AbstractMelleaTool, ModelOutputThunk, ModelToolCall
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import (
     ChatCompletion,
     ChatCompletionRequest,
     ChatMessage,
@@ -15,8 +17,6 @@ from cli.serve.models import (
     FunctionParameters,
     ToolFunction,
 )
-from mellea.backends import ModelOption
-from mellea.core.base import AbstractMelleaTool, ModelOutputThunk, ModelToolCall
 
 
 class MockTool(AbstractMelleaTool):

--- a/test/cli/test_serve_utils.py
+++ b/test/cli/test_serve_utils.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import Mock
 
-from cli.serve.utils import extract_finish_reason
 from mellea.core.base import ModelOutputThunk, RawProviderResponse
+from mellea.serve.utils import extract_finish_reason
 
 
 class TestExtractFinishReason:

--- a/test/cli/test_tool_call_index_verification.py
+++ b/test/cli/test_tool_call_index_verification.py
@@ -9,9 +9,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from cli.serve.app import make_chat_endpoint
-from cli.serve.models import ChatCompletionRequest, ChatMessage
 from mellea.core.base import ModelOutputThunk, ModelToolCall
+from mellea.serve.app import make_chat_endpoint
+from mellea.serve.models import ChatCompletionRequest, ChatMessage
 
 
 @pytest.mark.asyncio

--- a/test/package/test_dependency_isolation.py
+++ b/test/package/test_dependency_isolation.py
@@ -63,7 +63,7 @@ IMPORTS: dict[str, list[str]] = {
         "import elasticsearch",
     ],
     "cli": ["from cli.m import cli"],
-    "server": ["from cli.serve.app import run_server"],
+    "server": ["from mellea.serve.app import run_server"],
     "sandbox": ["import llm_sandbox"],
     "switch": ["import huggingface_hub"],
     "hooks": [

--- a/uv.lock
+++ b/uv.lock
@@ -55,13 +55,13 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "aiosignal", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "attrs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "yarl", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
 wheels = [
@@ -162,13 +162,13 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "aiosignal", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "attrs", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "frozenlist", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "multidict", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "propcache", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "yarl", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
@@ -693,7 +693,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -710,7 +710,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (python_full_version >= '3.14' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -971,37 +971,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1880,15 +1880,15 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "hf-xet", marker = "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
@@ -1905,16 +1905,16 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "hf-xet", marker = "(python_full_version < '3.12' and platform_machine == 'AMD64') or (python_full_version >= '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.12' and platform_machine == 'amd64') or (python_full_version >= '3.14' and platform_machine == 'amd64') or (python_full_version < '3.12' and platform_machine == 'arm64') or (python_full_version >= '3.14' and platform_machine == 'arm64') or (python_full_version < '3.12' and platform_machine == 'x86_64') or (python_full_version >= '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d8/748ea0a47f0fa15227fe682f7a80826b4b7c096e4818044b8f56d6cb66d6/huggingface_hub-1.18.0.tar.gz", hash = "sha256:f0c5ecd1ef8c6a60f86f61ee278f2c1570ba9e279c9f54de9094210723b3613b", size = 812699, upload-time = "2026-06-05T09:26:33.401Z" }
 wheels = [
@@ -2022,7 +2022,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
 wheels = [
@@ -2039,7 +2039,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -2352,10 +2352,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jsonschema-specifications", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "referencing", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "rpds-py", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
 wheels = [
@@ -2364,14 +2364,14 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "uri-template" },
-    { name = "webcolors" },
+    { name = "fqdn", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "idna", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "isoduration", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jsonpointer", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "rfc3339-validator", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "rfc3986-validator", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "uri-template", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "webcolors", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -2384,10 +2384,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "referencing", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "rpds-py", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -2396,15 +2396,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors" },
+    { name = "fqdn", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "idna", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "isoduration", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jsonpointer", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "rfc3339-validator", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "rfc3986-validator", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "rfc3987-syntax", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "uri-template", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "webcolors", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 
 [[package]]
@@ -2843,18 +2843,18 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "openai", version = "2.33.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic", version = "2.13.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "openai", version = "2.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.13.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
 wheels = [
@@ -2870,18 +2870,18 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.23.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "openai", version = "2.24.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jsonschema", version = "4.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openai", version = "2.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
@@ -3339,7 +3339,6 @@ sandbox = [
 ]
 server = [
     { name = "fastapi" },
-    { name = "typer" },
     { name = "uvicorn" },
 ]
 switch = [
@@ -3454,7 +3453,6 @@ requires-dist = [
     { name = "math-verify" },
     { name = "mcp", marker = "extra == 'tools'", specifier = ">=1.27.0" },
     { name = "mellea", extras = ["backends", "docling", "tools", "telemetry", "server", "sandbox", "switch", "granite-retriever", "hooks", "cli"], marker = "extra == 'all'", editable = "." },
-    { name = "mellea", extras = ["cli"], marker = "extra == 'server'", editable = "." },
     { name = "mellea", extras = ["hooks"], marker = "extra == 'telemetry'", editable = "." },
     { name = "mellea", extras = ["watsonx", "hf", "litellm"], marker = "extra == 'backends'", editable = "." },
     { name = "mistletoe", specifier = ">=1.4.0" },
@@ -4265,14 +4263,14 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "distro", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jiter", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
@@ -4289,14 +4287,14 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic", version = "2.13.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "distro", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jiter", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic", version = "2.13.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
 wheels = [
@@ -5244,10 +5242,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -5264,10 +5262,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.46.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic-core", version = "2.46.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
@@ -5283,7 +5281,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -5385,7 +5383,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
 wheels = [
@@ -6230,7 +6228,7 @@ name = "rfc3987-syntax"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lark" },
+    { name = "lark", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [


### PR DESCRIPTION
# Pull Request

## Issue
n/a

## Description
A little experiment, based on a comment @HendrikStrobelt made, on what it would look like to remove `m serve` from the cli. Not something I'm planning to merge at this time.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
