### PR TITLE
fix: raise ValueError for image/audio inputs in LocalHFBackend

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -610,8 +610,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             intrinsic output.
 
         Raises:
-            ValueError: If no adapter is registered for the requested intrinsic.
-            ValueError: If the context contains images or audio; `LocalHFBackend`
+            ValueError: If no adapter is registered for the requested intrinsic,
+                or if the context contains images or audio; `LocalHFBackend`
                 does not support multimodal inputs.
             TypeError: If the adapter isn't an IntrinsicAdapter.
         """

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -276,19 +276,20 @@ _GENERATE_KWARGS_ALLOWLIST: frozenset[str] = _compute_generate_kwargs_allowlist(
 
 
 def _check_no_multimodal_blocks(
-    action: Component | CBlock | ModelOutputThunk | None, ctx: Context
+    action: Component | CBlock | ModelOutputThunk | None, ctx: Context | None
 ) -> None:
     """Raise ValueError if any component in ctx or action carries image/audio blocks.
 
     Args:
         action: The generation action component, or None for intrinsic paths.
-        ctx: The current conversation context.
+        ctx: The current conversation context, or None to skip the context scan
+            (used on paths where ctx content is never rendered, e.g. `_generate_from_raw`).
 
     Raises:
         ValueError: If any component contains images or audio.
             `LocalHFBackend` does not support multimodal inputs.
     """
-    linearized = ctx.view_for_generation() or []
+    linearized = (ctx.view_for_generation() or []) if ctx is not None else []
     candidates: list[Any] = list(linearized)
     if action is not None:
         candidates.append(action)
@@ -1671,6 +1672,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 `results` is a list of model output thunks, one per action, and
                 `usage` is the aggregate token-usage dict for the batch.
         """
+        for action in actions:
+            _check_no_multimodal_blocks(action, None)
         await self.do_generate_walks(list(actions))
 
         if tool_calls:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -55,6 +55,8 @@ from ..core import (
     MelleaLogger,
     ModelOutputThunk,
     Requirement,
+    get_audio_from_component,
+    get_images_from_component,
 )
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter, granite as granite_formatters
@@ -271,6 +273,36 @@ def _compute_generate_kwargs_allowlist() -> frozenset[str]:
 
 
 _GENERATE_KWARGS_ALLOWLIST: frozenset[str] = _compute_generate_kwargs_allowlist()
+
+
+def _check_no_multimodal_blocks(
+    action: Component | CBlock | ModelOutputThunk | None, ctx: Context
+) -> None:
+    """Raise ValueError if any component in ctx or action carries image/audio blocks.
+
+    Args:
+        action: The generation action component, or None for intrinsic paths.
+        ctx: The current conversation context.
+
+    Raises:
+        ValueError: If any component contains images or audio.
+            `LocalHFBackend` does not support multimodal inputs.
+    """
+    linearized = ctx.view_for_generation() or []
+    candidates: list[Any] = list(linearized)
+    if action is not None:
+        candidates.append(action)
+    for c in candidates:
+        if get_images_from_component(c) is not None:
+            raise ValueError(
+                "LocalHFBackend does not support images. "
+                "Remove image content before passing messages to the Hugging Face backend."
+            )
+        if get_audio_from_component(c) is not None:
+            raise ValueError(
+                "LocalHFBackend does not support audio. "
+                "Remove audio content before passing messages to the Hugging Face backend."
+            )
 
 
 class LocalHFBackend(FormatterBackend, AdapterMixin):
@@ -578,10 +610,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         Raises:
             ValueError: If no adapter is registered for the requested intrinsic.
