### PR TITLE
fix(hf): stop generation workers on stream timeout

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1119,9 +1119,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             # Arm the cancel hook before creating tasks so a cancel racing
             # task creation still finds the hook set.
             if stream:
-                # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
-                # through stream_with_chunking; direct avalue()/astream() callers do not,
-                # so the worker thread leaks on STREAM_TIMEOUT for those paths.
                 output._gen.cancel_hook = _cancel_event.set
             output._gen.start = datetime.datetime.now()
             output._call.context = ctx.view_for_generation()
@@ -1170,6 +1167,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                         chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
+                        on_timeout=output._gen.cancel_hook,
                     )  # type: ignore
                 )
                 output._gen.generate_type = GenerateType.ASYNC
@@ -1314,9 +1312,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             # Arm the cancel hook before creating tasks so a cancel racing
             # task creation still finds the hook set.
             if stream:
-                # TODO(#1242): send_to_queue fires this hook via mot.cancel_generation() only
-                # through stream_with_chunking; direct avalue()/astream() callers do not,
-                # so the worker thread leaks on STREAM_TIMEOUT for those paths.
                 output._gen.cancel_hook = _cancel_event.set
             output._gen.start = datetime.datetime.now()
             output._call.context = ctx.view_for_generation()
@@ -1365,6 +1360,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                         chunk_timeout=model_options.get(
                             ModelOption.STREAM_TIMEOUT, DEFAULT_CHUNK_TIMEOUT
                         ),
+                        on_timeout=output._gen.cancel_hook,
                     )  # type: ignore
                 )
                 output._gen.generate_type = GenerateType.ASYNC

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -41,6 +41,7 @@ async def send_to_queue(
     aqueue: asyncio.Queue,
     *,
     chunk_timeout: float | None = DEFAULT_CHUNK_TIMEOUT,
+    on_timeout: Callable[[], None] | None = None,
 ) -> None:
     """Processes the output of an async chat request by sending the output to an async queue.
 
@@ -57,6 +58,10 @@ async def send_to_queue(
             the queue and the stream is aborted. `None` disables the timeout.
             Defaults to `DEFAULT_CHUNK_TIMEOUT` (120 s). Note that `0` sets the
             deadline to "now" and aborts immediately — use `None` to disable.
+        on_timeout: Optional non-blocking callback invoked when this function's
+            per-chunk guard expires. Backends may use it to cooperatively stop work
+            running outside the event loop. Callback errors are logged and suppressed
+            so the original stream timeout remains the consumer-visible error.
 
     Raises:
         TimeoutError: Re-raised verbatim when the backend itself raises `TimeoutError`
@@ -83,6 +88,15 @@ async def send_to_queue(
                 except TimeoutError:
                     if cm is None or not cm.expired():
                         raise  # backend's own TimeoutError — forward verbatim
+                    if on_timeout is not None:
+                        try:
+                            on_timeout()
+                        except Exception as e:
+                            from ..core import MelleaLogger
+
+                            MelleaLogger.get_logger().debug(
+                                f"Failed to notify backend of stream timeout: {e}"
+                            )
                     await aqueue.put(
                         TimeoutError(
                             f"Stream timed out after {chunk_timeout}s without a chunk "

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for HuggingFace backend pure-logic helpers — no model load required."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -638,6 +639,79 @@ async def test_logits_none_when_stream_and_logits_both_set():
     await backend.post_processing(mot, [], None, False, {}, None, input_ids)
 
     assert mot.generation.logits is None
+
+
+@pytest.mark.asyncio
+async def test_stream_timeout_signals_generation_thread():
+    """Direct streaming signals the HF worker's cooperative cancel event on timeout."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello"))
+    cancel_event = MagicMock()
+
+    async def _stalling_stream():
+        await asyncio.sleep(1)
+        yield "never"  # pragma: no cover
+
+    with (
+        patch(
+            "mellea.backends.huggingface.AsyncTextIteratorStreamer",
+            return_value=_stalling_stream(),
+        ),
+        patch(
+            "mellea.backends.huggingface._install_cancel_stopping_criteria",
+            return_value=cancel_event,
+        ),
+    ):
+        output = await backend._generate_from_context_standard(
+            Message("assistant", ""),
+            ctx,
+            model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 0.05},
+        )
+
+        with pytest.raises(TimeoutError, match="Stream timed out"):
+            await output.astream()
+
+    cancel_event.set.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_stream_timeout_signals_generation_thread():
+    """Direct KV-cache streaming signals the HF worker on timeout."""
+    backend = _make_backend()
+    ctx = ChatContext().add(Message("user", "Hello"))
+    cancel_event = MagicMock()
+    input_ids = torch.tensor([[1]])
+    attention_mask = torch.tensor([[1]])
+
+    async def _stalling_stream():
+        await asyncio.sleep(1)
+        yield "never"  # pragma: no cover
+
+    with (
+        patch(
+            "mellea.backends.huggingface.AsyncTextIteratorStreamer",
+            return_value=_stalling_stream(),
+        ),
+        patch(
+            "mellea.backends.huggingface._install_cancel_stopping_criteria",
+            return_value=cancel_event,
+        ),
+        patch.object(
+            backend,
+            "_make_merged_kv_cache",
+            return_value=("", input_ids, MagicMock(), attention_mask),
+        ),
+    ):
+        output = await backend._generate_from_context_with_kv_cache(
+            Message("assistant", ""),
+            ctx,
+            model_options={ModelOption.STREAM: True, ModelOption.STREAM_TIMEOUT: 0.05},
+        )
+
+        with pytest.raises(TimeoutError, match="Stream timed out"):
+            await output.astream()
+
+    cancel_event.set.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/test/helpers/test_async_helpers.py
+++ b/test/helpers/test_async_helpers.py
@@ -100,6 +100,89 @@ class TestSendToQueue:
         assert "STREAM_TIMEOUT" in str(item)
         assert q.empty()  # no trailing sentinel after a timeout
 
