### PR TITLE
docs: note policy_guardrails now raises AdapterSchemaMismatchError

### DIFF
--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -303,35 +303,6 @@ For pages documenting features that don't yet exist in any released version, use
 
 Do not use per-feature version tags in prose — incomplete tagging misleads readers.
 
-### Backporting a fix to a published version
-
-`versioned_docs/version-X.Y.Z/` files are ordinary files in the repo tree, not
-a separate deploy artifact. Editing one and merging to `main` is enough —
-`docs-publish.yml` rebuilds `Next` and every versioned snapshot on each push to
-`main` that touches `docs/**`, then redeploys the whole site
-(`force_orphan: true`), so the corrected page republishes under that version's
-tab with no extra workflow step.
-
-Backport a doc change into a published version's snapshot when it:
-
-- Corrects a factual error that was already wrong in the frozen snapshot, or
-- Documents a breaking or behavioural change that shipped **in** that version
-  (e.g. a changed exception type) — readers on the stable tab should see it,
-  not only `Next`.
-
-Don't backport new features or prose/style improvements that weren't true of
-the docs at release time — that would misrepresent the historical snapshot.
-When you do backport, mirror the same edit into both `docs/docs/` (`Next`) and
-the affected `versioned_docs/version-X.Y.Z/` copies in the same PR, and say so
-in the PR description.
-
-This applies to hand-authored pages. Don't hand-edit a versioned snapshot's
-copy of the generated API or CLI reference (`api/**`, `reference/cli.md`) —
-those are produced by `tooling/docs-autogen/build.py` and nothing ever
-re-runs it for an already-released version, so a manual edit would silently
-drift from its source the next time that page's docstring changes. Fix the
-docstring and file an issue against the generator instead.
-
 ---
 
 ## Deprecation

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -325,6 +325,13 @@ When you do backport, mirror the same edit into both `docs/docs/` (`Next`) and
 the affected `versioned_docs/version-X.Y.Z/` copies in the same PR, and say so
 in the PR description.
 
+This applies to hand-authored pages. Don't hand-edit a versioned snapshot's
+copy of the generated API or CLI reference (`api/**`, `reference/cli.md`) —
+those are produced by `tooling/docs-autogen/build.py` and nothing ever
+re-runs it for an already-released version, so a manual edit would silently
+drift from its source the next time that page's docstring changes. Fix the
+docstring and file an issue against the generator instead.
+
 ---
 
 ## Deprecation

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -303,6 +303,28 @@ For pages documenting features that don't yet exist in any released version, use
 
 Do not use per-feature version tags in prose — incomplete tagging misleads readers.
 
+### Backporting a fix to a published version
+
+`versioned_docs/version-X.Y.Z/` files are ordinary files in the repo tree, not
+a separate deploy artifact. Editing one and merging to `main` is enough —
+`docs-publish.yml` rebuilds `Next` and every versioned snapshot on each push to
+`main` that touches `docs/**`, then redeploys the whole site
+(`force_orphan: true`), so the corrected page republishes under that version's
+tab with no extra workflow step.
+
+Backport a doc change into a published version's snapshot when it:
+
+- Corrects a factual error that was already wrong in the frozen snapshot, or
+- Documents a breaking or behavioural change that shipped **in** that version
+  (e.g. a changed exception type) — readers on the stable tab should see it,
+  not only `Next`.
+
+Don't backport new features or prose/style improvements that weren't true of
+the docs at release time — that would misrepresent the historical snapshot.
+When you do backport, mirror the same edit into both `docs/docs/` (`Next`) and
+the affected `versioned_docs/version-X.Y.Z/` copies in the same PR, and say so
+in the PR description.
+
 ---
 
 ## Deprecation

--- a/docs/docs/how-to/safety-guardrails.md
+++ b/docs/docs/how-to/safety-guardrails.md
@@ -218,6 +218,16 @@ print(f"Policy compliance: {label}")
 `"Ambiguous"` is returned when the scenario does not contain enough information
 to determine compliance with certainty.
 
+> **Exception contract (changed in v0.7.0):** when the adapter returns malformed
+> output — a result with neither a `label` nor a `score`, or with both —
+> `policy_guardrails()` raises `AdapterSchemaMismatchError` (from
+> `mellea.backends.adapters`). This replaces the `ValueError` raised for that
+> case in earlier releases, and `AdapterSchemaMismatchError` does **not** subclass
+> `ValueError`, so any caller that wrapped the call in `except ValueError` to
+> handle a bad verdict must also catch `AdapterSchemaMismatchError`. A `ValueError`
+> is still raised separately when the output is not valid JSON. See
+> [Common Errors](../troubleshooting/common-errors.md) for a handler example.
+
 ## Factuality detection
 
 `factuality_detection()` evaluates whether the assistant's response is factually

