### PR TITLE
refactor(intrinsics): promote _DictContract to shared adapters module; collapse guardian.py's factuality contracts

### DIFF
--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -23,6 +23,7 @@ Note:
 """
 
 import abc
+import json
 import warnings
 from dataclasses import dataclass
 from typing import Literal
@@ -130,6 +131,50 @@ class IOContract(abc.ABC):
                 benign additions to the output schema).
         """
         ...
+
+
+class _DictContract(IOContract):
+    """Validate dict-shaped adapter output against a fixed set of required keys.
+
+    Args:
+        name: Adapter capability name; included in
+            :class:`~mellea.backends.adapters.AdapterSchemaMismatchError` messages.
+        required_keys: Keys that must be present in the parsed output dict.
+    """
+
+    def __init__(self, name: str, required_keys: frozenset[str]) -> None:
+        self._name = name
+        self._required_keys = required_keys
+
+    def build_prompt(self, **_kwargs: object) -> Component:
+        raise NotImplementedError(
+            "build_prompt is not used in Phase 1; implemented in Phase 2."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        """Parse and validate dict-shaped adapter output.
+
+        Args:
+            raw (str): Raw JSON string from the model.
+
+        Returns:
+            dict[str, object]: Parsed output dict, unchanged.
+
+        Raises:
+            ValueError: When *raw* is not valid JSON or is not a JSON object.
+            AdapterSchemaMismatchError: When a required key is absent.
+        """
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Adapter '{self._name}' output must be a JSON object, "
+                f"got {type(data).__name__}."
+            )
+        observed = frozenset(data.keys())
+        missing = self._required_keys - observed
+        if missing:
+            raise AdapterSchemaMismatchError(self._name, observed, self._required_keys)
+        return data
 
 
 class WeightsBinding(abc.ABC):

--- a/mellea/stdlib/components/intrinsic/guardian.py
+++ b/mellea/stdlib/components/intrinsic/guardian.py
@@ -25,6 +25,7 @@ from ....backends.adapters import (
     IOContract,
     LocalFileBinding,
 )
+from ....backends.adapters._core import _DictContract
 from ....core import Component
 from ....core.utils import MelleaLogger
 from ...components import Document
@@ -142,76 +143,6 @@ class _GuardianCheckContract(IOContract):
         return data
 
 
-class _FactualityDetectionContract(IOContract):
-    """Validate factuality-detection output: required key `score`."""
-
-    def build_prompt(self, **_kwargs: object) -> Component:
-        raise NotImplementedError(
-            "build_prompt is not used in Phase 1; implemented in Phase 2."
-        )
-
-    def parse(self, raw: str) -> dict[str, object]:
-        """Parse and validate factuality-detection output.
-
-        Args:
-            raw (str): Raw JSON string from the model.
-
-        Returns:
-            dict[str, object]: Parsed output dict with `score` key.
-
-        Raises:
-            ValueError: When *raw* is not valid JSON or is not a JSON object.
-            AdapterSchemaMismatchError: When `score` key is absent.
-        """
-        data = json.loads(raw)
-        if not isinstance(data, dict):
-            raise ValueError(
-                f"Adapter 'factuality-detection' output must be a JSON object, "
-                f"got {type(data).__name__}."
-            )
-        if "score" not in data:
-            raise AdapterSchemaMismatchError(
-                "factuality-detection", frozenset(data.keys()), frozenset({"score"})
-            )
-        return data
-
-
-class _FactualityCorrectionContract(IOContract):
-    """Validate factuality-correction output: required key `correction`."""
-
-    def build_prompt(self, **_kwargs: object) -> Component:
-        raise NotImplementedError(
-            "build_prompt is not used in Phase 1; implemented in Phase 2."
-        )
-
-    def parse(self, raw: str) -> dict[str, object]:
-        """Parse and validate factuality-correction output.
-
-        Args:
-            raw (str): Raw JSON string from the model.
-
-        Returns:
-            dict[str, object]: Parsed output dict with `correction` key.
-
-        Raises:
-            ValueError: When *raw* is not valid JSON or is not a JSON object.
-            AdapterSchemaMismatchError: When `correction` key is absent.
-        """
-        data = json.loads(raw)
-        if not isinstance(data, dict):
-            raise ValueError(
-                f"Adapter 'factuality-correction' output must be a JSON object, "
-                f"got {type(data).__name__}."
-            )
-        if "correction" not in data:
-            raise AdapterSchemaMismatchError(
-                "factuality-correction",
-                frozenset(data.keys()),
-                frozenset({"correction"}),
-            )
-        return data
-
-
 # ---------------------------------------------------------------------------
 # Module-level Adapter constants (one per helper)
 # ---------------------------------------------------------------------------
