### PR TITLE
refactor: enforce act/aact without strategy

### DIFF
--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -632,11 +632,18 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
                 "calling a generative stub with precondition requirements but no args to validate the preconditions against; ignoring precondition validation"
             )
 
+        # The stub renders its own requirements into the prompt regardless of
+        # strategy, so only forward them to act when a strategy will validate
+        # them. Passing them without a strategy would raise (see mfuncs.aact).
+        forwarded_requirements = (
+            stub_copy.requirements if extracted.strategy is not None else None
+        )
+
         response, context = None, None
         if extracted.m is not None:
             response = extracted.m.act(
                 stub_copy,
-                requirements=stub_copy.requirements,
+                requirements=forwarded_requirements,
                 strategy=extracted.strategy,
                 format=self._response_model,
                 model_options=extracted.model_options,
@@ -649,7 +656,7 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
                 stub_copy,
                 extracted.context,
                 extracted.backend,
-                requirements=stub_copy.requirements,
+                requirements=forwarded_requirements,
                 strategy=extracted.strategy,
                 format=self._response_model,
                 model_options=extracted.model_options,
@@ -771,10 +778,17 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
                     "calling a generative stub with precondition requirements but no args to validate the preconditions against; ignoring precondition validation"
                 )
 
+            # The stub renders its own requirements into the prompt regardless of
+            # strategy, so only forward them to aact when a strategy will validate
+            # them. Passing them without a strategy would raise (see mfuncs.aact).
+            forwarded_requirements = (
+                stub_copy.requirements if extracted.strategy is not None else None
+            )
+
             if extracted.m is not None:
                 response = await extracted.m.aact(
                     stub_copy,
-                    requirements=stub_copy.requirements,
+                    requirements=forwarded_requirements,
                     strategy=extracted.strategy,
                     format=self._response_model,
                     model_options=extracted.model_options,
@@ -788,7 +802,7 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
                     stub_copy,
                     extracted.context,
                     extracted.backend,
-                    requirements=stub_copy.requirements,
+                    requirements=forwarded_requirements,
                     strategy=extracted.strategy,
                     format=self._response_model,
                     model_options=extracted.model_options,

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -56,6 +56,42 @@ from .context import SimpleContext
 from .sampling import RejectionSamplingStrategy
 
 
+def _requirements_rendered_by_action(
+    action: Component | CBlock | ModelOutputThunk,
+) -> set[int]:
+    """Collect the ids of `Requirement` objects the action renders into its prompt.
+
+    Components such as `Instruction` and `GenerativeStub` attach requirements to
+    themselves — they appear in `parts()` and are rendered into the prompt
+    independently of any sampling strategy. This walks the component tree and
+    returns the identities of every attached `Requirement` so callers can tell
+    those apart from requirements that only a strategy would validate.
+
+    Args:
+        action: the action being generated from.
+
+    Returns:
+        A set of `id()` values for every `Requirement` reachable through the
+        action's `parts()`.
+    """
+    rendered: set[int] = set()
+    if not isinstance(action, Component):
+        return rendered
+
+    stack: list[Component | CBlock | ModelOutputThunk] = list(action.parts())
+    seen: set[int] = set()
+    while stack:
+        part = stack.pop()
+        if id(part) in seen:
+            continue
+        seen.add(id(part))
+        if isinstance(part, Requirement):
+            rendered.add(id(part))
+        if isinstance(part, Component):
+            stack.extend(part.parts())
+    return rendered
+
+
 @overload
 def act(
     action: Component[S] | CBlock | ModelOutputThunk,
@@ -104,8 +140,8 @@ def act(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — no validate/repair loop runs and any `requirements` go unchecked (a warning is logged). Required when `return_sampling_results=True`.
+        requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — no validate/repair loop runs and `requirements` are not validated (see above). Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a
@@ -115,7 +151,7 @@ def act(
         tool_calls: if true, tool calling is enabled.
 
     Raises:
-        ValueError: if `return_sampling_results=True` without a `strategy`.
+        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
 
     Returns:
         A (ComputedModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -596,8 +632,8 @@ async def aact(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
-        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
+        requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+        strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs, `requirements` are not validated (see above), and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
             schema. The result's `.value` is always a JSON string — not a
@@ -609,7 +645,7 @@ async def aact(
         await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. If True or strategy is not None, awaits and returns ComputedModelOutputThunk. Default is False.
 
     Raises:
-        ValueError: if `return_sampling_results=True` without a `strategy`.
+        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
 
     Returns:
         A (ModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -663,17 +699,23 @@ async def aact(
             )
 
         if strategy is None:
-            # No strategy means no validate/repair loop, so any `requirements`
-            # passed here are not checked. Warn rather than raise: some callers
-            # (e.g. generative stubs) attach requirements to the component itself
-            # and render them into the prompt independently of a strategy. A
-            # follow-up issue tracks a proper enforcement design for that case.
-            if requirements is not None and len(requirements) > 0:
-                MelleaLogger.get_logger().warning(
-                    "Requirements were provided without a SamplingStrategy. "
-                    "Requirements are only checked by a strategy; pass a "
-                    "`strategy` (e.g. RejectionSamplingStrategy) to validate them."
-                )
+            # No strategy means no validate/repair loop, so `requirements` are
+            # not validated. Requirements the action renders into its prompt
+            # (e.g. those attached to an Instruction or generative stub) are
+            # exempt — they still shape generation. Any requirement that is only
+            # passed here, and not rendered by the action, would be silently
+            # dropped, so raise instead of failing quietly.
+            if requirements:
+                rendered = _requirements_rendered_by_action(action)
+                unvalidated = [r for r in requirements if id(r) not in rendered]
+                if unvalidated:
+                    raise ValueError(
+                        "Requirements were provided without a SamplingStrategy and "
+                        "are not rendered by the action, so they cannot be validated: "
+                        f"{[r.description for r in unvalidated]}. Pass a `strategy` "
+                        "(e.g. RejectionSamplingStrategy) to validate them, or attach "
+                        "them to the action so it renders them into the prompt."
+                    )
 
             result, new_ctx = await backend.generate_from_context(
                 action,

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -699,12 +699,9 @@ async def aact(
             )
 
         if strategy is None:
-            # No strategy means no validate/repair loop, so `requirements` are
-            # not validated. Requirements the action renders into its prompt
-            # (e.g. those attached to an Instruction or generative stub) are
-            # exempt — they still shape generation. Any requirement that is only
-            # passed here, and not rendered by the action, would be silently
-            # dropped, so raise instead of failing quietly.
+            # No strategy means no validate/repair loop. Requirements the action
+            # renders into its prompt still shape generation, but any passed only
+            # here would be silently dropped — so raise instead (see message below).
             if requirements:
                 rendered = _requirements_rendered_by_action(action)
                 unvalidated = [r for r in requirements if id(r) not in rendered]

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -56,42 +56,6 @@ from .context import SimpleContext
 from .sampling import RejectionSamplingStrategy
 
 
-def _requirements_rendered_by_action(
-    action: Component | CBlock | ModelOutputThunk,
-) -> set[int]:
-    """Collect the ids of `Requirement` objects the action renders into its prompt.
-
-    Components such as `Instruction` and `GenerativeStub` attach requirements to
-    themselves — they appear in `parts()` and are rendered into the prompt
-    independently of any sampling strategy. This walks the component tree and
-    returns the identities of every attached `Requirement` so callers can tell
-    those apart from requirements that only a strategy would validate.
-
-    Args:
-        action: the action being generated from.
-
-    Returns:
-        A set of `id()` values for every `Requirement` reachable through the
-        action's `parts()`.
-    """
-    rendered: set[int] = set()
-    if not isinstance(action, Component):
-        return rendered
-
-    stack: list[Component | CBlock | ModelOutputThunk] = list(action.parts())
-    seen: set[int] = set()
-    while stack:
-        part = stack.pop()
-        if id(part) in seen:
-            continue
-        seen.add(id(part))
-        if isinstance(part, Requirement):
-            rendered.add(id(part))
-        if isinstance(part, Component):
-            stack.extend(part.parts())
-    return rendered
-
-
 @overload
 def act(
     action: Component[S] | CBlock | ModelOutputThunk,
@@ -140,7 +104,7 @@ def act(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+        requirements: requirements validated by the sampling strategy. These are only used when a `strategy` is provided; passing them without a `strategy` cannot validate them and raises `ValueError`. (Requirements a component renders into its own prompt — e.g. those attached to an `Instruction` — still shape generation regardless, and are passed via the action, not this parameter.)
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — no validate/repair loop runs and `requirements` are not validated (see above). Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
@@ -151,7 +115,7 @@ def act(
         tool_calls: if true, tool calling is enabled.
 
     Raises:
-        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
+        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` are provided without a `strategy` to validate them.
 
     Returns:
         A (ComputedModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -296,11 +260,14 @@ def instruct(
         audio=audio,
     )
 
+    # The Instruction renders its own requirements into the prompt regardless of
+    # strategy, so only forward them to act when a strategy will validate them.
+    # Passing them without a strategy would raise (see aact).
     return act(
         i,
         context=context,
         backend=backend,
-        requirements=i.requirements,
+        requirements=i.requirements if strategy is not None else None,
         strategy=strategy,
         return_sampling_results=return_sampling_results,
         format=format,
@@ -632,7 +599,7 @@ async def aact(
         action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
         context: the context being used as a history from which to generate the response.
         backend: the backend used to generate the response.
-        requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+        requirements: requirements validated by the sampling strategy. These are only used when a `strategy` is provided; passing them without a `strategy` cannot validate them and raises `ValueError`. (Requirements a component renders into its own prompt — e.g. those attached to an `Instruction` — still shape generation regardless, and are passed via the action, not this parameter.)
         strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs, `requirements` are not validated (see above), and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
         return_sampling_results: attach the (successful and failed) sampling attempts to the results.
         format: Constrains generation to JSON matching this Pydantic
@@ -645,7 +612,7 @@ async def aact(
         await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. If True or strategy is not None, awaits and returns ComputedModelOutputThunk. Default is False.
 
     Raises:
-        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
+        ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` are provided without a `strategy` to validate them.
 
     Returns:
         A (ModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -699,20 +666,19 @@ async def aact(
             )
 
         if strategy is None:
-            # No strategy means no validate/repair loop. Requirements the action
-            # renders into its prompt still shape generation, but any passed only
-            # here would be silently dropped — so raise instead (see message below).
+            # No strategy means no validate/repair loop, so requirements passed
+            # here cannot be validated and would be silently dropped. Raise instead.
+            # (Requirements a component renders into its own prompt — e.g. an
+            # `Instruction`'s — shape generation regardless; callers such as
+            # `instruct` simply don't forward those here when no strategy is set.)
             if requirements:
-                rendered = _requirements_rendered_by_action(action)
-                unvalidated = [r for r in requirements if id(r) not in rendered]
-                if unvalidated:
-                    raise ValueError(
-                        "Requirements were provided without a SamplingStrategy and "
-                        "are not rendered by the action, so they cannot be validated: "
-                        f"{[r.description for r in unvalidated]}. Pass a `strategy` "
-                        "(e.g. RejectionSamplingStrategy) to validate them, or attach "
-                        "them to the action so it renders them into the prompt."
-                    )
+                raise ValueError(
+                    "Requirements were provided without a SamplingStrategy, so they "
+                    "cannot be validated: "
+                    f"{[getattr(r, 'description', str(r)) for r in requirements]}. "
+                    "Pass a `strategy` (e.g. RejectionSamplingStrategy) to validate "
+                    "them."
+                )
 
             result, new_ctx = await backend.generate_from_context(
                 action,
@@ -977,11 +943,14 @@ async def ainstruct(
         audio=audio,
     )
 
+    # The Instruction renders its own requirements into the prompt regardless of
+    # strategy, so only forward them to aact when a strategy will validate them.
+    # Passing them without a strategy would raise (see aact).
     return await aact(
         i,
         context=context,
         backend=backend,
-        requirements=i.requirements,
+        requirements=i.requirements if strategy is not None else None,
         strategy=strategy,
         return_sampling_results=return_sampling_results,
         format=format,

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -519,8 +519,8 @@ class MelleaSession:
 
         Args:
             action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
-            requirements: used as additional requirements when a sampling strategy is provided
-            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used.
+            requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None, meaning no sampling strategy is used and `requirements` are not validated (see above).
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
             format: Constrains generation to JSON matching this Pydantic
                 schema. The result's `.value` is always a JSON string — not a
@@ -530,7 +530,7 @@ class MelleaSession:
             tool_calls: if true, tool calling is enabled.
 
         Raises:
-            ValueError: if `return_sampling_results=True` without a `strategy`.
+            ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
 
         Returns:
             A ModelOutputThunk if `return_sampling_results` is `False`, else returns a `SamplingResult`.
@@ -887,8 +887,8 @@ class MelleaSession:
 
         Args:
             action: the `Component`, `CBlock`, or `ModelOutputThunk` from which to generate.
-            requirements: additional requirements checked by the sampling strategy. Providing requirements without a `strategy` logs a warning, since requirements are only validated by a strategy.
-            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
+            requirements: requirements validated by the sampling strategy. Requirements the action already renders into its prompt (e.g. those attached to an `Instruction` or generative stub) still shape generation with no strategy. Any other requirement passed here without a `strategy` cannot be validated and raises `ValueError`.
+            strategy: a SamplingStrategy that describes the strategy for validating and repairing/retrying for the instruct-validate-repair pattern. Defaults to None — in that case no validate/repair loop runs, `requirements` are not validated (see above), and, unless `await_result=True`, the returned thunk is uncomputed. Required when `return_sampling_results=True`.
             return_sampling_results: attach the (successful and failed) sampling attempts to the results.
             format: Constrains generation to JSON matching this Pydantic
                 schema. The result's `.value` is always a JSON string — not a
@@ -899,7 +899,7 @@ class MelleaSession:
             await_result: if False and strategy is None, returns uncomputed ModelOutputThunk for streaming. Default is False.
 
         Raises:
-            ValueError: if `return_sampling_results=True` without a `strategy`.
+            ValueError: if `return_sampling_results=True` without a `strategy`, or if `requirements` not rendered by the action are provided without a `strategy` to validate them.
 
         Returns:
             A ModelOutputThunk if `return_sampling_results` is `False`, else returns a `SamplingResult`.

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -308,5 +308,80 @@ def test_act_sampling_results_without_strategy_raises():
         act(CBlock("x"), SimpleContext(), backend, return_sampling_results=True)
 
 
+# --- requirements-without-strategy enforcement (issue #1448) ---
+
+
+@pytest.mark.asyncio
+async def test_aact_raises_for_strategy_only_requirements():
+    """aact rejects requirements not rendered by the action when strategy is None.
+
+    A raw CBlock has no `parts()`, so a requirement passed via the kwarg can only
+    be validated by a strategy. With `strategy=None` it would go unchecked, so
+    aact must raise ValueError (issue #1448).
+    """
+    from mellea.core import CBlock
+    from mellea.stdlib.requirements import Requirement
+
+    backend = _mock_backend_returning("ignored")
+    with pytest.raises(ValueError):
+        await aact(
+            CBlock("x"),
+            SimpleContext(),
+            backend,
+            requirements=[Requirement("must be short")],
+        )
+
+
+def test_act_raises_for_strategy_only_requirements():
+    """act surfaces the same ValueError as aact for strategy-only requirements."""
+    from mellea.core import CBlock
+    from mellea.stdlib.functional import act
+    from mellea.stdlib.requirements import Requirement
+
+    backend = _mock_backend_returning("ignored")
+    with pytest.raises(ValueError):
+        act(
+            CBlock("x"),
+            SimpleContext(),
+            backend,
+            requirements=[Requirement("must be short")],
+        )
+
+
+@pytest.mark.asyncio
+async def test_aact_no_raise_when_requirements_attached_to_component():
+    """aact does not raise when the requirements are rendered by the action.
+
+    An Instruction attaches its requirements to the component (they appear in
+    `parts()` and are rendered into the prompt), so passing those same objects as
+    the kwarg with `strategy=None` is legitimate — this is the generative-stubs
+    pattern (issue #1448).
+    """
+    from mellea.stdlib.requirements import Requirement
+
+    backend = _mock_backend_returning("ok")
+    req = Requirement("must be short")
+    instruction = Instruction(description="say hi", requirements=[req])
+
+    out, _ = await aact(
+        instruction,
+        SimpleContext(),
+        backend,
+        requirements=instruction.requirements,
+        await_result=True,
+    )
+    assert str(out) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_aact_no_raise_without_requirements():
+    """aact with no requirements and no strategy generates without raising."""
+    from mellea.core import CBlock
+
+    backend = _mock_backend_returning("ok")
+    out, _ = await aact(CBlock("x"), SimpleContext(), backend, await_result=True)
+    assert str(out) == "ok"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -312,12 +312,12 @@ def test_act_sampling_results_without_strategy_raises():
 
 
 @pytest.mark.asyncio
-async def test_aact_raises_for_strategy_only_requirements():
-    """aact rejects requirements not rendered by the action when strategy is None.
+async def test_aact_raises_for_requirements_without_strategy():
+    """aact rejects any requirements passed without a strategy (issue #1448).
 
-    A raw CBlock has no `parts()`, so a requirement passed via the kwarg can only
-    be validated by a strategy. With `strategy=None` it would go unchecked, so
-    aact must raise ValueError (issue #1448).
+    With `strategy=None` there is no validate/repair loop, so a requirement passed
+    via the kwarg can never be validated — it would be silently dropped. aact
+    raises ValueError instead. This holds regardless of the action type.
     """
     from mellea.core import CBlock
     from mellea.stdlib.requirements import Requirement
@@ -332,8 +332,8 @@ async def test_aact_raises_for_strategy_only_requirements():
         )
 
 
-def test_act_raises_for_strategy_only_requirements():
-    """act surfaces the same ValueError as aact for strategy-only requirements."""
+def test_act_raises_for_requirements_without_strategy():
+    """act surfaces the same ValueError as aact for requirements without a strategy."""
     from mellea.core import CBlock
     from mellea.stdlib.functional import act
     from mellea.stdlib.requirements import Requirement
@@ -349,13 +349,14 @@ def test_act_raises_for_strategy_only_requirements():
 
 
 @pytest.mark.asyncio
-async def test_aact_no_raise_when_requirements_attached_to_component():
-    """aact does not raise when the requirements are rendered by the action.
+async def test_aact_raises_even_when_requirements_attached_to_component():
+    """aact raises for requirements-without-strategy even if attached to the action.
 
-    An Instruction attaches its requirements to the component (they appear in
-    `parts()` and are rendered into the prompt), so passing those same objects as
-    the kwarg with `strategy=None` is legitimate — this is the generative-stubs
-    pattern (issue #1448).
+    aact makes no exception for requirements a component also renders into its own
+    prompt — the check is purely on the `requirements` kwarg. Callers like
+    `instruct`/`ainstruct` avoid the raise by not forwarding their Instruction's
+    requirements when no strategy is set; the Instruction still renders them
+    (issue #1448).
     """
     from mellea.stdlib.requirements import Requirement
 
@@ -363,11 +364,33 @@ async def test_aact_no_raise_when_requirements_attached_to_component():
     req = Requirement("must be short")
     instruction = Instruction(description="say hi", requirements=[req])
 
-    out, _ = await aact(
-        instruction,
+    with pytest.raises(ValueError):
+        await aact(
+            instruction,
+            SimpleContext(),
+            backend,
+            requirements=instruction.requirements,
+            await_result=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_ainstruct_does_not_raise_for_requirements_without_strategy():
+    """ainstruct(strategy=None, requirements=...) does not forward reqs, so no raise.
+
+    The Instruction renders its own requirements into the prompt; ainstruct only
+    forwards them to aact when a strategy is present, so passing requirements with
+    `strategy=None` generates without raising (issue #1448).
+    """
+    from mellea.stdlib.functional import ainstruct
+
+    backend = _mock_backend_returning("ok")
+    out, _ = await ainstruct(
+        "say hi",
         SimpleContext(),
         backend,
-        requirements=instruction.requirements,
+        requirements=["must be short"],
+        strategy=None,
         await_result=True,
     )
     assert str(out) == "ok"


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1448 

## Description
<!-- What does this PR do and why? -->
Code now has two requirements set apart:

1. Requirements the action renders into its prompt - e.g. those attached to an Instruction or a generative stub. These still shape the output even with no strategy, so they're fine. -> exempt, no error.
2. Requirements only a strategy could check - passed via the requirements= kwarg but not attached to the action. With strategy=None these do literally nothing. -> now raises ValueError.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