--- a/docs/docs/troubleshooting/common-errors.md
+++ b/docs/docs/troubleshooting/common-errors.md
@@ -226,6 +226,28 @@ See [Safety Guardrails](../how-to/safety-guardrails.md) for full usage.
   user message.
 - Scores below `0.5` are safe; at or above `0.5` indicates risk detected.
 
+### `except ValueError` no longer catches guardrail schema failures
+
+As of v0.7.0, `policy_guardrails()` raises `AdapterSchemaMismatchError` (from
+`mellea.backends.adapters`) when the adapter returns malformed output — a result
+with neither a `label` nor a `score`, or with both. This replaces the
+`ValueError` raised for that case in earlier releases. Because
+`AdapterSchemaMismatchError` does not subclass `ValueError`, a caller that only
+catches `ValueError` will now let the error propagate:
+
+```python
+from mellea.backends.adapters import AdapterSchemaMismatchError
+
+try:
+    label = policy_guardrails(context, backend, policy_text=policy)
+except AdapterSchemaMismatchError:
+    ...  # adapter returned malformed output
+except ValueError:
+    ...  # output was not valid JSON
+```
+
+See [Safety Guardrails](../how-to/safety-guardrails.md) for the full contract.
+
 ### Deprecated `GuardianCheck` warnings
 
 ```text

--- a/docs/versioned_docs/version-0.7.0/how-to/safety-guardrails.md
+++ b/docs/versioned_docs/version-0.7.0/how-to/safety-guardrails.md
@@ -218,6 +218,16 @@ print(f"Policy compliance: {label}")
 `"Ambiguous"` is returned when the scenario does not contain enough information
 to determine compliance with certainty.
 
+> **Exception contract (changed in v0.7.0):** when the adapter returns malformed
+> output — a result with neither a `label` nor a `score`, or with both —
+> `policy_guardrails()` raises `AdapterSchemaMismatchError` (from
+> `mellea.backends.adapters`). This replaces the `ValueError` raised for that
+> case in earlier releases, and `AdapterSchemaMismatchError` does **not** subclass
+> `ValueError`, so any caller that wrapped the call in `except ValueError` to
+> handle a bad verdict must also catch `AdapterSchemaMismatchError`. A `ValueError`
+> is still raised separately when the output is not valid JSON. See
+> [Common Errors](../troubleshooting/common-errors.md) for a handler example.
+
 ## Factuality detection
 
 `factuality_detection()` evaluates whether the assistant's response is factually

--- a/docs/versioned_docs/version-0.7.0/troubleshooting/common-errors.md
+++ b/docs/versioned_docs/version-0.7.0/troubleshooting/common-errors.md
@@ -226,6 +226,28 @@ See [Safety Guardrails](../how-to/safety-guardrails.md) for full usage.
   user message.
 - Scores below `0.5` are safe; at or above `0.5` indicates risk detected.
 
+### `except ValueError` no longer catches guardrail schema failures
+
+As of v0.7.0, `policy_guardrails()` raises `AdapterSchemaMismatchError` (from
+`mellea.backends.adapters`) when the adapter returns malformed output — a result
+with neither a `label` nor a `score`, or with both. This replaces the
+`ValueError` raised for that case in earlier releases. Because
+`AdapterSchemaMismatchError` does not subclass `ValueError`, a caller that only
+catches `ValueError` will now let the error propagate:
+
+```python
+from mellea.backends.adapters import AdapterSchemaMismatchError
+
+try:
+    label = policy_guardrails(context, backend, policy_text=policy)
+except AdapterSchemaMismatchError:
+    ...  # adapter returned malformed output
+except ValueError:
+    ...  # output was not valid JSON
+```
+
+See [Safety Guardrails](../how-to/safety-guardrails.md) for the full contract.
+
 ### Deprecated `GuardianCheck` warnings
 
 ```text


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1413

## Description
PR #1357 changed `policy_guardrails()` so that malformed adapter output — a
result with neither a `label` nor a `score`, or with both — now raises
`AdapterSchemaMismatchError` rather than the `ValueError` raised in earlier
releases. Because `AdapterSchemaMismatchError` extends `Exception` and does not
subclass `ValueError`, any caller that wrapped the call in `except ValueError`
silently stopped catching that failure when v0.7.0 shipped. The function's own
docstring documents the new exception, but there was no user-facing callout of
the behaviour change.

This adds that callout in two places:

- **`docs/docs/how-to/safety-guardrails.md`** — an exception-contract note under
  *Policy compliance*, where the API is taught and a reader would write their
  `try`/`except`.
- **`docs/docs/troubleshooting/common-errors.md`** — a matching entry in the
  Guardian section, with a handler example, for someone debugging why their
  existing `except ValueError` stopped firing.

The two pages cross-link each other. A `ValueError` is still raised when the
output is not valid JSON, which both notes state explicitly.

Documentation only — no code changes.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