@@ -232,7 +163,7 @@ _FACTUALITY_DETECTION_ADAPTER = Adapter(
     identity=Identity(
         "factuality-detection", "alora", capability="factuality_detection"
     ),
-    io_contract=_FactualityDetectionContract(),
+    io_contract=_DictContract("factuality-detection", frozenset({"score"})),
     weights=LocalFileBinding(),
 )
 
@@ -240,7 +171,7 @@ _FACTUALITY_CORRECTION_ADAPTER = Adapter(
     identity=Identity(
         "factuality-correction", "alora", capability="factuality_correction"
     ),
-    io_contract=_FactualityCorrectionContract(),
+    io_contract=_DictContract("factuality-correction", frozenset({"correction"})),
     weights=LocalFileBinding(),
 )
 

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -16,6 +16,7 @@ from ....backends.adapters import (
     IOContract,
     LocalFileBinding,
 )
+from ....backends.adapters._core import _DictContract
 from ....core import Component
 from ...components import Document
 from ...context import ChatContext
@@ -26,50 +27,6 @@ from ._util import _resolve_question, _resolve_response, call_intrinsic
 # ---------------------------------------------------------------------------
 # IOContract implementations
 # ---------------------------------------------------------------------------
-
-
-class _DictContract(IOContract):
-    """Validate dict-shaped adapter output against a fixed set of required keys.
-
-    Args:
-        name: Adapter capability name; included in
-            :class:`~mellea.backends.adapters.AdapterSchemaMismatchError` messages.
-        required_keys: Keys that must be present in the parsed output dict.
-    """
-
-    def __init__(self, name: str, required_keys: frozenset[str]) -> None:
-        self._name = name
-        self._required_keys = required_keys
-
-    def build_prompt(self, **_kwargs: object) -> Component:
-        raise NotImplementedError(
-            "build_prompt is not used in Phase 1; implemented in Phase 2."
-        )
-
-    def parse(self, raw: str) -> dict[str, object]:
-        """Parse and validate dict-shaped adapter output.
-
-        Args:
-            raw (str): Raw JSON string from the model.
-
-        Returns:
-            dict[str, object]: Parsed output dict, unchanged.
-
-        Raises:
-            ValueError: When *raw* is not valid JSON or is not a JSON object.
-            AdapterSchemaMismatchError: When a required key is absent.
-        """
-        data = json.loads(raw)
-        if not isinstance(data, dict):
-            raise ValueError(
-                f"Adapter '{self._name}' output must be a JSON object, "
-                f"got {type(data).__name__}."
-            )
-        observed = frozenset(data.keys())
-        missing = self._required_keys - observed
-        if missing:
-            raise AdapterSchemaMismatchError(self._name, observed, self._required_keys)
-        return data
 
 
 class _ListContract(IOContract):

--- a/test/backends/test_adapters/test_core_types.py
+++ b/test/backends/test_adapters/test_core_types.py
@@ -4,6 +4,7 @@
 """Unit tests for the Phase 0 adapter scaffolding types (issue #1134)."""
 
 import dataclasses
+import json
 import pickle
 import warnings
 
@@ -20,6 +21,7 @@ from mellea.backends.adapters import (
     ServerMediatedBinding,
     WeightsBinding,
 )
+from mellea.backends.adapters._core import _DictContract
 from mellea.backends.adapters.catalog import _INTRINSICS_CATALOG_ENTRIES
 from mellea.core import Component
 
@@ -217,3 +219,63 @@ def test_known_capabilities_count_matches_catalog():
     # Every catalog entry must contribute exactly one distinct effective_capability.
     # If two entries resolve to the same token, the frozenset shrinks and this fails.
     assert len(KNOWN_CAPABILITIES) == len(_INTRINSICS_CATALOG_ENTRIES)