+    async def test_chunk_timeout_calls_timeout_callback(self):
+        """A stream-guard timeout notifies the backend before returning."""
+        timeout_called = False
+
+        def on_timeout() -> None:
+            nonlocal timeout_called
+            timeout_called = True
+
+        async def _stalling_gen():
+            yield "first"
+            await asyncio.sleep(1)
+            yield "never"  # pragma: no cover
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(
+            _stalling_gen(), q, chunk_timeout=0.05, on_timeout=on_timeout
+        )
+
+        assert await q.get() == "first"
+        assert isinstance(await q.get(), TimeoutError)
+        assert timeout_called is True
+
+    async def test_chunk_timeout_callback_error_does_not_mask_timeout(self):
+        """A backend cleanup failure must not replace the stream timeout."""
+
+        def on_timeout() -> None:
+            raise RuntimeError("cleanup failed")
+
+        async def _stalling_gen():
+            await asyncio.sleep(1)
+            yield "never"  # pragma: no cover
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(
+            _stalling_gen(), q, chunk_timeout=0.05, on_timeout=on_timeout
+        )
+
+        item = await q.get()
+        assert isinstance(item, TimeoutError)
+        assert "STREAM_TIMEOUT" in str(item)
+
+    async def test_completed_stream_does_not_call_timeout_callback(self):
+        """Normal completion leaves the backend cancellation hook untouched."""
+        timeout_called = False
+
+        def on_timeout() -> None:
+            nonlocal timeout_called
+            timeout_called = True
+
+        async def _completed_gen():
+            yield "done"
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(
+            _completed_gen(), q, chunk_timeout=0.05, on_timeout=on_timeout
+        )
+
+        assert await q.get() == "done"
+        assert await q.get() is None
+        assert timeout_called is False
+
+    async def test_backend_timeout_does_not_call_timeout_callback(self):
+        """A backend-raised TimeoutError is not mistaken for the stream guard."""
+        timeout_called = False
+
+        def on_timeout() -> None:
+            nonlocal timeout_called
+            timeout_called = True
+
+        async def _backend_timeout():
+            raise TimeoutError("backend timeout")
+            yield  # pragma: no cover
+
+        q: asyncio.Queue = asyncio.Queue()
+        await send_to_queue(
+            _backend_timeout(), q, chunk_timeout=1, on_timeout=on_timeout
+        )
+
+        item = await q.get()
+        assert isinstance(item, TimeoutError)
+        assert str(item) == "backend timeout"
+        assert timeout_called is False
+
     async def test_chunk_timeout_none_disables_timeout(self):
         """chunk_timeout=None allows a slow-but-completing iterator to finish normally."""
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1242

## Description

Hugging Face generation runs in a worker thread with a cooperative cancellation event. When Mellea's per-chunk stream guard timed out, direct `avalue()` and `astream()` calls raised the timeout without signaling that event, so generation continued in the background until natural completion.

This change adds an optional timeout callback to `send_to_queue()` and connects it to the Hugging Face cancellation hook in both the standard and KV-cache streaming paths. The callback runs only when Mellea's own stream guard expires. Backend-raised `TimeoutError` instances remain unchanged, and callback failures cannot replace the original stream timeout.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Local verification:

- `uv run pytest --no-cov -q test/helpers/test_async_helpers.py test/backends/test_huggingface_unit.py` (`74 passed`)
- `uv run pre-commit run --all-files` (all hooks passed, including Ruff, MyPy, uv-lock, codespell, license headers, markdownlint, and generated MDX validation)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