+            ValueError: If the context contains images or audio; `LocalHFBackend`
+                does not support multimodal inputs.
             TypeError: If the adapter isn't an IntrinsicAdapter.
         """
         if not ctx.is_chat_context:
             raise Exception("Does not yet support non-chat contexts.")
+
+        _check_no_multimodal_blocks(None, ctx)
 
         seed = model_options.get(ModelOption.SEED, None)
         if seed is not None:
@@ -954,10 +990,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         model_options: dict[str, Any],
         tool_calls: bool = False,
     ) -> ModelOutputThunk[C]:
+        """Generate a completion using the KV cache path.
+
+        Raises:
+            ValueError: If the context or action contains images or audio;
+                `LocalHFBackend` does not support multimodal inputs.
+        """
         # Construct input.
         # If the Context is a ChatHistory then we will pretty-print each content as a message and then use apply_chat_template.
         # Otherwise, we will linearize the context and treat it as a raw input.
         if ctx.is_chat_context:
+            _check_no_multimodal_blocks(action, ctx)
             system_prompt = model_options.get(ModelOption.SYSTEM_PROMPT, None)
             ctx_as_chat = to_chat(action, ctx, self.formatter, system_prompt)
 
@@ -1145,10 +1188,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         model_options: dict[str, Any],
         tool_calls: bool = False,
     ) -> ModelOutputThunk:
+        """Generate a completion using the standard (non-KV-cache) path.
+
+        Raises:
+            ValueError: If the context or action contains images or audio;
+                `LocalHFBackend` does not support multimodal inputs.
+        """
         # Construct input.
         # If the Context is a ChatHistory then we will pretty-print each content as a message and then use apply_chat_template.
         # Otherwise, we will linearize the context and treat it as a raw input.
         if ctx.is_chat_context:
+            _check_no_multimodal_blocks(action, ctx)
             system_prompt = model_options.get(ModelOption.SYSTEM_PROMPT, None)
             ctx_as_chat = to_chat(action, ctx, self.formatter, system_prompt)
 

--- a/mellea/core/__init__.py
+++ b/mellea/core/__init__.py
@@ -35,6 +35,7 @@ from .base import (
     TemplateRepresentation,
     blockify,
     get_audio_from_component,
+    get_images_from_component,
     make_image_block,
 )
 from .formatter import Formatter
@@ -96,6 +97,7 @@ __all__ = [
     "default_output_to_bool",
     "generate_walk",
     "get_audio_from_component",
+    "get_images_from_component",
     "log_context",
     "make_image_block",
     "set_log_context",

--- a/mellea/stdlib/components/instruction.py
+++ b/mellea/stdlib/components/instruction.py
@@ -227,6 +227,16 @@ class Instruction(Component[str]):
         return jinja2.Template(s).render(user_dict)
 
     @property
+    def images(self) -> list[ImageBlock | ImageUrlBlock] | None:
+        """Returns the images associated with this instruction."""
+        return self._images
+
+    @property
+    def audio(self) -> list[AudioBlock | AudioUrlBlock] | None:
+        """Returns the audio associated with this instruction."""
+        return self._audio
+
+    @property
     def requirements(self) -> list[Requirement]:
         """Returns a list of Requirement instances."""
         return self._requirements

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -883,3 +883,32 @@ async def test_multimodal_blocks_on_instruction_as_action_raise_error(images, au
             ctx,
             model_options={},
         )
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
+    stub_backend, images, audio
+):
+    """_generate_from_intrinsic raises ValueError when ctx contains image/audio blocks.
+
+    The guard on the intrinsic path passes ``action=None`` and scans only the context;
+    this test exercises that branch directly.
+    """
+    backend = _make_intrinsic_backend_stub(stub_backend)
+    adapter = _make_intrinsic_adapter_stub()
+    backend._added_adapters = {adapter.qualified_name: adapter}
+    ctx = ChatContext().add(Message("user", "Hello", images=images, audio=audio))
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await LocalHFBackend._generate_from_intrinsic(
+            backend, Intrinsic("answerability"), ctx, model_options={}
+        )

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -16,6 +16,9 @@ pytest.importorskip(
     "llguidance", reason="llguidance not installed — install mellea[hf]"
 )
 
+import base64
+import struct
+
 from transformers.generation.utils import GenerateDecoderOnlyOutput
 
 from mellea.backends import ModelOption
@@ -23,8 +26,38 @@ from mellea.backends.adapters import AdapterMixin, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
-from mellea.stdlib.components import Intrinsic, Message
+from mellea.stdlib.components import (
+    AudioBlock,
+    AudioUrlBlock,
+    ImageBlock,
+    ImageUrlBlock,
+    Intrinsic,
+    Message,
+)
 from mellea.stdlib.context import ChatContext
+
+# Minimal 1x1 PNG for testing
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx"
+    b"\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N\x00"
+    b"\x00\x00\x00IEND\xaeB`\x82"
+)
+_B64_PNG = base64.b64encode(_MINIMAL_PNG).decode()
+
+# Minimal WAV for testing
+_SILENT_SAMPLE = struct.pack("<h", 0)
+_WAV_HEADER = (
+    b"RIFF"
+    + struct.pack("<I", 36 + len(_SILENT_SAMPLE))
+    + b"WAVEfmt "
+    + struct.pack("<IHHIIHH", 16, 1, 1, 16000, 32000, 2, 16)
+    + b"data"
+    + struct.pack("<I", len(_SILENT_SAMPLE))
+)
+_MINIMAL_WAV = _WAV_HEADER + _SILENT_SAMPLE
+_B64_WAV = base64.b64encode(_MINIMAL_WAV).decode()
 
 
 def _make_backend(eos_token_id: int | list[int] = 0) -> LocalHFBackend:
@@ -676,3 +709,59 @@ async def test_intrinsic_logits_populated_when_option_set(stub_backend):
     )
     assert len(output.generation.logits) == len(fake_scores)
     assert all(t.shape == (vocab_size,) for t in output.generation.logits)
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_raise_error(images, audio):
+    """LocalHFBackend raises ValueError for image/audio inputs instead of silently dropping them."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello", images=images, audio=audio))
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_context_standard(
+            Message("assistant", ""), ctx, model_options={}
+        )
+
+
+@pytest.mark.asyncio
+async def test_multimodal_blocks_in_action_raise_error():
+    """LocalHFBackend raises ValueError when action contains image/audio blocks."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello"))
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_context_standard(
+            Message("assistant", "", images=[ImageBlock(_B64_PNG)]),
+            ctx,
+            model_options={},
+        )
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_kv_cache_path_raises_error(images, audio):
+    """LocalHFBackend KV cache path raises ValueError for image/audio inputs."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello", images=images, audio=audio))
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_context_with_kv_cache(
+            Message("assistant", ""), ctx, model_options={}
+        )

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -765,3 +765,66 @@ async def test_multimodal_blocks_kv_cache_path_raises_error(images, audio):
         await backend._generate_from_context_with_kv_cache(
             Message("assistant", ""), ctx, model_options={}
         )
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_in_raw_action_raises_error(images, audio):
+    """_generate_from_raw raises ValueError for actions with image/audio blocks instead of silently dropping them."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello"))
+    action = Message("assistant", "", images=images, audio=audio)
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_raw([action], ctx, model_options={})
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_in_raw_ctx_not_checked(images, audio):
+    """_generate_from_raw does not scan ctx for multimodal content.
+
+    ctx is accepted by the signature but never rendered on the raw path — only
+    the actions are formatted and sent to the model. Multimodal blocks stored
+    in the context do not cause an error here (they are simply unused).
+    """
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello", images=images, audio=audio))
+    action = Message("assistant", "")
+
+    # Should not raise — ctx content is not rendered by _generate_from_raw.
+    # We mock the model to avoid loading weights; just verify no ValueError is raised.
+    mock_outputs = MagicMock()
+    mock_outputs.sequences = [MagicMock()]
+    mock_outputs.sequences[0].__getitem__ = MagicMock(return_value=MagicMock())
+    mock_outputs.scores = None
+    mock_outputs.logits = None
+    with patch.object(
+        backend, "_generate_with_adapter_lock", return_value=mock_outputs
+    ):
+        with patch.object(
+            backend._tokenizer,
+            "__call__",
+            return_value={
+                "input_ids": MagicMock(size=lambda i: 0),
+                "attention_mask": MagicMock(),
+            },
+        ):
+            with patch.object(backend._tokenizer, "batch_decode", return_value=[""]):
+                await backend._generate_from_raw([action], ctx, model_options={})

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -60,6 +60,14 @@ _WAV_HEADER = (
 _MINIMAL_WAV = _WAV_HEADER + _SILENT_SAMPLE
 _B64_WAV = base64.b64encode(_MINIMAL_WAV).decode()
 
+# All four multimodal block types — reused by every parametrized guard test below.
+_MULTIMODAL_CASES = [
+    ([ImageBlock(_B64_PNG)], None),
+    ([ImageUrlBlock(value="http://example.com/image.png")], None),
+    (None, [AudioBlock(_B64_WAV, format="wav")]),
+    (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+]
+
 
 def _make_backend(eos_token_id: int | list[int] = 0) -> LocalHFBackend:
     mock_tok = MagicMock(eos_token_id=eos_token_id, vocab_size=32000)
@@ -712,15 +720,7 @@ async def test_intrinsic_logits_populated_when_option_set(stub_backend):
     assert all(t.shape == (vocab_size,) for t in output.generation.logits)
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_raise_error(images, audio):
     """LocalHFBackend raises ValueError for image/audio inputs instead of silently dropping them."""
@@ -747,15 +747,7 @@ async def test_multimodal_blocks_in_action_raise_error():
         )
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_kv_cache_path_raises_error(images, audio):
     """LocalHFBackend KV cache path raises ValueError for image/audio inputs."""
@@ -768,15 +760,7 @@ async def test_multimodal_blocks_kv_cache_path_raises_error(images, audio):
         )
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_in_raw_action_raises_error(images, audio):
     """_generate_from_raw raises ValueError for actions with image/audio blocks instead of silently dropping them."""
@@ -788,15 +772,7 @@ async def test_multimodal_blocks_in_raw_action_raises_error(images, audio):
         await backend._generate_from_raw([action], ctx, model_options={})
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_in_raw_ctx_not_checked(images, audio):
     """_generate_from_raw does not scan ctx for multimodal content.
