### PR TITLE
test: honor capability overrides during example collection

### DIFF
--- a/docs/examples/conftest.py
+++ b/docs/examples/conftest.py
@@ -88,8 +88,13 @@ def _extract_markers_from_file(file_path):
     return []
 
 
-def _should_skip_collection(markers):
+def _should_skip_collection(markers, config=None):
     """Check if example should be skipped during collection based on markers.
+
+    Args:
+        markers (list[str]): Markers extracted from the example's `# pytest:` line.
+        config (pytest.Config | None): Active config, used to honour capability-check
+            overrides. When omitted, capability gating applies as before.
 
     Returns (should_skip, reason) tuple.
     """
@@ -100,11 +105,30 @@ def _should_skip_collection(markers):
     if "skip_always" in markers:
         return True, "Example marked to always skip (skip_always marker)"
 
-    try:
-        capabilities = get_system_capabilities()
-    except Exception:
-        # If we can't get capabilities, don't skip (fail open)
-        return False, None
+    ignore_all = config is not None and config.getoption(
+        "--ignore-all-checks", default=False
+    )
+    ignore_gpu = ignore_all or (
+        config is not None
+        and (
+            config.getoption("--ignore-gpu-check", default=False)
+            or config.getoption("skip_resource_checks", default=False)
+        )
+    )
+    ignore_ollama = ignore_all or (
+        config is not None and config.getoption("--ignore-ollama-check", default=False)
+    )
+    ignore_api_key = ignore_all or (
+        config is not None and config.getoption("--ignore-api-key-check", default=False)
+    )
+
+    capabilities = None
+    if not ignore_all:
+        try:
+            capabilities = get_system_capabilities()
+        except Exception:
+            # If we can't get capabilities, don't skip (fail open)
+            return False, None
 
     gh_run = int(os.environ.get("CICD", 0))
 
@@ -120,21 +144,28 @@ def _should_skip_collection(markers):
     if "slow" in markers and int(os.environ.get("SKIP_SLOW", 0)) == 1:
         return True, "Skipping slow test (SKIP_SLOW=1)"
 
+    # The runtime gate treats `--ignore-all-checks` as a capability-check bypass,
+    # not as permission to override explicit or environment-driven skip markers.
+    if ignore_all:
+        return False, None
+
+    assert capabilities is not None
+
     # Skip tests requiring GPU if not available
-    if "huggingface" in markers or "vllm" in markers:
+    if ("huggingface" in markers or "vllm" in markers) and not ignore_gpu:
         if not capabilities["has_gpu"]:
             return True, "GPU not available"
 
     # Skip tests requiring Ollama if not available
-    if "ollama" in markers:
+    if "ollama" in markers and not ignore_ollama:
         if not capabilities["has_ollama"]:
             return True, "Ollama not available (port 11434 not listening)"
 
     # Skip tests requiring API keys
-    if "watsonx" in markers:
+    if "watsonx" in markers and not ignore_api_key:
         if not capabilities["has_api_keys"].get("watsonx"):
             return True, "Watsonx API credentials not found"
-    if "openai" in markers:
+    if "openai" in markers and not ignore_api_key:
         if not capabilities["has_api_keys"].get("openai"):
             return True, "OpenAI API key not found"
 
@@ -319,10 +350,7 @@ def pytest_pycollect_makemodule(module_path, parent):
     if file_path.name == "conftest.py":
         return None
 
-    # Initialize capabilities cache if needed
     config = parent.config
-    if not hasattr(config, "_example_capabilities"):
-        config._example_capabilities = get_system_capabilities()
 
     # Check manual skip list
     if str(file_path) in examples_to_skip:
@@ -334,7 +362,7 @@ def pytest_pycollect_makemodule(module_path, parent):
     if not markers:
         return SkippedFile.from_parent(parent, path=file_path)
 
-    should_skip, _reason = _should_skip_collection(markers)
+    should_skip, _reason = _should_skip_collection(markers, config)
 
     if should_skip:
         # Prevent import by returning custom collector
