### PR TITLE
fix: Context.last_turn

### DIFF
--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1605,19 +1605,13 @@ class Context(abc.ABC):
         if len(history) == 0:
             return None
         last_element = history[-1]
-        if isinstance(last_element, ModelOutputThunk):
-            if len(history) >= 2:
-                # Last two elements are input and output
-                return ContextTurn(history[-2], last_element)
-            else:
-                # Single output element, return partial turn without input
-                return ContextTurn(None, last_element)
-        elif isinstance(last_element, Message) and last_element.role == "assistant":
-            # Manually-added assistant message is treated as output
+        if isinstance(last_element, ModelOutputThunk) or (
+            isinstance(last_element, Message) and last_element.role == "assistant"
+        ):
+            # Only role=="assistant" is output; tool messages fall through to input (matches #377 scoping)
             if len(history) >= 2:
                 return ContextTurn(history[-2], last_element)
             else:
-                # Single assistant message, return partial turn without input
                 return ContextTurn(None, last_element)
         else:
             # Last element is an input (user message or other component)

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1401,13 +1401,14 @@ class ContextTurn:
     Args:
         model_input (CBlock | Component | ModelOutputThunk | None): The input component or content block for this turn,
             or `None` for an output-only partial turn.
-        output (ModelOutputThunk | None): The model's output thunk for this turn,
+        output (ModelOutputThunk | Component | None): The model's output thunk for this turn,
+            or a manually-added response component (e.g., `Message` with role="assistant"),
             or `None` for an input-only partial turn.
 
     """
 
     model_input: CBlock | Component | ModelOutputThunk | None
-    output: ModelOutputThunk | None
+    output: ModelOutputThunk | Component | None
 
 
 ContextT = TypeVar("ContextT", bound="Context")
@@ -1591,10 +1592,14 @@ class Context(abc.ABC):
         """The last input/output turn of the context.
 
         This can be partial. If the last event is an input, then the output is None.
+        Recognizes both `ModelOutputThunk` (session-generated) and `Message` with
+        role="assistant" (manually-added) as valid response outputs.
 
         Returns:
             The most recent turn, or `None` if the context is empty.
         """
+        from mellea.stdlib.components import Message
+
         history = self.as_list(last_n_components=2)
 
         if len(history) == 0:
@@ -1602,13 +1607,20 @@ class Context(abc.ABC):
         last_element = history[-1]
         if isinstance(last_element, ModelOutputThunk):
             if len(history) >= 2:
-                # assuming that the last two elements are input and output
+                # Last two elements are input and output
                 return ContextTurn(history[-2], last_element)
             else:
-                # if self._ctx is of size 1 and only element is output element, return partial turn without an input.
+                # Single output element, return partial turn without input
+                return ContextTurn(None, last_element)
+        elif isinstance(last_element, Message) and last_element.role == "assistant":
+            # Manually-added assistant message is treated as output
+            if len(history) >= 2:
+                return ContextTurn(history[-2], last_element)
+            else:
+                # Single assistant message, return partial turn without input
                 return ContextTurn(None, last_element)
         else:
-            # if the last element is input element, return partial turn without output
+            # Last element is an input (user message or other component)
             return ContextTurn(last_element, None)
 
     # Abstract methods below this line.

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -86,36 +86,37 @@ def _extract_last_response(context: ChatContext) -> tuple[str, ChatContext]:
             assistant response, if the response has not been computed yet,
             or if there is no preceding node.
     """
+    from ....core import ModelOutputThunk
     from ..chat import Message
 
     turn = context.last_turn()
     if turn is None:
         raise ValueError("Context is empty; cannot extract an assistant response.")
 
-    if turn.output is not None and turn.output.value is not None:
-        # Session-generated response stored as a ModelOutputThunk.
-        # Only the text value is preserved; thunk metadata is intentionally dropped.
-        response_text: str = turn.output.value
-        prev_ctx = context.previous_node
-    elif turn.output is not None and turn.output.value is None:
-        raise ValueError(
-            "Cannot extract assistant response: it has not been computed yet. "
-            "Await the response before calling this adapter function."
-        )
-    elif (
-        turn.model_input is not None
-        and isinstance(turn.model_input, Message)
-        and turn.model_input.role == "assistant"
-    ):
-        # Manually-added assistant Message (e.g. built from test fixtures).
-        response_text = turn.model_input.content
-        prev_ctx = context.previous_node
-    else:
+    if turn.output is None:
         raise ValueError(
             "Cannot extract assistant response: the last context element is "
             "not an assistant response."
         )
 
