### PR TITLE
fix: port analytics review improvements from website PR

### DIFF
--- a/docs/static/analytics.js
+++ b/docs/static/analytics.js
@@ -1,9 +1,9 @@
 // IBM Analytics — loaded via scripts: in docusaurus.config.ts
 
 (function() {
-  // Only run in production or when explicitly enabled
-  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-    console.log('IBM Analytics disabled in development');
+  // Only run on the production site
+  if (window.location.hostname !== 'docs.mellea.ai') {
+    console.log('IBM Analytics disabled outside production');
     return;
   }
 
@@ -36,16 +36,18 @@
   var script = document.createElement('script');
   script.src = 'https://1.www.s81c.com/common/stats/ibm-common.js';
   script.type = 'text/javascript';
-  script.defer = true;
   document.head.appendChild(script);
 
   function trackPageview() {
-    // Wait for IBM Analytics to load, then track pageview
-    setTimeout(function() {
+    // Wait for IBM Analytics to load, then track pageview (poll up to ~2s)
+    var attempts = 0;
+    (function attempt() {
       if (window.ibmStats && typeof window.ibmStats.pageview === 'function') {
         window.ibmStats.pageview();
+      } else if (attempts++ < 20) {
+        setTimeout(attempt, 100);
       }
-    }, 100);
+    })();
   }
 
   // Track initial page load
@@ -55,9 +57,19 @@
     trackPageview();
   }
 
-  if(window.navigation) {
-    window.navigation.addEventListener("navigate", trackPageview)
+  function emitOnHistoryChange(type) {
+    var orig = history[type];
+    history[type] = function() {
+      var ret = orig.apply(this, arguments);
+      trackPageview();
+      return ret;
+    };
+  }
+  if (window.navigation) {
+    window.navigation.addEventListener("navigate", trackPageview);
   } else {
+    emitOnHistoryChange('pushState');
+    emitOnHistoryChange('replaceState');
     window.addEventListener('popstate', trackPageview);
   }
 })();

--- a/docs/static/analytics.js
+++ b/docs/static/analytics.js
@@ -9,15 +9,15 @@
 
   // Set up IBM Analytics configuration
   window.idaPageIsSPA = true;
-  
+
   // Configure digital data
   window.digitalData = {
     page: {
-      category: { 
+      category: {
         primaryCategory: 'PC340'
       },
-      pageInfo: { 
-        ibm: { 
+      pageInfo: {
+        ibm: {
           siteId: 'granite-developer-enablement'
         }
       }
@@ -26,7 +26,7 @@
 
   // Configure IBM Analytics settings
   window._ibmAnalytics = {
-    settings: { 
+    settings: {
       name: 'granite-developer-enablement',
       isSpa: true
     }
@@ -38,10 +38,15 @@
   script.type = 'text/javascript';
   document.head.appendChild(script);
 
+  // Cancellation token: a newer navigation supersedes any in-flight poll so
+  // rapid navigations before ibmStats loads don't each fire a pageview.
+  var currentPollId = 0;
   function trackPageview() {
+    var myId = ++currentPollId;
     // Wait for IBM Analytics to load, then track pageview (poll up to ~2s)
     var attempts = 0;
     (function attempt() {
+      if (myId !== currentPollId) return; // superseded by a newer navigation
       if (window.ibmStats && typeof window.ibmStats.pageview === 'function') {
         window.ibmStats.pageview();
       } else if (attempts++ < 20) {
@@ -58,15 +63,22 @@
   }
 
   function emitOnHistoryChange(type) {
+    if (history[type].__analyticsPatched) return; // don't double-wrap if included twice
     var orig = history[type];
     history[type] = function() {
       var ret = orig.apply(this, arguments);
       trackPageview();
       return ret;
     };
+    history[type].__analyticsPatched = true;
   }
   if (window.navigation) {
-    window.navigation.addEventListener("navigate", trackPageview);
+    // Skip in-page #anchor jumps; only track real path/query changes.
+    window.navigation.addEventListener("navigate", function(event) {
+      var to = new URL(event.destination.url);
+      if (to.pathname === location.pathname && to.search === location.search) return;
+      trackPageview();
+    });
   } else {
     emitOnHistoryChange('pushState');
     emitOnHistoryChange('replaceState');


### PR DESCRIPTION
## Issue
Fixes #

## Description
The website analytics script ([mellea-website#72](https://github.com/generative-computing/mellea-website/pull/72)) was forked from this repo's docs analytics script, then refined during review. This ports those improvements back:

- **Restrict to production host** — analytics now runs only on `docs.mellea.ai`. Previously it ran everywhere except `localhost`/`127.0.0.1`, so the `planetf1.github.io` fork/preview build reported to the prod `siteId`.
- **Poll for `ibmStats`** instead of a single 100ms wait, so the initial pageview isn't dropped on a cold cache.
- **Track `pushState`/`replaceState` navigations** so non-Chromium browsers (Firefox/Safari, which lack the Navigation API) record in-app page views, not just the entry page. Docusaurus is a client-side SPA, so this was previously losing nearly all navigation events on those browsers.
- **Remove dead `script.defer`** on the dynamically injected script tag (no effect on injected scripts).

The website PR's basePath fix does not apply here — the config already loads the script via `${BASE_URL}analytics.js`.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Client-side analytics script; no automated test coverage. Verified the host gate, `ibmStats` poll, and history-patching logic by inspection against the reviewed website script.

### Attribution
- [x] AI coding assistants used

---

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