@@ -380,7 +408,7 @@ def pytest_ignore_collect(collection_path, config):
             # No markers → not a runnable example (e.g. __init__.py, helpers)
             if not markers:
                 return True
-            should_skip, reason = _should_skip_collection(markers)
+            should_skip, reason = _should_skip_collection(markers, config)
             if should_skip and reason:
                 # Add to skip list with reason for terminal summary
                 examples_to_skip[str(collection_path)] = reason
@@ -420,7 +448,7 @@ def pytest_collect_file(parent: pytest.Dir, file_path: pathlib.PosixPath):
         markers = _extract_markers_from_file(file_path)
         if not markers:
             return None
-        should_skip, _reason = _should_skip_collection(markers)
+        should_skip, _reason = _should_skip_collection(markers, parent.config)
         if should_skip:
             return SkippedFile.from_parent(parent, path=file_path)
 

--- a/test/test_example_collection.py
+++ b/test/test_example_collection.py
@@ -125,13 +125,19 @@ def test_ignore_all_checks_applies_to_direct_example():
 
 def test_ignore_all_avoids_detection_in_direct_hook(monkeypatch):
     """Verify the direct-file hook does not probe capabilities under the aggregate flag."""
+    capability_probes = []
 
-    def fail_capability_detection():
-        raise RuntimeError("capability detection should be bypassed")
+    def record_capability_detection():
+        capability_probes.append(True)
+        return {
+            "has_gpu": True,
+            "has_ollama": True,
+            "has_api_keys": {"watsonx": "set", "openai": "set"},
+        }
 
     expected = object()
     monkeypatch.setattr(
-        example_conftest, "get_system_capabilities", fail_capability_detection
+        example_conftest, "get_system_capabilities", record_capability_detection
     )
     monkeypatch.setattr(
         example_conftest.ExampleModule, "from_parent", lambda *args, **kwargs: expected
@@ -146,6 +152,40 @@ def test_ignore_all_avoids_detection_in_direct_hook(monkeypatch):
         )
         is expected
     )
+    assert capability_probes == []
+
+
+def test_direct_hook_applies_capability_gate(monkeypatch):
+    """Verify the direct-file hook probes and skips without an override."""
+    capability_probes = []
+
+    def record_capability_detection():
+        capability_probes.append(True)
+        return {"has_gpu": False, "has_ollama": False, "has_api_keys": {}}
+
+    expected = object()
+    monkeypatch.setattr(
+        example_conftest, "get_system_capabilities", record_capability_detection
+    )
+    monkeypatch.setattr(
+        example_conftest.SkippedFile, "from_parent", lambda *args, **kwargs: expected
+    )
+    monkeypatch.setattr(
+        example_conftest.ExampleModule,
+        "from_parent",
+        lambda *args, **kwargs: pytest.fail("capability-gated example was collected"),
+    )
+
+    class DirectParent:
+        config = _Config()
+
+    assert (
+        example_conftest.pytest_pycollect_makemodule(
+            REPO_ROOT / DIRECT_EXAMPLE, DirectParent()
+        )
+        is expected
+    )
+    assert capability_probes == [True]
 
 
 def test_collection_capability_gates(monkeypatch):
@@ -180,37 +220,67 @@ def test_collection_capability_gates(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("option", "markers"),
+    ("option", "markers", "still_gated"),
     [
-        ("--ignore-gpu-check", ["huggingface"]),
-        ("skip_resource_checks", ["vllm"]),
-        ("--ignore-ollama-check", ["ollama"]),
-        ("--ignore-api-key-check", ["watsonx"]),
-        ("--ignore-api-key-check", ["openai"]),
+        (
+            "--ignore-gpu-check",
+            ["huggingface"],
+            ((["ollama"], "Ollama"), (["watsonx"], "Watsonx")),
+        ),
+        (
+            "skip_resource_checks",
+            ["vllm"],
+            ((["ollama"], "Ollama"), (["openai"], "OpenAI")),
+        ),
+        (
+            "--ignore-ollama-check",
+            ["ollama"],
+            ((["huggingface"], "GPU"), (["watsonx"], "Watsonx")),
+        ),
+        (
+            "--ignore-api-key-check",
+            ["watsonx"],
+            ((["huggingface"], "GPU"), (["ollama"], "Ollama")),
+        ),
+        (
+            "--ignore-api-key-check",
+            ["openai"],
+            ((["vllm"], "GPU"), (["ollama"], "Ollama")),
+        ),
     ],
 )
