### PR TITLE
feat: add support for audio-text-to-text with m serve CLI and include examples

### DIFF
--- a/cli/serve/models.py
+++ b/cli/serve/models.py
@@ -9,6 +9,8 @@ from mellea.helpers.openai_compatible_helpers import CompletionUsage
 from mellea.serve.models import (
     ChatMessage,
     ImageUrlContent,
+    InputAudioContent,
+    InputAudioData,
     MessageContent,
     TextContent,
 )

--- a/cli/serve/models.py
+++ b/cli/serve/models.py
@@ -1,6 +1,16 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Re-exported so callers can import from cli.serve.models instead of mellea.serve.models
+__all__ = [
+    "ChatMessage",
+    "ImageUrlContent",
+    "InputAudioContent",
+    "InputAudioData",
+    "MessageContent",
+    "TextContent",
+]
+
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, RootModel, model_validator

--- a/docs/examples/m_serve/README.md
+++ b/docs/examples/m_serve/README.md
@@ -33,12 +33,6 @@ Example of serving a vision model through `m serve` with image inputs.
 ### client_multimodal_image.py
 Client code for testing the multimodal image endpoint with an OpenAI-compatible request.
 
-### m_serve_example_multimodal_audio.py
-
-Example of an audio-text-to-text serve function using Ollama + granite3.3.
-**Note:** granite3.3 is not an audio model; Ollama rejects audio input for it.
-See the llama-server and granite two-step variants below for working examples.
-
 ### m_serve_example_multimodal_audio_llama_server.py
 
 Audio-text-to-text serve function using llama-server with a Gemma audio

--- a/docs/examples/m_serve/README.md
+++ b/docs/examples/m_serve/README.md
@@ -50,9 +50,10 @@ handles the multimodal fusion natively. Requires a running llama-server with
 
 Audio-text-to-text serve function using a two-step Ollama/Granite pipeline:
 
-1. **granite-speech** (`gabegoodhart/granite4.1-speech:2b`) transcribes the
-   audio via the Ollama SDK's native `audio` message field.
-2. **granite3.3** answers the user's question with the transcript injected
+1. **granite-speech** (`hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M`)
+   transcribes the audio via Ollama's OpenAI-compatible
+   `/v1/audio/transcriptions` endpoint.
+2. **granite4.1:3b** answers the user's question with the transcript injected
    into the prompt.
 
 Both models run locally through Ollama — no llama-server or cloud API needed.
@@ -182,8 +183,8 @@ uv run python docs/examples/m_serve/client_multimodal_audio.py
 Requires both models pulled locally:
 
 ```bash
-ollama pull gabegoodhart/granite4.1-speech:2b
-ollama pull granite3.3
+ollama pull hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M
+ollama pull granite4.1:3b
 ```
 
 ```bash

--- a/docs/examples/m_serve/README.md
+++ b/docs/examples/m_serve/README.md
@@ -33,6 +33,35 @@ Example of serving a vision model through `m serve` with image inputs.
 ### client_multimodal_image.py
 Client code for testing the multimodal image endpoint with an OpenAI-compatible request.
 
+### m_serve_example_multimodal_audio.py
+
+Example of an audio-text-to-text serve function using Ollama + granite3.3.
+**Note:** granite3.3 is not an audio model; Ollama rejects audio input for it.
+See the llama-server and granite two-step variants below for working examples.
+
+### m_serve_example_multimodal_audio_llama_server.py
+
+Audio-text-to-text serve function using llama-server with a Gemma audio
+checkpoint. Audio and text are sent together in a single request; llama-server
+handles the multimodal fusion natively. Requires a running llama-server with
+`--mmproj` loaded (see prerequisites in the file header).
+
+### m_serve_example_multimodal_audio_granite.py
+
+Audio-text-to-text serve function using a two-step Ollama/Granite pipeline:
+
+1. **granite-speech** (`gabegoodhart/granite4.1-speech:2b`) transcribes the
+   audio via the Ollama SDK's native `audio` message field.
+2. **granite3.3** answers the user's question with the transcript injected
+   into the prompt.
+
+Both models run locally through Ollama — no llama-server or cloud API needed.
+
+### client_multimodal_audio.py
+
+Client code for testing any of the multimodal audio endpoints with an
+OpenAI-compatible `input_audio` content part request.
+
 ### pii_serve.py
 Example of serving a PII (Personally Identifiable Information) detection service.
 
@@ -65,6 +94,7 @@ Client code demonstrating streaming responses combined with tool calling.
 - **Streaming Responses**: Real-time token streaming via Server-Sent Events (SSE)
 - **Structured Output**: Using `response_format` for JSON schema validation
 - **Multimodal Inputs**: Sending text plus image content to vision-capable models
+- **Audio-Text-to-Text**: Sending base64-encoded audio alongside text in a chat request; the model responds in text (not transcription)
 
 ## Basic Pattern
 
@@ -130,6 +160,38 @@ m serve docs/examples/m_serve/m_serve_example_multimodal_image.py
 
 # In another terminal, test with the multimodal client
 uv run python docs/examples/m_serve/client_multimodal_image.py
+```
+
+### Multimodal Audio (llama-server + Gemma)
+
+Requires a local llama-server with an audio-capable Gemma checkpoint and
+`--mmproj` loaded (see the file header for the full `llama-server` command).
+Configure via `LLAMA_SERVER_URL`, `LLAMA_SERVER_API_KEY`, and
+`LLAMA_SERVER_MODEL` environment variables.
+
+```bash
+# Start the llama-server audio example
+m serve docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+
+# In another terminal, test with the audio client
+uv run python docs/examples/m_serve/client_multimodal_audio.py
+```
+
+### Multimodal Audio (Ollama + Granite — two-step transcribe + chat)
+
+Requires both models pulled locally:
+
+```bash
+ollama pull gabegoodhart/granite4.1-speech:2b
+ollama pull granite3.3
+```
+
+```bash
+# Start the Granite two-step audio example
+m serve docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+
+# In another terminal, test with the audio client
+uv run python docs/examples/m_serve/client_multimodal_audio.py
 ```
 
 ## Response Format Support