@@ -831,15 +807,7 @@ async def test_multimodal_blocks_in_raw_ctx_not_checked(images, audio):
                 await backend._generate_from_raw([action], ctx, model_options={})
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_on_instruction_in_ctx_raise_error(images, audio):
     """LocalHFBackend raises ValueError when an Instruction in ctx carries image/audio blocks.
@@ -858,15 +826,7 @@ async def test_multimodal_blocks_on_instruction_in_ctx_raise_error(images, audio
         )
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_on_instruction_as_action_raise_error(images, audio):
     """LocalHFBackend raises ValueError when an Instruction used as the action carries image/audio.
@@ -885,15 +845,7 @@ async def test_multimodal_blocks_on_instruction_as_action_raise_error(images, au
         )
 
 
-@pytest.mark.parametrize(
-    "images,audio",
-    [
-        ([ImageBlock(_B64_PNG)], None),
-        ([ImageUrlBlock(value="http://example.com/image.png")], None),
-        (None, [AudioBlock(_B64_WAV, format="wav")]),
-        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
-    ],
-)
+@pytest.mark.parametrize("images,audio", _MULTIMODAL_CASES)
 @pytest.mark.asyncio
 async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
     stub_backend, images, audio

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -31,6 +31,7 @@ from mellea.stdlib.components import (
     AudioUrlBlock,
     ImageBlock,
     ImageUrlBlock,
+    Instruction,
     Intrinsic,
     Message,
 )