-def test_collection_capability_overrides(option, markers, monkeypatch):
-    """Verify individual runtime overrides also apply during collection."""
+def test_collection_capability_overrides(option, markers, still_gated, monkeypatch):
+    """Verify individual runtime overrides apply only to their capability gate."""
     monkeypatch.setattr(
         example_conftest,
         "get_system_capabilities",
         lambda: {"has_gpu": False, "has_ollama": False, "has_api_keys": {}},
     )
+    config = _Config(option)
 
-    assert example_conftest._should_skip_collection(markers, _Config(option)) == (
-        False,
-        None,
-    )
+    assert example_conftest._should_skip_collection(markers, config) == (False, None)
+    for gated_markers, reason_fragment in still_gated:
+        should_skip, reason = example_conftest._should_skip_collection(
+            gated_markers, config
+        )
+        assert should_skip
+        assert reason_fragment in reason
 
 
 def test_ignore_all_preserves_non_capability_gates(monkeypatch):
     """Verify the aggregate override avoids detection but preserves explicit gates."""
+    capability_probes = []
 
-    def fail_capability_detection():
-        raise AssertionError("capability detection should be bypassed")
+    def record_capability_detection():
+        capability_probes.append(True)
+        return {
+            "has_gpu": True,
+            "has_ollama": True,
+            "has_api_keys": {"watsonx": "set", "openai": "set"},
+        }
 
     monkeypatch.setattr(
-        example_conftest, "get_system_capabilities", fail_capability_detection
+        example_conftest, "get_system_capabilities", record_capability_detection
     )
     monkeypatch.setenv("CICD", "1")
     monkeypatch.setenv("SKIP_SLOW", "1")
@@ -221,3 +291,4 @@ def test_ignore_all_preserves_non_capability_gates(monkeypatch):
         should_skip, reason = example_conftest._should_skip_collection(markers, config)
         assert should_skip
         assert reason
+    assert capability_probes == []

