### PR TITLE
fix: allow act to operate on CBlock and ModelOutputThunk

### DIFF
--- a/docs/docs/advanced/custom-components.md
+++ b/docs/docs/advanced/custom-components.md
@@ -261,7 +261,9 @@ async def main() -> None:
     backend = OllamaModelBackend("granite4:latest")
     ctx = SimpleContext()
     component = SummaryComponent("Long article text here...", max_words=30)
-    thunk, _ = await mfuncs.aact(action=component, context=ctx, backend=backend)
+    thunk, _ = await mfuncs.aact(
+        action=component, context=ctx, backend=backend, await_result=True
+    )
     print(component.parse(thunk))
 
 

--- a/docs/docs/advanced/mellea-core-internals.md
+++ b/docs/docs/advanced/mellea-core-internals.md
@@ -142,6 +142,7 @@ async def main():
         Instruction("What is 1+1?"),
         context=SimpleContext(),
         backend=OllamaModelBackend("granite4:latest"),
+        await_result=True,
     )
     print(response.value)
 

--- a/docs/docs/how-to/act-and-aact.md
+++ b/docs/docs/how-to/act-and-aact.md
@@ -231,7 +231,7 @@ from mellea.stdlib.components import Instruction
 async def main():
     m = start_session()
     instruction = Instruction(description="Write a limerick about debugging.")
-    result = await m.aact(instruction)
+    result = await m.aact(instruction, await_result=True)
     print(str(result))
     # Output will vary — LLM responses depend on model and temperature.
 

--- a/docs/rewrite/session_deepdive/mellea_core_intro.md
+++ b/docs/rewrite/session_deepdive/mellea_core_intro.md
@@ -97,7 +97,7 @@ import asyncio
 
 async def main(backend: Backend, ctx: Context):
     response, next_context = await mfuncs.aact(
-        CBlock("What is 1+1?"), context=ctx, backend=backend
+        CBlock("What is 1+1?"), context=ctx, backend=backend, await_result=True
     )
 
     print(response.value)

--- a/docs/rewrite/session_deepdive/step3_async.py
+++ b/docs/rewrite/session_deepdive/step3_async.py
@@ -9,7 +9,10 @@ from mellea.stdlib.context import SimpleContext
 
 async def main(backend: Backend, ctx: Context):
     response, _next_context = await mfuncs.aact(
-        action=Instruction("What is 1+1?"), context=ctx, backend=backend
+        action=Instruction("What is 1+1?"),
+        context=ctx,
+        backend=backend,
+        await_result=True,
     )
 
     print(response.value)

--- a/mellea/core/__init__.py
+++ b/mellea/core/__init__.py
@@ -44,7 +44,7 @@ from .requirement import (
     ValidationResult,
     default_output_to_bool,
 )
-from .sampling import SamplingResult, SamplingStrategy
+from .sampling import SampleActionType, SamplingResult, SamplingStrategy
 from .utils import MelleaLogger, clear_log_context, log_context, set_log_context
 
 
@@ -87,6 +87,7 @@ __all__ = [
     "RawProviderResponse",
     "Requirement",
     "S",
+    "SampleActionType",
     "SamplingResult",
     "SamplingStrategy",
     "TemplateRepresentation",

--- a/mellea/core/sampling.py
+++ b/mellea/core/sampling.py
@@ -118,7 +118,7 @@ class SamplingStrategy(abc.ABC):
     @abc.abstractmethod
     async def sample(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement] | None,
@@ -133,7 +133,7 @@ class SamplingStrategy(abc.ABC):
         It must be implemented by any concrete subclasses to provide specific sampling logic.
 
         Args:
-            action : The action object to be sampled.
+            action : The action object to be sampled. A `Component`, `CBlock`, or `ModelOutputThunk`.
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).

--- a/mellea/core/sampling.py
+++ b/mellea/core/sampling.py
@@ -12,6 +12,7 @@ process.
 """
 
 import abc
+from collections.abc import Sequence
 from typing import Generic
 
 from .backend import Backend, BaseModelSubclass
@@ -25,6 +26,12 @@ from .base import (
 )
 from .requirement import Requirement, ValidationResult
 
+# The kinds of action a sampling strategy may operate on. Originally `Component`
+# only; widened to include `CBlock` and `ModelOutputThunk` so that `act`/`aact`
+# can sample over non-Component actions (see #356). Only `Component` carries
+# `.parse()` semantics; the others are carried through as opaque spans.
+SampleActionType = Component | CBlock | ModelOutputThunk
+
 
 class SamplingResult(CBlock, Generic[S]):
     """Stores the results from a sampling operation. This includes successful and failed samplings.
@@ -35,7 +42,7 @@ class SamplingResult(CBlock, Generic[S]):
         sample_generations (list[ModelOutputThunk[S]] | None): All output thunks generated during sampling.
         sample_validations (list[list[tuple[Requirement, ValidationResult]]] | None): Per-generation validation
             results; each inner list contains one tuple per requirement evaluated.
-        sample_actions (list[Component] | None): The actions used to produce each generation.
+        sample_actions (Sequence[SampleActionType] | None): The actions used to produce each generation.
         sample_contexts (list[Context] | None): The contexts associated with each generation.
 
     Attributes:
@@ -45,7 +52,7 @@ class SamplingResult(CBlock, Generic[S]):
             sampling; always a list (`None` input is normalised to `[]`).
         sample_validations (list[list[tuple[Requirement, ValidationResult]]]): Per-generation
             validation results; always a list (`None` input is normalised to `[]`).
-        sample_actions (list[Component]): The actions used to produce each generation;
+        sample_actions (list[SampleActionType]): The actions used to produce each generation;
             always a list (`None` input is normalised to `[]`).
         sample_contexts (list[Context]): The contexts associated with each generation;
             always a list (`None` input is normalised to `[]`).
@@ -59,7 +66,7 @@ class SamplingResult(CBlock, Generic[S]):
         sample_generations: list[ComputedModelOutputThunk[S]] | None = None,
         sample_validations: list[list[tuple[Requirement, ValidationResult]]]
         | None = None,
-        sample_actions: list[Component] | None = None,
+        sample_actions: Sequence[SampleActionType] | None = None,
         sample_contexts: list[Context] | None = None,
     ):
         """Initialize SamplingResult with the chosen output index, success flag, and generation history."""
@@ -67,8 +74,9 @@ class SamplingResult(CBlock, Generic[S]):
             sample_generations = []
         if sample_validations is None:
             sample_validations = []