--- a/docs/examples/m_serve/client_multimodal_audio.py
+++ b/docs/examples/m_serve/client_multimodal_audio.py
@@ -1,0 +1,44 @@
+# pytest: skip_always
+import base64
+
+import openai
+import requests
+
+PORT = 8080
+
+client = openai.OpenAI(api_key="na", base_url=f"http://0.0.0.0:{PORT}/v1")
+
+# "Roses are red, violets are blue." — the same sample used in mellea's audio tests.
+_AUDIO_URL = "https://ai.google.dev/gemma/docs/audio/roses-are.wav"
+
+
+def _download_audio() -> bytes:
+    """Download the roses-are-red speech sample from Google's Gemma docs."""
+    response = requests.get(_AUDIO_URL, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+wav_bytes = _download_audio()
+audio_base64 = base64.b64encode(wav_bytes).decode("utf-8")
+
+query = "What colors and flowers are mentioned in the audio?"
+
+response = client.chat.completions.create(
+    model="ignored",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": query},
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": audio_base64, "format": "wav"},
+                },
+            ],
+        }
+    ],
+)
+
+print("Query: ", query)
+print("Response: ", response.choices[0].message.content)

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -3,14 +3,14 @@
 """Example: M serve with audio input via Ollama — two-step transcribe + chat.
 
 Ollama does not pass audio through its generic chat backends, but since
-version 0.7 it exposes an OpenAI-compatible ``POST /v1/audio/transcriptions``
+version 0.7 it exposes an OpenAI-compatible `POST /v1/audio/transcriptions`
 endpoint that accepts multipart WAV/MP3 uploads and returns a JSON transcript.
 This example uses that endpoint to split the work into two steps:
 
 1. **Transcribe** — POST the raw audio bytes to Ollama's
-   ``/v1/audio/transcriptions`` endpoint using
-   ``hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M``.
-2. **Chat** — pass the transcript to a standard ``granite4.1:3b`` session
+   `/v1/audio/transcriptions` endpoint using
+   `hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M`.
+2. **Chat** — pass the transcript to a standard `granite4.1:3b` session
    (via Mellea's Ollama backend) so the model can reason about it and
    produce a response to the caller's question.
 
@@ -72,9 +72,9 @@ def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
     """Decode an AudioBlock's base64 value to raw bytes and return (bytes, format).
 
     AudioBlock values may be stored in two forms:
-    - Data URI: ``data:audio/wav;base64,<b64>`` (e.g. from session.chat() audio)
-    - Raw base64 string without a prefix (e.g. from ``get_audio_blocks()`` on a
-      serve ChatMessage whose ``InputAudioData.data`` is plain base64)
+    - Data URI: `data:audio/wav;base64,<b64>` (e.g. from session.chat() audio)
+    - Raw base64 string without a prefix (e.g. from `get_audio_blocks()` on a
+      serve ChatMessage whose `InputAudioData.data` is plain base64)
     """
     value = block.value or ""
     fmt = block.format or "wav"
@@ -88,7 +88,7 @@ async def _transcribe(audio_blocks: list[AudioBlock | AudioUrlBlock]) -> str:
     """Transcribe audio using Ollama's OpenAI-compatible transcriptions endpoint.
 
     POSTs each AudioBlock as a multipart WAV upload to