--- a/test/test_example_collection.py
+++ b/test/test_example_collection.py
@@ -9,21 +9,87 @@ These hooks have regressed twice (#794, #796). This test ensures:
 - No example is collected twice (duplicate guard)
 """
 
+import importlib.util
+import pathlib
 import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+EXAMPLE_CONFTEST_PATH = REPO_ROOT / "docs" / "examples" / "conftest.py"
+# Keep this fixture capability-gated but free of skip, slow, and qualitative gates.
+DIRECT_EXAMPLE = "docs/examples/tutorial/simple_email.py"
+DIRECT_NODEID = f"{DIRECT_EXAMPLE}::simple_email.py"
+
+
+def _load_example_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "example_collection_conftest", EXAMPLE_CONFTEST_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+example_conftest = _load_example_conftest()
+
+
+class _Config:
+    def __init__(self, *enabled: str):
+        self.enabled = set(enabled)
+
+    def getoption(self, name: str, default: bool = False) -> bool:
+        return True if name in self.enabled else default
+
+
+def _collect_example_nodeids(
+    *paths: str, capability_options: tuple[str, ...] = ("--ignore-all-checks",)
+) -> list[str]:
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "pytest",
+            *paths,
+            "--collect-only",
+            "-q",
+            # This subprocess only discovers tests; nested coverage reports add
+            # noise and can overwrite the parent run's outputs.
+            "--no-cov",
+            # Collection is otherwise narrowed by whatever this host provides
+            # (Ollama, GPU, credentials), which would make the floor below a
+            # property of the machine rather than of the hooks (#1346).
+            *capability_options,
+            # Pin the rootdir so node IDs stay repo-relative even when an
+            # outer run exports PYTEST_ADDOPTS with its own --rootdir.
+            "--rootdir=.",
+            # vLLM examples are currently also skip-marked, so this is
+            # defensive: if that changes, `pytest_collection_finish` can execute
+            # multiple vLLM examples even under `--collect-only`. An explicit
+            # `-m` replaces the configured `not slow`, so preserve that too.
+            "-m",
+            "not slow and not vllm",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0, (
+        f"example collection failed (exit {result.returncode}):\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+
+    return [line for line in result.stdout.splitlines() if "::" in line]
 
 
 def test_example_collection_sanity():
     """Verify example collection excludes support files and avoids duplicates."""
-    result = subprocess.run(
-        ["uv", "run", "pytest", "docs/examples/", "--collect-only", "-q"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    lines = result.stdout.splitlines()
-    # Collected test IDs are lines before the blank/summary lines
-    collected = [line for line in lines if "::" in line]
+    collected = _collect_example_nodeids("docs/examples/")
 
     # Support files must never appear as collected tests
     for item in collected:
@@ -43,3 +109,115 @@ def test_example_collection_sanity():
     for item in collected:
         assert item not in seen, f"Duplicate collection detected: {item}"
         seen.add(item)
+
+
+def test_ignore_all_checks_applies_to_direct_example():
+    """Verify directly specified examples receive config through the module hook."""
+    expected = [DIRECT_NODEID]
+    assert _collect_example_nodeids(DIRECT_EXAMPLE) == expected
+    assert (
+        _collect_example_nodeids(
+            DIRECT_EXAMPLE, capability_options=("--ignore-ollama-check",)
+        )
+        == expected
+    )
+
+
+def test_ignore_all_avoids_detection_in_direct_hook(monkeypatch):
+    """Verify the direct-file hook does not probe capabilities under the aggregate flag."""
+
+    def fail_capability_detection():
+        raise RuntimeError("capability detection should be bypassed")
+
+    expected = object()
+    monkeypatch.setattr(
+        example_conftest, "get_system_capabilities", fail_capability_detection
+    )
+    monkeypatch.setattr(
+        example_conftest.ExampleModule, "from_parent", lambda *args, **kwargs: expected
+    )
+
+    class DirectParent:
+        config = _Config("--ignore-all-checks")
+
+    assert (
+        example_conftest.pytest_pycollect_makemodule(
+            REPO_ROOT / DIRECT_EXAMPLE, DirectParent()
+        )
+        is expected
+    )
+
+
+def test_collection_capability_gates(monkeypatch):
+    """Verify capability gates distinguish available from unavailable hosts."""
+    capabilities = {
+        "has_gpu": True,
+        "has_ollama": True,
+        "has_api_keys": {"watsonx": "set", "openai": "set"},
+    }
+    monkeypatch.setattr(
+        example_conftest, "get_system_capabilities", lambda: capabilities
+    )
+    config = _Config()
+
+    for markers in (["huggingface"], ["vllm"], ["ollama"], ["watsonx"], ["openai"]):
+        assert example_conftest._should_skip_collection(markers, config) == (
+            False,
+            None,
+        )
+
+    capabilities.update(has_gpu=False, has_ollama=False, has_api_keys={})
+    for markers, reason_fragment in (
+        (["huggingface"], "GPU"),
+        (["vllm"], "GPU"),
+        (["ollama"], "Ollama"),
+        (["watsonx"], "Watsonx"),
+        (["openai"], "OpenAI"),
+    ):
+        should_skip, reason = example_conftest._should_skip_collection(markers, config)
+        assert should_skip
+        assert reason_fragment in reason
+
+
+@pytest.mark.parametrize(
+    ("option", "markers"),
+    [
+        ("--ignore-gpu-check", ["huggingface"]),
+        ("skip_resource_checks", ["vllm"]),
+        ("--ignore-ollama-check", ["ollama"]),
+        ("--ignore-api-key-check", ["watsonx"]),
+        ("--ignore-api-key-check", ["openai"]),
+    ],
+)
+def test_collection_capability_overrides(option, markers, monkeypatch):
+    """Verify individual runtime overrides also apply during collection."""
+    monkeypatch.setattr(
+        example_conftest,
+        "get_system_capabilities",
+        lambda: {"has_gpu": False, "has_ollama": False, "has_api_keys": {}},
+    )
+
+    assert example_conftest._should_skip_collection(markers, _Config(option)) == (
+        False,
+        None,
+    )
+
+
+def test_ignore_all_preserves_non_capability_gates(monkeypatch):
+    """Verify the aggregate override avoids detection but preserves explicit gates."""
+
+    def fail_capability_detection():
+        raise AssertionError("capability detection should be bypassed")
+
+    monkeypatch.setattr(
+        example_conftest, "get_system_capabilities", fail_capability_detection
+    )
+    monkeypatch.setenv("CICD", "1")
+    monkeypatch.setenv("SKIP_SLOW", "1")
+    config = _Config("--ignore-all-checks")
+
+    assert example_conftest._should_skip_collection(["ollama"], config) == (False, None)
+    for markers in (["skip_always"], ["qualitative"], ["skip"], ["slow"]):
+        should_skip, reason = example_conftest._should_skip_collection(markers, config)
+        assert should_skip
+        assert reason


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1346.

## Description

`test_example_collection_sanity` is intended to detect regressions that silently prevent most
examples from being collected. On `main` at `8774ad5`, however, the test collects only 7 examples
on a machine without Ollama, a GPU, or API credentials and fails its floor of 50. The result is
therefore a property of the host rather than only of the collection hooks.

This change keeps the existing floor, support-file checks, and duplicate guard while making the
sanity probe capability-independent:

- all three example collection hooks pass their active pytest config to
  `_should_skip_collection`;
- collection honours the existing aggregate and individual GPU, Ollama, API-key, and resource
  overrides;
- `skip_always`, explicit `skip`, qualitative-in-CI, and `SKIP_SLOW` remain authoritative;
- the sanity subprocess runs from the repository root with capability checks disabled, the
  repository's `not slow` selection preserved, vLLM excluded defensively, nested coverage
  disabled, and non-zero collection exits rejected;
- a write-only direct-file capability probe is removed, making that path use the helper's existing
  fail-open behaviour as well;
- deterministic tests cover available and unavailable capability gates, while direct subprocess
  tests cover module-hook wiring, exact nodeids, duplicate collection, and real CLI option
  registration.

The vLLM exclusion currently deselects no additional item because all vLLM examples are also
explicitly `skip`-marked. It prevents a future unskipped vLLM example from reaching
`pytest_collection_finish`, which can launch multiple files even during `--collect-only`.

Default collection without an override is unchanged. An explicit override may allow an example to
run far enough to fail when the bypassed service, hardware, or credential is genuinely absent;
that is the documented purpose of these options.

Observed collection counts in the no-service test environment:

```text
default                  7
--ignore-ollama-check   62
--ignore-gpu-check      20
--skip-resource-checks  20
--ignore-api-key-check   7
--ignore-all-checks     75
```

Sibling #1345 was reported in the same two-failure baseline, but it concerns a different test and
root cause. It remains separate, so this PR does not claim that the reporter's complete baseline
becomes green.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Additional local validation:

- focused regression file: 11 passed;
- the same tests with inherited `PYTEST_ADDOPTS="--rootdir=C:/w -m unit"`: 11 passed;
- default collection nodeids are byte-identical to the audited base;
- 14 targeted mutations covering capability gates, option registration, all three hook paths,
  support-file leakage, duplicate collection, and large collection loss were killed after their
  intermediate states were confirmed;
- Ruff format and lint, targeted mypy (including `possibly-undefined`), SPDX, and
  `git diff --check` pass.

The full Linux pre-commit and unit matrix could not be run on the Windows review host and remains
for repository CI.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
