### PR TITLE
feat(telemetry): emit execute_tool spans for tool calls

### DIFF
--- a/docs/docs/observability/metrics.md
+++ b/docs/docs/observability/metrics.md
@@ -282,7 +282,7 @@ All sampling metrics include:
 
 | Attribute | Description | Example Values |
 | --------- | ----------- | -------------- |
-| `tool` | Name of the invoked tool | `"search"`, `"calculator"` |
+| `gen_ai.tool.name` | Name of the invoked tool | `"search"`, `"calculator"` |
 | `status` | Execution outcome | `success`, `failure` |
 
 ## Metrics export configuration

--- a/docs/docs/observability/tracing.md
+++ b/docs/docs/observability/tracing.md
@@ -103,10 +103,12 @@ Mellea has two trace scopes.
 
 ### Application spans (`mellea.application`)
 
-Application spans cover user-facing Mellea operations. They appear whenever you
-call `m.act()`, `m.instruct()`, `m.chat()`, or a `@generative` function.
+Application spans cover user-facing Mellea operations, on the
+`mellea.application` tracer.
 
-The `session` span:
+#### `session` span
+
+Covers the lifetime of a session used as a context manager.
 
 | Attribute | Description |
 | --------- | ----------- |
@@ -114,7 +116,9 @@ The `session` span:
 | `mellea.context_type` | Context class name (e.g., `SimpleContext`) |
 | `mellea.backend` | Backend identifier (e.g., `"ollama"`); set when known |
 
-The `start_session` span:
+#### `start_session` span
+
+Covers session construction (backend setup and model resolution).
 
 | Attribute | Description |
 | --------- | ----------- |
@@ -122,7 +126,9 @@ The `start_session` span:
 | `mellea.model_id` | Resolved model id string |
 | `mellea.context_type` | Context class name |
 
-The `action` span:
+#### `action` span
+
+One per `m.act()`, `m.instruct()`, `m.chat()`, or `@generative` call.
 
 | Attribute | Description |
 | --------- | ----------- |
@@ -137,8 +143,29 @@ The `action` span:
 | `mellea.response` | Model response truncated to 500 characters; recorded only when `MELLEA_TRACES_CONTENT=true` |
 | `mellea.response_length` | Length of the model response (always recorded) |
 
-The `stream_with_chunking` span covers one streaming-generation run. It wraps
-the backend generation and any per-chunk validation:
+#### `execute_tool {name}` span
+
+One per tool the model calls, following the OTel Gen-AI tool-execution
+convention.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `gen_ai.operation.name` | Always `"execute_tool"` |
+| `gen_ai.tool.name` | Name of the invoked tool |
+| `gen_ai.tool.type` | Tool type from the tool schema (e.g., `"function"`), when known |
+| `gen_ai.tool.description` | Tool description from the tool schema, when known |
+| `gen_ai.tool.call.id` | Provider-supplied tool-call id, when available |
+| `gen_ai.tool.call.arguments` | Tool arguments truncated to 500 characters; recorded only when `MELLEA_TRACES_CONTENT=true` |
+| `gen_ai.tool.call.result` | Tool result truncated to 500 characters; recorded only when `MELLEA_TRACES_CONTENT=true` |
+| `mellea.tool.status` | Execution outcome (`success` or `failure`) |
+| `mellea.tool.execution_time_ms` | Wall-clock tool execution time in milliseconds |
+| `mellea.tool.is_control_flow` | Whether the tool is framework control flow (e.g., `final_answer` in ReAct) |
+| `mellea.tool.arguments_hash` | Stable hash of the arguments; recorded independent of content capture, when the call has arguments |
+
+#### `stream_with_chunking` span
+
+One per `stream_with_chunking()` run, wrapping the backend generation and any
+per-chunk validation.
 
 | Attribute | Description |
 | --------- | ----------- |
@@ -200,11 +227,18 @@ session                   (mellea.application)
 │   │                     [gen_ai.usage.input_tokens=150]
 │   │                     [gen_ai.usage.output_tokens=42]
 │   └── requirement_validation  (mellea.application)