@@ -828,3 +829,57 @@ async def test_multimodal_blocks_in_raw_ctx_not_checked(images, audio):
         ):
             with patch.object(backend._tokenizer, "batch_decode", return_value=[""]):
                 await backend._generate_from_raw([action], ctx, model_options={})
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_on_instruction_in_ctx_raise_error(images, audio):
+    """LocalHFBackend raises ValueError when an Instruction in ctx carries image/audio blocks.
+
+    The guard uses hasattr(c, "images") / hasattr(c, "audio"), so it must fire
+    for Instruction just as it does for Message.
+    """
+    backend = _make_backend()
+    ctx = ChatContext().add(
+        Instruction(description="describe this", images=images, audio=audio)
+    )
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_context_standard(
+            Message("assistant", ""), ctx, model_options={}
+        )
+
+
+@pytest.mark.parametrize(
+    "images,audio",
+    [
+        ([ImageBlock(_B64_PNG)], None),
+        ([ImageUrlBlock(value="http://example.com/image.png")], None),
+        (None, [AudioBlock(_B64_WAV, format="wav")]),
+        (None, [AudioUrlBlock(value="http://example.com/audio.wav", format="wav")]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_multimodal_blocks_on_instruction_as_action_raise_error(images, audio):
+    """LocalHFBackend raises ValueError when an Instruction used as the action carries image/audio.
+
+    The guard checks the action component as well as components in ctx; this test
+    exercises the action branch via Instruction instead of Message.
+    """
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello"))
+
+    with pytest.raises(ValueError, match="LocalHFBackend does not support"):
+        await backend._generate_from_context_standard(
+            Instruction(description="describe this", images=images, audio=audio),
+            ctx,
+            model_options={},
+        )


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1405 

## Description
<!-- What does this PR do and why? -->
LocalHFBackend silently dropped image and audio content on all three generation paths (_generate_from_context_standard, _generate_from_context_with_kv_cache, _generate_from_intrinsic). This encouraged hallucination when attempting image-text-to-text or audio-text-to-text with a query and an image/audio block that is dropped.

- Add _check_no_multimodal_blocks() helper using get_images_from_component and get_audio_from_component so Instruction images/audio are caught as well as Message images/audio and future components
- Call the check before to_chat() on all three paths so no formatting work is done on the error path
- Add public .images and .audio properties to Instruction (Message already had them; required for get_*_from_component to work)
- Export get_images_from_component from mellea.core (get_audio already was exported)


### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [x] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