-        if sample_actions is None:
-            sample_actions = []
+        # Accept any Sequence (e.g. a `list[Component]`) but store a list so the
+        # attribute stays mutable and covariantly assignable at call sites.
+        sample_actions = list(sample_actions) if sample_actions is not None else []
         if sample_contexts is None:
             sample_contexts = []
 
@@ -98,7 +106,7 @@ class SamplingResult(CBlock, Generic[S]):
         return self.sample_contexts[self.result_index]
 
     @property
-    def result_action(self) -> Component[S]:
+    def result_action(self) -> SampleActionType:
         """The action that generated the final output or result from applying the sampling strategy."""
         return self.sample_actions[self.result_index]
 

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -77,7 +77,7 @@ def act(
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = None,
+    strategy: SamplingStrategy,
     return_sampling_results: Literal[True],
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -103,8 +103,8 @@ def act(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: used as additional requirements when a sampling strategy is provided.
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
+        requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — no validate/repair loop runs and any `requirements` go unchecked (a warning is logged). Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a
@@ -112,6 +112,9 @@ def act(
             `MyModel.model_validate_json(str(result))` to get a typed instance.
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tool_calls: if true, tool calling is enabled.
+
+    Raises:
+        ValueError: if `return_sampling_results=True` without a `strategy`.
 
     Returns:
         A (ComputedModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -562,7 +565,7 @@ async def aact(
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = None,
+    strategy: SamplingStrategy,
     return_sampling_results: Literal[True],
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -592,8 +595,8 @@ async def aact(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: used as additional requirements when a sampling strategy is provided
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
+        requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a
@@ -603,6 +606,9 @@ async def aact(
         tool_calls: if true, tool calling is enabled.
         silence_context_type_warning: if called directly from an asynchronous function, will log a warning if not using a SimpleContext
         await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. If True or strategy is not None, awaits and returns ComputedModelOutputThunk. Default is False.
+
+    Raises:
+        ValueError: if `return_sampling_results=True` without a `strategy`.
 
     Returns:
         A (ModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -651,16 +657,22 @@ async def aact(
         sampling_result: SamplingResult | None = None
         generate_logs: list[GenerateLog] = []
 
-        if return_sampling_results:
-            assert strategy is not None, (
-                "Must provide a SamplingStrategy when return_sampling_results==True"
+        if return_sampling_results and strategy is None:
+            raise ValueError(
+                "Must provide a SamplingStrategy when return_sampling_results==True."
             )
 
         if strategy is None:
-            # Only use the strategy if one is provided. Add a warning if requirements were passed in though.
+            # No strategy means no validate/repair loop, so any `requirements`
+            # passed here are not checked. Warn rather than raise: some callers
+            # (e.g. generative stubs) attach requirements to the component itself
+            # and render them into the prompt independently of a strategy. A
+            # follow-up issue tracks a proper enforcement design for that case.
             if requirements is not None and len(requirements) > 0:
                 MelleaLogger.get_logger().warning(
-                    "Calling the function with NO strategy BUT requirements. No requirement is being checked!"
+                    "Requirements were provided without a SamplingStrategy. "
+                    "Requirements are only checked by a strategy; pass a "
+                    "`strategy` (e.g. RejectionSamplingStrategy) to validate them."
                 )
 
             result, new_ctx = await backend.generate_from_context(

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -57,12 +57,12 @@ from .sampling import RejectionSamplingStrategy
 
 @overload
 def act(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    strategy: SamplingStrategy | None = None,
     return_sampling_results: Literal[False] = False,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -72,12 +72,12 @@ def act(
 
 @overload
 def act(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    strategy: SamplingStrategy | None = None,
     return_sampling_results: Literal[True],
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -86,12 +86,12 @@ def act(
 
 
 def act(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    strategy: SamplingStrategy | None = None,
     return_sampling_results: bool = False,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -100,11 +100,11 @@ def act(
     """Runs a generic action, and adds both the action and the result to the context.
 
     Args:
-        action: the Component from which to generate.
+        action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
         requirements: used as additional requirements when a sampling strategy is provided.
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a
@@ -130,7 +130,7 @@ def act(
             tool_calls=tool_calls,
             silence_context_type_warning=True,  # We can safely silence this here since it's in a sync function.
             await_result=True,  # Sync functions must always await
-        )  # type: ignore[call-overload]
+        )  # type: ignore[call-overload, misc]
     )
 
     computed = False
@@ -506,7 +506,7 @@ def transform(
 
 @overload
 async def aact(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
@@ -523,7 +523,7 @@ async def aact(
 
 @overload
 async def aact(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
@@ -540,7 +540,7 @@ async def aact(
 
 @overload
 async def aact(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
@@ -557,12 +557,12 @@ async def aact(
 
 @overload
 async def aact(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    strategy: SamplingStrategy | None = None,
     return_sampling_results: Literal[True],
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -573,12 +573,12 @@ async def aact(
 
 
 async def aact(
-    action: Component[S],
+    action: Component[S] | CBlock | ModelOutputThunk,
     context: Context,
     backend: Backend,
     *,
     requirements: list[Requirement] | None = None,
-    strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+    strategy: SamplingStrategy | None = None,
     return_sampling_results: bool = False,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
@@ -589,11 +589,11 @@ async def aact(
     """Asynchronous version of .act; runs a generic action, and adds both the action and the result to the context.
 
     Args:
-        action: the Component from which to generate.
+        action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
         requirements: used as additional requirements when a sampling strategy is provided
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -19,7 +19,7 @@ Sampling strategies control how Mellea handles validation failures during genera
 
 import abc
 import asyncio
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Generic
@@ -37,6 +37,7 @@ from ...core import (
     ModelOutputThunk,
     Requirement,
     S,
+    SampleActionType,
     SamplingResult,
     SamplingStrategy,
     ValidationResult,
@@ -58,14 +59,14 @@ class _SamplingResultSlice(Generic[S]):
     generation: ComputedModelOutputThunk[S]
     validation: list[tuple[Requirement, ValidationResult]]
     context: Context
-    action: Component
+    action: SampleActionType
 
 
 def _get_sampling_result(
     slices: list[_SamplingResultSlice[S]],
     select_from_failure: Callable[
         [
-            list[Component],
+            Sequence[SampleActionType],
             list[ComputedModelOutputThunk],
             list[list[tuple[Requirement, ValidationResult]]],
         ],
@@ -79,7 +80,7 @@ def _get_sampling_result(
     """
     sample_generations: list[ComputedModelOutputThunk] = []
     sample_validations: list[list[tuple[Requirement, ValidationResult]]] = []
-    sample_actions: list[Component] = []
+    sample_actions: list[SampleActionType] = []
     sample_contexts: list[Context] = []
 
     success = False
@@ -161,10 +162,10 @@ class BaseSamplingStrategy(SamplingStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[ComputedModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Repair function that is being invoked if not all requirements are fulfilled. It should return a next action component.
 
         Args:
@@ -184,7 +185,7 @@ class BaseSamplingStrategy(SamplingStrategy):
     @staticmethod
     @abc.abstractmethod
     def select_from_failure(
-        sampled_actions: list[Component],
+        sampled_actions: Sequence[SampleActionType],
         sampled_results: list[ComputedModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
@@ -466,7 +467,7 @@ class BaseSamplingStrategy(SamplingStrategy):
         flog = MelleaLogger.get_logger()
         sampled_results: list[ComputedModelOutputThunk[S]] = []
         sampled_scores: list[list[tuple[Requirement, ValidationResult]]] = []
-        sampled_actions: list[Component] = []
+        sampled_actions: list[SampleActionType] = []
 
         next_action = deepcopy(action)
         next_context = context
@@ -491,8 +492,13 @@ class BaseSamplingStrategy(SamplingStrategy):
                 # type / value. Explicitly overwrite that here.
                 # TODO: See if there's a more elegant way for this so that each sampling
                 # strategy doesn't have to re-implement it.
-                # CBlocks and ModelOutputThunks have no `.parse`, so fall back to the
-                # raw value (mirrors how backends handle non-Component actions).
+                # Only a Component knows how to `.parse()` a result. A CBlock has no
+                # parse semantics, and a ModelOutputThunk does not retain its
+                # originating Component — only the already-parsed *value* (see
+                # ModelOutputThunk.avalue in core/base.py, which stores
+                # `parsed_repr = value` for CBlock/MOT actions). So there is no
+                # Component to re-parse against, even for a MOT[Component]; fall back
+                # to the raw value (mirrors how backends handle non-Component actions).
                 result.parsed_repr = (
                     action.parse(result)
                     if isinstance(action, Component)
@@ -550,9 +556,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                     generation=result,
                     validation=constraint_scores,
                     context=result_ctx,
-                    # A CBlock/MOT action has no repair semantics; the machinery
-                    # carries it through as an opaque Component-shaped span.
-                    action=next_action,  # type: ignore[arg-type]
+                    action=next_action,
                 )
 
                 if all_validations_passed:
@@ -567,7 +571,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                 # sees the most recent failed attempt.
                 sampled_results.append(result)
                 sampled_scores.append(constraint_scores)
-                sampled_actions.append(next_action)  # type: ignore[arg-type]
+                sampled_actions.append(next_action)
 
                 next_action, next_context = self.repair(
                     next_context,
@@ -602,7 +606,7 @@ class RejectionSamplingStrategy(BaseSamplingStrategy):
 
     @staticmethod
     def select_from_failure(
-        sampled_actions: list[Component],
+        sampled_actions: Sequence[SampleActionType],
         sampled_results: list[ComputedModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
@@ -622,10 +626,10 @@ class RejectionSamplingStrategy(BaseSamplingStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[ComputedModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Always returns the unedited, last action.
 
         Args:
@@ -646,7 +650,7 @@ class RepairTemplateStrategy(BaseSamplingStrategy):
 
     @staticmethod
     def select_from_failure(
-        sampled_actions: list[Component],
+        sampled_actions: Sequence[SampleActionType],
         sampled_results: list[ComputedModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
@@ -666,10 +670,10 @@ class RepairTemplateStrategy(BaseSamplingStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[ComputedModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Adds a description of the requirements that failed to a copy of the original instruction.
 
         Args:
@@ -711,7 +715,7 @@ class MultiTurnStrategy(BaseSamplingStrategy):
 
     @staticmethod
     def select_from_failure(
-        sampled_actions: list[Component],
+        sampled_actions: Sequence[SampleActionType],
         sampled_results: list[ComputedModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
@@ -734,10 +738,10 @@ class MultiTurnStrategy(BaseSamplingStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[ComputedModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Returns a Message with a description (and validation reasons) of the failed requirements.
 
         Args:

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -29,10 +29,12 @@ import tqdm
 from ...core import (
     Backend,
     BaseModelSubclass,
+    CBlock,
     Component,
     ComputedModelOutputThunk,
     Context,
     MelleaLogger,
+    ModelOutputThunk,
     Requirement,
     S,
     SamplingResult,
@@ -200,7 +202,7 @@ class BaseSamplingStrategy(SamplingStrategy):
 
     async def sample(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement] | None,
@@ -214,7 +216,7 @@ class BaseSamplingStrategy(SamplingStrategy):
         """This method performs a sampling operation based on the given instruction.
 
         Args:
-            action : The action object to be sampled.
+            action : The action object to be sampled. A `Component`, `CBlock`, or `ModelOutputThunk`.
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
@@ -445,7 +447,7 @@ class BaseSamplingStrategy(SamplingStrategy):
         self,
         subsample_index: int,
         iterations: int,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement],
@@ -489,7 +491,13 @@ class BaseSamplingStrategy(SamplingStrategy):
                 # type / value. Explicitly overwrite that here.
                 # TODO: See if there's a more elegant way for this so that each sampling
                 # strategy doesn't have to re-implement it.
-                result.parsed_repr = action.parse(result)
+                # CBlocks and ModelOutputThunks have no `.parse`, so fall back to the
+                # raw value (mirrors how backends handle non-Component actions).
+                result.parsed_repr = (
+                    action.parse(result)
+                    if isinstance(action, Component)
+                    else result.value  # type: ignore[assignment]
+                )
 
                 # validation pass
                 val_scores_co = mfuncs.avalidate(
@@ -542,7 +550,9 @@ class BaseSamplingStrategy(SamplingStrategy):
                     generation=result,
                     validation=constraint_scores,
                     context=result_ctx,
-                    action=next_action,
+                    # A CBlock/MOT action has no repair semantics; the machinery
+                    # carries it through as an opaque Component-shaped span.
+                    action=next_action,  # type: ignore[arg-type]
                 )
 
                 if all_validations_passed:
@@ -557,7 +567,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                 # sees the most recent failed attempt.
                 sampled_results.append(result)
                 sampled_scores.append(constraint_scores)
-                sampled_actions.append(next_action)
+                sampled_actions.append(next_action)  # type: ignore[arg-type]
 
                 next_action, next_context = self.repair(
                     next_context,

--- a/mellea/stdlib/sampling/budget_forcing.py
+++ b/mellea/stdlib/sampling/budget_forcing.py
@@ -19,6 +19,7 @@ from ...core import (
     ModelOutputThunk,
     Requirement,
     S,
+    SampleActionType,
     SamplingResult,
     ValidationResult,
     log_context,
@@ -136,7 +137,7 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
         with log_context(strategy=type(self).__name__, loop_budget=self.loop_budget):
             sampled_results: list[ComputedModelOutputThunk] = []
             sampled_scores: list[list[tuple[Requirement, ValidationResult]]] = []
-            sampled_actions: list[Component] = []
+            sampled_actions: list[SampleActionType] = []
             sample_contexts: list[Context] = []
 
             # The `logging_redirect_tqdm` approach did not work, so instead we will use the show_progress

--- a/mellea/stdlib/sampling/budget_forcing.py
+++ b/mellea/stdlib/sampling/budget_forcing.py
@@ -11,10 +11,12 @@ from ...backends.ollama import OllamaModelBackend
 from ...core import (
     Backend,
     BaseModelSubclass,
+    CBlock,
     Component,
     ComputedModelOutputThunk,
     Context,
     MelleaLogger,
+    ModelOutputThunk,
     Requirement,
     S,
     SamplingResult,
@@ -97,7 +99,7 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
 
     async def sample(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement] | None,
@@ -111,7 +113,7 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
         """This method performs a sampling operation based on the given instruction.
 
         Args:
-            action : The action object to be sampled.
+            action : The action object to be sampled. A `Component`, `CBlock`, or `ModelOutputThunk`.
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
@@ -197,7 +199,13 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
                 # Sampling strategies may use different components from the original
                 # action. This might cause discrepancies in the expected parsed_repr
                 # type / value. Explicitly overwrite that here.
-                result.parsed_repr = action.parse(result)
+                # CBlocks and ModelOutputThunks have no `.parse`, so fall back to the
+                # raw value (mirrors how backends handle non-Component actions).
+                result.parsed_repr = (
+                    action.parse(result)
+                    if isinstance(action, Component)
+                    else result.value
+                )
 
                 # validation pass
                 val_scores_co = mfuncs.avalidate(
@@ -217,7 +225,9 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
                 # collect all data
                 sampled_results.append(result)
                 sampled_scores.append(constraint_scores)
-                sampled_actions.append(next_action)
+                # A CBlock/MOT action has no repair semantics; the machinery
+                # carries it through as an opaque Component-shaped span.
+                sampled_actions.append(next_action)  # type: ignore[arg-type]
                 sample_contexts.append(result_ctx)
 
                 # if all vals are true -- break and return success

--- a/mellea/stdlib/sampling/budget_forcing.py
+++ b/mellea/stdlib/sampling/budget_forcing.py
@@ -228,7 +228,7 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
                 sampled_scores.append(constraint_scores)
                 # A CBlock/MOT action has no repair semantics; the machinery
                 # carries it through as an opaque Component-shaped span.
-                sampled_actions.append(next_action)  # type: ignore[arg-type]
+                sampled_actions.append(next_action)
                 sample_contexts.append(result_ctx)
 
                 # if all vals are true -- break and return success

--- a/mellea/stdlib/sampling/feedback.py
+++ b/mellea/stdlib/sampling/feedback.py
@@ -20,6 +20,7 @@ For example:
 """
 
 import re
+from collections.abc import Sequence
 from typing import Any
 
 from ...core import (
@@ -28,6 +29,7 @@ from ...core import (
     Context,
     MelleaLogger,
     Requirement,
+    SampleActionType,
     ValidationResult,
 )
 from ..components import Instruction
@@ -368,10 +370,10 @@ class ModelFriendlyRepairStrategy(RepairTemplateStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[Any],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Repair with model-friendly feedback formatting.
 
         Identical to RepairTemplateStrategy.repair() but uses

--- a/mellea/stdlib/sampling/feedback.py
+++ b/mellea/stdlib/sampling/feedback.py
@@ -25,7 +25,6 @@ from typing import Any
 
 from ...core import (
     Backend,
-    Component,
     Context,
     MelleaLogger,
     Requirement,

--- a/mellea/stdlib/sampling/majority_voting.py
+++ b/mellea/stdlib/sampling/majority_voting.py
@@ -13,8 +13,10 @@ from rouge_score.rouge_scorer import RougeScorer  # codespell:ignore
 from ...core import (
     Backend,
     BaseModelSubclass,
+    CBlock,
     Component,
     Context,
+    ModelOutputThunk,
     Requirement,
     S,
     SamplingResult,
@@ -99,7 +101,7 @@ class BaseMBRDSampling(RejectionSamplingStrategy):
 
     async def sample(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement] | None,

--- a/mellea/stdlib/sampling/sofai.py
+++ b/mellea/stdlib/sampling/sofai.py
@@ -12,6 +12,7 @@ feedback for repair, enabling more effective iterative improvement.
 """
 
 import re
+from collections.abc import Sequence
 from copy import deepcopy
 from typing import Literal
 
@@ -28,6 +29,7 @@ from ...core import (
     ModelOutputThunk,
     Requirement,
     S,
+    SampleActionType,
     SamplingResult,
     SamplingStrategy,
     TemplateRepresentation,
@@ -110,10 +112,10 @@ class SOFAISamplingStrategy(SamplingStrategy):
     def repair(
         old_ctx: Context,
         new_ctx: Context,
-        past_actions: list[Component],
+        past_actions: Sequence[SampleActionType],
         past_results: list[ComputedModelOutputThunk],
         past_val: list[list[tuple[Requirement, ValidationResult]]],
-    ) -> tuple[Component, Context]:
+    ) -> tuple[SampleActionType, Context]:
         """Create targeted feedback message from validation results.
 
         Extracts failed requirements and uses their ValidationResult.reason fields
@@ -156,7 +158,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
 
     @staticmethod
     def select_from_failure(
-        sampled_actions: list[Component],
+        sampled_actions: Sequence[SampleActionType],
         sampled_results: list[ComputedModelOutputThunk],
         sampled_val: list[list[tuple[Requirement, ValidationResult]]],
     ) -> int:
@@ -619,7 +621,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
             # State tracking for all attempts
             sampled_results: list[ComputedModelOutputThunk] = []
             sampled_scores: list[list[tuple[Requirement, ValidationResult]]] = []
-            sampled_actions: list[Component] = []
+            sampled_actions: list[SampleActionType] = []
             sample_contexts: list[Context] = []
 
             # ---------------------------------------------------------------------

--- a/mellea/stdlib/sampling/sofai.py
+++ b/mellea/stdlib/sampling/sofai.py
@@ -20,10 +20,12 @@ import tqdm
 from ...core import (
     Backend,
     BaseModelSubclass,
+    CBlock,
     Component,
     ComputedModelOutputThunk,
     Context,
     MelleaLogger,
+    ModelOutputThunk,
     Requirement,
     S,
     SamplingResult,
@@ -560,7 +562,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
 
     async def sample(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         context: Context,
         backend: Backend,
         requirements: list[Requirement] | None,
@@ -658,7 +660,9 @@ class SOFAISamplingStrategy(SamplingStrategy):
                     constraint_scores,
                 ) = await self._generate_and_validate(
                     solver_backend=self.s1_solver_backend,
-                    action=next_action,
+                    # A CBlock/MOT action is carried through as an opaque
+                    # Component-shaped span (SOFAI has no repair semantics for it).
+                    action=next_action,  # type: ignore[arg-type]
                     ctx=next_context,
                     reqs=reqs,
                     session_backend=backend,
@@ -670,7 +674,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
                 # Store attempt
                 sampled_results.append(result)
                 sampled_scores.append(constraint_scores)
-                sampled_actions.append(next_action)
+                sampled_actions.append(next_action)  # type: ignore[arg-type]
                 sample_contexts.append(result_ctx)
 
                 # Check for success
@@ -733,10 +737,11 @@ class SOFAISamplingStrategy(SamplingStrategy):
             # Prepare S2 context based on mode
             s2_action, s2_context = self._prepare_s2_context(
                 s2_mode=self.s2_solver_mode,
-                original_action=action,
+                # See note above: non-Component actions are opaque spans here.
+                original_action=action,  # type: ignore[arg-type]
                 original_context=context,
                 last_result_ctx=result_ctx,
-                last_action=next_action,
+                last_action=next_action,  # type: ignore[arg-type]
                 sampled_results=sampled_results,
                 sampled_scores=sampled_scores,
                 loop_count=loop_count,

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -860,7 +860,7 @@ class MelleaSession:
         action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = None,
+        strategy: SamplingStrategy,
         return_sampling_results: Literal[True],
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -884,8 +884,8 @@ class MelleaSession:
 
         Args:
             action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
-            requirements: used as additional requirements when a sampling strategy is provided
-            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
+            requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
             format: Constrains generation to JSON matching this Pydantic
                 schema. The result's `.value` is always a JSON string — not a
@@ -894,6 +894,9 @@ class MelleaSession:
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
             await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. Default is False.
+
+        Raises:
+            ValueError: if `return_sampling_results=True` without a `strategy`.
 
         Returns:
             A ModelOutputThunk if `return_sampling_results` is `False`, else returns a `SamplingResult`.

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -481,10 +481,10 @@ class MelleaSession:
     @overload
     def act(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        strategy: SamplingStrategy | None = None,
         return_sampling_results: Literal[False] = False,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -494,10 +494,10 @@ class MelleaSession:
     @overload
     def act(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        strategy: SamplingStrategy | None = None,
         return_sampling_results: Literal[True],
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -506,10 +506,10 @@ class MelleaSession:
 
     def act(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        strategy: SamplingStrategy | None = None,
         return_sampling_results: bool = False,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -518,9 +518,9 @@ class MelleaSession:
         """Runs a generic action, and adds both the action and the result to the context.
 
         Args:
-            action: the Component from which to generate.
+            action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
             requirements: used as additional requirements when a sampling strategy is provided
-            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
             format: Constrains generation to JSON matching this Pydantic
                 schema. The result's `.value` is always a JSON string — not a
@@ -815,7 +815,7 @@ class MelleaSession:
     @overload
     async def aact(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
         strategy: None = None,
@@ -829,7 +829,7 @@ class MelleaSession:
     @overload
     async def aact(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
         strategy: SamplingStrategy,
@@ -843,7 +843,7 @@ class MelleaSession:
     @overload
     async def aact(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
         strategy: None = None,
@@ -857,10 +857,10 @@ class MelleaSession:
     @overload
     async def aact(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        strategy: SamplingStrategy | None = None,
         return_sampling_results: Literal[True],
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -870,10 +870,10 @@ class MelleaSession:
 
     async def aact(
         self,
-        action: Component[S],
+        action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = RejectionSamplingStrategy(loop_budget=2),
+        strategy: SamplingStrategy | None = None,
         return_sampling_results: bool = False,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -883,9 +883,9 @@ class MelleaSession:
         """Runs a generic action, and adds both the action and the result to the context.
 
         Args:
-            action: the Component from which to generate.
+            action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
             requirements: used as additional requirements when a sampling strategy is provided
-            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. None means that no particular sampling strategy is used.
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
             format: Constrains generation to JSON matching this Pydantic
                 schema. The result's `.value` is always a JSON string — not a

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -497,7 +497,7 @@ class MelleaSession:
         action: Component[S] | CBlock | ModelOutputThunk,
         *,
         requirements: list[Requirement] | None = None,
-        strategy: SamplingStrategy | None = None,
+        strategy: SamplingStrategy,
         return_sampling_results: Literal[True],
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
@@ -528,6 +528,9 @@ class MelleaSession:
                 `MyModel.model_validate_json(str(result))` to get a typed instance.
             model_options: additional model options, which will upsert into the model/backend's defaults.
             tool_calls: if true, tool calling is enabled.
+
+        Raises:
+            ValueError: if `return_sampling_results=True` without a `strategy`.
 
         Returns:
             A ModelOutputThunk if `return_sampling_results` is `False`, else returns a `SamplingResult`.

--- a/test/core/test_component_typing.py
+++ b/test/core/test_component_typing.py
@@ -3,6 +3,7 @@
 
 """Tests for checking the functionality of typed components, model output thunks and sampling results."""
 
+from collections.abc import Sequence
 from typing import get_args
 
 import pytest
@@ -18,6 +19,7 @@ from mellea.core import (
     Context,
     ModelOutputThunk,
     Requirement,
+    SampleActionType,
     ValidationResult,
 )
 from mellea.core.base import ComputedModelOutputThunk
@@ -189,7 +191,7 @@ async def test_generating_with_sampling(session):
     class CustomSamplingStrat(BaseSamplingStrategy):
         @staticmethod
         def select_from_failure(
-            sampled_actions: list[Component],
+            sampled_actions: Sequence[SampleActionType],
             sampled_results: list[ComputedModelOutputThunk],
             sampled_val: list[list[tuple[Requirement, ValidationResult]]],
         ) -> int:
@@ -199,10 +201,10 @@ async def test_generating_with_sampling(session):
         def repair(
             old_ctx: Context,
             new_ctx: Context,
-            past_actions: list[Component],
+            past_actions: Sequence[SampleActionType],
             past_results: list[ComputedModelOutputThunk],
             past_val: list[list[tuple[Requirement, ValidationResult]]],
-        ) -> tuple[Component, Context]:
+        ) -> tuple[SampleActionType, Context]:
             return Instruction("print another number 100 greater"), old_ctx
 
     css = CustomSamplingStrat(loop_budget=3)

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -491,5 +491,33 @@ async def test_sampling_over_mot_action_does_not_raise(mocked_context_backend):
     assert result.result.parsed_repr == "mocked"
 
 
+async def test_sampling_over_cblock_action_failing_requirement_does_not_raise(
+    mocked_context_backend,
+):
+    """A failing requirement over a CBlock must exercise the repair/append path.
+
+    The always-pass cases above only cover the happy path. When validation
+    fails, the strategy appends `next_action` to `sampled_actions` and calls
+    `repair` on the non-Component action (the sites carrying
+    `type: ignore[arg-type]`). This must exhaust the budget and return a
+    failed result rather than raising.
+    """
+    always_fail = Requirement(
+        "always_fail", validation_fn=lambda _ctx: ValidationResult(result=False)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=2, concurrency_budget=1)
+
+    result = await strategy.sample(
+        action=CBlock("What is 1+1?"),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_fail],
+    )
+
+    assert result.success is False
+    # Even on the failure path, parsed_repr falls back to the raw model value.
+    assert result.result.parsed_repr == "mocked"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 from mellea.core import (
+    CBlock,
     ComputedModelOutputThunk,
     Context,
     GenerateLog,
@@ -444,6 +445,50 @@ async def test_backend_exception_does_not_mask_concurrent_success():
         "subsample peer raised an exception and prevented result from being successful"
     )
     assert len(result.sample_generations) >= 1
+
+
+# --- Sampling over non-Component actions (issue #356) ---
+
+
+async def test_sampling_over_cblock_action_does_not_raise(mocked_context_backend):
+    """A CBlock action has no `.parse`; sampling must fall back to `result.value`.
+
+    Regression test for #356: previously `action.parse(result)` raised
+    `AttributeError: 'CBlock' object has no attribute 'parse'`.
+    """
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=2, concurrency_budget=1)
+
+    result = await strategy.sample(
+        action=CBlock("What is 1+1?"),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_pass],
+    )
+
+    assert result.success is True
+    # parsed_repr falls back to the raw model value for non-Component actions.
+    assert result.result.parsed_repr == "mocked"
+
+
+async def test_sampling_over_mot_action_does_not_raise(mocked_context_backend):
+    """A ModelOutputThunk action also lacks `.parse`; sampling must not raise."""
+    always_pass = Requirement(
+        "always_pass", validation_fn=lambda _ctx: ValidationResult(result=True)
+    )
+    strategy = RejectionSamplingStrategy(loop_budget=2, concurrency_budget=1)
+
+    result = await strategy.sample(
+        action=ModelOutputThunk("prior output"),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[always_pass],
+    )
+
+    assert result.success is True
+    assert result.result.parsed_repr == "mocked"
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -277,9 +277,12 @@ async def test_aact_accepts_mot_action():
     backend = _mock_backend_returning("4")
     ctx = SimpleContext()
 
-    out, _ = await aact(ModelOutputThunk("prior"), ctx, backend, await_result=True)
+    out, new_ctx = await aact(
+        ModelOutputThunk("prior"), ctx, backend, await_result=True
+    )
 
     assert str(out) == "4"
+    assert new_ctx is not ctx
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -18,6 +18,7 @@ from mellea.stdlib.components import Document, Instruction, Message
 from mellea.stdlib.context import SimpleContext
 from mellea.stdlib.functional import (
     _parse_and_clean_image_args,
+    aact,
     achat,
     ainstruct,
     chat,
@@ -210,6 +211,75 @@ async def test_ainstruct_forwards_audio(mock_aact):
     instruction = mock_aact.call_args[0][0]
     assert isinstance(instruction, Instruction)
     assert instruction._audio == [audio]
+
+
+# --- act/aact accept CBlock and ModelOutputThunk (issue #356) ---
+
+
+def _default_strategy(func) -> object:
+    """Return the default value of the `strategy` parameter of `func`."""
+    import inspect
+
+    return inspect.signature(func).parameters["strategy"].default
+
+
+def test_act_default_strategy_is_none():
+    """act's default sampling strategy must be None (issue #356, decision #2)."""
+    from mellea.stdlib.functional import act
+    from mellea.stdlib.session import MelleaSession
+
+    assert _default_strategy(act) is None
+    assert _default_strategy(MelleaSession.act) is None
+
+
+def test_instruct_default_strategy_unchanged():
+    """instruct keeps its RejectionSamplingStrategy default (scope: act only)."""
+    from mellea.stdlib.functional import instruct
+    from mellea.stdlib.sampling import RejectionSamplingStrategy
+
+    assert isinstance(_default_strategy(instruct), RejectionSamplingStrategy)
+
+
+def _mock_backend_returning(value: str):
+    """Return a mock backend whose generate_from_context yields a computed MOT."""
+    from mellea.core import GenerateLog, ModelOutputThunk
+
+    backend = MagicMock()
+
+    async def mock_generate(action, *, ctx, **kwargs):
+        output = ModelOutputThunk(value)
+        output._generate_log = GenerateLog()
+        return output, ctx.add(action).add(output)
+
+    backend.generate_from_context = mock_generate
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_aact_accepts_cblock_action():
+    """aact over a raw CBlock generates without sampling (issue #356)."""
+    from mellea.core import CBlock
+
+    backend = _mock_backend_returning("2")
+    ctx = SimpleContext()
+
+    out, new_ctx = await aact(CBlock("What is 1+1?"), ctx, backend, await_result=True)
+
+    assert str(out) == "2"
+    assert new_ctx is not ctx
+
+
+@pytest.mark.asyncio
+async def test_aact_accepts_mot_action():
+    """aact over a raw ModelOutputThunk generates without sampling (issue #356)."""
+    from mellea.core import ModelOutputThunk
+
+    backend = _mock_backend_returning("4")
+    ctx = SimpleContext()
+
+    out, _ = await aact(ModelOutputThunk("prior"), ctx, backend, await_result=True)
+
+    assert str(out) == "4"
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -285,5 +285,28 @@ async def test_aact_accepts_mot_action():
     assert new_ctx is not ctx
 
 
+# --- return_sampling_results without a strategy raises ValueError ---
+
+
+@pytest.mark.asyncio
+async def test_aact_sampling_results_without_strategy_raises():
+    """aact rejects return_sampling_results=True with no strategy (ValueError)."""
+    from mellea.core import CBlock
+
+    backend = _mock_backend_returning("ignored")
+    with pytest.raises(ValueError):
+        await aact(CBlock("x"), SimpleContext(), backend, return_sampling_results=True)
+
+
+def test_act_sampling_results_without_strategy_raises():
+    """act surfaces the same ValueError as aact when no strategy is given."""
+    from mellea.core import CBlock
+    from mellea.stdlib.functional import act
+
+    backend = _mock_backend_returning("ignored")
+    with pytest.raises(ValueError):
+        act(CBlock("x"), SimpleContext(), backend, return_sampling_results=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/stdlib/test_session.py
+++ b/test/stdlib/test_session.py
@@ -9,7 +9,7 @@ import pytest
 from mellea.backends import ModelOption
 from mellea.core import ModelOutputThunk
 from mellea.stdlib.components import Message
-from mellea.stdlib.context import ChatContext
+from mellea.stdlib.context import ChatContext, SimpleContext
 from mellea.stdlib.session import MelleaSession, start_session
 from test.predicates import require_api_key
 
@@ -47,7 +47,13 @@ def test_start_session_openai_with_kwargs(m_session):
 
 async def test_aact(m_session):
     initial_ctx = m_session.ctx
-    out = await m_session.aact(Message(role="user", content="Hello!"))
+    # aact defaults to strategy=None; pass await_result=True to compute the
+    # result (matching act's synchronous contract) and to keep the
+    # module-scoped session's context free of an uncomputed ModelOutputThunk,
+    # which later deepcopy/clone-based tests cannot handle.
+    out = await m_session.aact(
+        Message(role="user", content="Hello!"), await_result=True
+    )
     assert m_session.ctx is not initial_ctx
     assert out.value is not None
 
@@ -79,20 +85,32 @@ async def test_async_await_with_chat_context(m_session):
     assert ctx.is_root_node  # type: ignore
 
 
-async def test_async_without_waiting_with_chat_context(m_session):
-    m_session.ctx = ChatContext()
+async def test_async_without_waiting_with_simple_context(m_session):
+    # Concurrent fire-and-forget aact calls must use SimpleContext. With aact's
+    # default strategy=None (and await_result=False), each call adds an
+    # uncomputed ModelOutputThunk to its context; on a shared ChatContext two
+    # gathered calls race and one reads the other's uncomputed thunk during
+    # rendering (assert c.is_computed() failure). SimpleContext keeps each turn
+    # independent, which is the documented context for parallel generation.
+    m_session.ctx = SimpleContext()
 
     m1 = Message(role="user", content="1")
     m2 = Message(role="user", content="2")
     co1 = m_session.aact(m1)
     co2 = m_session.aact(m2)
-    _, _ = await asyncio.gather(co2, co1)
+    r2, r1 = await asyncio.gather(co2, co1)
 
-    ctx = m_session.ctx
-    assert len(ctx.view_for_generation()) == 2  # type: ignore
+    # Both fire-and-forget generations resolve to real values once awaited.
+    assert await r1.avalue() is not None
+    assert await r2.avalue() is not None
 
 
 def test_session_copy_with_context_ops(m_session):
+    # Start from a clean ChatContext. The module-scoped session is mutated by
+    # earlier async tests, so reset here to make this test order-independent
+    # and to get the chained history the previous_node assertions below rely on.
+    m_session.ctx = ChatContext()
+
     out = m_session.instruct("What is 2x2?")
     main_ctx = m_session.ctx
 

--- a/test/typing/check_functional_aact.py
+++ b/test/typing/check_functional_aact.py
@@ -3,10 +3,11 @@
 
 """Mypy overload-resolution checks for functional aact."""
 
-from typing import assert_type, cast
+from typing import Any, assert_type, cast
 
 from mellea.core import (
     Backend,
+    CBlock,
     ComputedModelOutputThunk,
     Context,
     ModelOutputThunk,
@@ -19,6 +20,8 @@ from mellea.stdlib.sampling import RejectionSamplingStrategy
 ctx = cast(Context, None)
 backend = cast(Backend, None)
 action: Instruction = cast(Instruction, None)
+cblock_action: CBlock = cast(CBlock, None)
+mot_action: ModelOutputThunk[str] = cast(ModelOutputThunk[str], None)
 
 
 async def check_computed_await() -> None:
@@ -41,3 +44,22 @@ async def check_sampling() -> None:
     strat = RejectionSamplingStrategy(loop_budget=2)
     r = await aact(action, ctx, backend, strategy=strat, return_sampling_results=True)
     assert_type(r, SamplingResult[str])
+
+
+async def check_cblock_action() -> None:
+    # The core widening of #356: aact accepts a raw CBlock action. A CBlock is
+    # not generic, so S falls back to its Any default.
+    r = await aact(cblock_action, ctx, backend, strategy=None, await_result=True)
+    assert_type(r, tuple[ComputedModelOutputThunk[Any], Context])
+
+    u = await aact(cblock_action, ctx, backend, strategy=None)
+    assert_type(u, tuple[ModelOutputThunk[Any], Context])
+
+
+async def check_mot_action() -> None:
+    # aact also accepts a ModelOutputThunk action.
+    r = await aact(mot_action, ctx, backend, strategy=None, await_result=True)
+    assert_type(r, tuple[ComputedModelOutputThunk[Any], Context])
+
+    u = await aact(mot_action, ctx, backend, strategy=None)
+    assert_type(u, tuple[ModelOutputThunk[Any], Context])

--- a/test/typing/check_functional_aact.py
+++ b/test/typing/check_functional_aact.py
@@ -38,5 +38,6 @@ async def check_uncomputed() -> None:
 
 
 async def check_sampling() -> None:
-    r = await aact(action, ctx, backend, return_sampling_results=True)
+    strat = RejectionSamplingStrategy(loop_budget=2)
+    r = await aact(action, ctx, backend, strategy=strat, return_sampling_results=True)
     assert_type(r, SamplingResult[str])

--- a/test/typing/check_session.py
+++ b/test/typing/check_session.py
@@ -8,6 +8,7 @@ from typing import Any, assert_type, cast
 from mellea.core import (
     AudioBlock,
     AudioUrlBlock,
+    CBlock,
     ComputedModelOutputThunk,
     ModelOutputThunk,
     SamplingResult,
@@ -18,6 +19,8 @@ from mellea.stdlib.session import MelleaSession
 
 s = cast(MelleaSession, None)
 action: Instruction = cast(Instruction, None)
+cblock_action: CBlock = cast(CBlock, None)
+mot_action: ModelOutputThunk[str] = cast(ModelOutputThunk[str], None)
 
 
 async def check_aact_computed() -> None:
@@ -34,6 +37,25 @@ async def check_aact_sampling() -> None:
     strat = RejectionSamplingStrategy(loop_budget=2)
     r = await s.aact(action, strategy=strat, return_sampling_results=True)
     assert_type(r, SamplingResult[str])
+
+
+async def check_aact_cblock_action() -> None:
+    # The core widening of #356: aact accepts a raw CBlock action. A CBlock is
+    # not generic, so S falls back to its Any default.
+    r = await s.aact(cblock_action, strategy=None, await_result=True)
+    assert_type(r, ComputedModelOutputThunk[Any])
+
+    u = await s.aact(cblock_action, strategy=None)
+    assert_type(u, ModelOutputThunk[Any])
+
+
+async def check_aact_mot_action() -> None:
+    # aact also accepts a ModelOutputThunk action.
+    r = await s.aact(mot_action, strategy=None, await_result=True)
+    assert_type(r, ComputedModelOutputThunk[Any])
+
+    u = await s.aact(mot_action, strategy=None)
+    assert_type(u, ModelOutputThunk[Any])
 
 
 async def check_ainstruct_computed() -> None:

--- a/test/typing/check_session.py
+++ b/test/typing/check_session.py
@@ -13,6 +13,7 @@ from mellea.core import (
     SamplingResult,
 )
 from mellea.stdlib.components import Instruction
+from mellea.stdlib.sampling import RejectionSamplingStrategy
 from mellea.stdlib.session import MelleaSession
 
 s = cast(MelleaSession, None)
@@ -30,7 +31,8 @@ async def check_aact_uncomputed() -> None:
 
 
 async def check_aact_sampling() -> None:
-    r = await s.aact(action, return_sampling_results=True)
+    strat = RejectionSamplingStrategy(loop_budget=2)
+    r = await s.aact(action, strategy=strat, return_sampling_results=True)
     assert_type(r, SamplingResult[str])
 
 

--- a/test/typing/check_session.py
+++ b/test/typing/check_session.py
@@ -88,6 +88,19 @@ def check_query_sync() -> None:
     assert_type(r, ComputedModelOutputThunk[Any])
 
 
+def check_act_sync_computed() -> None:
+    r = s.act(action)
+    assert_type(r, ComputedModelOutputThunk[str])
+
+
+def check_act_sync_sampling() -> None:
+    # The Literal[True] overload requires an explicit strategy — the runtime
+    # asserts strategy is not None, so mypy must reject a missing strategy here.
+    strat = RejectionSamplingStrategy(loop_budget=2)
+    r = s.act(action, strategy=strat, return_sampling_results=True)
+    assert_type(r, SamplingResult[str])
+
+
 async def check_ainstruct_audio_accepted() -> None:
     """Verify audio param is present on all ainstruct overload variants."""
     audio: list[AudioBlock | AudioUrlBlock] = []


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #356 

## Description
<!-- What does this PR do and why? -->
mfuncs.act(CBlock("What is 1+1?"), ...) crashed with AttributeError: 'CBlock' object has no attribute 'parse'. act/aact defaulted to RejectionSamplingStrategy(loop_budget=2), so even a bare CBlock entered the sampling loop, which unconditionally called action.parse(result) — a method only Component has.

Per the maintainer decision on the issue thread, this widens act/aact to accept Component | CBlock | ModelOutputThunk and defaults their sampling strategy to None. instruct/chat/ainstruct keep their existing RejectionSamplingStrategy default — the change is scoped to act only.

Changes

- act/aact (functional.py, session.py): widened the action type to Component | CBlock | ModelOutputThunk; default strategy → None.
- Sampling strategies (base.py, budget_forcing.py, sofai.py, core/sampling.py): widened the sample() action param and guarded the parsed_repr assignment so non-Component actions fall back to the raw value (result.value) instead of calling .parse.
- majority_voting.py: widened BaseMBRDSampling.sample's action param to match the now-wider abstract supertype (fixes an LSP violation surfaced by mypy).
- Tests: added unit coverage for sampling and act/aact over CBlock/ModelOutputThunk actions and the new default strategy; updated test_session.py for the new async contract (see below).

Behavior note (async contract)

With strategy=None, an un-awaited aact now returns an uncomputed ModelOutputThunk for streaming (.value is None until awaited) — the least-surprise contract. Pass await_result=True to get a computed result. Two session tests were updated accordingly: test_aact now awaits its result, and the concurrent no-wait test was switched to SimpleContext (the documented context for parallel generation — ChatContext under asyncio.gather races on shared context). This race was previously masked by the old default strategy serializing the work.

Notice:
act/aact (both the `mellea.stdlib.functional` functions and the `MelleaSession` methods) now accept `Component | CBlock | ModelOutputThunk` as the action, and their default sampling strategy changes from `RejectionSamplingStrategy(loop_budget=2)` to `None` (single generation, no validation/repair loop). As a consequence, callers that relied on the implicit default while passing `return_sampling_results=True` will now raise `AssertionError` (a strategy must be supplied explicitly), and callers passing `requirements=` without an explicit `strategy=` will have those requirements ignored with a warning rather than validated.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