+    if isinstance(turn.output, ModelOutputThunk):
+        # Session-generated response stored as a ModelOutputThunk.
+        if turn.output.value is None:
+            raise ValueError(
+                "Cannot extract assistant response: it has not been computed yet. "
+                "Await the response before calling this adapter function."
+            )
+        response_text: str = turn.output.value
+    elif isinstance(turn.output, Message):
+        # Manually-added assistant Message (e.g. built from test fixtures).
+        response_text = turn.output.content
+    else:
+        raise ValueError(
+            f"Cannot extract assistant response: output is of type "
+            f"{type(turn.output).__name__}, not ModelOutputThunk or Message."
+        )
+
+    prev_ctx = context.previous_node
     if prev_ctx is None:
         raise ValueError(
             "Context has no previous node; cannot rewind past the assistant turn."

--- a/mellea/stdlib/requirements/safety/guardian.py
+++ b/mellea/stdlib/requirements/safety/guardian.py
@@ -13,6 +13,7 @@ from ....core import (
     CBlock,
     Context,
     MelleaLogger,
+    ModelOutputThunk,
     Requirement,
     ValidationResult,
 )
@@ -314,8 +315,11 @@ class GuardianCheck(Requirement):
                     # Extract content from either ModelOutputThunk or Message
                     if isinstance(last_turn.output, Message):
                         content = last_turn.output.content
-                    else:
+                    elif isinstance(last_turn.output, ModelOutputThunk):
                         content = last_turn.output.value or ""
+                    else:
+                        # Fallback for other Component types
+                        content = ""
                     tcalls = getattr(last_turn.output, "tool_calls", None)
                     if tcalls:
                         calls = [

--- a/mellea/stdlib/requirements/safety/guardian.py
+++ b/mellea/stdlib/requirements/safety/guardian.py
@@ -311,7 +311,11 @@ class GuardianCheck(Requirement):
             if last_turn.output is not None:
                 # For function call risk, append tool call info as text; otherwise add thunk directly.
                 if self._risk == "function_call" or effective_risk == "function_call":
-                    content = last_turn.output.value or ""
+                    # Extract content from either ModelOutputThunk or Message
+                    if isinstance(last_turn.output, Message):
+                        content = last_turn.output.content
+                    else:
+                        content = last_turn.output.value or ""
                     tcalls = getattr(last_turn.output, "tool_calls", None)
                     if tcalls:
                         calls = [

--- a/mellea/stdlib/requirements/safety/guardian.py
+++ b/mellea/stdlib/requirements/safety/guardian.py
@@ -319,6 +319,10 @@ class GuardianCheck(Requirement):
                         content = last_turn.output.value or ""
                     else:
                         # Fallback for other Component types
+                        logger.warning(
+                            f"Unexpected component type in last_turn.output: {type(last_turn.output).__name__}. "
+                            "Treating as empty content."
+                        )
                         content = ""
                     tcalls = getattr(last_turn.output, "tool_calls", None)
                     if tcalls:

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -952,3 +952,90 @@ def test_blockify_mot_returns_unchanged():
 def test_blockify_uncomputed_mot_returns_unchanged():
     mot = ModelOutputThunk(value=None)
     assert blockify(mot) is mot
+
+
+# --- Context.last_turn() tests ---
+
+
+def test_last_turn_empty_context():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext()
+    turn = ctx.last_turn()
+    assert turn is None
+
+
+def test_last_turn_with_model_output_thunk():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("user", "hello")).add(ModelOutputThunk("response"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "user"
+    assert isinstance(turn.output, ModelOutputThunk)
+    assert turn.output.value == "response"
+
+
+def test_last_turn_with_assistant_message():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = (
+        ChatContext()
+        .add(Message("user", "hello"))
+        .add(Message("assistant", "response"))
+    )
+    turn = ctx.last_turn()
+    assert turn is not None
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "user"
+    assert isinstance(turn.output, Message)
+    assert turn.output.role == "assistant"
+    assert turn.output.content == "response"
+
+
+def test_last_turn_output_only_assistant_message():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("assistant", "response"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    assert turn.model_input is None
+    assert isinstance(turn.output, Message)
+    assert turn.output.role == "assistant"
+    assert turn.output.content == "response"
+
+
+def test_last_turn_input_only_user_message():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("user", "hello"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "user"
+    assert turn.output is None
+
+
+def test_last_turn_user_message_treated_as_input():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("user", "hello"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    # User message should be in model_input, not output
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "user"
+    assert turn.output is None
+
+
+def test_last_turn_system_message_treated_as_input():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("system", "system prompt"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    # System message should be in model_input, not output
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "system"
+    assert turn.output is None

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -1039,3 +1039,15 @@ def test_last_turn_system_message_treated_as_input():
     assert isinstance(turn.model_input, Message)
     assert turn.model_input.role == "system"
     assert turn.output is None
+
+
+def test_last_turn_tool_message_treated_as_input():
+    from mellea.stdlib.context import ChatContext
+
+    ctx = ChatContext().add(Message("tool", "tool result"))
+    turn = ctx.last_turn()
+    assert turn is not None
+    # Tool message should be in model_input, not output (matches #377 scoping)
+    assert isinstance(turn.model_input, Message)
+    assert turn.model_input.role == "tool"
+    assert turn.output is None

--- a/test/stdlib/components/intrinsic/test_resolve_util.py
+++ b/test/stdlib/components/intrinsic/test_resolve_util.py
@@ -37,11 +37,12 @@ class TestResolveQuestion:
         )
         text, rewound = _resolve_question(None, ctx)
         assert text == "second"
-        # Rewound context should end with the assistant reply
+        # Rewound context should end with the assistant reply as the output
         last = rewound.last_turn()  # type: ignore[union-attr]
         assert last is not None
-        assert isinstance(last.model_input, Message)
-        assert last.model_input.content == "reply"
+        assert isinstance(last.output, Message)
+        assert last.output.content == "reply"
+        assert last.output.role == "assistant"
 
     def test_empty_context_raises(self):
         ctx = ChatContext()

--- a/test/stdlib/requirements/test_guardian_check_unit.py
+++ b/test/stdlib/requirements/test_guardian_check_unit.py
@@ -35,3 +35,29 @@ async def test_guardian_validate_uses_thinking_trace_in_reason() -> None:
     assert result.as_bool() is True
     assert result.reason is not None
     assert "Reasoning: grounded in provided content" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_guardian_function_call_risk_with_assistant_message() -> None:
+    """function_call risk should extract content from Message(role='assistant') in last_turn.output."""
+    # Mock backend that returns a successful validation response
+    mot = ModelOutputThunk(value="<score>yes</score>")
+    backend = MagicMock()
+    backend.generate_from_context = AsyncMock(return_value=(mot, ChatContext()))
+
+    with pytest.warns(DeprecationWarning, match="GuardianCheck is deprecated"):
+        req = GuardianCheck(
+            risk="function_call", backend=backend, backend_type="ollama"
+        )
+
+    # Build context with manually-added assistant Message (simulating extracted content)
+    ctx = (
+        ChatContext()
+        .add(Message("user", "Execute this function"))
+        .add(Message("assistant", "Executing function X"))
+    )
+    await req.validate(backend, ctx)
+
+    # Verify validation succeeded and backend.generate_from_context was called
+    # The key assertion is that no exception was raised when extracting content from Message
+    assert backend.generate_from_context.called


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1002

## Description
<!-- What does this PR do and why? -->
1. Core Fix (mellea/core/base.py):
- Updated ContextTurn.output type: ModelOutputThunk | Component | None (was just ModelOutputThunk | None)
- Modified last_turn() method to check if last element is Message(role="assistant")
- If found, place it in output slot (not model_input)
- Uses local import to avoid circular dependency

2. Simplified Workaround (mellea/stdlib/components/intrinsic/_util.py):
- Removed the manual Message(role="assistant") workaround in _extract_last_response()
- Now correctly expects Message in turn.output instead of turn.model_input
- Simplified logic flow

3. Fixed Dependent Code (mellea/stdlib/requirements/safety/guardian.py):
- Found code accessing last_turn.output.value that would fail with Message (has .content, not .value)
- Added type check to handle both Message and ModelOutputThunk

4. Added Tests (test/core/test_base.py):
- 7 new comprehensive tests for last_turn() with various scenarios
- Tests for Message(role="assistant"), Message(role="user"), Message(role="system")
- Tests for 1-element and 2-element history cases

5. Updated Tests (test/stdlib/components/intrinsic/test_resolve_util.py):
- Updated 1 test assertion to reflect corrected behavior
- Now expects Message in turn.output (not turn.model_input)


### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
