### PR TITLE
fix: bump pinned Ollama version to 0.32.2 (rc0 tag removed)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -112,10 +112,13 @@ jobs:
         # draws) crashed during model warmup, independent of ollama version and
         # unreachable by any env var (the code path is correct; the machine code was
         # not). Ollama PR #17244 ("bump Linux toolchain to GCC 13", Fixes ollama#17006
-        # / #17205) first ships in v0.32.2-rc0. Drop this pin once v0.32.2+ is a
-        # stable release. NB: OLLAMA_VERSION must omit the leading "v" -- install.sh
-        # prepends it (a "v" yields a broken .../download/vv0.32.2-rc0/... path).
-        run: curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.32.2-rc0 sh
+        # / #17205) first shipped in the 0.32.2 line. The rc0 tag has since been
+        # removed (promoted to the v0.32.2 release), so its download URL now 404s and
+        # the pin is bumped to 0.32.2. Drop this pin once a stable (non-prerelease)
+        # release includes the GCC-13 build. NB: OLLAMA_VERSION must omit the leading
+        # "v" -- install.sh prepends it (a "v" yields a broken .../download/vv0.32.2/...
+        # path).
+        run: curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.32.2 sh
       - name: Start serving ollama
         run: nohup ollama serve &
       - name: Pull models


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1424

## Description
`.github/workflows/quality.yml` pins `OLLAMA_VERSION=0.32.2-rc0` (added in 39002da7 to fix the #1388 GCC-13 AMX segfault). Ollama has since promoted that release candidate to the `v0.32.2` release and removed the `rc0` tag, so `install.sh` 404s on the missing version and the **Install Ollama** step fails on every `pull_request` and `merge_group` run — blocking all PRs and the merge queue.

This bumps the pin to `0.32.2`:

- **Verified downloadable**: `releases/download/v0.32.2/ollama-linux-amd64.tar.zst` returns HTTP 200; the `v0.32.2-rc0` asset returns 404.
- **Pin kept, not dropped**: dropping it would fall back to the latest stable release, `0.32.1`, which is the GCC-11 build that reintroduces #1388. `v0.32.2` carries the same GCC-13 build as the rc.
- The comment is updated to record the rc0 → release promotion; the guidance to drop the pin once a stable (non-prerelease) release includes the GCC-13 build is retained.

This PR's own `quality` run is the validation: a green run confirms `0.32.2` installs cleanly.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes — CI workflow change; validated by this PR's own quality run

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
