### PR TITLE
refactor(backends): unify mot.raw.response shape across streaming and non-streaming

### DIFF
--- a/cli/serve/utils.py
+++ b/cli/serve/utils.py
@@ -54,16 +54,12 @@ def extract_finish_reason(output: Any) -> FinishReason:
         elif provider in ("openai", "watsonx", "litellm") and isinstance(
             response, dict
         ):
-            # Chat path: full response dict, finish_reason nested under choices[0].
+            # Chat path: top-level response dict, finish_reason nested under choices[0].
             choices = response.get("choices", [])
             if choices and len(choices) > 0:
                 finish_reason = choices[0].get("finish_reason")
                 if finish_reason in valid_reasons:
                     return finish_reason
-            # Raw-completion path: single choice dict, finish_reason at top level.
-            finish_reason = response.get("finish_reason")
-            if finish_reason in valid_reasons:
-                return finish_reason
 
     # Default to "stop" per OpenAI spec
     return "stop"

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -614,9 +614,10 @@ class LiteLLMBackend(FormatterBackend):
             # Must handle ollama differently due to: https://github.com/BerriAI/litellm/issues/14579.
             # Check that we are targeting ollama with the model_id prefix litellm uses.
             separate_tools = "ollama" in self._model_id.split("/")[0]
-            mot.raw.response = chat_completion_delta_merge(
+            merged = chat_completion_delta_merge(
                 mot.raw.streamed_chunks, force_all_tool_calls_separate=separate_tools
             )
+            mot.raw.response = {"choices": [merged], "usage": mot.generation.usage}
 
         assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
@@ -625,18 +626,9 @@ class LiteLLMBackend(FormatterBackend):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
-        # OpenAI-like streamed responses potentially give you chunks of tool calls.
-        # As a result, we have to store data between calls and only then
-        # check for complete tool calls in the post_processing step.
-        # Non-streaming stores a top-level response (index into choices); streaming
-        # stores the already-merged choice dict (use directly).
         response = mot.raw.response
         assert response is not None
-        choice_response = (
-            response["choices"][0]
-            if isinstance(response, dict) and "choices" in response
-            else response
-        )
+        choice_response = response["choices"][0]
         tool_chunk = extract_model_tool_requests(tools, choice_response)
         if tool_chunk is not None:
             if mot.tool_calls is None:

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -626,6 +626,9 @@ class LiteLLMBackend(FormatterBackend):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
+        # OpenAI-like streamed responses potentially give you chunks of tool calls.
+        # As a result, we have to store data between calls and only then
+        # check for complete tool calls in the post_processing step.
         response = mot.raw.response
         assert response is not None
         choice_response = response["choices"][0]

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1120,7 +1120,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         """
         # Reconstruct the top-level response from chunks if streamed.
         if mot.raw.streamed_chunks is not None:
-            mot.raw.response = chat_completion_delta_merge(mot.raw.streamed_chunks)
+            merged = chat_completion_delta_merge(mot.raw.streamed_chunks)
+            mot.raw.response = {"choices": [merged], "usage": mot.generation.usage}
 
         assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
@@ -1129,18 +1130,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
-        # OpenAI streamed responses give you chunks of tool calls.
-        # As a result, we have to store data between calls and only then
-        # check for complete tool calls in the post_processing step.
-        # Non-streaming stores a top-level response (index into choices); streaming
-        # stores the already-merged choice dict (use directly).
         response = mot.raw.response
         assert response is not None
-        choice_response = (
-            response["choices"][0]
-            if isinstance(response, dict) and "choices" in response
-            else response
-        )
+        choice_response = response["choices"][0]
         tool_chunk = extract_model_tool_requests(tools, choice_response)
         if tool_chunk is not None:
             if mot.tool_calls is None:

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1130,6 +1130,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
+        # OpenAI streamed responses give you chunks of tool calls.
+        # As a result, we have to store data between calls and only then
+        # check for complete tool calls in the post_processing step.
         response = mot.raw.response
         assert response is not None
         choice_response = response["choices"][0]

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -601,7 +601,8 @@ class WatsonxAIBackend(FormatterBackend):
         """
         # Reconstruct the top-level response from chunks if streamed.
         if mot.raw.streamed_chunks is not None:
-            mot.raw.response = chat_completion_delta_merge(mot.raw.streamed_chunks)
+            merged = chat_completion_delta_merge(mot.raw.streamed_chunks)
+            mot.raw.response = {"choices": [merged], "usage": mot.generation.usage}
 
         assert mot._call.action is not None, (
             "ModelOutputThunks should have their action assigned during generation"
@@ -610,18 +611,9 @@ class WatsonxAIBackend(FormatterBackend):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
-        # OpenAI streamed responses give you chunks of tool calls.
-        # As a result, we have to store data between calls and only then
-        # check for complete tool calls in the post_processing step.
-        # Non-streaming stores a top-level response (index into choices); streaming
-        # stores the already-merged choice dict (use directly).
         response = mot.raw.response
         assert response is not None
-        choice_response = (
-            response["choices"][0]
-            if isinstance(response, dict) and "choices" in response
-            else response
-        )
+        choice_response = response["choices"][0]
         tool_chunk = extract_model_tool_requests(tools, choice_response)
         if tool_chunk is not None:
             if mot.tool_calls is None:

--- a/mellea/backends/watsonx.py
+++ b/mellea/backends/watsonx.py
@@ -611,6 +611,9 @@ class WatsonxAIBackend(FormatterBackend):
             "ModelOutputThunks should have their model_opts assigned during generation"
         )
 
+        # OpenAI streamed responses give you chunks of tool calls.
+        # As a result, we have to store data between calls and only then
+        # check for complete tool calls in the post_processing step.
         response = mot.raw.response
         assert response is not None
         choice_response = response["choices"][0]

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -193,7 +193,7 @@ class Message(Component["Message"]):
             if provider in ("openai", "watsonx", "litellm") and isinstance(
                 response, dict
             ):
-                choice = response["choices"][0] if "choices" in response else response
+                choice = response["choices"][0]
                 msg = choice["message"]
                 thinking = computed.thinking if msg["role"] == "assistant" else None
                 return Message(
@@ -223,14 +223,9 @@ class Message(Component["Message"]):
                 thinking=thinking,
             )
         if provider in ("openai", "watsonx", "litellm") and isinstance(response, dict):
-            choices = response.get("choices") or [{}]
-            msg = choices[0].get("message", {})
-            role = msg.get("role") or response.get("message", {}).get(
-                "role", "assistant"
-            )
-            content = msg.get("content") or response.get("message", {}).get(
-                "content", ""
-            )
+            msg = response["choices"][0].get("message", {})
+            role = msg.get("role", "assistant")
+            content = msg.get("content") or ""
             thinking = computed.thinking if role == "assistant" else None
             return Message(role=role, content=content, thinking=thinking)
 

--- a/test/backends/test_litellm_post_processing.py
+++ b/test/backends/test_litellm_post_processing.py
@@ -1,0 +1,114 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for LiteLLMBackend.post_processing — normalized response shape.
+
+Verifies that the streaming path stores a top-level envelope in mot.raw.response
+(``{"choices": [...], "usage": ...}``) identical in shape to the non-streaming path.
+No API calls are made.
+"""
+
+import pytest
+
+pytest.importorskip("litellm", reason="litellm not installed — install mellea[litellm]")
+
+from litellm import Choices, Message, ModelResponse
+
+from mellea.backends.litellm import LiteLLMBackend
+from mellea.core.base import CBlock, ModelOutputThunk
+
+
+def _make_backend() -> "LiteLLMBackend":
+    """Return a LiteLLMBackend with a fake base URL."""
+    return LiteLLMBackend(
+        model_id="hosted_vllm/qwen3", base_url="http://localhost:9997"
+    )
+
+
+def _streaming_chunks() -> list[dict]:
+    """Minimal choice-level delta chunks as stored by LiteLLMBackend.processing()."""
+    return [
+        {"delta": {"role": "assistant", "content": "hello"}, "finish_reason": None},
+        {"delta": {"content": " world"}, "finish_reason": "stop"},
+    ]
+
+
+def _non_streaming_response() -> dict:
+    """Minimal non-streaming LiteLLM response dict."""
+    msg = Message(content="hello world", role="assistant")
+    choice = Choices(finish_reason="stop", index=0, message=msg)
+    response = ModelResponse(
+        id="test",
+        choices=[choice],
+        created=0,
+        model="hosted_vllm/qwen3",
+        object="chat.completion",
+        usage={"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+    )
+    return dict(response)
+
+
+class TestPostProcessingStreamingShape:
+    @pytest.mark.asyncio
+    async def test_streaming_response_has_top_level_choices_envelope(self):
+        """Streaming path stores a top-level envelope with a 'choices' list."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+
+        await backend.post_processing(
+            mot, conversation=[], tools={}, thinking=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert "choices" in response
+        assert isinstance(response["choices"], list)
+        assert len(response["choices"]) == 1
+        assert response["choices"][0]["message"]["content"] == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_streaming_response_includes_usage(self):
+        """Streaming envelope carries usage from mot.generation.usage."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+        mot.generation.usage = {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        }
+
+        await backend.post_processing(
+            mot, conversation=[], tools={}, thinking=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert response["usage"] == {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_response_shape_unchanged(self):
+        """Non-streaming path still stores a top-level shape with 'choices' (regression guard)."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.response = _non_streaming_response()
+
+        await backend.post_processing(
+            mot, conversation=[], tools={}, thinking=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert "choices" in response
+        assert response["choices"][0]["message"]["content"] == "hello world"

--- a/test/backends/test_litellm_post_processing.py
+++ b/test/backends/test_litellm_post_processing.py
@@ -4,7 +4,7 @@
 """Unit tests for LiteLLMBackend.post_processing — normalized response shape.
 
 Verifies that the streaming path stores a top-level envelope in mot.raw.response
-(``{"choices": [...], "usage": ...}``) identical in shape to the non-streaming path.
+(`{"choices": [...], "usage": ...}`) identical in shape to the non-streaming path.
 No API calls are made.
 """
 

--- a/test/backends/test_openai_post_processing.py
+++ b/test/backends/test_openai_post_processing.py
@@ -1,0 +1,114 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OpenAIBackend.post_processing — normalized response shape.
+
+Verifies that the streaming path stores a top-level envelope in mot.raw.response
+(``{"choices": [...], "usage": ...}``) identical in shape to the non-streaming path.
+No API calls are made.
+"""
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+
+from mellea.backends.openai import OpenAIBackend
+from mellea.core.base import CBlock, ModelOutputThunk
+
+
+def _make_backend() -> OpenAIBackend:
+    """Return an OpenAIBackend with a fake API key."""
+    return OpenAIBackend(
+        model_id="gpt-4o", api_key="fake-key", base_url="http://localhost:9999/v1"
+    )
+
+
+def _streaming_chunks() -> list[dict]:
+    """Minimal choice-level delta chunks as stored by processing()."""
+    return [
+        {"delta": {"role": "assistant", "content": "hello"}, "finish_reason": None},
+        {"delta": {"content": " world"}, "finish_reason": "stop"},
+    ]
+
+
+def _non_streaming_response() -> ChatCompletion:
+    """Minimal real ChatCompletion for the non-streaming path."""
+    return ChatCompletion(
+        id="test",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hello world"),
+            )
+        ],
+        created=0,
+        model="gpt-4o",
+        object="chat.completion",
+    )
+
+
+class TestPostProcessingStreamingShape:
+    @pytest.mark.asyncio
+    async def test_streaming_response_has_top_level_choices_envelope(self):
+        """Streaming path stores a top-level envelope with a 'choices' list."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+
+        await backend.post_processing(
+            mot, tools={}, conversation=[], thinking=None, seed=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert "choices" in response
+        assert isinstance(response["choices"], list)
+        assert len(response["choices"]) == 1
+        assert response["choices"][0]["message"]["content"] == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_streaming_response_includes_usage(self):
+        """Streaming envelope carries usage from mot.generation.usage."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+        mot.generation.usage = {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }
+
+        await backend.post_processing(
+            mot, tools={}, conversation=[], thinking=None, seed=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert response["usage"] == {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_response_shape_unchanged(self):
+        """Non-streaming path still stores a top-level shape with 'choices' (regression guard)."""
+        backend = _make_backend()
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.response = _non_streaming_response().model_dump()
+
+        await backend.post_processing(
+            mot, tools={}, conversation=[], thinking=None, seed=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert "choices" in response
+        assert response["choices"][0]["message"]["content"] == "hello world"

--- a/test/backends/test_openai_post_processing.py
+++ b/test/backends/test_openai_post_processing.py
@@ -4,7 +4,7 @@
 """Unit tests for OpenAIBackend.post_processing — normalized response shape.
 
 Verifies that the streaming path stores a top-level envelope in mot.raw.response
-(``{"choices": [...], "usage": ...}``) identical in shape to the non-streaming path.
+(`{"choices": [...], "usage": ...}`) identical in shape to the non-streaming path.
 No API calls are made.
 """
 

--- a/test/backends/test_watsonx_post_processing.py
+++ b/test/backends/test_watsonx_post_processing.py
@@ -4,8 +4,8 @@
 """Unit tests for WatsonxAIBackend.post_processing — normalized response shape.
 
 Verifies that the streaming path stores a top-level envelope in mot.raw.response
-(``{"choices": [...], "usage": ...}``).  Also explicitly documents that Watsonx
-streaming usage is ``None`` (known limitation, canary test).
+(`{"choices": [...], "usage": ...}`).  Also explicitly documents that Watsonx
+streaming usage is `None` (known limitation, canary test).
 No live credentials or API calls are made.
 """
 

--- a/test/backends/test_watsonx_post_processing.py
+++ b/test/backends/test_watsonx_post_processing.py
@@ -42,9 +42,9 @@ def _make_backend(monkeypatch: pytest.MonkeyPatch) -> "WatsonxAIBackend":
 def _streaming_chunks() -> list[dict]:
     """Minimal choice-level delta chunks as stored by WatsonxAIBackend.processing().
 
-    Note: Watsonx's processing() appends ``chunk["choices"][0]`` (the choice dict),
+    Note: Watsonx's processing() appends `chunk["choices"][0]` (the choice dict),
     not the full top-level chunk, so streamed_chunks holds choice-level dicts.
-    ``chat_completion_delta_merge`` then merges these into a single choice dict.
+    `chat_completion_delta_merge` then merges these into a single choice dict.
     """
     return [
         {"delta": {"role": "assistant", "content": "hello"}, "finish_reason": None},

--- a/test/backends/test_watsonx_post_processing.py
+++ b/test/backends/test_watsonx_post_processing.py
@@ -1,0 +1,98 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for WatsonxAIBackend.post_processing — normalized response shape.
+
+Verifies that the streaming path stores a top-level envelope in mot.raw.response
+(``{"choices": [...], "usage": ...}``).  Also explicitly documents that Watsonx
+streaming usage is ``None`` (known limitation, canary test).
+No live credentials or API calls are made.
+"""
+
+import pytest
+
+pytest.importorskip(
+    "ibm_watsonx_ai", reason="ibm_watsonx_ai not installed — install mellea[watsonx]"
+)
+
+from unittest.mock import patch
+
+from mellea.backends.watsonx import WatsonxAIBackend
+from mellea.core.base import CBlock, ModelOutputThunk
+
+
+def _make_backend(monkeypatch: pytest.MonkeyPatch) -> "WatsonxAIBackend":
+    """Build a WatsonxAIBackend with SDK internals mocked out."""
+    monkeypatch.delenv("WATSONX_API_KEY", raising=False)
+    monkeypatch.delenv("WATSONX_URL", raising=False)
+    monkeypatch.delenv("WATSONX_PROJECT_ID", raising=False)
+    with (
+        patch("mellea.backends.watsonx.Credentials"),
+        patch("mellea.backends.watsonx.APIClient"),
+        patch("mellea.backends.watsonx.ModelInference"),
+    ):
+        return WatsonxAIBackend(
+            model_id="ibm/granite-4-h-small",
+            base_url="https://example.com",
+            project_id="test-project",
+            api_key="fake-key",
+        )
+
+
+def _streaming_chunks() -> list[dict]:
+    """Minimal choice-level delta chunks as stored by WatsonxAIBackend.processing().
+
+    Note: Watsonx's processing() appends ``chunk["choices"][0]`` (the choice dict),
+    not the full top-level chunk, so streamed_chunks holds choice-level dicts.
+    ``chat_completion_delta_merge`` then merges these into a single choice dict.
+    """
+    return [
+        {"delta": {"role": "assistant", "content": "hello"}, "finish_reason": None},
+        {"delta": {"content": " world"}, "finish_reason": "stop"},
+    ]
+
+
+class TestPostProcessingStreamingShape:
+    @pytest.mark.asyncio
+    async def test_streaming_response_has_top_level_choices_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Streaming path stores a top-level envelope with a 'choices' list."""
+        backend = _make_backend(monkeypatch)
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+
+        await backend.post_processing(
+            mot, conversation=[], tools={}, seed=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert "choices" in response
+        assert isinstance(response["choices"], list)
+        assert len(response["choices"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_response_usage_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Watsonx streaming drops usage — mot.raw.response['usage'] is None.
+
+        This test acts as a canary: if the behaviour changes unexpectedly, it will fail.
+        """
+        backend = _make_backend(monkeypatch)
+        mot = ModelOutputThunk(value="hello world")
+        mot._call.action = CBlock("q")
+        mot._call.model_options = {}
+        mot.raw.streamed_chunks = _streaming_chunks()
+        # generation.usage is not pre-populated for Watsonx streaming.
+
+        await backend.post_processing(
+            mot, conversation=[], tools={}, seed=None, _format=None
+        )
+
+        response = mot.raw.response
+        assert isinstance(response, dict)
+        assert response["usage"] is None

--- a/test/cli/test_serve_utils.py
+++ b/test/cli/test_serve_utils.py
@@ -239,7 +239,7 @@ class TestExtractFinishReason:
         assert extract_finish_reason(output) == "tool_calls"
 
     def test_openai_streaming_normalized_shape(self):
-        """Streaming now stores a top-level envelope; finish_reason is under choices[0]."""
+        """Streaming stores a top-level envelope; finish_reason is under choices[0]."""
         output = ModelOutputThunk("test response")
         output.raw = RawProviderResponse(
             provider="openai",

--- a/test/cli/test_serve_utils.py
+++ b/test/cli/test_serve_utils.py
@@ -206,7 +206,7 @@ class TestExtractFinishReason:
         assert extract_finish_reason(output) == "stop"
 
     def test_litellm_normalized_streaming_shape(self):
-        """Streaming now stores a top-level envelope; finish_reason is under choices[0]."""
+        """Streaming stores a top-level envelope; finish_reason is under choices[0]."""
         output = ModelOutputThunk("test response")
         output.raw = RawProviderResponse(
             provider="litellm",

--- a/test/cli/test_serve_utils.py
+++ b/test/cli/test_serve_utils.py
@@ -205,11 +205,15 @@ class TestExtractFinishReason:
         output.raw = RawProviderResponse(provider="litellm", response="not a dict")
         assert extract_finish_reason(output) == "stop"
 
-    def test_litellm_per_choice_dict_fallback(self):
-        """Test that a LiteLLM per-choice dict (no choices key) uses top-level finish_reason."""
+    def test_litellm_normalized_streaming_shape(self):
+        """Streaming now stores a top-level envelope; finish_reason is under choices[0]."""
         output = ModelOutputThunk("test response")
         output.raw = RawProviderResponse(
-            provider="litellm", response={"finish_reason": "tool_calls"}
+            provider="litellm",
+            response={
+                "choices": [{"finish_reason": "tool_calls", "index": 0}],
+                "usage": None,
+            },
         )
         assert extract_finish_reason(output) == "tool_calls"
 
@@ -233,3 +237,27 @@ class TestExtractFinishReason:
             response={"choices": [{"finish_reason": "stop", "index": 0}]},
         )
         assert extract_finish_reason(output) == "tool_calls"
+
+    def test_openai_streaming_normalized_shape(self):
+        """Streaming now stores a top-level envelope; finish_reason is under choices[0]."""
+        output = ModelOutputThunk("test response")
+        output.raw = RawProviderResponse(
+            provider="openai",
+            response={
+                "choices": [{"finish_reason": "stop", "index": 0}],
+                "usage": None,
+            },
+        )
+        assert extract_finish_reason(output) == "stop"
+
+    def test_watsonx_streaming_normalized_shape(self):
+        """Watsonx streaming stores a top-level envelope; finish_reason is under choices[0]."""
+        output = ModelOutputThunk("test response")
+        output.raw = RawProviderResponse(
+            provider="watsonx",
+            response={
+                "choices": [{"finish_reason": "stop", "index": 0}],
+                "usage": None,
+            },
+        )
+        assert extract_finish_reason(output) == "stop"

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -228,7 +228,7 @@ def test_parse_openai_chat_response():
 
 
 def test_parse_openai_streamed_choice_shape():
-    """Streaming now stores the top-level envelope (choices wrapper) same as non-streaming."""
+    """Streaming stores the merged choice dict in a top-level envelope (choices wrapper) matching non-streaming."""
     msg = Message("user", "q")
     mot = ModelOutputThunk(value="v")
     mot.raw = RawProviderResponse(

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -381,7 +381,7 @@ def test_parse_tool_calls_openai():
 
 
 def test_parse_tool_calls_openai_streamed_choice_shape():
-    """Streamed tool calls now store the top-level envelope shape, same as non-streaming.
+    """Streamed tool calls store the merged choice dict in a top-level envelope shape, matching non-streaming.
 
     Regression test: verifies that the tool branch correctly indexes `response["choices"][0]`
     on the normalized streaming shape.

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -228,14 +228,19 @@ def test_parse_openai_chat_response():
 
 
 def test_parse_openai_streamed_choice_shape():
-    """Streaming stores the merged choice dict (no top-level `choices` wrapper)."""
+    """Streaming now stores the top-level envelope (choices wrapper) same as non-streaming."""
     msg = Message("user", "q")
     mot = ModelOutputThunk(value="v")
     mot.raw = RawProviderResponse(
         provider="openai",
         response={
-            "finish_reason": "stop",
-            "message": {"role": "assistant", "content": "streamed answer"},
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "streamed answer"},
+                }
+            ],
+            "usage": None,
         },
     )
     result = msg._parse(mot)
@@ -376,10 +381,10 @@ def test_parse_tool_calls_openai():
 
 
 def test_parse_tool_calls_openai_streamed_choice_shape():
-    """Streamed tool calls store the merged choice dict, not a top-level envelope.
+    """Streamed tool calls now store the top-level envelope shape, same as non-streaming.
 
-    Regression test: the tool branch previously indexed `response["choices"][0]`
-    unconditionally and raised `KeyError` on the streaming choice-level shape.
+    Regression test: verifies that the tool branch correctly indexes `response["choices"][0]`
+    on the normalized streaming shape.
     """
     msg = Message("user", "q")
     mot = ModelOutputThunk(value="v", tool_calls={"fn": None})
@@ -393,8 +398,17 @@ def test_parse_tool_calls_openai_streamed_choice_shape():
     mot.raw = RawProviderResponse(
         provider="openai",
         response={
-            "finish_reason": "tool_calls",
-            "message": {"role": "assistant", "content": None, "tool_calls": tool_calls},
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": tool_calls,
+                    },
+                }
+            ],
+            "usage": None,
         },
     )
     result = msg._parse(mot)
@@ -417,8 +431,17 @@ def test_tool_call_message_survives_formatter_to_openai_history():
     mot.raw = RawProviderResponse(
         provider="openai",
         response={
-            "finish_reason": "tool_calls",
-            "message": {"role": "assistant", "content": None, "tool_calls": tool_calls},
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": tool_calls,
+                    },
+                }
+            ],
+            "usage": None,
         },
     )
     mot.parsed_repr = prompt._parse(mot)
@@ -498,17 +521,23 @@ def test_parse_tool_calls_openai_carries_thinking():
 
 
 def test_parse_tool_calls_openai_streamed_carries_thinking():
+    """Streaming normalized shape: thinking is carried onto the tool-issuing assistant turn."""
     msg = Message("user", "q")
     mot = ModelOutputThunk(value="v", tool_calls={"fn": None})
     mot.thinking = "tool-turn reasoning"
     mot.raw = RawProviderResponse(
         provider="openai",
         response={
-            "finish_reason": "tool_calls",
-            "message": {
-                "role": "assistant",
-                "tool_calls": [{"function": {"name": "fn"}}],
-            },
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [{"function": {"name": "fn"}}],
+                    },
+                }
+            ],
+            "usage": None,
         },
     )
     result = msg._parse(mot)
@@ -935,6 +964,60 @@ class TestMessageDocumentRendering:
         assert "What is the capital of France?" in result
         assert "[Document 7]" in result
         assert "Geography: The capital of France is Paris." in result
+
+
+def test_parse_openai_streaming_normalized_shape():
+    """Streaming normalized shape: _parse extracts role+content from top-level envelope."""
+    msg = Message("user", "q")
+    mot = ModelOutputThunk(value="v")
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "streamed answer"},
+                }
+            ],
+            "usage": None,
+        },
+    )
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.content == "streamed answer"
+
+
+def test_parse_tool_calls_openai_streaming_normalized_shape():
+    """Streaming normalized shape: _parse extracts tool calls from top-level envelope."""
+    msg = Message("user", "q")
+    tool_calls = [
+        {
+            "id": "call_norm",
+            "type": "function",
+            "function": {"name": "fn", "arguments": "{}"},
+        }
+    ]
+    mot = ModelOutputThunk(value="v", tool_calls={"fn": None})
+    mot.raw = RawProviderResponse(
+        provider="openai",
+        response={
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": tool_calls,
+                    },
+                }
+            ],
+            "usage": None,
+        },
+    )
+    result = msg._parse(mot)
+    assert result.role == "assistant"
+    assert result.content == ""
+    assert result.tool_calls == tool_calls
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1330 

## Description
Streaming responses from the OpenAI, Watsonx, and LiteLLM backends previously stored a bare choice-level dict in mot.raw.response ({"message": …, "finish_reason": …}), while non-streaming stored a full top-level envelope ({"choices": […], "usage": …}).  Every consumer had to branch on "choices" in response to handle both shapes.

Wrap the chat_completion_delta_merge() result in a top-level envelope in post_processing() for all three backends:

    merged = chat_completion_delta_merge(mot.raw.streamed_chunks)
    mot.raw.response = {"choices": [merged], "usage": mot.generation.usage}

This makes mot.raw.response always carry the top-level shape, on both the streaming and non-streaming paths.

Consumer simplifications:
- cli/serve/utils.py extract_finish_reason: remove the top-level finish_reason fallback; read choices[0].finish_reason unconditionally.
- mellea/stdlib/components/chat.py _parse tool-call branch: replace the "choices" in response guard with a direct choices[0] index.
- mellea/stdlib/components/chat.py _parse non-tool branch: replace the dual-fallback (response.get("choices") or [{}] + response.get("message")) with response["choices"][0].get("message", {}).

Tests:
- Update test_parse_openai_streamed_choice_shape, test_parse_tool_calls_openai_streamed_choice_shape, test_parse_tool_calls_openai_streamed_carries_thinking, and test_tool_call_message_survives_formatter_to_openai_history to use the new top-level envelope shape.
- Replace test_litellm_per_choice_dict_fallback with test_litellm_normalized_streaming_shape.
- Add test_openai_streaming_normalized_shape and test_watsonx_streaming_normalized_shape to test_serve_utils.py.
- Add test_parse_openai_streaming_normalized_shape and test_parse_tool_calls_openai_streaming_normalized_shape to test_chat.py.
- Add test/backends/test_openai_post_processing.py, test_watsonx_post_processing.py, and test_litellm_post_processing.py with post_processing shape assertions and usage/canary tests.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
