### PR TITLE
feat: add Atlas Cloud backend helper

### DIFF
--- a/mellea/backends/atlascloud.py
+++ b/mellea/backends/atlascloud.py
@@ -1,0 +1,91 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atlas Cloud OpenAI-compatible backend helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from mellea.backends.openai import OpenAIBackend
+
+ATLASCLOUD_DEFAULT_BASE_URL: Final = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_DEFAULT_MODEL: Final = "qwen/qwen3.5-flash"
+ATLASCLOUD_REASONING_MODEL: Final = "deepseek-ai/deepseek-v4-pro"
+
+
+class AtlasCloudBackend(OpenAIBackend):
+    """OpenAI-compatible backend preconfigured for Atlas Cloud.
+
+    Args:
+        model_id: Atlas Cloud model identifier.
+        base_url: Atlas Cloud OpenAI-compatible endpoint. Defaults to
+            `ATLASCLOUD_API_BASE`, `ATLASCLOUD_BASE_URL`, or
+            `https://api.atlascloud.ai/v1`.
+        api_key: Atlas Cloud API key. Defaults to `ATLASCLOUD_API_KEY`.
+        kwargs: Additional keyword arguments forwarded to `OpenAIBackend`.
+
+    Raises:
+        ValueError: If no API key is passed and `ATLASCLOUD_API_KEY` is unset.
+    """
+
+    def __init__(
+        self,
+        model_id: str = ATLASCLOUD_DEFAULT_MODEL,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize an Atlas Cloud backend."""
+        resolved_api_key = api_key or os.getenv("ATLASCLOUD_API_KEY")
+        if resolved_api_key is None:
+            raise ValueError(
+                "ATLASCLOUD_API_KEY or api_key is required but not set. Please either:\n"
+                "  1. Set the environment variable: export ATLASCLOUD_API_KEY='your-key-here'\n"
+                "  2. Pass it as a parameter: AtlasCloudBackend(api_key='your-key-here')"
+            )
+
+        resolved_base_url = (
+            base_url
+            or os.getenv("ATLASCLOUD_API_BASE")
+            or os.getenv("ATLASCLOUD_BASE_URL")
+            or ATLASCLOUD_DEFAULT_BASE_URL
+        )
+
+        super().__init__(
+            model_id=model_id,
+            base_url=resolved_base_url,
+            api_key=resolved_api_key,
+            **kwargs,
+        )
+        self._provider = "atlascloud"
+
+
+def create_atlascloud_openai_backend(
+    model_id: str = ATLASCLOUD_DEFAULT_MODEL,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    **kwargs,
+) -> AtlasCloudBackend:
+    """Return an OpenAI-compatible backend configured for Atlas Cloud.
+
+    Args:
+        model_id: Atlas Cloud model identifier.
+        base_url: Optional endpoint override. Defaults to `ATLASCLOUD_API_BASE`,
+            `ATLASCLOUD_BASE_URL`, or `https://api.atlascloud.ai/v1`.
+        api_key: Optional API key override. Defaults to `ATLASCLOUD_API_KEY`.
+        kwargs: Additional keyword arguments forwarded to `AtlasCloudBackend`.
+
+    Returns:
+        AtlasCloudBackend: A backend configured with Atlas Cloud credentials and
+        endpoint defaults.
+
+    Raises:
+        ValueError: If no API key is passed and `ATLASCLOUD_API_KEY` is unset.
+    """
+    return AtlasCloudBackend(
+        model_id=model_id, base_url=base_url, api_key=api_key, **kwargs
+    )

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -92,7 +92,16 @@ def get_session() -> MelleaSession:
 
 
 def start_session(
-    backend_name: Literal["ollama", "hf", "openai", "watsonx", "litellm"] = "ollama",
+    backend_name: Literal[
+        "ollama",
+        "hf",
+        "openai",
+        "atlascloud",
+        "atlas-cloud",
+        "atlas",
+        "watsonx",
+        "litellm",
+    ] = "ollama",
     model_id: str | ModelIdentifier = IBM_GRANITE_4_1_3B,
     ctx: Context | None = None,
     *,
@@ -114,6 +123,7 @@ def start_session(
             - "ollama": Use Ollama backend for local models
             - "hf" or "huggingface": Use Hugging Face transformers backend
             - "openai": Use OpenAI API backend
+            - "atlascloud": Use Atlas Cloud's OpenAI-compatible API backend
             - "watsonx": Use IBM WatsonX backend, WARNING: this defaults to the IBM_GRANITE_4_HYBRID_SMALL model for now.
             - "litellm": Use the LiteLLM backend
         model_id: Model identifier or name. Can be a `ModelIdentifier` from
@@ -168,12 +178,19 @@ def start_session(
 
     # Validate args.
     resolved_ctx = _resolve_context(ctx, context_type)
+    if (
+        backend_name in {"atlascloud", "atlas-cloud", "atlas"}
+        and model_id == IBM_GRANITE_4_1_3B
+    ):
+        from ..backends.atlascloud import ATLASCLOUD_DEFAULT_MODEL
+
+        model_id = ATLASCLOUD_DEFAULT_MODEL
     model_id_str = _resolve_model_id_str(model_id, backend_name)
     backend_class = backend_name_to_class(backend_name)
     if backend_class is None:
         raise Exception(
             f"Backend name {backend_name} unknown. Valid options are: "
-            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`."
+            "`ollama`, `hf`, `openai`, `atlascloud`, `watsonx`, `litellm`."
         )
 
     # Pre-generate so the startup span and session_pre_init payload share an id.

--- a/mellea/stdlib/start_backend.py
+++ b/mellea/stdlib/start_backend.py
@@ -14,6 +14,7 @@ from ..core import Backend, Context
 from .context import ChatContext, SimpleContext
 
 if TYPE_CHECKING:
+    from ..backends.atlascloud import AtlasCloudBackend
     from ..backends.huggingface import LocalHFBackend
     from ..backends.litellm import LiteLLMBackend
     from ..backends.ollama import OllamaModelBackend
@@ -56,6 +57,10 @@ def backend_name_to_class(name: str) -> Any:
         from ..backends.openai import OpenAIBackend
 
         return OpenAIBackend
+    elif name == "atlascloud" or name == "atlas-cloud" or name == "atlas":
+        from ..backends.atlascloud import AtlasCloudBackend
+
+        return AtlasCloudBackend
     elif name == "watsonx":
         try:
             from ..backends.watsonx import WatsonxAIBackend
@@ -101,12 +106,21 @@ def _resolve_context(
 
 def _resolve_model_id_str(model_id: str | ModelIdentifier, backend_name: str) -> str:
     """Resolve a model identifier to its string representation for a given backend."""
+    if backend_name in {"atlascloud", "atlas-cloud", "atlas"}:
+        from ..backends.atlascloud import ATLASCLOUD_DEFAULT_MODEL
+
+        if model_id == IBM_GRANITE_4_MICRO_3B:
+            return ATLASCLOUD_DEFAULT_MODEL
+
     if isinstance(model_id, ModelIdentifier):
         backend_to_attr = {
             "ollama": "ollama_name",
             "hf": "hf_model_name",
             "huggingface": "hf_model_name",
             "openai": "openai_name",
+            "atlascloud": "openai_name",
+            "atlas-cloud": "openai_name",
+            "atlas": "openai_name",
             "watsonx": "watsonx_name",
             "litellm": "hf_model_name",
         }
@@ -233,6 +247,45 @@ def start_backend(
 
 
 # ---------------------------------------------------------------------------
+# Overloads: atlascloud
+# ---------------------------------------------------------------------------
+@overload
+def start_backend(
+    backend_name: Literal["atlascloud", "atlas-cloud", "atlas"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: Literal["chat"],
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[ChatContext, AtlasCloudBackend]: ...
+
+
+@overload
+def start_backend(
+    backend_name: Literal["atlascloud", "atlas-cloud", "atlas"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: Literal["simple"],
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[SimpleContext, AtlasCloudBackend]: ...
+
+
+@overload
+def start_backend(
+    backend_name: Literal["atlascloud", "atlas-cloud", "atlas"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: None = ...,
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[CtxT, AtlasCloudBackend]: ...
+
+
+# ---------------------------------------------------------------------------
 # Overloads: watsonx
 # ---------------------------------------------------------------------------
 @overload
@@ -314,7 +367,16 @@ def start_backend(
 # Implementation
 # ---------------------------------------------------------------------------
 def start_backend(
-    backend_name: Literal["ollama", "hf", "openai", "watsonx", "litellm"] = "ollama",
+    backend_name: Literal[
+        "ollama",
+        "hf",
+        "openai",
+        "atlascloud",
+        "atlas-cloud",
+        "atlas",
+        "watsonx",
+        "litellm",
+    ] = "ollama",
     model_id: str | ModelIdentifier = IBM_GRANITE_4_MICRO_3B,
     ctx: Context | None = None,
     *,
@@ -330,7 +392,7 @@ def start_backend(
 
     Args:
         backend_name: The backend to use (`"ollama"`, `"hf"`, `"openai"`,
-            `"watsonx"`, or `"litellm"`).
+            `"atlascloud"`, `"watsonx"`, or `"litellm"`).
         model_id: Model identifier or name.
         ctx: An explicit `Context` instance. Mutually exclusive with
             `context_type`.
@@ -351,11 +413,12 @@ def start_backend(
         Exception: If `backend_name` is not recognised.
     """
     resolved_ctx = _resolve_context(ctx, context_type)
+    model_id_str = _resolve_model_id_str(model_id, backend_name)
     backend_class = backend_name_to_class(backend_name)
     if backend_class is None:
         raise Exception(
             f"Backend name {backend_name} unknown. Valid options are: "
-            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`."
+            "`ollama`, `hf`, `openai`, `atlascloud`, `watsonx`, `litellm`."
         )
-    backend = backend_class(model_id, model_options=model_options, **backend_kwargs)
+    backend = backend_class(model_id_str, model_options=model_options, **backend_kwargs)
     return resolved_ctx, backend

--- a/test/backends/test_atlascloud.py
+++ b/test/backends/test_atlascloud.py
@@ -1,0 +1,118 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Atlas Cloud backend helpers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mellea.backends.atlascloud import (
+    ATLASCLOUD_DEFAULT_BASE_URL,
+    ATLASCLOUD_DEFAULT_MODEL,
+    AtlasCloudBackend,
+    create_atlascloud_openai_backend,
+)
+from mellea.stdlib.context import ChatContext
+from mellea.stdlib.session import backend_name_to_class
+from mellea.stdlib.start_backend import start_backend
+
+
+def test_atlascloud_backend_uses_env_defaults(monkeypatch):
+    """AtlasCloudBackend resolves key, base URL, and default model from Atlas settings."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+    monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+    monkeypatch.delenv("ATLASCLOUD_BASE_URL", raising=False)
+
+    with patch(
+        "mellea.backends.openai.is_vllm_server_with_structured_output",
+        return_value=False,
+    ):
+        backend = AtlasCloudBackend()
+
+    assert backend.model_id == ATLASCLOUD_DEFAULT_MODEL
+    assert backend._api_key == "atlas-key"
+    assert str(backend._client.base_url) == ATLASCLOUD_DEFAULT_BASE_URL + "/"
+    assert backend._provider == "atlascloud"
+
+
+def test_atlascloud_backend_prefers_explicit_over_env(monkeypatch):
+    """Explicit API configuration takes precedence over environment defaults."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+    monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://env.example/v1")
+
+    with patch(
+        "mellea.backends.openai.is_vllm_server_with_structured_output",
+        return_value=False,
+    ):
+        backend = create_atlascloud_openai_backend(
+            "deepseek-ai/deepseek-v4-pro",
+            api_key="explicit-key",
+            base_url="https://explicit.example/v1",
+        )
+
+    assert backend.model_id == "deepseek-ai/deepseek-v4-pro"
+    assert backend._api_key == "explicit-key"
+    assert str(backend._client.base_url) == "https://explicit.example/v1/"
+
+
+def test_atlascloud_backend_env_base_url_alias(monkeypatch):
+    """ATLASCLOUD_BASE_URL is accepted as a base URL alias."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+    monkeypatch.delenv("ATLASCLOUD_API_BASE", raising=False)
+    monkeypatch.setenv("ATLASCLOUD_BASE_URL", "https://alias.example/v1")
+
+    with patch(
+        "mellea.backends.openai.is_vllm_server_with_structured_output",
+        return_value=False,
+    ):
+        backend = AtlasCloudBackend()
+
+    assert str(backend._client.base_url) == "https://alias.example/v1/"
+
+
+def test_atlascloud_backend_requires_atlas_api_key(monkeypatch):
+    """Missing Atlas credentials raise an Atlas-specific error."""
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="ATLASCLOUD_API_KEY"):
+        AtlasCloudBackend()
+
+
+def test_backend_name_to_class_resolves_atlascloud_aliases():
+    """Atlas Cloud backend aliases resolve to the same backend class."""
+    assert backend_name_to_class("atlascloud") is AtlasCloudBackend
+    assert backend_name_to_class("atlas-cloud") is AtlasCloudBackend
+    assert backend_name_to_class("atlas") is AtlasCloudBackend
+
+
+def test_start_backend_can_create_atlascloud_backend(monkeypatch):
+    """start_backend can create a chat context with the Atlas Cloud backend."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+
+    with patch(
+        "mellea.backends.openai.is_vllm_server_with_structured_output",
+        return_value=False,
+    ):
+        ctx, backend = start_backend(
+            "atlascloud", "qwen/qwen3.5-flash", context_type="chat"
+        )
+
+    assert isinstance(ctx, ChatContext)
+    assert isinstance(backend, AtlasCloudBackend)
+    assert backend.model_id == "qwen/qwen3.5-flash"
+
+
+def test_start_backend_atlascloud_uses_atlas_default_model(monkeypatch):
+    """start_backend uses the Atlas Cloud default model when none is specified."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlas-key")
+
+    with patch(
+        "mellea.backends.openai.is_vllm_server_with_structured_output",
+        return_value=False,
+    ):
+        _ctx, backend = start_backend("atlascloud")
+
+    assert isinstance(backend, AtlasCloudBackend)
+    assert backend.model_id == ATLASCLOUD_DEFAULT_MODEL


### PR DESCRIPTION
# Pull Request

## Issue
N/A

## Description
Adds an Atlas Cloud OpenAI-compatible backend helper that reuses the existing `OpenAIBackend` path while applying Atlas Cloud defaults:

- adds `AtlasCloudBackend` and `create_atlascloud_openai_backend`
- reads `ATLASCLOUD_API_KEY` for auth, with optional `ATLASCLOUD_API_BASE` / `ATLASCLOUD_BASE_URL` overrides
- sets `https://api.atlascloud.ai/v1` and `qwen/qwen3.5-flash` as defaults
- registers `atlascloud`, `atlas-cloud`, and `atlas` backend aliases for `start_backend` / `start_session`
- keeps provider metadata as `atlascloud` for telemetry paths

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Local validation:

- `uv run ruff format mellea/backends/atlascloud.py mellea/stdlib/start_backend.py mellea/stdlib/session.py test/backends/test_atlascloud.py`
- `uv run pytest test/backends/test_atlascloud.py test/stdlib/test_session_unit.py -q`
- `uv run ruff check mellea/backends/atlascloud.py mellea/stdlib/start_backend.py mellea/stdlib/session.py test/backends/test_atlascloud.py test/stdlib/test_session_unit.py`
- `git diff --check`
- `uv run python -m py_compile mellea/backends/atlascloud.py mellea/stdlib/start_backend.py mellea/stdlib/session.py test/backends/test_atlascloud.py`
- `uv run mypy mellea/backends/atlascloud.py mellea/stdlib/start_backend.py mellea/stdlib/session.py test/backends/test_atlascloud.py`
- `uv run python tooling/docs-autogen/build.py`
- `uv run python tooling/docs-autogen/audit_coverage.py --docs-dir docs/docs/api --quality --fail-on-quality --threshold 100`

The Atlas Cloud model catalog was checked live before committing; `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` were both present.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