+├── execute_tool search   (mellea.application)
+│                         [gen_ai.tool.name=search]
+│                         [mellea.tool.status=success]
 └── action                (mellea.application)
     └── chat              (mellea.backend)
                           [gen_ai.provider.name=openai]
                           [gen_ai.request.model=gpt-4o]
 ```
+
+Tool execution happens after the generating call completes, so `execute_tool`
+spans are not nested inside the `action` that requested them. Outside a session
+they are root spans.
 
 In a `stream_with_chunking` run, the backend generation and each per-chunk
 validation call nest under the `stream_with_chunking` span as sibling `chat`

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -836,7 +836,10 @@ class LiteLLMBackend(FormatterBackend):
                 # Validate and coerce argument types
                 validated_args = validate_tool_arguments(func, args, strict=False)
                 model_tool_calls[tool_name] = ModelToolCall(
-                    tool_name, func, validated_args
+                    tool_name,
+                    func,
+                    validated_args,
+                    tool_call_id=getattr(tool_call, "id", None),
                 )
 
         if len(model_tool_calls) > 0:

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -713,7 +713,10 @@ class OllamaModelBackend(FormatterBackend):
                 # Validate and coerce argument types
                 validated_args = validate_tool_arguments(func, args, strict=False)
                 model_tool_calls[tool.function.name] = ModelToolCall(
-                    tool.function.name, func, validated_args
+                    tool.function.name,
+                    func,
+                    validated_args,
+                    tool_call_id=getattr(tool, "id", None),
                 )
 
         if len(model_tool_calls) > 0:

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -785,7 +785,9 @@ class WatsonxAIBackend(FormatterBackend):
 
             # Validate and coerce argument types
             validated_args = validate_tool_arguments(func, args, strict=False)
-            model_tool_calls[tool_name] = ModelToolCall(tool_name, func, validated_args)
+            model_tool_calls[tool_name] = ModelToolCall(
+                tool_name, func, validated_args, tool_call_id=tool_call.get("id")
+            )
 
         if len(model_tool_calls) > 0:
             return model_tool_calls

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1752,12 +1752,15 @@ class ModelToolCall:
         name (str): The name of the tool the model requested to call.
         func (AbstractMelleaTool): The `AbstractMelleaTool` instance that will be invoked.
         args (Mapping[str, Any]): The keyword arguments the model supplied for the tool call.
+        tool_call_id (str | None): The provider-supplied tool-call id, when the backend
+            exposes one; `None` for backends or paths that do not (e.g., raw-string parsing).
 
     """
 
     name: str
     func: AbstractMelleaTool
     args: Mapping[str, Any]
+    tool_call_id: str | None = None
 
     def call_func(self) -> Any:
         """Invokes the tool represented by this object and returns the result.

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -92,7 +92,9 @@ def extract_model_tool_requests(
 
             # Validate and coerce argument types
             validated_args = validate_tool_arguments(func, args, strict=False)
-            model_tool_calls[tool_name] = ModelToolCall(tool_name, func, validated_args)
+            model_tool_calls[tool_name] = ModelToolCall(
+                tool_name, func, validated_args, tool_call_id=tool_call.get("id")
+            )
 
     if len(model_tool_calls) > 0:
         return model_tool_calls
@@ -172,6 +174,12 @@ def chat_completion_delta_merge(
                 else:
                     # This tool has already started to be defined.
                     current_tool = m_tool_calls[idx]
+
+                # id and type arrive only on the first chunk of a tool call.
+                if tool_call.get("id") is not None:
+                    current_tool["id"] = tool_call["id"]
+                if tool_call.get("type") is not None:
+                    current_tool["type"] = tool_call["type"]
 
                 # Get the info from the function chunk.
                 fx_info = tool_call["function"]

--- a/mellea/plugins/hooks/tool.py
+++ b/mellea/plugins/hooks/tool.py
@@ -14,6 +14,8 @@ class ToolPreInvokePayload(MelleaBasePayload):
     """Payload for `tool_pre_invoke` — before tool/function invocation.
 
     Attributes:
+        tool_invocation_id: UUID correlating the pre/post hooks for a single
+            tool invocation.
         model_tool_call: The `ModelToolCall` about to be executed (writable —
             plugins may modify arguments or swap the tool entirely).
         is_control_flow: `True` when this tool is used for framework control
@@ -21,6 +23,7 @@ class ToolPreInvokePayload(MelleaBasePayload):
             Plugins should check this field to decide whether to act.
     """
 
+    tool_invocation_id: str = ""
     model_tool_call: Any = None
     is_control_flow: bool = False
 
@@ -29,6 +32,8 @@ class ToolPostInvokePayload(MelleaBasePayload):
     """Payload for `tool_post_invoke` — after tool execution.
 
     Attributes:
+        tool_invocation_id: UUID correlating the pre/post hooks for a single
+            tool invocation.
         model_tool_call: The `ModelToolCall` that was executed.
         tool_output: The return value of the tool function (writable —
             plugins may transform the output before it is formatted).
@@ -41,6 +46,7 @@ class ToolPostInvokePayload(MelleaBasePayload):
             Plugins should check this field to decide whether to act.
     """
 
+    tool_invocation_id: str = ""
     model_tool_call: Any = None
     tool_output: Any = None
     tool_message: Any = None

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from collections.abc import Coroutine, Iterable
 from typing import Any, Literal, overload
 
@@ -609,7 +610,6 @@ async def aact(
     """
     import time
     import traceback
-    import uuid
 
     action_id = str(uuid.uuid4())
 
@@ -1314,11 +1314,14 @@ async def _acall_tools(result: ModelOutputThunk, backend: Backend) -> list[ToolM
 
     for name, tool in tool_calls.items():
         control_flow = is_internal_tool(name)
+        tool_invocation_id = str(uuid.uuid4())
 
         # --- tool_pre_invoke ---
         if has_plugins(HookType.TOOL_PRE_INVOKE):
             pre_payload = ToolPreInvokePayload(
-                model_tool_call=tool, is_control_flow=control_flow
+                tool_invocation_id=tool_invocation_id,
+                model_tool_call=tool,
+                is_control_flow=control_flow,
             )
             _, pre_payload = await invoke_hook(
                 HookType.TOOL_PRE_INVOKE, pre_payload, backend=backend
@@ -1359,6 +1362,7 @@ async def _acall_tools(result: ModelOutputThunk, backend: Backend) -> list[ToolM
         # --- tool_post_invoke ---
         if has_plugins(HookType.TOOL_POST_INVOKE):
             post_payload = ToolPostInvokePayload(
+                tool_invocation_id=tool_invocation_id,
                 model_tool_call=tool,
                 tool_output=output,
                 tool_message=tool_msg,

--- a/mellea/telemetry/_tracing_helpers.py
+++ b/mellea/telemetry/_tracing_helpers.py
@@ -1,13 +1,55 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Span attribute setters used by tracing plugins."""
+"""Helpers for the tracing instrumentation."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+from collections.abc import Mapping
 from typing import Any
 
 from mellea.core.base import GenerationMetadata
+
+# Max characters of captured content recorded on a span.
+_MAX_CONTENT_LEN = 500
+
+
+def _env_true(name: str) -> bool:
+    """Return True if `name` is set to a truthy value (1/true/yes)."""
+    return os.getenv(name, "false").lower() in ("true", "1", "yes")
+
+
+def content_capture_enabled() -> bool:
+    """Check if content capture is opted into via environment variable.
+
+    Internal env-var check behind `is_content_tracing_enabled`.
+
+    Returns:
+        True if `MELLEA_TRACES_CONTENT` or
+        `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` is truthy.
+    """
+    return _env_true("MELLEA_TRACES_CONTENT") or _env_true(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+    )
+
+
+def get_capture_content_value(value: Any) -> str | None:
+    """Stringify and truncate a content value for a span attribute.
+
+    Args:
+        value: The content value to record.
+
+    Returns:
+        The value truncated to `_MAX_CONTENT_LEN` characters, or `None` when
+        content capture is disabled or `value` is `None`.
+    """
+    if value is None or not content_capture_enabled():
+        return None
+    text = str(value)
+    return text[:_MAX_CONTENT_LEN] + "..." if len(text) > _MAX_CONTENT_LEN else text
 
 
 def set_attribute_safe(span: Any, key: str, value: Any) -> None:
@@ -118,3 +160,70 @@ def set_conversation_id(span: Any) -> None:
     session_id = get_session_id()
     if session_id is not None:
         span.set_attribute("gen_ai.conversation.id", session_id)
+
+
+def _serialize_arguments(arguments: Mapping[str, Any] | None) -> str | None:
+    """Return a stable, key-sorted JSON string of tool arguments, or `None`.
+
+    Falls back to `str()` for values JSON cannot serialize.
+    """
+    if not arguments:
+        return None
+    try:
+        return json.dumps(arguments, sort_keys=True, default=str)
+    except Exception:
+        return str(arguments)
+
+
+def _tool_schema_attrs(tool_call: Any) -> tuple[str | None, str | None]:
+    """Return `(tool_type, tool_description)` from a `ModelToolCall`'s tool schema.
+
+    Reads `tool_call.func.as_json_tool` defensively; returns `(None, None)` on any
+    failure so attribute capture never breaks the caller.
+    """
+    func = getattr(tool_call, "func", None)
+    try:
+        schema = func.as_json_tool if func is not None else None
+    except Exception:
+        return None, None
+    if not isinstance(schema, dict):
+        return None, None
+    tool_type = schema.get("type")
+    function_schema = schema.get("function")
+    description = None
+    if isinstance(function_schema, Mapping):
+        description = function_schema.get("description") or None
+    return tool_type, description
+
+
+def get_tool_call_attrs(tool_call: Any) -> dict[str, Any]:
+    """Unpack a `ModelToolCall` into `execute_tool` span attributes.
+
+    `gen_ai.tool.call.arguments` (semconv Opt-In, may contain PII) is included
+    only when content capture is enabled; `mellea.tool.arguments_hash` (a
+    non-content stable hash) is recorded independent of content capture,
+    whenever the call has arguments. Attributes the tool does not provide (type,
+    description, call id) are left as `None`.
+
+    Args:
+        tool_call: The `ModelToolCall` being executed.
+
+    Returns:
+        Span attributes keyed by attribute name.
+    """
+    tool_type, tool_description = _tool_schema_attrs(tool_call)
+    serialized = _serialize_arguments(getattr(tool_call, "args", None))
+    arguments_hash = (
+        hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+        if serialized is not None
+        else None
+    )
+    return {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": getattr(tool_call, "name", None) or "unknown",
+        "gen_ai.tool.type": tool_type,
+        "gen_ai.tool.description": tool_description,
+        "gen_ai.tool.call.id": getattr(tool_call, "tool_call_id", None),
+        "mellea.tool.arguments_hash": arguments_hash,
+        "gen_ai.tool.call.arguments": get_capture_content_value(serialized),
+    }

--- a/mellea/telemetry/metrics.py
+++ b/mellea/telemetry/metrics.py
@@ -980,7 +980,7 @@ def record_tool_call(tool: str, status: str) -> None:
         return
 
     counter = _get_tool_calls_counter()
-    counter.add(1, {"tool": tool, "status": status})
+    counter.add(1, {"gen_ai.tool.name": tool, "status": status})
 
 
 __all__ = [

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -50,11 +50,18 @@ except ImportError:
     trace = None  # type: ignore
     otel_context = None  # type: ignore
 
-
-def _env_true(name: str) -> bool:
-    """Return True if `name` is set to a truthy value (1/true/yes)."""
-    return os.getenv(name, "false").lower() in ("true", "1", "yes")
-
+from mellea.telemetry._tracing_helpers import (
+    _env_true,
+    content_capture_enabled,
+    get_capture_content_value,
+    get_tool_call_attrs,
+    set_attribute_safe,
+    set_conversation_id,
+    set_mellea_attrs,
+    set_request_attrs,
+    set_response_attrs,
+    set_usage_attrs,
+)
 
 _tracer_provider: Any = None
 _application_tracer: Any = None
@@ -200,11 +207,7 @@ def is_content_tracing_enabled() -> bool:
         True if enabled via `MELLEA_TRACES_CONTENT` or
         `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`.
     """
-    if not _OTEL_AVAILABLE:
-        return False
-    return _env_true("MELLEA_TRACES_CONTENT") or _env_true(
-        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
-    )
+    return _OTEL_AVAILABLE and content_capture_enabled()
 
 
 def get_application_tracer() -> Any:
@@ -363,7 +366,6 @@ def start_backend_span(
         The span, or `None` if tracing is disabled.
     """
     from mellea.core.base import GenerationMetadata
-    from mellea.telemetry._tracing_setters import set_conversation_id, set_request_attrs
 
     tracer = get_backend_tracer()
     if tracer is None:
@@ -413,13 +415,6 @@ def finish_backend_span_success(
         mot: The fully-computed `ModelOutputThunk`, or `None`.
         gen: The `GenerationMetadata` from the MOT, or `None`.
     """
-    from mellea.telemetry._tracing_setters import (
-        set_mellea_attrs,
-        set_request_attrs,
-        set_response_attrs,
-        set_usage_attrs,
-    )
-
     entry = _in_flight_spans.pop(generation_id, None)
     if entry is None:
         return
@@ -452,8 +447,6 @@ def finish_backend_span_error(
         exception: The exception raised by the backend.
         gen: Optional `GenerationMetadata` for refreshing request attrs.
     """
-    from mellea.telemetry._tracing_setters import set_request_attrs
-
     entry = _in_flight_spans.pop(generation_id, None)
     if entry is None:
         return
@@ -483,8 +476,6 @@ def _start_application_span(
     Returns:
         The span, or `None` if the application tracer is unavailable.
     """
-    from mellea.telemetry._tracing_setters import set_attribute_safe
-
     tracer = get_application_tracer()
     if tracer is None:
         return None
@@ -512,8 +503,6 @@ def _finish_application_span_success(
         key: Correlation key from the matching open call.
         extra_attributes: Optional response-side attributes; `None` values are skipped.
     """
-    from mellea.telemetry._tracing_setters import set_attribute_safe
-
     entry = _in_flight_spans.pop(key, None)
     if entry is None:
         return
@@ -546,8 +535,6 @@ def _finish_application_span_error(
         exception: The exception to record, when one was raised.
         description: ERROR-status description used when `exception` is `None`.
     """
-    from mellea.telemetry._tracing_setters import set_attribute_safe
-
     entry = _in_flight_spans.pop(key, None)
     if entry is None:
         return
@@ -720,8 +707,7 @@ def finish_action_span_success(
 ) -> None:
     """End the action span with response-side attributes.
 
-    `mellea.response` is recorded only when `is_content_tracing_enabled()`
-    returns true; the helper truncates to 500 chars before recording.
+    `mellea.response` is recorded (truncated) only when content capture is enabled;
     `mellea.response_length` is always recorded (a non-content metric).
 
     Args:
@@ -732,30 +718,101 @@ def finish_action_span_success(
             when content tracing is enabled.
         response_length: `mellea.response_length` (always safe; ungated).
     """
-    response_value: str | None = None
-    if response_text is not None and is_content_tracing_enabled():
-        response_value = (
-            response_text[:500] + "..." if len(response_text) > 500 else response_text
-        )
     _finish_application_span_success(
         action_id,
         extra_attributes={
             "mellea.num_generate_logs": num_generate_logs,
             "mellea.sampling_success": sampling_success,
-            "mellea.response": response_value,
+            "mellea.response": get_capture_content_value(response_text),
             "mellea.response_length": response_length,
         },
     )
 
 
-def finish_action_span_error(action_id: str, *, exception: BaseException) -> None:
+def finish_action_span_error(
+    action_id: str, *, exception: BaseException | None
+) -> None:
     """End the action span with ERROR status.
 
     Args:
         action_id: Correlation key from the matching open call.
-        exception: The exception that ended the action.
+        exception: The exception that ended the action, or `None` to set ERROR
+            status without a recorded exception.
     """
     _finish_application_span_error(action_id, exception=exception)
+
+
+def start_tool_span(
+    tool_invocation_id: str,
+    model_tool_call: Any,
+    *,
+    is_control_flow: bool,
+    attach_context: bool = True,
+) -> Span | None:
+    """Open the `execute_tool` span for a single tool invocation.
+
+    Args:
+        tool_invocation_id: UUID correlating this invocation across the pre/post hooks.
+        model_tool_call: The `ModelToolCall` being executed.
+        is_control_flow: Whether this tool is framework control flow.
+        attach_context: Whether to attach the span as the ambient OTel context.
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    attrs = get_tool_call_attrs(model_tool_call)
+    attrs["mellea.tool.is_control_flow"] = is_control_flow
+    return _start_application_span(
+        f"execute_tool {attrs['gen_ai.tool.name']}",
+        tool_invocation_id,
+        attrs,
+        attach_context=attach_context,
+    )
+
+
+def finish_tool_span_success(
+    tool_invocation_id: str, *, execution_time_ms: int, result: Any | None
+) -> None:
+    """End the tool span with success status and response-side attributes.
+
+    `gen_ai.tool.call.result` is recorded (truncated) only when content capture
+    is enabled.
+
+    Args:
+        tool_invocation_id: Correlation key from the matching open call.
+        execution_time_ms: Wall-clock tool execution time.
+        result: The tool's return value. Recorded as `gen_ai.tool.call.result`
+            only when content tracing is enabled.
+    """
+    _finish_application_span_success(
+        tool_invocation_id,
+        extra_attributes={
+            "mellea.tool.status": "success",
+            "mellea.tool.execution_time_ms": execution_time_ms,
+            "gen_ai.tool.call.result": get_capture_content_value(result),
+        },
+    )
+
+
+def finish_tool_span_error(
+    tool_invocation_id: str, *, execution_time_ms: int, exception: BaseException | None
+) -> None:
+    """End the tool span with ERROR status, recording the exception.
+
+    Args:
+        tool_invocation_id: Correlation key from the matching open call.
+        execution_time_ms: Wall-clock tool execution time.
+        exception: The exception raised by the tool, or `None` to set ERROR
+            status without a recorded exception.
+    """
+    _finish_application_span_error(
+        tool_invocation_id,
+        extra_attributes={
+            "mellea.tool.status": "failure",
+            "mellea.tool.execution_time_ms": execution_time_ms,
+        },
+        exception=exception,
+    )
 
 
 def start_streaming_span(

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -12,6 +12,7 @@ pipelines to automatically emit spans when tracing is enabled:
   execution.
 - StreamingTracingPlugin: Emits an application-level orchestration span and
   per-chunk span events for `stream_with_chunking` runs.
+- ToolTracingPlugin: Emits an `execute_tool` span for every tool invocation.
 """
 
 from __future__ import annotations
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
         StreamingOrchestrationStartPayload,
         StreamingStartPayload,
     )
+    from mellea.plugins.hooks.tool import ToolPostInvokePayload, ToolPreInvokePayload
 
 
 class BackendTracingPlugin(Plugin, name="backend_tracing", priority=40):
@@ -261,8 +263,7 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
             return
         from mellea.telemetry.tracing import finish_action_span_error
 
-        exc = payload.error if payload.error is not None else Exception("unknown error")
-        finish_action_span_error(payload.action_id, exception=exc)
+        finish_action_span_error(payload.action_id, exception=payload.error)
 
 
 class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
@@ -399,9 +400,62 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
         )
 
 
+class ToolTracingPlugin(Plugin, name="tool_tracing", priority=43):
+    """Emits an `execute_tool` span per tool invocation (pre/post lifecycle).
+
+    `tool_pre_invoke` opens the span; `tool_post_invoke` closes it with success
+    or error status, correlated via `tool_invocation_id`.
+
+    All hooks run SEQUENTIAL so the OTel context token attached in the pre hook
+    can be detached on the same task in the post hook.
+    """
+
+    @hook("tool_pre_invoke")
+    async def on_tool_pre_invoke(
+        self, payload: ToolPreInvokePayload, context: dict[str, Any]
+    ) -> None:
+        """Open the `execute_tool` span for this tool invocation."""
+        if not payload.tool_invocation_id:
+            return
+        from mellea.telemetry.tracing import start_tool_span
+
+        start_tool_span(
+            payload.tool_invocation_id,
+            payload.model_tool_call,
+            is_control_flow=payload.is_control_flow,
+            attach_context=_CONTEXT_ATTACH_SUPPORTED,
+        )
+
+    @hook("tool_post_invoke")
+    async def on_tool_post_invoke(
+        self, payload: ToolPostInvokePayload, context: dict[str, Any]
+    ) -> None:
+        """Close the `execute_tool` span with success or error status."""
+        if not payload.tool_invocation_id:
+            return
+        from mellea.telemetry.tracing import (
+            finish_tool_span_error,
+            finish_tool_span_success,
+        )
+
+        if payload.success:
+            finish_tool_span_success(
+                payload.tool_invocation_id,
+                execution_time_ms=payload.execution_time_ms,
+                result=payload.tool_output,
+            )
+        else:
+            finish_tool_span_error(
+                payload.tool_invocation_id,
+                execution_time_ms=payload.execution_time_ms,
+                exception=payload.error,
+            )
+
+
 # All tracing plugins to auto-register when tracing is enabled.
 _TRACING_PLUGIN_CLASSES = (
     BackendTracingPlugin,
     ComponentTracingPlugin,
     StreamingTracingPlugin,
+    ToolTracingPlugin,
 )

--- a/test/helpers/test_openai_compatible_helpers.py
+++ b/test/helpers/test_openai_compatible_helpers.py
@@ -241,7 +241,12 @@ class TestChatCompletionDeltaMerge:
             _delta_chunk(
                 role="assistant",
                 tool_calls=[
-                    {"index": 0, "function": {"name": "get_weather", "arguments": None}}
+                    {
+                        "index": 0,
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": None},
+                    }
                 ],
             ),
             _delta_chunk(
@@ -262,6 +267,8 @@ class TestChatCompletionDeltaMerge:
         result = chat_completion_delta_merge(chunks)
         tc = result["message"]["tool_calls"]
         assert len(tc) == 1
+        assert tc[0]["id"] == "call_abc"
+        assert tc[0]["type"] == "function"
         assert tc[0]["function"]["name"] == "get_weather"
         assert json.loads(tc[0]["function"]["arguments"]) == {"location": "Dallas"}
 

--- a/test/plugins/test_all_payloads.py
+++ b/test/plugins/test_all_payloads.py
@@ -854,6 +854,7 @@ class TestToolPreInvokePayload:
     def test_defaults(self):
         payload = ToolPreInvokePayload()
         assert payload.model_tool_call is None
+        assert payload.tool_invocation_id == ""
 
     def test_construction_with_values(self):
         payload = ToolPreInvokePayload(
@@ -894,6 +895,7 @@ class TestToolPostInvokePayload:
         assert payload.execution_time_ms == 0
         assert payload.success is True
         assert payload.error is None
+        assert payload.tool_invocation_id == ""
 
     def test_construction_successful(self):
         payload = ToolPostInvokePayload(

--- a/test/telemetry/test_metrics_operational.py
+++ b/test/telemetry/test_metrics_operational.py
@@ -265,7 +265,7 @@ def test_record_tool_call_success(clean_metrics_env):
 
     assert len(dps) == 1
     attrs = dict(dps[0].attributes)
-    assert attrs["tool"] == "search"
+    assert attrs["gen_ai.tool.name"] == "search"
     assert attrs["status"] == "success"
 
 
@@ -301,7 +301,7 @@ def test_record_tool_call_multiple_tools(clean_metrics_env):
     dps = _data_points_for(reader.get_metrics_data(), "mellea.tool.calls")
 
     assert len(dps) == 2
-    tools = {dict(dp.attributes)["tool"] for dp in dps}
+    tools = {dict(dp.attributes)["gen_ai.tool.name"] for dp in dps}
     assert tools == {"search", "calculator"}
 
 

--- a/test/telemetry/test_tracing_helpers.py
+++ b/test/telemetry/test_tracing_helpers.py
@@ -1,12 +1,15 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for span-attribute setters in `mellea.telemetry._tracing_setters`."""
+"""Unit tests for the helpers in `mellea.telemetry._tracing_helpers`."""
 
 from unittest.mock import MagicMock
 
 from mellea.core.base import GenerationMetadata
-from mellea.telemetry._tracing_setters import (
+from mellea.telemetry._tracing_helpers import (
+    _MAX_CONTENT_LEN,
+    get_capture_content_value,
+    get_tool_call_attrs,
     set_attribute_safe,
     set_conversation_id,
     set_mellea_attrs,
@@ -264,3 +267,103 @@ def test_set_conversation_id_no_op_when_session_id_unset():
     span = MagicMock()
     set_conversation_id(span)
     span.set_attribute.assert_not_called()
+
+
+# get_tool_call_attrs
+
+
+def _tool_call(name="search", args=None, tool_call_id="call-abc", description="Search"):
+    tc = MagicMock()
+    tc.name = name
+    tc.args = args if args is not None else {"q": "hi"}
+    tc.tool_call_id = tool_call_id
+    tc.func.as_json_tool = {
+        "type": "function",
+        "function": {"name": name, "description": description},
+    }
+    return tc
+
+
+def test_get_tool_call_attrs_unpacks_object(monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    attrs = get_tool_call_attrs(_tool_call())
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert attrs["gen_ai.tool.name"] == "search"
+    assert attrs["gen_ai.tool.type"] == "function"
+    assert attrs["gen_ai.tool.description"] == "Search"
+    assert attrs["gen_ai.tool.call.id"] == "call-abc"
+    assert attrs["mellea.tool.arguments_hash"]  # non-empty hash
+    # is_control_flow is set by start_tool_span, not the unpacker.
+    assert "mellea.tool.is_control_flow" not in attrs
+
+
+def test_get_tool_call_attrs_arguments_gated_by_content_capture(monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    off = get_tool_call_attrs(_tool_call())
+    assert off["gen_ai.tool.call.arguments"] is None
+
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    on = get_tool_call_attrs(_tool_call())
+    assert on["gen_ai.tool.call.arguments"] == '{"q": "hi"}'
+
+
+def test_get_tool_call_attrs_hash_stable_regardless_of_key_order():
+    a = get_tool_call_attrs(_tool_call(args={"a": 1, "b": 2}))
+    b = get_tool_call_attrs(_tool_call(args={"b": 2, "a": 1}))
+    assert a["mellea.tool.arguments_hash"] == b["mellea.tool.arguments_hash"]
+
+
+def test_get_tool_call_attrs_missing_schema_yields_none(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    tc = MagicMock()
+    tc.name = "bare"
+    tc.args = {}
+    tc.tool_call_id = None
+    type(tc.func).as_json_tool = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("no schema"))
+    )
+    attrs = get_tool_call_attrs(tc)
+    assert attrs["gen_ai.tool.name"] == "bare"
+    assert attrs["gen_ai.tool.type"] is None
+    assert attrs["gen_ai.tool.description"] is None
+    assert attrs["gen_ai.tool.call.id"] is None
+    # Empty args -> no hash, no captured arguments.
+    assert attrs["mellea.tool.arguments_hash"] is None
+    assert attrs["gen_ai.tool.call.arguments"] is None
+
+
+def test_get_tool_call_attrs_unnamed_tool_falls_back_to_unknown():
+    tc = MagicMock()
+    tc.name = None
+    tc.args = {}
+    tc.tool_call_id = None
+    tc.func.as_json_tool = {"type": "function", "function": {}}
+    attrs = get_tool_call_attrs(tc)
+    assert attrs["gen_ai.tool.name"] == "unknown"
+
+
+def test_get_tool_call_attrs_non_mapping_function_schema_yields_none():
+    tc = MagicMock()
+    tc.name = "search"
+    tc.args = {}
+    tc.tool_call_id = None
+    tc.func.as_json_tool = {"type": "function", "function": "bad"}
+    attrs = get_tool_call_attrs(tc)
+    assert attrs["gen_ai.tool.type"] == "function"
+    assert attrs["gen_ai.tool.description"] is None
+
+
+# get_capture_content_value
+
+
+def test_get_capture_content_value_truncates_over_limit(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    long = "x" * (_MAX_CONTENT_LEN + 50)
+    out = get_capture_content_value(long)
+    assert out == "x" * _MAX_CONTENT_LEN + "..."
+
+
+def test_get_capture_content_value_keeps_value_at_or_under_limit(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    exact = "y" * _MAX_CONTENT_LEN
+    assert get_capture_content_value(exact) == exact

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the BackendTracingPlugin span lifecycle."""
+"""Unit tests for the tracing plugin lifecycles."""
 
 import asyncio
 from unittest.mock import MagicMock, patch
@@ -33,6 +33,7 @@ from mellea.plugins.hooks.streaming import (
     StreamingEventPayload,
     StreamingStartPayload,
 )
+from mellea.plugins.hooks.tool import ToolPostInvokePayload, ToolPreInvokePayload
 from mellea.stdlib.streaming import (
     ChunkEvent,
     ErrorEvent,
@@ -46,6 +47,7 @@ from mellea.telemetry.tracing_plugins import (
     BackendTracingPlugin,
     ComponentTracingPlugin,
     StreamingTracingPlugin,
+    ToolTracingPlugin,
 )
 from test.telemetry.conftest import reset_tracing_state
 
@@ -63,6 +65,11 @@ def component_plugin():
 @pytest.fixture
 def streaming_plugin():
     return StreamingTracingPlugin()
+
+
+@pytest.fixture
+def tool_plugin():
+    return ToolTracingPlugin()
 
 
 @pytest.fixture
@@ -1017,3 +1024,256 @@ async def test_streaming_start_end_skip_when_streaming_id_empty(
     await streaming_plugin.on_streaming_end(
         StreamingEndPayload(streaming_id="", success=True), {}
     )
+
+
+# ToolTracingPlugin tests
+
+
+def _mock_tool_call(
+    name="search", args=None, tool_call_id="call-abc", description="Search the web"
+):
+    """Build a mock ModelToolCall exposing name/args/tool_call_id and a tool schema."""
+    tc = MagicMock()
+    tc.name = name
+    tc.args = args if args is not None else {"q": "hello"}
+    tc.tool_call_id = tool_call_id
+    tc.func.as_json_tool = {
+        "type": "function",
+        "function": {"name": name, "description": description},
+    }
+    return tc
+
+
+@pytest.mark.asyncio
+async def test_tool_pre_call_starts_and_stashes(tool_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    payload = ToolPreInvokePayload(
+        model_tool_call=_mock_tool_call(),
+        tool_invocation_id="iid-1",
+        is_control_flow=True,
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(payload, {})
+
+    fake_tracer.start_span.assert_called_once_with("execute_tool search")
+    assert "iid-1" in tracing._in_flight_spans
+    fake_span.end.assert_not_called()
+    attrs = _attrs(fake_span)
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert attrs["gen_ai.tool.name"] == "search"
+    assert attrs["gen_ai.tool.type"] == "function"
+    assert attrs["gen_ai.tool.description"] == "Search the web"
+    assert attrs["gen_ai.tool.call.id"] == "call-abc"
+    assert attrs["mellea.tool.is_control_flow"] is True
+    assert "mellea.tool.arguments_hash" in attrs
+
+
+@pytest.mark.asyncio
+async def test_tool_span_omits_optional_attrs_when_absent(tool_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    tc = MagicMock()
+    tc.name = "bare"
+    tc.args = {}
+    tc.tool_call_id = None
+    # No usable schema: as_json_tool raises.
+    type(tc.func).as_json_tool = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("no schema"))
+    )
+
+    payload = ToolPreInvokePayload(model_tool_call=tc, tool_invocation_id="iid-bare")
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(payload, {})
+
+    attrs = _attrs(fake_span)
+    assert attrs["gen_ai.tool.name"] == "bare"
+    assert attrs["gen_ai.operation.name"] == "execute_tool"
+    assert "gen_ai.tool.type" not in attrs
+    assert "gen_ai.tool.description" not in attrs
+    assert "gen_ai.tool.call.id" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_tool_post_call_finishes_success(tool_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    tc = _mock_tool_call()
+    pre = ToolPreInvokePayload(model_tool_call=tc, tool_invocation_id="iid-2")
+    post = ToolPostInvokePayload(
+        model_tool_call=tc,
+        tool_output="done",
+        execution_time_ms=42,
+        success=True,
+        tool_invocation_id="iid-2",
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(pre, {})
+        await tool_plugin.on_tool_post_invoke(post, {})
+
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.tool.status"] == "success"
+    assert attrs["mellea.tool.execution_time_ms"] == 42
+    assert "iid-2" not in tracing._in_flight_spans
+
+
+@pytest.mark.asyncio
+async def test_tool_post_call_finishes_error(tool_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    tc = _mock_tool_call()
+    pre = ToolPreInvokePayload(model_tool_call=tc, tool_invocation_id="iid-err")
+    post = ToolPostInvokePayload(
+        model_tool_call=tc,
+        execution_time_ms=5,
+        success=False,
+        error=ValueError("boom"),
+        tool_invocation_id="iid-err",
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(pre, {})
+        await tool_plugin.on_tool_post_invoke(post, {})
+
+    fake_span.end.assert_called_once()
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.tool.status"] == "failure"
+    assert attrs["error.type"] == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_tool_post_without_pre_is_noop(tool_plugin, enabled_tracing):
+    """A post hook with no matching in-flight span is a silent no-op."""
+    fake_tracer = MagicMock()
+
+    post = ToolPostInvokePayload(
+        model_tool_call=_mock_tool_call(),
+        tool_output="done",
+        execution_time_ms=10,
+        success=True,
+        tool_invocation_id="iid-orphan",
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_post_invoke(post, {})
+
+    fake_tracer.start_span.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_span_content_gating(tool_plugin, enabled_tracing, monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    tc = _mock_tool_call(args={"q": "hello"})
+    pre = ToolPreInvokePayload(model_tool_call=tc, tool_invocation_id="iid-c")
+    post = ToolPostInvokePayload(
+        model_tool_call=tc,
+        tool_output="the result",
+        execution_time_ms=1,
+        success=True,
+        tool_invocation_id="iid-c",
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(pre, {})
+        await tool_plugin.on_tool_post_invoke(post, {})
+
+    attrs = _attrs(fake_span)
+    assert "gen_ai.tool.call.arguments" in attrs
+    assert attrs["gen_ai.tool.call.result"] == "the result"
+
+
+@pytest.mark.asyncio
+async def test_tool_span_content_gated_off_by_default(
+    tool_plugin, enabled_tracing, monkeypatch
+):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    tc = _mock_tool_call(args={"q": "hello"})
+    pre = ToolPreInvokePayload(model_tool_call=tc, tool_invocation_id="iid-d")
+    post = ToolPostInvokePayload(
+        model_tool_call=tc,
+        tool_output="the result",
+        execution_time_ms=1,
+        success=True,
+        tool_invocation_id="iid-d",
+    )
+
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(pre, {})
+        await tool_plugin.on_tool_post_invoke(post, {})
+
+    attrs = _attrs(fake_span)
+    assert "gen_ai.tool.call.arguments" not in attrs
+    assert "gen_ai.tool.call.result" not in attrs
+    # Hash is always recorded (non-content).
+    assert "mellea.tool.arguments_hash" in attrs
+
+
+@pytest.mark.asyncio
+async def test_tool_span_noop_when_tracing_disabled(tool_plugin, enabled_tracing):
+    with patch("mellea.telemetry.tracing.get_application_tracer", return_value=None):
+        await tool_plugin.on_tool_pre_invoke(
+            ToolPreInvokePayload(
+                model_tool_call=_mock_tool_call(), tool_invocation_id="iid-off"
+            ),
+            {},
+        )
+    assert "iid-off" not in tracing._in_flight_spans
+
+
+@pytest.mark.asyncio
+async def test_tool_span_skips_without_id(tool_plugin, enabled_tracing):
+    fake_tracer = MagicMock()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await tool_plugin.on_tool_pre_invoke(
+            ToolPreInvokePayload(
+                model_tool_call=_mock_tool_call(), tool_invocation_id=""
+            ),
+            {},
+        )
+        await tool_plugin.on_tool_post_invoke(
+            ToolPostInvokePayload(
+                model_tool_call=_mock_tool_call(), success=True, tool_invocation_id=""
+            ),
+            {},
+        )
+    fake_tracer.start_span.assert_not_called()

--- a/test/telemetry/test_tracing_tools.py
+++ b/test/telemetry/test_tracing_tools.py
@@ -1,0 +1,136 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the `execute_tool` tracing span through real hooks."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry", reason="opentelemetry not installed — install mellea[telemetry]"
+)
+pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from mellea.backends.tools import MelleaTool
+from mellea.core.backend import Backend
+from mellea.core.base import ModelOutputThunk, ModelToolCall
+from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.session import MelleaSession
+from mellea.telemetry import tracing
+from test.telemetry.conftest import reset_tracing_state
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def enabled_tracing(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_ENABLED", "true")
+    reset_tracing_state()
+    yield
+    reset_tracing_state()
+
+
+@pytest.fixture
+def span_exporter(enabled_tracing):
+    """Attach an in-memory span exporter to the active tracer provider."""
+    if tracing._tracer_provider is None:
+        pytest.skip("Telemetry not initialized")
+    exporter = InMemorySpanExporter()
+    tracing._tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter
+    exporter.clear()
+
+
+def _spans_by_name(exporter: InMemorySpanExporter) -> dict[str, Any]:
+    tracing._tracer_provider.force_flush()  # type: ignore[union-attr]
+    return {s.name: s for s in exporter.get_finished_spans()}
+
+
+def _tool_call(func: Any, name: str) -> ModelToolCall:
+    tool = MelleaTool.from_callable(func, name=name)
+    return ModelToolCall(name=name, func=tool, args={})
+
+
+class _MockBackend(Backend):
+    """Minimal non-formatter backend; inference is patched, so it makes no calls."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._model_id = "mock-model"
+        self._provider = "mock-provider"
+
+    async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
+        raise NotImplementedError("inference is patched in these tests")
+
+    async def _generate_from_raw(self, actions: Any, ctx: Any, **kwargs: Any):
+        raise NotImplementedError("inference is patched in these tests")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests through real hooks + real exporter
+# ---------------------------------------------------------------------------
+
+
+def test_session_tool_calls_emit_parented_spans_per_call(span_exporter):
+    """A turn that calls two tools emits one `execute_tool` span per call, each
+    parented under the session span, with per-call success/error status.
+
+    Only inference (`act`) is faked; the real `transform` -> `_call_tools` ->
+    `tool_*_invoke` hooks -> `ToolTracingPlugin` path runs and emits the spans.
+    """
+
+    def _ok() -> str:
+        """A tool that succeeds."""
+        return "done"
+
+    def _boom() -> str:
+        """A tool that raises."""
+        raise ValueError("boom")
+
+    mot: ModelOutputThunk = ModelOutputThunk(value="")
+    mot.tool_calls = {"ok": _tool_call(_ok, "ok"), "boom": _tool_call(_boom, "boom")}
+
+    class _Subject:
+        """Trivial mify-able object to transform."""
+
+        value = "subject"
+
+    with MelleaSession(_MockBackend(), ctx=SimpleContext()) as m:
+        # Patch inference so `transform` returns our scripted tool calls; the
+        # downstream tool-execution + span emission is all real.
+        with patch("mellea.stdlib.functional.act", return_value=(mot, m.ctx)):
+            m.transform(_Subject(), "do the thing")
+
+    by_name = _spans_by_name(span_exporter)
+
+    # 1. Both tool spans emitted (assert existence before parentage/status so a
+    #    missing span fails here, not misleadingly on a downstream assertion).
+    assert "session" in by_name
+    assert "execute_tool ok" in by_name
+    assert "execute_tool boom" in by_name
+
+    ok_span = by_name["execute_tool ok"]
+    boom_span = by_name["execute_tool boom"]
+
+    # 2. Per-call status.
+    assert ok_span.attributes["mellea.tool.status"] == "success"
+    assert boom_span.attributes["mellea.tool.status"] == "failure"
+    assert boom_span.attributes["error.type"] == "ValueError"
+    assert boom_span.status.status_code.name == "ERROR"
+
+    # 3. Parentage: both nest under the session span.
+    session_span = by_name["session"]
+    assert session_span.parent is None
+    assert ok_span.parent is not None
+    assert ok_span.parent.span_id == session_span.context.span_id
+    assert boom_span.parent is not None
+    assert boom_span.parent.span_id == session_span.context.span_id


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1049

## Description

Adds OpenTelemetry tracing coverage for tool calls. A new `ToolTracingPlugin` emits one `execute_tool {name}` span per tool invocation via the existing `tool_pre_invoke` / `tool_post_invoke` hooks, following the OTel Gen-AI tool-execution semantic convention.

### What it adds

- **`ToolTracingPlugin`** (`mellea/telemetry/tracing_plugins.py`) — opens the span on `tool_pre_invoke`, closes it (success/error) on `tool_post_invoke`, correlated via a new `tool_invocation_id`. Registered alongside the Backend, Component, and Streaming tracing plugins. Hooks run SEQUENTIAL (the OTel context token must detach on the same task).
- **`execute_tool` span attributes**:
  - `gen_ai.operation.name`, `gen_ai.tool.name` (required), `gen_ai.tool.type`, `gen_ai.tool.description`, `gen_ai.tool.call.id` — semconv request-side attrs
  - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` — content-gated (`MELLEA_TRACES_CONTENT`), truncated to 500 chars
  - `mellea.tool.status`, `mellea.tool.execution_time_ms`, `mellea.tool.is_control_flow`, `mellea.tool.arguments_hash` — Mellea extensions