-    ``/v1/audio/transcriptions`` and concatenates the results.
+    `/v1/audio/transcriptions` and concatenates the results.
 
     A fresh httpx.AsyncClient is created per call so that it always belongs
     to the running event loop (avoids loop-mismatch errors when the serve
@@ -122,12 +122,12 @@ async def serve(
 ) -> ModelOutputThunk:
     """Serve function that emulates audio-text-to-text via two Ollama calls.
 
-    Step 1: ``hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M`` transcribes the audio.
-    Step 2: ``granite4.1:3b`` answers the user's text question, informed by the transcript.
+    Step 1: `hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M` transcribes the audio.
+    Step 2: `granite4.1:3b` answers the user's text question, informed by the transcript.
 
-    The session retains conversation history across calls (via ``ChatContext``),
+    The session retains conversation history across calls (via `ChatContext`),
     so follow-up questions work without re-uploading audio.  Caller-supplied
-    ``requirements`` and ``model_options`` are forwarded to ``ainstruct``.
+    `requirements` and `model_options` are forwarded to `ainstruct`.
     """
     if not input:
         return ModelOutputThunk(value="No input provided")

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -24,7 +24,8 @@ The session uses `ChatContext` so conversation history accumulates across
 turns: follow-up questions like "who sang it?" work without re-uploading
 the audio.  The serve function also honours caller-supplied `requirements`
 and `model_options`, and uses `session.ainstruct()` with a built-in
-`Requirement` to keep answers grounded in the transcript.
+`Requirement` to keep answers grounded in the transcript (tuned to the
+bundled "roses are red and violets are blue" audio sample).
 
 Prerequisites:
     - Ollama running locally with both models pulled:
@@ -145,15 +146,29 @@ async def serve(
 
     prompt = f"{user_text}\n\n[Audio transcript: {transcript}]"
 
-    # Python-checkable grounding requirement: verify the answer shares at least
-    # one word with the transcript.  This avoids LLM-as-a-Judge overhead and
-    # makes the RejectionSamplingStrategy retry loop deterministic.
-    _words = set(transcript.lower().split())
+    # Grounding check tuned to the bundled audio sample ("roses are red and
+    # violets are blue"): the answer must mention at least 2 colors that also
+    # appear in the transcript.  This avoids LLM-as-a-Judge overhead and gives
+    # the RejectionSamplingStrategy retry loop real teeth.
+    # This is a contrived example to let you experiment with requirements.
+    # If you swap in your own audio, replace _COLORS with words relevant to
+    # your content, or remove/replace this requirement entirely.
+    _COLORS = {"red", "orange", "yellow", "green", "blue", "purple", "pink", "white"}
+    _transcript_words = set(transcript.lower().split())
+
+    def _has_two_transcript_colors(output: str) -> bool:
+        return (
+            sum(
+                1
+                for w in output.lower().split()
+                if w in _COLORS and w in _transcript_words
+            )
+            >= 2
+        )
+
     grounding_req: Requirement = Requirement(
         "Base your answer only on the provided audio transcript",
-        validation_fn=simple_validate(
-            lambda output: bool(_words & set(output.lower().split()))
-        ),
+        validation_fn=simple_validate(_has_two_transcript_colors),
     )
 
     result = await chat_session.ainstruct(

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -17,6 +17,12 @@ This example uses that endpoint to split the work into two steps:
 This emulates audio-text-to-text on an all-Ollama/Granite stack without
 requiring a separate llama-server or cloud API.
 
+The session uses `ChatContext` so conversation history accumulates across
+turns: follow-up questions like "who sang it?" work without re-uploading
+the audio.  The serve function also honours caller-supplied `requirements`
+and `model_options`, and uses `session.ainstruct()` with a built-in
+`Requirement` to keep answers grounded in the transcript.
+
 Prerequisites:
     - Ollama running locally with both models pulled:
 
@@ -40,13 +46,16 @@ Then test with:
 import base64
 import io
 import os
-from typing import Any, cast
+from typing import Any
 
 import httpx
 
 from mellea import start_session
-from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk
+from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk, Requirement
 from mellea.serve import ChatMessage
+from mellea.stdlib.context import ChatContext
+from mellea.stdlib.requirements import simple_validate
+from mellea.stdlib.sampling import RejectionSamplingStrategy
 
 _ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 _speech_model = os.environ.get(
@@ -54,8 +63,9 @@ _speech_model = os.environ.get(
 )
 _chat_model = os.environ.get("GRANITE_CHAT_MODEL", "granite4.1:3b")
 
-# Standard Mellea session for the chat step.
-chat_session = start_session(model_id=_chat_model)
+# ChatContext accumulates conversation history across turns so follow-up
+# questions work without re-uploading the audio.
+chat_session = start_session(model_id=_chat_model, ctx=ChatContext())
 
 
 def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
@@ -114,10 +124,11 @@ async def serve(
 
     Step 1: ``hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M`` transcribes the audio.
     Step 2: ``granite4.1:3b`` answers the user's text question, informed by the transcript.
+
+    The session retains conversation history across calls (via ``ChatContext``),
+    so follow-up questions work without re-uploading audio.  Caller-supplied
+    ``requirements`` and ``model_options`` are forwarded to ``ainstruct``.
     """
-
-    _ = requirements, model_options  # Not used in this example
-
     if not input:
         return ModelOutputThunk(value="No input provided")
 
@@ -127,18 +138,36 @@ async def serve(
         last_message.get_audio_blocks()
     )
 
-    transcript = ""
-    if audio_blocks:
-        transcript = await _transcribe(audio_blocks)
-        print(f"Transcript: {transcript[:120]}...")
+    if not audio_blocks:
+        raise ValueError(
+            "No audio provided. Please include an audio clip in your message."
+        )
 
-    # Build the prompt that combines the user question with the transcript.
-    if transcript:
-        prompt = f"{user_text}\n\n[Audio transcript: {transcript}]"
-    else:
-        prompt = user_text
+    transcript = await _transcribe(audio_blocks)
+    if not transcript:
+        raise ValueError("Audio was provided but could not be transcribed.")
+    print(f"Transcript: {transcript[:120]}...")
 
-    result = chat_session.chat(content=prompt)
+    prompt = f"{user_text}\n\n[Audio transcript: {transcript}]"
 
-    print(f"Result content: {result.content[:100] if result.content else 'None'}...")
-    return cast(ModelOutputThunk, chat_session.ctx.as_list()[-1])
+    # Python-checkable grounding requirement: verify the answer shares at least
+    # one word with the transcript.  This avoids LLM-as-a-Judge overhead and
+    # makes the RejectionSamplingStrategy retry loop deterministic.
+    _words = set(transcript.lower().split())
+    grounding_req: Requirement = Requirement(
+        "Base your answer only on the provided audio transcript",
+        validation_fn=simple_validate(
+            lambda output: bool(_words & set(output.lower().split()))
+        ),
+    )
+
+    result = await chat_session.ainstruct(
+        description=prompt,
+        requirements=[grounding_req, *[Requirement(r) for r in (requirements or [])]],
+        strategy=RejectionSamplingStrategy(loop_budget=2),
+        model_options=model_options,
+        await_result=True,
+    )
+
+    print(f"Result content: {result.value[:100] if result.value else 'None'}...")
+    return result

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -15,7 +15,10 @@ This example uses that endpoint to split the work into two steps:
    produce a response to the caller's question.
 
 This emulates audio-text-to-text on an all-Ollama/Granite stack without
-requiring a separate llama-server or cloud API.
+requiring a separate llama-server or cloud API. Because the audio is
+transcribed to plain text before reaching the chat model, only word-level
+content survives the pipeline — tone of voice, emotion, background sound,
+and speaker identity are not available to the chat model on this path.
 
 The session uses `ChatContext` so conversation history accumulates across
 turns: follow-up questions like "who sang it?" work without re-uploading

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -81,10 +81,8 @@ def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
     """
     value = block.value or ""
     fmt = block.format or "wav"
-    if isinstance(value, str):
-        raw_b64 = value.split("base64,")[-1] if "base64," in value else value
-        return base64.b64decode(raw_b64), fmt
-    return value, fmt  # type: ignore[return-value]
+    raw_b64 = value.split("base64,")[-1] if "base64," in value else value
+    return base64.b64decode(raw_b64), fmt
 
 
 async def _transcribe(audio_blocks: list[AudioBlock | AudioUrlBlock]) -> str:

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -163,7 +163,10 @@ async def serve(
 
     result = await chat_session.ainstruct(
         description=prompt,
-        requirements=[grounding_req, *[Requirement(r) for r in (requirements or [])]],
+        requirements=[
+            grounding_req,
+            *[Requirement(r) for r in (requirements or []) if r],
+        ],
         strategy=RejectionSamplingStrategy(loop_budget=2),
         model_options=model_options,
         await_result=True,

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -9,8 +9,8 @@ This example uses that endpoint to split the work into two steps:
 
 1. **Transcribe** — POST the raw audio bytes to Ollama's
    ``/v1/audio/transcriptions`` endpoint using
-   ``gabegoodhart/granite4.1-speech:2b``.
-2. **Chat** — pass the transcript to a standard ``granite3.3`` session
+   ``hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M``.
+2. **Chat** — pass the transcript to a standard ``granite4.1:3b`` session
    (via Mellea's Ollama backend) so the model can reason about it and
    produce a response to the caller's question.
 
@@ -21,14 +21,14 @@ Prerequisites:
     - Ollama running locally with both models pulled:
 
     ```bash
-    ollama pull gabegoodhart/granite4.1-speech:2b
-    ollama pull granite3.3
+    ollama pull hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M
+    ollama pull granite4.1:3b
     ```
 
 Environment variables (all optional):
     OLLAMA_HOST            Ollama server base URL  (default: http://localhost:11434)
-    GRANITE_SPEECH_MODEL   speech model name       (default: gabegoodhart/granite4.1-speech:2b)
-    GRANITE_CHAT_MODEL     chat model name         (default: granite3.3)
+    GRANITE_SPEECH_MODEL   speech model name       (default: hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M)
+    GRANITE_CHAT_MODEL     chat model name         (default: granite4.1:3b)
 
 Usage:
     m serve docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -50,9 +50,9 @@ from mellea.serve import ChatMessage
 
 _ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 _speech_model = os.environ.get(
-    "GRANITE_SPEECH_MODEL", "gabegoodhart/granite4.1-speech:2b"
+    "GRANITE_SPEECH_MODEL", "hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M"
 )
-_chat_model = os.environ.get("GRANITE_CHAT_MODEL", "granite3.3")
+_chat_model = os.environ.get("GRANITE_CHAT_MODEL", "granite4.1:3b")
 
 # Standard Mellea session for the chat step.
 chat_session = start_session(model_id=_chat_model)
@@ -112,8 +112,8 @@ async def serve(
 ) -> ModelOutputThunk:
     """Serve function that emulates audio-text-to-text via two Ollama calls.
 
-    Step 1: granite-speech transcribes the audio.
-    Step 2: granite3.3 answers the user's text question, informed by the transcript.
+    Step 1: ``hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M`` transcribes the audio.
+    Step 2: ``granite4.1:3b`` answers the user's text question, informed by the transcript.
     """
 
     _ = requirements, model_options  # Not used in this example

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -54,7 +54,7 @@ from typing import Any
 import httpx
 
 from mellea import start_session
-from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk, Requirement
+from mellea.core import AudioBlock, ModelOutputThunk, Requirement
 from mellea.serve import ChatMessage
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import simple_validate
@@ -85,7 +85,7 @@ def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
     return base64.b64decode(raw_b64), fmt
 
 
-async def _transcribe(audio_blocks: list[AudioBlock | AudioUrlBlock]) -> str:
+async def _transcribe(audio_blocks: list[AudioBlock]) -> str:
     """Transcribe audio using Ollama's OpenAI-compatible transcriptions endpoint.
 
     POSTs each AudioBlock as a multipart WAV upload to
@@ -94,14 +94,10 @@ async def _transcribe(audio_blocks: list[AudioBlock | AudioUrlBlock]) -> str:
     A fresh httpx.AsyncClient is created per call so that it always belongs
     to the running event loop (avoids loop-mismatch errors when the serve
     function is called from different async contexts).
-
-    AudioUrlBlock is not supported (skipped); download it first if needed.
     """
     parts: list[str] = []
     async with httpx.AsyncClient(base_url=_ollama_host, timeout=120) as client:
         for block in audio_blocks:
-            if not isinstance(block, AudioBlock):
-                continue
             audio_bytes, fmt = _audio_block_to_bytes(block)
             response = await client.post(
                 "/v1/audio/transcriptions",
@@ -135,9 +131,7 @@ async def serve(
 
     last_message = input[-1]
     user_text = last_message.get_text_content() or "What is in this audio?"
-    audio_blocks: list[AudioBlock | AudioUrlBlock] = list(
-        last_message.get_audio_blocks()
-    )
+    audio_blocks: list[AudioBlock] = list(last_message.get_audio_blocks())
 
     if not audio_blocks:
         raise ValueError(

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
@@ -1,0 +1,144 @@
+# pytest: ollama, e2e, qualitative
+
+"""Example: M serve with audio input via Ollama — two-step transcribe + chat.
+
+Ollama does not pass audio through its generic chat backends, but since
+version 0.7 it exposes an OpenAI-compatible ``POST /v1/audio/transcriptions``
+endpoint that accepts multipart WAV/MP3 uploads and returns a JSON transcript.
+This example uses that endpoint to split the work into two steps:
+
+1. **Transcribe** — POST the raw audio bytes to Ollama's
+   ``/v1/audio/transcriptions`` endpoint using
+   ``gabegoodhart/granite4.1-speech:2b``.
+2. **Chat** — pass the transcript to a standard ``granite3.3`` session
+   (via Mellea's Ollama backend) so the model can reason about it and
+   produce a response to the caller's question.
+
+This emulates audio-text-to-text on an all-Ollama/Granite stack without
+requiring a separate llama-server or cloud API.
+
+Prerequisites:
+    - Ollama running locally with both models pulled:
+
+    ```bash
+    ollama pull gabegoodhart/granite4.1-speech:2b
+    ollama pull granite3.3
+    ```
+
+Environment variables (all optional):
+    OLLAMA_HOST            Ollama server base URL  (default: http://localhost:11434)
+    GRANITE_SPEECH_MODEL   speech model name       (default: gabegoodhart/granite4.1-speech:2b)
+    GRANITE_CHAT_MODEL     chat model name         (default: granite3.3)
+
+Usage:
+    m serve docs/examples/m_serve/m_serve_example_multimodal_audio_granite.py
+
+Then test with:
+    uv run python docs/examples/m_serve/client_multimodal_audio.py
+"""
+
+import base64
+import io
+import os
+from typing import Any, cast
+
+import httpx
+
+from mellea import start_session
+from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk
+from mellea.serve import ChatMessage
+
+_ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+_speech_model = os.environ.get(
+    "GRANITE_SPEECH_MODEL", "gabegoodhart/granite4.1-speech:2b"
+)
+_chat_model = os.environ.get("GRANITE_CHAT_MODEL", "granite3.3")
+
+# Standard Mellea session for the chat step.
+chat_session = start_session(model_id=_chat_model)
+
+
+def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
+    """Decode an AudioBlock's base64 value to raw bytes and return (bytes, format).
+
+    AudioBlock values may be stored in two forms:
+    - Data URI: ``data:audio/wav;base64,<b64>`` (e.g. from session.chat() audio)
+    - Raw base64 string without a prefix (e.g. from ``get_audio_blocks()`` on a
+      serve ChatMessage whose ``InputAudioData.data`` is plain base64)
+    """
+    value = block.value or ""
+    fmt = block.format or "wav"
+    if isinstance(value, str):
+        raw_b64 = value.split("base64,")[-1] if "base64," in value else value
+        return base64.b64decode(raw_b64), fmt
+    return value, fmt  # type: ignore[return-value]
+
+
+async def _transcribe(audio_blocks: list[AudioBlock | AudioUrlBlock]) -> str:
+    """Transcribe audio using Ollama's OpenAI-compatible transcriptions endpoint.
+
+    POSTs each AudioBlock as a multipart WAV upload to
+    ``/v1/audio/transcriptions`` and concatenates the results.
+
+    A fresh httpx.AsyncClient is created per call so that it always belongs
+    to the running event loop (avoids loop-mismatch errors when the serve
+    function is called from different async contexts).
+
+    AudioUrlBlock is not supported (skipped); download it first if needed.
+    """
+    parts: list[str] = []
+    async with httpx.AsyncClient(base_url=_ollama_host, timeout=120) as client:
+        for block in audio_blocks:
+            if not isinstance(block, AudioBlock):
+                continue
+            audio_bytes, fmt = _audio_block_to_bytes(block)
+            response = await client.post(
+                "/v1/audio/transcriptions",
+                files={
+                    "file": (f"audio.{fmt}", io.BytesIO(audio_bytes), f"audio/{fmt}")
+                },
+                data={"model": _speech_model},
+            )
+            response.raise_for_status()
+            parts.append(response.json().get("text", ""))
+
+    return " ".join(p for p in parts if p)
+
+
+async def serve(
+    input: list[ChatMessage],
+    requirements: list[str] | None = None,
+    model_options: dict[str, Any] | None = None,
+) -> ModelOutputThunk:
+    """Serve function that emulates audio-text-to-text via two Ollama calls.
+
+    Step 1: granite-speech transcribes the audio.
+    Step 2: granite3.3 answers the user's text question, informed by the transcript.
+    """
+
+    _ = requirements, model_options  # Not used in this example
+
+    if not input:
+        return ModelOutputThunk(value="No input provided")
+
+    last_message = input[-1]
+    user_text = last_message.get_text_content() or "What is in this audio?"
+    audio_blocks: list[AudioBlock | AudioUrlBlock] = list(
+        last_message.get_audio_blocks()
+    )
+
+    transcript = ""
+    if audio_blocks:
+        transcript = await _transcribe(audio_blocks)
+        print(f"Transcript: {transcript[:120]}...")
+
+    # Build the prompt that combines the user question with the transcript.
+    if transcript:
+        prompt = f"{user_text}\n\n[Audio transcript: {transcript}]"
+    else:
+        prompt = user_text
+
+    result = chat_session.chat(content=prompt)
+
+    print(f"Result content: {result.content[:100] if result.content else 'None'}...")
+    return cast(ModelOutputThunk, chat_session.ctx.as_list()[-1])

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
@@ -10,6 +10,10 @@ Unlike the Ollama version, llama-server with a multimodal Gemma checkpoint
 supports native audio-text-to-text: audio and text are sent together in a
 single request and the model responds in text.
 
+The session uses `ChatContext` so conversation history accumulates across
+turns: follow-up questions work without re-uploading audio.  Caller-supplied
+`requirements` and `model_options` are forwarded to `ainstruct`.
+
 Prerequisites:
     - llama-server running with an audio-capable Gemma checkpoint, e.g.:
 
@@ -38,22 +42,27 @@ Then test with:
 """
 
 import os
-from typing import Any, cast
+from typing import Any
 
 from mellea import start_session
 from mellea.backends import ModelOption
-from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk
+from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk, Requirement
 from mellea.serve import ChatMessage
+from mellea.stdlib.context import ChatContext
+from mellea.stdlib.sampling import RejectionSamplingStrategy
 
 _base_url = os.environ.get("LLAMA_SERVER_URL", "http://localhost:8088/v1")
 _api_key = os.environ.get("LLAMA_SERVER_API_KEY", "default")
 _model_id = os.environ.get("LLAMA_SERVER_MODEL", "gemma-4-12b-it-Q8_0.gguf")
 
+# ChatContext accumulates conversation history across turns so follow-up
+# questions work without re-uploading audio.
 session = start_session(
     "openai",
     model_id=_model_id,
     base_url=_base_url,
     api_key=_api_key,
+    ctx=ChatContext(),
     model_options={ModelOption.MAX_NEW_TOKENS: 1000, "modalities": ["text"]},
 )
 
@@ -63,10 +72,12 @@ async def serve(
     requirements: list[str] | None = None,
     model_options: dict[str, Any] | None = None,
 ) -> ModelOutputThunk:
-    """Serve function that supports native audio-text-to-text via llama-server."""
+    """Serve function that supports native audio-text-to-text via llama-server.
 
-    _ = requirements, model_options  # Not used in this example
-
+    The session retains conversation history across calls (via ``ChatContext``),
+    so follow-up questions work without re-uploading audio.  Caller-supplied
+    ``requirements`` and ``model_options`` are forwarded to ``ainstruct``.
+    """
     if not input:
         return ModelOutputThunk(value="No input provided")
 
@@ -75,7 +86,20 @@ async def serve(
     audio_blocks: list[AudioBlock | AudioUrlBlock] = list(
         last_message.get_audio_blocks()
     )
-    result = session.chat(content=text, audio=audio_blocks)
 
-    print(f"Result content: {result.content[:100] if result.content else 'None'}...")
-    return cast(ModelOutputThunk, session.ctx.as_list()[-1])
+    if not audio_blocks:
+        raise ValueError(
+            "No audio provided. Please include an audio clip in your message."
+        )
+
+    result = await session.ainstruct(
+        description=text,
+        audio=audio_blocks,
+        requirements=[Requirement(r) for r in (requirements or [])],
+        strategy=RejectionSamplingStrategy(loop_budget=2),
+        model_options=model_options,
+        await_result=True,
+    )
+
+    print(f"Result content: {result.value[:100] if result.value else 'None'}...")
+    return result

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
@@ -1,0 +1,81 @@
+# pytest: openai, e2e, qualitative
+
+"""Example: M serve with audio input support via llama-server + Gemma.
+
+This example shows how to create a serve function that reads audio from
+message objects and uses them with an audio-capable model via a
+llama-server OpenAI-compatible endpoint.
+
+Unlike the Ollama version, llama-server with a multimodal Gemma checkpoint
+supports native audio-text-to-text: audio and text are sent together in a
+single request and the model responds in text.
+
+Prerequisites:
+    - llama-server running with an audio-capable Gemma checkpoint, e.g.:
+
+    ```bash
+    llama-server \\
+        --model gemma-4-12b-it-Q8_0.gguf \\
+        --mmproj mmproj-F16.gguf \\
+        --n-gpu-layers 99 \\
+        --ctx-size 32768 \\
+        --flash-attn on \\
+        --parallel 1 \\
+        --jinja \\
+        --host 0.0.0.0 --port 8088
+    ```
+
+Environment variables (all optional):
+    LLAMA_SERVER_URL      base URL of the llama-server  (default: http://localhost:8088/v1)
+    LLAMA_SERVER_API_KEY  API key                       (default: default)
+    LLAMA_SERVER_MODEL    model name                    (default: gemma-4-12b-it-Q8_0.gguf)
+
+Usage:
+    m serve docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+
+Then test with:
+    uv run python docs/examples/m_serve/client_multimodal_audio.py
+"""
+
+import os
+from typing import Any, cast
+
+from mellea import start_session
+from mellea.backends import ModelOption
+from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk
+from mellea.serve import ChatMessage
+
+_base_url = os.environ.get("LLAMA_SERVER_URL", "http://localhost:8088/v1")
+_api_key = os.environ.get("LLAMA_SERVER_API_KEY", "default")
+_model_id = os.environ.get("LLAMA_SERVER_MODEL", "gemma-4-12b-it-Q8_0.gguf")
+
+session = start_session(
+    "openai",
+    model_id=_model_id,
+    base_url=_base_url,
+    api_key=_api_key,
+    model_options={ModelOption.MAX_NEW_TOKENS: 1000, "modalities": ["text"]},
+)
+
+
+async def serve(
+    input: list[ChatMessage],
+    requirements: list[str] | None = None,
+    model_options: dict[str, Any] | None = None,
+) -> ModelOutputThunk:
+    """Serve function that supports native audio-text-to-text via llama-server."""
+
+    _ = requirements, model_options  # Not used in this example
+
+    if not input:
+        return ModelOutputThunk(value="No input provided")
+
+    last_message = input[-1]
+    text = last_message.get_text_content() or "Transcribe or describe this audio"
+    audio_blocks: list[AudioBlock | AudioUrlBlock] = list(
+        last_message.get_audio_blocks()
+    )
+    result = session.chat(content=text, audio=audio_blocks)
+
+    print(f"Result content: {result.content[:100] if result.content else 'None'}...")
+    return cast(ModelOutputThunk, session.ctx.as_list()[-1])

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
@@ -74,9 +74,9 @@ async def serve(
 ) -> ModelOutputThunk:
     """Serve function that supports native audio-text-to-text via llama-server.
 
-    The session retains conversation history across calls (via ``ChatContext``),
+    The session retains conversation history across calls (via `ChatContext`),
     so follow-up questions work without re-uploading audio.  Caller-supplied
-    ``requirements`` and ``model_options`` are forwarded to ``ainstruct``.
+    `requirements` and `model_options` are forwarded to `ainstruct`.
     """
     if not input:
         return ModelOutputThunk(value="No input provided")

--- a/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
+++ b/docs/examples/m_serve/m_serve_example_multimodal_audio_llama_server.py
@@ -95,7 +95,7 @@ async def serve(
     result = await session.ainstruct(
         description=text,
         audio=audio_blocks,
-        requirements=[Requirement(r) for r in (requirements or [])],
+        requirements=[Requirement(r) for r in (requirements or []) if r],
         strategy=RejectionSamplingStrategy(loop_budget=2),
         model_options=model_options,
         await_result=True,

--- a/mellea/serve/__init__.py
+++ b/mellea/serve/__init__.py
@@ -7,6 +7,20 @@ This module provides the types that users need when writing serve() functions
 for use with the `m serve` command.
 """
 
-from .models import ChatMessage, ImageUrlContent, MessageContent, TextContent
+from .models import (
+    ChatMessage,
+    ImageUrlContent,
+    InputAudioContent,
+    InputAudioData,
+    MessageContent,
+    TextContent,
+)
 
-__all__ = ["ChatMessage", "ImageUrlContent", "MessageContent", "TextContent"]
+__all__ = [
+    "ChatMessage",
+    "ImageUrlContent",
+    "InputAudioContent",
+    "InputAudioData",
+    "MessageContent",
+    "TextContent",
+]

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -40,7 +40,7 @@ class InputAudioData(BaseModel):
 class InputAudioContent(BaseModel):
     """Audio content part in an OpenAI-compatible multimodal message.
 
-    Matches the ``{"type": "input_audio", "input_audio": {"data": "...", "format": "wav"}}``
+    Matches the `{"type": "input_audio", "input_audio": {"data": "...", "format": "wav"}}`
     wire format used by the OpenAI Chat Completions API.
     """
 
@@ -103,8 +103,8 @@ class ChatMessage(BaseModel):
         """Extract image blocks from message content.
 
         Returns:
-            List of ``ImageBlock`` (for base64/data-URI images) or
-            ``ImageUrlBlock`` (for http/https URLs) from all ImageUrlContent
+            List of `ImageBlock` (for base64/data-URI images) or
+            `ImageUrlBlock` (for http/https URLs) from all ImageUrlContent
             items. Empty list if content is a string or contains no images.
 
         Raises:
@@ -136,7 +136,7 @@ class ChatMessage(BaseModel):
         """Extract audio blocks from message content.
 
         Returns:
-            List of ``AudioBlock`` instances from all ``InputAudioContent`` items.
+            List of `AudioBlock` instances from all `InputAudioContent` items.
             Empty list if content is a string or contains no audio parts.
 
         Raises:

--- a/mellea/serve/models.py
+++ b/mellea/serve/models.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from mellea.core import ImageBlock, ImageUrlBlock
+from mellea.core import AudioBlock, ImageBlock, ImageUrlBlock
 
 
 class TextContent(BaseModel):
@@ -28,8 +28,28 @@ class ImageUrlContent(BaseModel):
     """Image URL object containing 'url' key and optional 'detail' key."""
 
 
+class InputAudioData(BaseModel):
+    """Audio data payload for an `input_audio` content part."""
+
+    data: str
+    """Base64-encoded audio data."""
+    format: str
+    """Audio format, e.g. `"wav"` or `"mp3"`."""
+
+
+class InputAudioContent(BaseModel):
+    """Audio content part in an OpenAI-compatible multimodal message.
+
+    Matches the ``{"type": "input_audio", "input_audio": {"data": "...", "format": "wav"}}``
+    wire format used by the OpenAI Chat Completions API.
+    """
+
+    type: Literal["input_audio"]
+    input_audio: InputAudioData
+
+
 # Union type for all content types
-MessageContent = TextContent | ImageUrlContent
+MessageContent = TextContent | ImageUrlContent | InputAudioContent
 
 
 class ChatMessage(BaseModel):
@@ -38,7 +58,7 @@ class ChatMessage(BaseModel):
     The content field can be:
     - A string (text-only, backward compatible)
     - None (for messages without content)
-    - A list of content objects (multimodal: text, images)
+    - A list of content objects (multimodal: text, images, audio)
     """
 
     role: Literal["system", "user", "assistant", "tool", "function"]
@@ -52,7 +72,7 @@ class ChatMessage(BaseModel):
 
         Returns:
             Concatenated text from all TextContent items, or empty string if no text.
-            Images are ignored (handled separately via extraction utilities).
+            Images and audio are ignored (handled separately via extraction utilities).
         """
         if isinstance(self.content, str):
             return self.content
@@ -111,3 +131,30 @@ class ChatMessage(BaseModel):
                     "Expected an http/https URL or a data: URI."
                 )
         return image_blocks
+
+    def get_audio_blocks(self) -> list[AudioBlock]:
+        """Extract audio blocks from message content.
+
+        Returns:
+            List of ``AudioBlock`` instances from all ``InputAudioContent`` items.
+            Empty list if content is a string or contains no audio parts.
+
+        Raises:
+            ValueError: If an audio data payload is invalid or cannot be processed.
+        """
+        if not isinstance(self.content, list):
+            return []
+        audio_blocks: list[AudioBlock] = []
+        for item in self.content:
+            if isinstance(item, InputAudioContent):
+                try:
+                    audio_blocks.append(
+                        AudioBlock(item.input_audio.data, item.input_audio.format)
+                    )
+                except (AssertionError, ValueError) as e:
+                    raise ValueError(
+                        f"Invalid audio data: {item.input_audio.data[:100]}"
+                        f"{'...' if len(item.input_audio.data) > 100 else ''}. "
+                        f"Error: {e}"
+                    ) from e
+        return audio_blocks

--- a/test/cli/test_serve_integration_multimodal.py
+++ b/test/cli/test_serve_integration_multimodal.py
@@ -17,9 +17,11 @@ from cli.serve.models import (
     ChatCompletionRequest,
     ChatMessage,
     ImageUrlContent,
+    InputAudioContent,
+    InputAudioData,
     TextContent,
 )
-from mellea.core import ModelOutputThunk
+from mellea.core import AudioBlock, ModelOutputThunk
 
 # --- Helper functions ---
 
@@ -33,6 +35,34 @@ def _make_valid_png_base64() -> str:
         b"\x00\x00\x00\x00IEND\xaeB`\x82"
     )
     return base64.b64encode(png_data).decode("utf-8")
+
+
+def _make_valid_wav_base64() -> str:
+    """Create a minimal valid WAV file (4 silent 16-bit PCM samples) as base64."""
+    import struct
+
+    num_samples = 4
+    sample_rate = 16000
+    data_size = num_samples * 2
+    chunk_size = 36 + data_size
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        chunk_size,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        1,
+        sample_rate,
+        sample_rate * 2,
+        2,
+        16,
+        b"data",
+        data_size,
+    )
+    samples = b"\x00\x00" * num_samples
+    return base64.b64encode(header + samples).decode("utf-8")
 
 
 # --- Test fixtures ---
@@ -258,3 +288,91 @@ class TestServeEndpointSyncFunction:
         image_urls = received_input[0].get_image_urls()
         assert len(image_urls) == 1
         assert image_urls[0].startswith("data:image/png;base64,")
+
+
+# --- Audio unit tests ---
+
+
+class TestGetAudioBlocks:
+    """Unit tests for ChatMessage.get_audio_blocks()."""
+
+    def test_returns_empty_list_for_string_content(self):
+        """get_audio_blocks() returns [] when content is a plain string."""
+        msg = ChatMessage(role="user", content="hello")
+        assert msg.get_audio_blocks() == []
+
+    def test_returns_empty_list_for_none_content(self):
+        """get_audio_blocks() returns [] when content is None."""
+        msg = ChatMessage(role="user", content=None)
+        assert msg.get_audio_blocks() == []
+
+    def test_returns_audio_block_for_valid_wav(self):
+        """get_audio_blocks() returns an AudioBlock for a valid base64 WAV part."""
+        wav_b64 = _make_valid_wav_base64()
+        msg = ChatMessage(
+            role="user",
+            content=[
+                InputAudioContent(
+                    type="input_audio",
+                    input_audio=InputAudioData(data=wav_b64, format="wav"),
+                )
+            ],
+        )
+        blocks = msg.get_audio_blocks()
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], AudioBlock)
+        assert blocks[0].format == "wav"
+
+    def test_returns_empty_list_for_no_audio_parts(self):
+        """get_audio_blocks() returns [] when content has only text parts."""
+        msg = ChatMessage(role="user", content=[TextContent(type="text", text="hello")])
+        assert msg.get_audio_blocks() == []
+
+    def test_raises_value_error_for_invalid_base64(self):
+        """get_audio_blocks() raises ValueError for an invalid base64 payload."""
+        msg = ChatMessage(
+            role="user",
+            content=[
+                InputAudioContent(
+                    type="input_audio",
+                    input_audio=InputAudioData(
+                        data="not-valid-base64!!!", format="wav"
+                    ),
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="Invalid audio data"):
+            msg.get_audio_blocks()
+
+    def test_get_text_content_ignores_audio_parts(self):
+        """get_text_content() skips InputAudioContent items."""
+        wav_b64 = _make_valid_wav_base64()
+        msg = ChatMessage(
+            role="user",
+            content=[
+                TextContent(type="text", text="describe this"),
+                InputAudioContent(
+                    type="input_audio",
+                    input_audio=InputAudioData(data=wav_b64, format="wav"),
+                ),
+            ],
+        )
+        assert msg.get_text_content() == "describe this"
+
+    def test_deserialises_mixed_text_and_audio(self):
+        """ChatMessage deserialises a mixed list of TextContent and InputAudioContent."""
+        wav_b64 = _make_valid_wav_base64()
+        raw = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": wav_b64, "format": "wav"},
+                },
+            ],
+        }
+        msg = ChatMessage.model_validate(raw)
+        assert len(msg.content) == 2  # type: ignore[arg-type]
+        assert isinstance(msg.content[0], TextContent)  # type: ignore[index]
+        assert isinstance(msg.content[1], InputAudioContent)  # type: ignore[index]


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1395 

## Description
<!-- What does this PR do and why? -->
audio-text-to-text examples using m serve.
This shows that our OpenAI API support can handle multimodal.
The backends are limited by Mellea and by the servers and models.
For now we show 2 examples:
1 - use llama-server/gemma to demonstrate a clean openai API audio-text-to-text implementation
2 - use ollama with 2 step granite (speech for transcribe, then LLM to query w/ transcription). 
Also trying to show more Mellea ability in 2 (e.g. a requirement).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