+
+
+# ---------------------------------------------------------------------------
+# _DictContract — shared dict-shaped output validator (promoted from rag.py so
+# both rag.py and guardian.py reuse it).
+# ---------------------------------------------------------------------------
+
+
+def test_dict_contract_parses_valid_output():
+    contract = _DictContract("answerability", frozenset({"answerability"}))
+    result = contract.parse(json.dumps({"answerability": "answerable"}))
+    assert result == {"answerability": "answerable"}
+
+
+def test_dict_contract_tolerates_extra_keys():
+    # Forward compatibility: unexpected keys are passed through, not rejected.
+    contract = _DictContract("answerability", frozenset({"answerability"}))
+    result = contract.parse(
+        json.dumps({"answerability": "answerable", "extra": "ignored"})
+    )
+    assert result["answerability"] == "answerable"
+    assert result["extra"] == "ignored"
+
+
+def test_dict_contract_missing_required_key_raises():
+    contract = _DictContract("factuality-detection", frozenset({"score"}))
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        contract.parse(json.dumps({"wrong_key": "yes"}))
+    err = exc_info.value
+    assert err.name == "factuality-detection"
+    assert "score" in err.expected_keys
+
+
+def test_dict_contract_rejects_non_object():
+    contract = _DictContract("answerability", frozenset({"answerability"}))
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        contract.parse(json.dumps(["not", "a", "dict"]))
+
+
+def test_dict_contract_rejects_invalid_json():
+    contract = _DictContract("answerability", frozenset({"answerability"}))
+    with pytest.raises(ValueError):
+        contract.parse("{not valid json")
+
+
+def test_dict_contract_reports_all_missing_multi_key():
+    # The promoted class generalises beyond the single-key checks the guardian
+    # contracts used: a multi-key required set surfaces every expected key.
+    contract = _DictContract("multi", frozenset({"a", "b"}))
+    with pytest.raises(AdapterSchemaMismatchError) as exc_info:
+        contract.parse(json.dumps({"a": 1}))
+    err = exc_info.value
+    assert err.expected_keys == frozenset({"a", "b"})
+    assert err.observed_keys == frozenset({"a"})
+
+
+def test_dict_contract_build_prompt_not_implemented():
+    contract = _DictContract("answerability", frozenset({"answerability"}))
+    with pytest.raises(NotImplementedError, match="Phase 1"):
+        contract.build_prompt()


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1412

## Description
Promotes the dict-shaped output validator out of `rag.py` into the shared
`mellea/backends/adapters/_core.py` module — alongside `IOContract` and
`AdapterSchemaMismatchError` — so both `rag.py` and `guardian.py` reuse a
single implementation rather than maintaining parallel copies.

- **`_core.py`** — `_DictContract` added (moved verbatim from `rag.py`), plus `import json`. Kept private (not added to `__all__`), so the public API surface and the docstring quality gate are unchanged.
- **`rag.py`** — local `_DictContract` removed; now imported from `._core`. `_ListContract` is unchanged.
- **`guardian.py`** — `_FactualityDetectionContract` and `_FactualityCorrectionContract` were single-key special cases of the same logic. They are replaced with `_DictContract("factuality-detection", frozenset({"score"}))` and `_DictContract("factuality-correction", frozenset({"correction"}))`. `_PolicyGuardrailsContract` (xor validation) and `_GuardianCheckContract` (nested-dict check) are deliberately left untouched.

Behaviour is preserved. For the single-key required sets in use, the
set-difference check (`required_keys - observed`) is equivalent to the old
`key not in data` membership test, and the exception type, constructor
argument order, and error message strings are identical. The existing
guardian and rag contract test suites exercise these paths through the
adapter constants and pass unchanged.

Net: +111 / −116 — a genuine de-duplication.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Added seven direct unit tests for `_DictContract` in
`test/backends/test_adapters/test_core_types.py` (valid parse, extra-key
tolerance, single- and multi-key mismatch, non-object rejection, invalid
JSON, `build_prompt` guard). Local run: `test/backends/test_adapters/` and
`test/stdlib/components/intrinsic/` — 233 passed. `ruff format`/`ruff check`
clean; `mypy` clean on the touched modules.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