- **Span helpers** in `tracing.py` (`start_tool_span` / `finish_tool_span_*`) routed through the shared `_start_application_span` / `_finish_application_span_*` core, mirroring the `action` span. Object-unpacking lives in `get_tool_call_attrs`.
- **Provider tool-call id capture** — `ModelToolCall` gains an optional `tool_call_id`, populated from the provider response where available (OpenAI-compatible, LiteLLM, Ollama, Watsonx); `None` for raw-string parsing.
- **Content gating extracted** — a single `get_capture_content_value` helper now handles the gate + 500-char truncation for `mellea.response`, `gen_ai.tool.call.arguments`, and `gen_ai.tool.call.result` (previously duplicated inline).
- **Docs** — added the `execute_tool` span to `observability/tracing.md` (with a restructure of the Application spans section) and updated the tool counter's label in `observability/metrics.md`.

### Parenting

Tool execution happens after the generating `action`/`chat` completes, so `execute_tool` spans are **not** nested inside the requesting `action` — they are siblings under the long-lived `session` span (or root spans outside a session). Verified end-to-end in the integration test.

### Breaking changes

1. **Tool metric label rename**: `mellea.tool.calls` now tags the tool name under `gen_ai.tool.name` (was `tool`), aligning the metric with the new span attribute. No deprecation shim, as telemetry is still early enough that dashboards are unlikely to depend on the old label.
2. **Internal module rename**: `mellea/telemetry/_tracing_setters.py` → `_tracing_helpers.py` (private module; not a public API change). It now holds non-setter helpers too (`content_capture_enabled`, `get_capture_content_value`, `get_tool_call_attrs`).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Test coverage:
- **Unit** (`test_tracing_plugins.py`, mock tracer) — full `ToolTracingPlugin` lifecycle: pre/post, success/error, content gating on/off, no-op when disabled, skip-without-id, missing optional attrs.
- **Unit** (`test_tracing_helpers.py`) — `get_tool_call_attrs` unpacking + hash stability + arg gating; `get_capture_content_value` truncation boundary.
- **Integration** (`test_tracing_tools.py`, real OTel SDK + in-memory exporter) — one `m.transform()` with two tool calls (one raises), only inference faked: asserts both `execute_tool` spans emit, per-call success/error status, and parenting under the real `session` span.
- Updated `test_metrics_operational.py` for the `gen_ai.tool.name` label and `test_all_payloads.py` for the new `tool_invocation_id` payload field.

### Attribution
- [x] AI coding assistants used

Assisted-by: Claude Code

---

### Adding a new component, requirement, sampling strategy, or tool?

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

<!-- Not checking Tool: this adds tracing *for* tool calls, not a new tool. It does add an optional `tool_call_id` field to `ModelToolCall`, but introduces no new tool type. -->
