### PR TITLE
docs: use markdown backticks in docstrings

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -133,7 +133,10 @@ jobs:
         env:
           # read-only public-repo HF token; environment gating not warranted
           HF_TOKEN: ${{ secrets.HF_TOKEN_READ_PUBLIC_ONLY }}  # zizmor: ignore[secrets-outside-env]
-        run: uv run -m pytest -v --junit-xml=/tmp/pytest-results.xml test
+        run: >-
+          uv run -m pytest -v --junit-xml=/tmp/pytest-results.xml
+          test
+          tooling/docs-autogen/test_validate.py::test_repository_docstrings_use_markdown_backticks
       - name: Send failure message tests
         if: failure() # This step will only run if a previous step failed
         run: echo "Tests failed. Please verify that tests are working locally."

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -434,7 +434,7 @@ def my_command(
     Extended description with more detail about the command's behaviour.
 
     Prerequisites:
-        Mellea installed (``uv add mellea``). Any other requirements
+        Mellea installed (`uv add mellea`). Any other requirements
         (running services, authentication, etc.).
 
     Output:

--- a/docs/examples/context/react_compaction.py
+++ b/docs/examples/context/react_compaction.py
@@ -6,13 +6,13 @@ Two integration points are available, and they're complementary:
 1. **Per-add** — the `ChatContext`'s own compactor runs every time the
    ReACT loop appends a Message, ToolMessage, or thunk. This is fine
    for cheap strategies like `WindowCompactor`.
-2. **Per-turn** — pass `compactor=` to ``react(...)`` to invoke a
+2. **Per-turn** — pass `compactor=` to `react(...)` to invoke a
    compactor once per ReACT iteration after the tool observation. Use
    it for heavier strategies that should fire at turn boundaries
    instead of on every component append.
 
-In both cases use ``pin_react_initiator`` (from
-``mellea.stdlib.components.react``) so the goal and tool registration
+In both cases use `pin_react_initiator` (from
+`mellea.stdlib.components.react`) so the goal and tool registration
 survive compaction.
 
 This example exercises the wiring end-to-end against a fake backend so
@@ -118,7 +118,7 @@ def _final(answer: str) -> _ScriptedTurn:
 
 async def per_add_compaction():
     """A `WindowCompactor(pin_react_initiator)` on the ChatContext compacts
-    on every ``add()`` — Messages, ToolMessages, thunks. The ReactInitiator
+    on every `add()` — Messages, ToolMessages, thunks. The ReactInitiator
     stays pinned across the whole loop.
     """
     search = _tool("search")
@@ -149,9 +149,9 @@ async def per_add_compaction():
 
 
 async def per_turn_compaction():
-    """Pass ``compactor=`` to ``react`` for once-per-turn invocation.
+    """Pass `compactor=` to `react` for once-per-turn invocation.
 
-    Use a permissive ``ChatContext`` (large window) so the per-add path is
+    Use a permissive `ChatContext` (large window) so the per-add path is
     effectively disabled — only the per-turn hook drives compaction.
     """
     search = _tool("search")
@@ -180,19 +180,19 @@ async def per_turn_compaction():
 
 
 async def llm_summarize_compaction():
-    """Wire :class:`LLMSummarizeCompactor` into ``react()``.
+    """Wire :class:`LLMSummarizeCompactor` into `react()`.
 
-    ``LLMSummarizeCompactor`` implements the sync :class:`Compactor`
-    protocol — its ``compact`` method internally orchestrates the async
+    `LLMSummarizeCompactor` implements the sync :class:`Compactor`
+    protocol — its `compact` method internally orchestrates the async
     backend call (running it on a worker thread when invoked from inside
-    an event loop). From ``react()``'s perspective it's just another
+    an event loop). From `react()`'s perspective it's just another
     sync compactor.
 
-    To keep the scripted backend simple, this example sets ``keep_n``
+    To keep the scripted backend simple, this example sets `keep_n`
     large enough that summarisation never fires (no LLM call is needed).
-    Real usage would pair it with ``ThresholdCompactor`` so it only
+    Real usage would pair it with `ThresholdCompactor` so it only
     activates once the conversation crosses a token budget. See
-    ``TestLLMSummarizeCompactor`` in ``test/stdlib/test_compactor.py`` for
+    `TestLLMSummarizeCompactor` in `test/stdlib/test_compactor.py` for
     unit tests that exercise the actual summary path.
     """
     from mellea.stdlib.context import LLMSummarizeCompactor

--- a/docs/examples/context/threshold_compactor.py
+++ b/docs/examples/context/threshold_compactor.py
@@ -1,10 +1,10 @@
 # pytest: unit
 """ThresholdCompactor — gate an inner Compactor on conversation size.
 
-Reads ``ModelOutputThunk.generation.usage`` from the most recent thunk
-in the context. For a chat backend, ``total_tokens`` on that thunk is
-``prompt_tokens`` (full conversation history sent to the model) plus
-``completion_tokens`` (the reply), so it tracks *cumulative* context
+Reads `ModelOutputThunk.generation.usage` from the most recent thunk
+in the context. For a chat backend, `total_tokens` on that thunk is
+`prompt_tokens` (full conversation history sent to the model) plus
+`completion_tokens` (the reply), so it tracks *cumulative* context
 size — not just one call's isolated tokens. The inner compactor fires
 once that running size exceeds the configured threshold.
 """

--- a/docs/examples/context/window_compactor.py
+++ b/docs/examples/context/window_compactor.py
@@ -1,8 +1,8 @@
 # pytest: unit
 """WindowCompactor — keep the last N body components.
 
-Demonstrates the default behaviour, the ``window_size=`` sugar on
-``ChatContext``, and how the auto-pinned system prefix is preserved.
+Demonstrates the default behaviour, the `window_size=` sugar on
+`ChatContext`, and how the auto-pinned system prefix is preserved.
 """
 
 from mellea.stdlib.components.chat import Message
@@ -15,8 +15,8 @@ from mellea.stdlib.context import (
 
 
 def basic_window():
-    """``ChatContext()`` keeps the full history by default; opt in via
-    ``compactor=`` to start truncating.
+    """`ChatContext()` keeps the full history by default; opt in via
+    `compactor=` to start truncating.
     """
     ctx = ChatContext(compactor=WindowCompactor(size=5))
     for i in range(8):
@@ -26,7 +26,7 @@ def basic_window():
 
 
 def window_size_sugar():
-    """``window_size=`` is sugar for ``WindowCompactor(size=...)``."""
+    """`window_size=` is sugar for `WindowCompactor(size=...)`."""
     ctx = ChatContext(window_size=3)
     for i in range(6):
         ctx = ctx.add(Message("user", f"msg {i}"))
@@ -35,7 +35,7 @@ def window_size_sugar():
 
 
 def system_prefix_pinned():
-    """Default predicate ``pin_system`` keeps a leading system message."""
+    """Default predicate `pin_system` keeps a leading system message."""
     ctx = ChatContext(window_size=3)
     ctx = ctx.add(Message("system", "You are a helpful assistant."))
     for i in range(6):
@@ -45,7 +45,7 @@ def system_prefix_pinned():
 
 
 def pin_initial_user_too():
-    """Use ``pin_system_and_initial_user`` to also keep the user's first turn."""
+    """Use `pin_system_and_initial_user` to also keep the user's first turn."""
     ctx = ChatContext(
         compactor=WindowCompactor(size=3, pin_predicate=pin_system_and_initial_user)
     )
@@ -57,7 +57,7 @@ def pin_initial_user_too():
 
 
 def pure_last_n():
-    """``pin_nothing`` disables prefix pinning — the system message is dropped."""
+    """`pin_nothing` disables prefix pinning — the system message is dropped."""
     ctx = ChatContext(compactor=WindowCompactor(size=3, pin_predicate=pin_nothing))
     ctx = ctx.add(Message("system", "ignored after a few turns"))
     for i in range(6):
@@ -66,7 +66,7 @@ def pure_last_n():
 
 
 def clear_body_keep_prefix():
-    """``size=0`` drops the body entirely while keeping the pinned prefix."""
+    """`size=0` drops the body entirely while keeping the pinned prefix."""
     ctx = ChatContext(window_size=10_000)
     ctx = ctx.add(Message("system", "You are helpful."))
     for i in range(5):

--- a/docs/examples/granite-switch/manual_adapter_loading.py
+++ b/docs/examples/granite-switch/manual_adapter_loading.py
@@ -2,10 +2,10 @@
 
 """Example: manually loading embedded adapters for the OpenAI backend.
 
-Instead of using ``load_embedded_adapters=True`` (which loads all adapters from
+Instead of using `load_embedded_adapters=True` (which loads all adapters from
 the model repo at init), this example shows how to create an OpenAIBackend with
-``load_embedded_adapters=False`` and then manually load individual adapters using
-``EmbeddedIntrinsicAdapter.from_hub()`` or ``from_model_directory()``.
+`load_embedded_adapters=False` and then manually load individual adapters using
+`EmbeddedIntrinsicAdapter.from_hub()` or `from_model_directory()`.
 
 This is useful when:
 - You only need a subset of the model's embedded adapters.

--- a/docs/examples/m_serve/streaming/client_streaming.py
+++ b/docs/examples/m_serve/streaming/client_streaming.py
@@ -6,9 +6,9 @@ started with:
 
     m serve docs/examples/m_serve/streaming/m_serve_example_streaming.py
 
-Set ``streaming`` below to:
-- ``True`` for incremental SSE chunks
-- ``False`` for a normal non-streaming response
+Set `streaming` below to:
+- `True` for incremental SSE chunks
+- `False` for a normal non-streaming response
 """
 
 import openai

--- a/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
+++ b/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
@@ -4,14 +4,14 @@
 
 This file supports two distinct usage patterns:
 
-1. Running it directly with ``uv run python ...`` performs a local smoke test
+1. Running it directly with `uv run python ...` performs a local smoke test
    using native Mellea tool calling.
-2. Serving it with ``m serve`` exposes an OpenAI-compatible endpoint that
+2. Serving it with `m serve` exposes an OpenAI-compatible endpoint that
    accepts OpenAI-style tool definitions in the request.
 
-The direct ``__main__`` smoke test is intentionally separate from the
-OpenAI-compatible server flow because local ``session.instruct(...)`` calls
-should use ``MelleaTool`` objects directly.
+The direct `__main__` smoke test is intentionally separate from the
+OpenAI-compatible server flow because local `session.instruct(...)` calls
+should use `MelleaTool` objects directly.
 """
 
 import os
@@ -167,7 +167,7 @@ def _extract_mellea_tools_from_model_options(
 
     This example supports only two shapes:
     - OpenAI-style JSON tool definitions from the server path
-    - native tool objects from the direct ``__main__`` path
+    - native tool objects from the direct `__main__` path
     """
     if model_options is None or ModelOption.TOOLS not in model_options:
         return {}

--- a/docs/examples/plugins/class_plugin.py
+++ b/docs/examples/plugins/class_plugin.py
@@ -30,9 +30,9 @@ class PIIRedactor(Plugin, name="pii-redactor", priority=5):
     """Redacts PII patterns from both input and output.
 
     .. warning:: Shared mutable state
-        ``redaction_count`` is shared across all hook invocations.  This is
-        safe today because all hooks run on the same ``asyncio`` event loop,
-        but would require a lock or ``contextvars`` if hooks ever execute in
+        `redaction_count` is shared across all hook invocations.  This is
+        safe today because all hooks run on the same `asyncio` event loop,
+        but would require a lock or `contextvars` if hooks ever execute in
         parallel threads.
     """
 
@@ -64,8 +64,8 @@ class PIIRedactor(Plugin, name="pii-redactor", priority=5):
     async def scan_output(self, payload, ctx):
         """Scan LLM output for PII and log a warning if detected.
 
-        ``generation_post_call`` is observe-only — plugins cannot modify the
-        ``model_output``.  This hook therefore only inspects the output and
+        `generation_post_call` is observe-only — plugins cannot modify the
+        `model_output`.  This hook therefore only inspects the output and
         records a warning for downstream monitoring/alerting.
         """
         mot_value = getattr(payload.model_output, "value", None)

--- a/docs/examples/streaming/custom_chunking.py
+++ b/docs/examples/streaming/custom_chunking.py
@@ -5,23 +5,23 @@
 Demonstrates:
 - Subclassing :class:`~mellea.stdlib.chunking.ChunkingStrategy` to define a
   new splitting boundary
-- Implementing ``split()`` (stateless, idempotent) and ``flush()`` (end-of-stream
+- Implementing `split()` (stateless, idempotent) and `flush()` (end-of-stream
   release of any withheld trailing fragment)
-- Using the custom chunker with ``stream_with_chunking()`` in place of a string alias
+- Using the custom chunker with `stream_with_chunking()` in place of a string alias
 - Validating line-by-line output from a numbered-list prompt
 
-``LineChunker`` splits on single newlines (``\\n``), emitting one line per
-``stream_validate`` call.  It sits between :class:`~mellea.stdlib.chunking.WordChunker`
+`LineChunker` splits on single newlines (`\\n`), emitting one line per
+`stream_validate` call.  It sits between :class:`~mellea.stdlib.chunking.WordChunker`
 (one word) and :class:`~mellea.stdlib.chunking.SentenceChunker` (one sentence) in
 granularity, and is a natural fit for list-formatted model output.
 
 Extension pattern:
-  1. Subclass ``ChunkingStrategy``.
-  2. Implement ``split(accumulated_text)`` — return all complete chunks found in
+  1. Subclass `ChunkingStrategy`.
+  2. Implement `split(accumulated_text)` — return all complete chunks found in
      the accumulated text so far; withhold any trailing fragment.  The method is
      called on every new token delta, so it must be stateless and idempotent.
-  3. Override ``flush(accumulated_text)`` to release the withheld trailing fragment
-     when the stream ends naturally.  The default base implementation returns ``[]``
+  3. Override `flush(accumulated_text)` to release the withheld trailing fragment
+     when the stream ends naturally.  The default base implementation returns `[]`
      (fragment discarded); override it when the trailing fragment is semantically
      significant.
 """
@@ -55,7 +55,7 @@ _NUMBERED_LINE = re.compile(r"^\s*\d+[\.\)]\s")
 class LineChunker(ChunkingStrategy):
     """Splits accumulated text on single newlines, emitting one line per chunk.
 
-    The line after the last ``\\n`` is withheld as a trailing fragment until
+    The line after the last `\\n` is withheld as a trailing fragment until
     the stream ends and :meth:`flush` is called.  Blank lines are skipped —
     they carry no content for a line-level validator.
 
@@ -102,9 +102,9 @@ class LineChunker(ChunkingStrategy):
 class NumberedLineReq(Requirement):
     """Fails the stream if any line does not start with a list number.
 
-    Each ``stream_validate`` call receives one complete line (from
+    Each `stream_validate` call receives one complete line (from
     :class:`LineChunker`).  This requirement enforces that every line follows
-    the ``N. item`` format, catching unstructured paragraphs or stray headers
+    the `N. item` format, catching unstructured paragraphs or stray headers
     that sneak into what should be a clean numbered list.
     """
 

--- a/docs/examples/streaming/paragraph_chunking.py
+++ b/docs/examples/streaming/paragraph_chunking.py
@@ -3,10 +3,10 @@
 """Streaming generation with per-paragraph validation using ParagraphChunker.
 
 Demonstrates:
-- Using the ``"paragraph"`` chunking alias for coarse-grained, structure-aware
+- Using the `"paragraph"` chunking alias for coarse-grained, structure-aware
   validation
 - A paragraph-length gate that cancels generation if any paragraph is too long
-- How ParagraphChunker withholds text until a blank line (``\\n\\n``) is seen,
+- How ParagraphChunker withholds text until a blank line (`\\n\\n`) is seen,
   then emits the entire paragraph as a single chunk
 - The latency trade-off vs. SentenceChunker: fewer, larger chunks mean lower
   validation overhead but later detection
@@ -44,7 +44,7 @@ _MAX_PARAGRAPH_WORDS = 60
 class ParagraphLengthReq(Requirement):
     """Fails the stream if any paragraph exceeds a word-count limit.
 
-    Each ``stream_validate`` call receives one complete paragraph (from
+    Each `stream_validate` call receives one complete paragraph (from
     :class:`~mellea.stdlib.chunking.ParagraphChunker`).  The validator counts
     words and immediately fails the stream if the paragraph is too long.  This
     lets you enforce a maximum paragraph length at generation time rather than

--- a/docs/examples/streaming/streaming_chunking.py
+++ b/docs/examples/streaming/streaming_chunking.py
@@ -39,7 +39,7 @@ class MaxSentencesReq(Requirement):
     """Fails if the model generates more than *limit* sentences mid-stream.
 
     Counts sentence terminators in the chunk *text* rather than counting
-    ``stream_validate`` calls.  This makes the requirement **chunker-agnostic**:
+    `stream_validate` calls.  This makes the requirement **chunker-agnostic**:
     the same instance behaves correctly with sentence, word, or paragraph
     chunking, because the semantics depend on content, not on the chunker's
     structural decisions.

--- a/docs/examples/streaming/word_chunking.py
+++ b/docs/examples/streaming/word_chunking.py
@@ -3,12 +3,12 @@
 """Streaming generation with per-word validation using WordChunker.
 
 Demonstrates:
-- Using the ``"word"`` chunking alias for the finest-grained validation
+- Using the `"word"` chunking alias for the finest-grained validation
 - Detecting a forbidden word the moment it appears in the stream
 - Early-exit cancelling generation before the consumer sees the bad word
 - How WordChunker compares to SentenceChunker in reaction time
 
-WordChunker splits on whitespace, so each ``stream_validate`` call receives
+WordChunker splits on whitespace, so each `stream_validate` call receives
 exactly one word.  This is the highest-sensitivity strategy: validation fires
 before the model has finished even the current clause, letting you catch
 prohibited content with minimal output produced.
@@ -45,7 +45,7 @@ _FORBIDDEN = {"competitor", "CompetitorX", "legacy", "inferior", "obsolete"}
 class ForbiddenWordReq(Requirement):
     """Fails the stream immediately if a forbidden word appears.
 
-    Each ``stream_validate`` call receives a single word (from
+    Each `stream_validate` call receives a single word (from
     :class:`~mellea.stdlib.chunking.WordChunker`).  The check is O(1)
     per word — set membership test — so it adds negligible latency.
     """

--- a/docs/examples/telemetry/otel_genai_semconv_example.py
+++ b/docs/examples/telemetry/otel_genai_semconv_example.py
@@ -2,13 +2,13 @@
 
 """Mellea backend spans carrying OTel GenAI semantic convention attributes.
 
-Each backend generation call emits a ``chat`` span with the following attributes
+Each backend generation call emits a `chat` span with the following attributes
 drawn from the OTel GenAI semconv (https://opentelemetry.io/docs/specs/semconv/gen-ai/):
 
   gen_ai.provider.name   — provider identity (replaces the deprecated gen_ai.system)
   gen_ai.request.model   — model identifier
   gen_ai.usage.*         — token counts (input, output, total, plus cache/reasoning when reported)
-  gen_ai.conversation.id — correlated to the active session via ``with_context``
+  gen_ai.conversation.id — correlated to the active session via `with_context`
   error.type             — set on the error path alongside ERROR span status
 
 Run against otelite for human verification:

--- a/docs/examples/tools/shell_example.py
+++ b/docs/examples/tools/shell_example.py
@@ -13,7 +13,7 @@ Demonstrates multiple ways to use Mellea's bash execution capabilities:
 safety denylist (recommended for typical agentic workflows). The denylist
 enforces: no sudo, no rm -rf, no destructive git operations, no writes to
 /etc, /sys, /proc, etc. Write operations can also be constrained with
-``working_dir`` and explicit ``allowed_paths``.
+`working_dir` and explicit `allowed_paths`.
 
 For higher isolation requirements (untrusted code, security research),
 provide isolation at the application layer (containers, VMs).

--- a/docs/scripts/check_docs.py
+++ b/docs/scripts/check_docs.py
@@ -433,7 +433,7 @@ def check_syntax(code: str, filename: str) -> tuple[str | None, bool]:
     """Try to compile; return (error_message, is_fragment).
 
     is_fragment is True when the error is due to the snippet being an
-    incomplete fragment (e.g. bare ``await`` or leading indentation)
+    incomplete fragment (e.g. bare `await` or leading indentation)
     rather than genuinely broken syntax.
     """
     try:
@@ -466,8 +466,8 @@ def extract_imports(code: str) -> list[tuple[str, int | None]]:
 def _mellea_module_exists(module_name: str) -> bool:
     """Check whether a mellea.* module exists on the filesystem.
 
-    Walks from the repo's ``mellea/`` package directory, checking each
-    dotted component resolves to a directory (package) or ``.py`` file.
+    Walks from the repo's `mellea/` package directory, checking each
+    dotted component resolves to a directory (package) or `.py` file.
     This avoids actually importing anything, so it's safe to call even
     when optional dependencies are missing.
     """
@@ -493,9 +493,9 @@ def module_importable(module_name: str) -> bool:
     """Check if module_name can be resolved without actually importing.
 
     For mellea.* modules, checks the full dotted path on the filesystem
-    so that typos like ``mellea.stdlib.docs`` (should be
-    ``mellea.stdlib.components.docs``) are caught even though the
-    top-level ``mellea`` package exists.
+    so that typos like `mellea.stdlib.docs` (should be
+    `mellea.stdlib.components.docs`) are caught even though the
+    top-level `mellea` package exists.
     """
     if module_name.startswith("mellea"):
         return _mellea_module_exists(module_name)

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -3,7 +3,7 @@
 
 """Core adapter scaffolding types (Epic #929 Phase 0).
 
-Introduces the composable ``Adapter`` dataclass and its three parts:
+Introduces the composable `Adapter` dataclass and its three parts:
 
 - :class:`Identity` — name, adapter_type, optional capability
 - :class:`IOContract` — ABC for prompt building and output parsing
@@ -15,10 +15,10 @@ Also provides three stub :class:`WeightsBinding` subclasses
 
 Note:
     The existing :class:`~mellea.backends.adapters.adapter.Adapter` ABC in
-    ``adapter.py`` is not modified here.  This module introduces a new
-    ``Adapter`` *dataclass* that is re-exported from
-    ``mellea.backends.adapters``.  Both coexist until shim removal in 4.1.
-    The old ABC is not part of the public ``__init__.py`` surface, so there is
+    `adapter.py` is not modified here.  This module introduces a new
+    `Adapter` *dataclass* that is re-exported from
+    `mellea.backends.adapters`.  Both coexist until shim removal in 4.1.
+    The old ABC is not part of the public `__init__.py` surface, so there is
     no namespace collision on the public API.
 """
 
@@ -107,8 +107,8 @@ class IOContract(abc.ABC):
         """Build the prompt component for this adapter.
 
         Args:
-            **kwargs: Adapter-specific keyword arguments (e.g. ``documents=...``,
-                ``requirement=...``). Concrete subclasses define the keys they
+            **kwargs: Adapter-specific keyword arguments (e.g. `documents=...`,
+                `requirement=...`). Concrete subclasses define the keys they
                 accept.
 
         Returns:
@@ -185,11 +185,11 @@ class WeightsBinding(abc.ABC):
 
     Lifecycle (informal state machine):
 
-    - ``prepare()`` — stage the weights (e.g. download); idempotent.
-    - ``activate()`` — load into the backend; requires ``prepare()`` first.
-    - ``deactivate()`` — unload from the backend; reversible by ``activate()``.
-    - ``release()`` — terminal; releases all resources. The binding is not
-      reusable after ``release()``.
+    - `prepare()` — stage the weights (e.g. download); idempotent.
+    - `activate()` — load into the backend; requires `prepare()` first.
+    - `deactivate()` — unload from the backend; reversible by `activate()`.
+    - `release()` — terminal; releases all resources. The binding is not
+      reusable after `release()`.
 
     Concrete implementations are expected to document any deviations from this
     contract (e.g. servers that prepare-and-activate atomically).

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -8,10 +8,10 @@ register an adapter by capability name) and :meth:`AdapterMixin._find_adapter`
 (look up a registered adapter).  :class:`AdapterMixin` is mixed into backends that
 support runtime adapter loading and unloading.
 
-``LocalHFAdapter``, ``IntrinsicAdapter``, and ``EmbeddedIntrinsicAdapter`` are
+`LocalHFAdapter`, `IntrinsicAdapter`, and `EmbeddedIntrinsicAdapter` are
 **deprecation shims** retained for backwards compatibility.  They satisfy
-``isinstance(x, _core.Adapter)`` but delegate all behaviour to the new dataclass.
-``get_adapter_for_intrinsic`` is similarly deprecated; prefer ``resolve_adapter``.
+`isinstance(x, _core.Adapter)` but delegate all behaviour to the new dataclass.
+`get_adapter_for_intrinsic` is similarly deprecated; prefer `resolve_adapter`.
 """
 
 import abc
@@ -33,18 +33,18 @@ class Adapter(abc.ABC):
     """An adapter that can be added to a single backend.
 
     An adapter can only be registered with one backend at a time. Use
-    ``adapter.qualified_name`` when referencing the adapter after adding it.
+    `adapter.qualified_name` when referencing the adapter after adding it.
 
     Args:
         name (str): Human-readable name of the adapter.
         adapter_type (AdapterType): Enum describing the adapter type (e.g.
-            ``AdapterType.LORA`` or ``AdapterType.ALORA``).
+            `AdapterType.LORA` or `AdapterType.ALORA`).
 
     Attributes:
         qualified_name (str): Unique name used for loading and lookup; formed
-            as ``"<name>_<adapter_type.value>"``.
+            as `"<name>_<adapter_type.value>"`.
         backend (Backend | None): The backend this adapter has been added to,
-            or ``None`` if not yet added.
+            or `None` if not yet added.
         path (str | None): Filesystem path to the adapter weights; set when
             the adapter is added to a backend.
     """
@@ -66,7 +66,7 @@ class Adapter(abc.ABC):
 class LocalHFAdapter(Adapter):
     """Abstract adapter subclass for locally loaded Hugging Face model backends.
 
-    Subclasses must implement ``get_local_hf_path`` to return the filesystem path
+    Subclasses must implement `get_local_hf_path` to return the filesystem path
     from which adapter weights should be loaded given a base model name.
     """
 
@@ -76,7 +76,7 @@ class LocalHFAdapter(Adapter):
 
         Args:
             base_model_name (str): The base model name; typically the last component
-                of the Hugging Face model ID (e.g. ``"granite-4.0-micro"``).
+                of the Hugging Face model ID (e.g. `"granite-4.0-micro"`).
 
         Returns:
             str: Filesystem path to the adapter weights directory.
@@ -127,43 +127,43 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
 
     .. deprecated::
         Use :class:`~mellea.backends.adapters.Adapter` directly.
-        ``IntrinsicAdapter`` will be removed in a future release (Epic #929,
+        `IntrinsicAdapter` will be removed in a future release (Epic #929,
         issue #1144).
 
     Subtype of :class:`Adapter` for models that:
 
     * implement adapter functions
     * are packaged as LoRA or aLoRA adapters on top of a base model
-    * use the shared model loading code in ``mellea.formatters.granite.intrinsics``
+    * use the shared model loading code in `mellea.formatters.granite.intrinsics`
     * use the shared input and output processing code in
-      ``mellea.formatters.granite.intrinsics``
+      `mellea.formatters.granite.intrinsics`
 
     Args:
-        intrinsic_name (str): Name of the adapter function (e.g. ``"answerability"``);
-            the adapter's ``qualified_name`` will be derived from this.
+        intrinsic_name (str): Name of the adapter function (e.g. `"answerability"`);
+            the adapter's `qualified_name` will be derived from this.
         adapter_type (AdapterType): Enum describing the adapter type; defaults to
-            ``AdapterType.ALORA``.
+            `AdapterType.ALORA`.
         config_file (str | pathlib.Path | None): Path to a YAML config file defining
             the adapter function's I/O transformations; mutually exclusive with
-            ``config_dict``.
+            `config_dict`.
         config_dict (dict | None): Dict defining the adapter function's I/O
-            transformations; mutually exclusive with ``config_file``.
+            transformations; mutually exclusive with `config_file`.
         base_model_name (str | None): Base model name used to look up the I/O
-            processing config when neither ``config_file`` nor ``config_dict`` are
+            processing config when neither `config_file` nor `config_dict` are
             provided.
 
     Attributes:
         intrinsic_name (str): Name of the adapter function this adapter implements.
         intrinsic_metadata (IntrinsicsCatalogEntry): Catalog metadata for the adapter function.
         base_model_name (str | None): Base model name provided at construction, if any.
-        adapter_type (AdapterType): The adapter type (``LORA`` or ``ALORA``).
+        adapter_type (AdapterType): The adapter type (`LORA` or `ALORA`).
         config (dict): Parsed I/O transformation configuration for the adapter function.
 
     .. note::
-        ``identity``, ``io_contract``, and ``weights`` are Phase 1 internal scaffolding
-        populated in ``__init__`` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
-        protocol.  They are not meaningful consumer-facing attributes; ``io_contract`` and
-        ``weights`` raise :exc:`NotImplementedError` and will be replaced in Phase 2
+        `identity`, `io_contract`, and `weights` are Phase 1 internal scaffolding
+        populated in `__init__` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
+        protocol.  They are not meaningful consumer-facing attributes; `io_contract` and
+        `weights` raise :exc:`NotImplementedError` and will be replaced in Phase 2
         (issues #1137, #1141).
     """
 
@@ -265,7 +265,7 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
 
         Args:
             base_model_name (str): The base model name; typically the last component
-                of the Hugging Face model ID (e.g. ``"granite-3.3-8b-instruct"``).
+                of the Hugging Face model ID (e.g. `"granite-3.3-8b-instruct"`).
 
         Returns:
             str: Filesystem path to the downloaded adapter weights directory.
@@ -306,15 +306,15 @@ def get_adapter_for_intrinsic(
     """Find an adapter from a dict of available adapters based on the adapter function name and its allowed adapter types.
 
     Args:
-        intrinsic_name (str): The name of the adapter function, e.g. ``"answerability"``.
+        intrinsic_name (str): The name of the adapter function, e.g. `"answerability"`.
         intrinsic_adapter_types (list[AdapterType] | tuple[AdapterType, ...]): The
             adapter types allowed for this adapter function, e.g.
-            ``[AdapterType.ALORA, AdapterType.LORA]``.
+            `[AdapterType.ALORA, AdapterType.LORA]`.
         available_adapters (dict[str, T]): The available adapters to choose from;
-            maps ``adapter.qualified_name`` to the adapter object.
+            maps `adapter.qualified_name` to the adapter object.
 
     Returns:
-        T | None: The first matching adapter found, or ``None`` if no match exists.
+        T | None: The first matching adapter found, or `None` if no match exists.
     """
     adapter = None
     for adapter_type in intrinsic_adapter_types:
@@ -340,15 +340,15 @@ class AdapterMixin(Backend, abc.ABC):
     """Mixin class for backends capable of utilizing adapters.
 
     Three verbs are universal across every adapter reality (LocalFile/PEFT,
-    Embedded/Granite Switch, ServerMediated): ``base_model_name``,
-    ``add_adapter``, and ``list_adapters``. The remaining four verbs are
+    Embedded/Granite Switch, ServerMediated): `base_model_name`,
+    `add_adapter`, and `list_adapters`. The remaining four verbs are
     reality-specific — a concrete backend overrides only the verb(s) matching
-    its own reality; the others keep raising ``NotImplementedError``.
+    its own reality; the others keep raising `NotImplementedError`.
 
     Attributes:
         base_model_name (str): The short model name used to identify adapter
-            variants (e.g. ``"granite-3.3-8b-instruct"`` for
-            ``"ibm-granite/granite-3.3-8b-instruct"``).
+            variants (e.g. `"granite-3.3-8b-instruct"` for
+            `"ibm-granite/granite-3.3-8b-instruct"`).
     """
 
     # ---- Universal verbs (every adapter reality) ----
@@ -359,7 +359,7 @@ class AdapterMixin(Backend, abc.ABC):
         """Return the short model name used for adapter variant lookup.
 
         Returns:
-            str: The base model name (e.g. ``"granite-3.3-8b-instruct"``).
+            str: The base model name (e.g. `"granite-3.3-8b-instruct"`).
         """
 
     @abc.abstractmethod
@@ -386,7 +386,7 @@ class AdapterMixin(Backend, abc.ABC):
 
         Returns:
             list[str]: Qualified adapter names for all adapters that have been
-                registered via ``add_adapter``.
+                registered via `add_adapter`.
         """
         ...
 
@@ -396,11 +396,11 @@ class AdapterMixin(Backend, abc.ABC):
         """Load a previously registered PEFT adapter into the underlying model.
 
         LocalFile/PEFT reality only (e.g. a locally hosted Hugging Face
-        model). The adapter must have been registered via ``add_adapter``
+        model). The adapter must have been registered via `add_adapter`
         before calling this method.
 
         Args:
-            adapter_qualified_name (str): The ``adapter.qualified_name`` of the
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to load.
 
         Raises:
@@ -418,7 +418,7 @@ class AdapterMixin(Backend, abc.ABC):
         model).
 
         Args:
-            adapter_qualified_name (str): The ``adapter.qualified_name`` of the
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to unload.
 
         Raises:
@@ -438,10 +438,10 @@ class AdapterMixin(Backend, abc.ABC):
         requests.
 
         Args:
-            adapter_qualified_name (str): The ``adapter.qualified_name`` of the
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to activate or deactivate.
-            active (bool): ``True`` to render the adapter's control tokens,
-                ``False`` to clear them.
+            active (bool): `True` to render the adapter's control tokens,
+                `False` to clear them.
 
         Raises:
             NotImplementedError: If this backend's adapter reality is not
@@ -460,7 +460,7 @@ class AdapterMixin(Backend, abc.ABC):
         yet.
 
         Args:
-            adapter_qualified_name (str): The ``adapter.qualified_name`` of the
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to select.
 
         Raises:
@@ -476,11 +476,11 @@ class AdapterMixin(Backend, abc.ABC):
         """Find or lazily register an adapter by capability name.
 
         Default implementation preserves Phase 0 behaviour, using the internal
-        ``_added_adapters`` dict that concrete backends maintain.  Override in
+        `_added_adapters` dict that concrete backends maintain.  Override in
         Phase 2 (see epic #929) to implement proper lifecycle management.
 
         Args:
-            name (str): Capability name (e.g. ``"answerability"``).
+            name (str): Capability name (e.g. `"answerability"`).
 
         Returns:
             _AdapterCore: The registered adapter with the given capability.
@@ -544,10 +544,10 @@ class AdapterMixin(Backend, abc.ABC):
         """Context manager wrapping adapter activation and deactivation.
 
         Phase 1 stub — yields immediately (no-op). Phase 2 (see epic #929) wires
-        in ``adapter.weights.activate()`` and ``adapter.weights.deactivate()``.
+        in `adapter.weights.activate()` and `adapter.weights.deactivate()`.
 
         Args:
-            adapter: The adapter to activate, or ``None`` (no-op in Phase 1).
+            adapter: The adapter to activate, or `None` (no-op in Phase 1).
         """
         yield
 
@@ -557,14 +557,14 @@ class AdapterMixin(Backend, abc.ABC):
         """Return the first registered adapter matching capability and (optionally) type.
 
         Args:
-            capability (str): Capability name (e.g. ``"answerability"``).
+            capability (str): Capability name (e.g. `"answerability"`).
             adapter_types (tuple[str, ...] | None): Adapter type strings in
-                preference order (e.g. ``("alora", "lora")``).  When provided,
+                preference order (e.g. `("alora", "lora")`).  When provided,
                 aLoRA is returned before LoRA if both are registered for the same
-                capability.  ``None`` matches any type (insertion order wins).
+                capability.  `None` matches any type (insertion order wins).
 
         Returns:
-            _AdapterCore | None: Matching adapter, or ``None`` if not found.
+            _AdapterCore | None: Matching adapter, or `None` if not found.
         """
         adapters = getattr(self, "_added_adapters", {})
         if adapter_types is None:
@@ -588,33 +588,33 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
 
     .. deprecated::
         Use :class:`~mellea.backends.adapters.Adapter` directly.
-        ``EmbeddedIntrinsicAdapter`` will be removed in a future release
+        `EmbeddedIntrinsicAdapter` will be removed in a future release
         (Epic #929, issue #1144).
 
     Unlike PEFT-based adapters that are loaded into the model at runtime,
     embedded adapters are already baked into the model weights and activated
     via control tokens injected by the model's chat template.  Only the I/O
-    transformation config (``io.yaml``) is needed; no adapter weights are
+    transformation config (`io.yaml`) is needed; no adapter weights are
     downloaded or loaded.
 
     Args:
-        intrinsic_name (str): Name of the adapter function (e.g. ``"answerability"``).
-        config (dict): Parsed I/O transformation configuration (from ``io.yaml``).
-        technology (str): Adapter technology in the switch model — ``"lora"`` or
-            ``"alora"``.  Determines where the control token is placed in the
+        intrinsic_name (str): Name of the adapter function (e.g. `"answerability"`).
+        config (dict): Parsed I/O transformation configuration (from `io.yaml`).
+        technology (str): Adapter technology in the switch model — `"lora"` or
+            `"alora"`.  Determines where the control token is placed in the
             chat template (beginning of sequence for LoRA, before generation
             prompt for aLoRA).
 
     Attributes:
         intrinsic_name (str): Name of the adapter function this adapter implements.
         config (dict): Parsed I/O transformation configuration.
-        technology (str): ``"lora"`` or ``"alora"``.
+        technology (str): `"lora"` or `"alora"`.
 
     .. note::
-        ``identity``, ``io_contract``, and ``weights`` are Phase 1 internal scaffolding
-        populated in ``__init__`` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
-        protocol.  They are not meaningful consumer-facing attributes; ``io_contract`` and
-        ``weights`` raise :exc:`NotImplementedError` and will be replaced in Phase 2
+        `identity`, `io_contract`, and `weights` are Phase 1 internal scaffolding
+        populated in `__init__` to satisfy the new :class:`~mellea.backends.adapters.Adapter`
+        protocol.  They are not meaningful consumer-facing attributes; `io_contract` and
+        `weights` raise :exc:`NotImplementedError` and will be replaced in Phase 2
         (issues #1137, #1142).
     """
 
@@ -670,21 +670,21 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
     ) -> list["EmbeddedIntrinsicAdapter"]:
         """Load embedded adapters from a Granite Switch model directory.
 
-        Reads ``adapter_index.json`` and the corresponding ``io_configs/*/io.yaml``
+        Reads `adapter_index.json` and the corresponding `io_configs/*/io.yaml`
         files from the model directory.
 
         Args:
             model_path (str | pathlib.Path): Path to a Granite Switch model
-                directory that contains ``adapter_index.json`` and ``io_configs/``.
+                directory that contains `adapter_index.json` and `io_configs/`.
             intrinsic_name (str | None): If provided, only load the adapter
-                matching this adapter function name. ``None`` loads all adapters.
+                matching this adapter function name. `None` loads all adapters.
 
         Returns:
             list[EmbeddedIntrinsicAdapter]: One adapter per entry in the index.
 
         Raises:
-            FileNotFoundError: If ``adapter_index.json`` is missing.
-            ValueError: If an ``io.yaml`` file listed in the index cannot be found
+            FileNotFoundError: If `adapter_index.json` is missing.
+            ValueError: If an `io.yaml` file listed in the index cannot be found
                 or if no adapters are found.
         """
         import json as _json
@@ -751,23 +751,23 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
     ) -> list["EmbeddedIntrinsicAdapter"]:
         """Load embedded adapters from a Granite Switch model on Hugging Face Hub.
 
-        Downloads ``adapter_index.json`` and the ``io_configs/`` directory, then
+        Downloads `adapter_index.json` and the `io_configs/` directory, then
         delegates to :meth:`from_model_directory`.
 
         Args:
             repo_id (str): Hugging Face Hub repository ID
-                (e.g. ``"ibm-granite/granite-switch-micro"``).
+                (e.g. `"ibm-granite/granite-switch-micro"`).
             revision (str): Git revision to download from.
-            cache_dir (str | None): Local cache directory; ``None`` for the default.
+            cache_dir (str | None): Local cache directory; `None` for the default.
             intrinsic_name (str | None): If provided, only load the adapter
-                matching this adapter function name. ``None`` loads all adapters.
+                matching this adapter function name. `None` loads all adapters.
 
         Returns:
             list[EmbeddedIntrinsicAdapter]: One adapter per entry in the index.
 
         Raises:
-            ImportError: If ``huggingface_hub`` is not installed.
-            FileNotFoundError: If ``adapter_index.json`` is missing (delegated
+            ImportError: If `huggingface_hub` is not installed.
+            FileNotFoundError: If `adapter_index.json` is missing (delegated
                 from :meth:`from_model_directory`).
             ValueError: If no adapters are found (delegated from
                 :meth:`from_model_directory`).
@@ -806,16 +806,16 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
     ) -> list["EmbeddedIntrinsicAdapter"]:
         """Load embedded adapters from a local directory or Hugging Face Hub.
 
-        Automatically detects whether ``source`` is a local filesystem path
+        Automatically detects whether `source` is a local filesystem path
         or a Hugging Face Hub repo ID, and delegates accordingly.
 
         Args:
             source (str): Local path to a model directory, or a Hugging Face
-                Hub repo ID (e.g. ``"ibm-granite/granite-switch-micro"``).
+                Hub repo ID (e.g. `"ibm-granite/granite-switch-micro"`).
             revision (str): Git revision (only used for Hub downloads).
             cache_dir (str | None): Cache directory (only used for Hub downloads).
             intrinsic_name (str | None): If provided, only load the adapter
-                matching this adapter function name. ``None`` loads all adapters.
+                matching this adapter function name. `None` loads all adapters.
 
         Returns:
             list[EmbeddedIntrinsicAdapter]: One adapter per entry in the index.
@@ -837,18 +837,18 @@ class CustomIntrinsicAdapter(IntrinsicAdapter):
 
     .. deprecated::
         Use :class:`~mellea.backends.adapters.Adapter` directly.
-        ``CustomIntrinsicAdapter`` will be removed in a future release
+        `CustomIntrinsicAdapter` will be removed in a future release
         (Epic #929, issue #1144).
 
-    This class has the same functionality as ``IntrinsicAdapter``, except that
+    This class has the same functionality as `IntrinsicAdapter`, except that
     its constructor monkey-patches Mellea global variables to enable the backend
     to load the user's adapter.
 
     Args:
         model_id (str): The Hugging Face model ID used for downloading model weights;
-            expected format is ``"<user-id>/<repo-name>"``.
+            expected format is `"<user-id>/<repo-name>"`.
         intrinsic_name (str | None): Catalog name for the adapter function; defaults to the
-            repository name portion of ``model_id`` if not provided.
+            repository name portion of `model_id` if not provided.
         base_model_name (str): The short name of the base model (NOT its repo ID).
     """
 

--- a/mellea/backends/adapters/capabilities.py
+++ b/mellea/backends/adapters/capabilities.py
@@ -9,7 +9,7 @@ capability outside this set is used, so that custom adapters and pre-release
 adapter functions are not blocked.
 
 Deriving from the catalog (rather than hand-copying) keeps the two registries in
-sync automatically — adding a new entry to ``catalog.py`` automatically registers
+sync automatically — adding a new entry to `catalog.py` automatically registers
 its :attr:`~mellea.backends.adapters.catalog.IntrinsicsCatalogEntry.effective_capability`
 as a known capability.
 """

--- a/mellea/backends/adapters/catalog.py
+++ b/mellea/backends/adapters/catalog.py
@@ -15,7 +15,7 @@ import pydantic
 def validate_revision(revision: str) -> str:
     """Validate a Hugging Face revision value.
 
-    Accepts any non-empty string. Hugging Face's ``revision`` parameter takes a
+    Accepts any non-empty string. Hugging Face's `revision` parameter takes a
     branch name, tag, or commit SHA; this validator mirrors that contract.
     Catalogue entries pin to commit SHAs by convention; that is enforced by
     review and (optionally) build-time drift checks rather than by this
@@ -43,8 +43,8 @@ class AdapterType(enum.Enum):
     """Possible types of adapters for a backend.
 
     Attributes:
-        LORA (str): Standard LoRA adapter; value ``"lora"``.
-        ALORA (str): aLoRA adapter (shares model KV cache across adapter functions); value ``"alora"``.
+        LORA (str): Standard LoRA adapter; value `"lora"`.
+        ALORA (str): aLoRA adapter (shares model KV cache across adapter functions); value `"alora"`.
     """
 
     LORA = "lora"
@@ -58,15 +58,15 @@ class IntrinsicsCatalogEntry(pydantic.BaseModel):
 
     Attributes:
         name (str): User-visible name of the adapter function. May contain hyphens when
-            that matches the upstream adapter name; prefer ``effective_capability``
+            that matches the upstream adapter name; prefer `effective_capability`
             to form the stable capability token. Must be non-empty with no leading
             or trailing whitespace.
         capability (str | None): Stable Mellea-level capability token, independent
-            of the upstream adapter name. Uses underscores. When ``None``,
-            :attr:`effective_capability` falls back to ``name``. When set, must be
+            of the upstream adapter name. Uses underscores. When `None`,
+            :attr:`effective_capability` falls back to `name`. When set, must be
             non-empty with no leading or trailing whitespace.
         internal_name (str | None): Internal name used for adapter loading, or
-            ``None`` if the same as ``name``.
+            `None` if the same as `name`.
         repo_id (str): Hugging Face repository where adapters for the adapter function
             are located.
         revision (str): Hugging Face revision — branch name, tag, or commit SHA.
@@ -77,7 +77,7 @@ class IntrinsicsCatalogEntry(pydantic.BaseModel):
             subsequent phase of the adapter-lifecycle epic (#929).
         adapter_types (tuple[AdapterType, ...]): Adapter types known to be
             available for this adapter function; defaults to
-            ``(AdapterType.LORA, AdapterType.ALORA)``.
+            `(AdapterType.LORA, AdapterType.ALORA)`.
     """
 
     name: str = pydantic.Field(
@@ -87,8 +87,8 @@ class IntrinsicsCatalogEntry(pydantic.BaseModel):
         default=None,
         description=(
             "Stable capability token, independent of the upstream adapter name. "
-            "Uses underscores; no leading/trailing whitespace. When ``None``, "
-            "``effective_capability`` falls back to ``name``."
+            "Uses underscores; no leading/trailing whitespace. When `None`, "
+            "`effective_capability` falls back to `name`."
         ),
     )
     internal_name: str | None = pydantic.Field(
@@ -140,8 +140,8 @@ class IntrinsicsCatalogEntry(pydantic.BaseModel):
     def effective_capability(self) -> str:
         """Return the stable capability token for this adapter function.
 
-        Returns ``capability`` when explicitly set; falls back to ``name``
-        otherwise. Use this property — not ``name`` — whenever building the
+        Returns `capability` when explicitly set; falls back to `name`
+        otherwise. Use this property — not `name` — whenever building the
         capability vocabulary or resolving an
         :class:`~mellea.backends.adapters.Identity` capability.
 
@@ -259,7 +259,7 @@ def fetch_intrinsic_metadata(intrinsic_name: str) -> IntrinsicsCatalogEntry:
             adapter function.
 
     Raises:
-        ValueError: If ``intrinsic_name`` is not a known adapter function name.
+        ValueError: If `intrinsic_name` is not a known adapter function name.
     """
     if intrinsic_name not in _INTRINSICS_CATALOG:
         raise ValueError(

--- a/mellea/backends/context_lengths.py
+++ b/mellea/backends/context_lengths.py
@@ -49,7 +49,7 @@ def get_context_length(model_id: str | ModelIdentifier) -> int | None:
         The values returned here reflect each model's theoretical maximum context
         window as recorded in the catalog — **not** the context window actually
         used by a running server.  Ollama in particular defaults to
-        ``num_ctx=2048`` regardless of the model's rated maximum; a caller that
+        `num_ctx=2048` regardless of the model's rated maximum; a caller that
         relies on this lookup to size a sliding context window will silently
         overflow Ollama's wire-level limit.
     """

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -241,25 +241,25 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
-    """Names that ``transformers``' ``model.generate`` accepts as keyword arguments.
+    """Names that `transformers`' `model.generate` accepts as keyword arguments.
 
     Combines two sources of truth:
 
-    - The explicit named parameters of ``GenerationMixin.generate``
-      (``stopping_criteria``, ``streamer``, ``synced_gpus``, …).
-    - Every public field on ``GenerationConfig``
-      (``temperature``, ``max_new_tokens``, ``return_dict_in_generate``, …).
+    - The explicit named parameters of `GenerationMixin.generate`
+      (`stopping_criteria`, `streamer`, `synced_gpus`, …).
+    - Every public field on `GenerationConfig`
+      (`temperature`, `max_new_tokens`, `return_dict_in_generate`, …).
 
-    Anything outside this set, passed as a free kwarg to ``generate``, is either
-    absorbed by ``**kwargs`` and forwarded to the model forward pass (rare, but
-    valid for forward-only kwargs Mellea sets explicitly — ``attention_mask``,
-    ``past_key_values``, ``cache_position``, ``token_type_ids``, ``inputs_embeds``)
-    or — far more commonly — raises ``TypeError`` because the chat template
-    variable name (``thinking``, ``enable_thinking``, ``custom_tools`` …) is not
+    Anything outside this set, passed as a free kwarg to `generate`, is either
+    absorbed by `**kwargs` and forwarded to the model forward pass (rare, but
+    valid for forward-only kwargs Mellea sets explicitly — `attention_mask`,
+    `past_key_values`, `cache_position`, `token_type_ids`, `inputs_embeds`)
+    or — far more commonly — raises `TypeError` because the chat template
+    variable name (`thinking`, `enable_thinking`, `custom_tools` …) is not
     a generation parameter. This allowlist is the self-maintaining filter that
-    drops those before they reach ``generate``.
+    drops those before they reach `generate`.
 
-    Computed at import time; depends only on the installed ``transformers``
+    Computed at import time; depends only on the installed `transformers`
     version.
     """
     import inspect
@@ -1874,18 +1874,18 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         `do_sample=True` with `temperature=0` would crash transformers
         ("temperature has to be a strictly positive float").
 
-        When ``for_generate`` is True (the default — and the right choice for any
-        kwargs about to be splatted into ``model.generate``), the result is filtered
-        through the module-level ``_GENERATE_KWARGS_ALLOWLIST`` so chat-template-only
-        variables (``thinking``, ``enable_thinking``, ``custom_tools`` …) cannot leak
-        in and crash ``generate`` with ``TypeError``.  Pass ``for_generate=False`` from
-        ``_filter_for_chat_template`` to skip that filter — that path applies the
+        When `for_generate` is True (the default — and the right choice for any
+        kwargs about to be splatted into `model.generate`), the result is filtered
+        through the module-level `_GENERATE_KWARGS_ALLOWLIST` so chat-template-only
+        variables (`thinking`, `enable_thinking`, `custom_tools` …) cannot leak
+        in and crash `generate` with `TypeError`.  Pass `for_generate=False` from
+        `_filter_for_chat_template` to skip that filter — that path applies the
         chat-template allowlist instead.
 
         Args:
             model_options: the model_options for this call
             for_generate: whether the result will be passed to
-                ``model.generate``; controls whether the generate-kwargs filter
+                `model.generate`; controls whether the generate-kwargs filter
                 runs.
 
         Returns:

--- a/mellea/backends/kv_block_helpers.py
+++ b/mellea/backends/kv_block_helpers.py
@@ -3,9 +3,9 @@
 
 """Low-level utilities for concatenating transformer KV caches (KV smashing).
 
-Provides ``prefill_cache_v5`` for converting a tokenized prompt into a prefilled
-``DynamicCache``, ``merge_dynamic_caches_v5`` for concatenating multiple
-``DynamicCache`` objects along the time axis, and ``merge_v5`` which composes
+Provides `prefill_cache_v5` for converting a tokenized prompt into a prefilled
+`DynamicCache`, `merge_dynamic_caches_v5` for concatenating multiple
+`DynamicCache` objects along the time axis, and `merge_v5` which composes
 the two. These helpers are used internally by local Hugging Face backends
 (transformers v5+) that reuse cached prefix computations across multiple
 generation calls.

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -71,10 +71,10 @@ class LiteLLMBackend(FormatterBackend):
         formatter (ChatFormatter | None): Formatter for rendering components.
             Defaults to `TemplateFormatter`.
         base_url (str | None): Base URL for the LLM API endpoint. When set,
-            forwarded as ``api_base`` to LiteLLM. When ``None`` (default),
+            forwarded as `api_base` to LiteLLM. When `None` (default),
             LiteLLM infers the endpoint from the model prefix (e.g.
-            ``ollama_chat/`` → localhost:11434, ``anthropic/`` → Anthropic API).
-            Use ``None`` for cloud providers; set explicitly for local servers
+            `ollama_chat/` → localhost:11434, `anthropic/` → Anthropic API).
+            Use `None` for cloud providers; set explicitly for local servers
             such as vLLM or a non-default Ollama port.
         model_options (dict | None): Default model options for generation requests.
 

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -35,7 +35,7 @@ class ModelOption:
         STREAM (str): Sentinel key for enabling streaming responses.
         STREAM_TIMEOUT (str): Sentinel key for the per-chunk streaming timeout in seconds
             (applied to every chunk, including time-to-first-token).
-            ``None`` disables the timeout. Defaults to ``120.0`` when not set.
+            `None` disables the timeout. Defaults to `120.0` when not set.
         STOP_SEQUENCES (str): Sentinel key for a `list[str]` of strings that, when
             encountered in the model output, cause generation to halt.
         LOGITS (str): Sentinel key for requesting per-token processed logit scores (post-LogitsProcessor).
@@ -57,23 +57,23 @@ class ModelOption:
 
     Accepted values:
 
-    * ``True`` — sets ``chat_template_kwargs.enable_thinking=True`` (vLLM,
-      Ollama OpenAI-compat) **and** ``reasoning_effort="medium"`` (OpenAI
+    * `True` — sets `chat_template_kwargs.enable_thinking=True` (vLLM,
+      Ollama OpenAI-compat) **and** `reasoning_effort="medium"` (OpenAI
       o-series, DeepSeek). Use this to engage reasoning on vLLM-served models
-      such as Qwen3, Gemma 4, and GLM-4.5 — ``"medium"`` alone is silently
+      such as Qwen3, Gemma 4, and GLM-4.5 — `"medium"` alone is silently
       ignored by those servers.
-    * ``False`` — sets ``chat_template_kwargs.enable_thinking=False`` to
-      suppress the think block. ``reasoning_effort`` is not sent (passing
-      ``False`` would be an invalid value for OpenAI).
-    * ``"low"`` / ``"medium"`` / ``"high"`` — passed directly as
-      ``reasoning_effort`` (OpenAI/DeepSeek only; no-op on vLLM).
+    * `False` — sets `chat_template_kwargs.enable_thinking=False` to
+      suppress the think block. `reasoning_effort` is not sent (passing
+      `False` would be an invalid value for OpenAI).
+    * `"low"` / `"medium"` / `"high"` — passed directly as
+      `reasoning_effort` (OpenAI/DeepSeek only; no-op on vLLM).
     """
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"
     STREAM_TIMEOUT = "@@@stream_timeout@@@"
     """Per-chunk timeout in seconds (applied to every chunk, including time-to-first-token).
-    If no chunk arrives within this window the stream is aborted with ``TimeoutError``.
-    ``None`` disables the timeout. Defaults to ``120.0`` seconds when not set."""
+    If no chunk arrives within this window the stream is aborted with `TimeoutError`.
+    `None` disables the timeout. Defaults to `120.0` seconds when not set."""
     STOP_SEQUENCES = "@@@stop_sequences@@@"
     """Must be a `list[str]`. Generation halts when the model emits any of these strings.
 
@@ -82,38 +82,38 @@ class ModelOption:
     text-generation endpoint).
     """
     LOGITS = "@@@logits@@@"
-    """When `True`, request per-token processed logit scores (``output_scores``).
+    """When `True`, request per-token processed logit scores (`output_scores`).
 
-    These are logits *after* the ``LogitsProcessor`` chain has run —
+    These are logits *after* the `LogitsProcessor` chain has run —
     temperature scaling, top-k/top-p masking, repetition penalty, etc.
-    Exposed on ``mot.generation.logits`` as a tuple of 1-D tensors of shape
-    ``(vocab_size,)``, one per generated token.
+    Exposed on `mot.generation.logits` as a tuple of 1-D tensors of shape
+    `(vocab_size,)`, one per generated token.
 
     Only supported by the HuggingFace local backend. Backends that cannot
     return logits (OpenAI, Ollama, LiteLLM, WatsonX) log a warning when this
-    option is set and leave ``generation.logits`` as ``None``.
+    option is set and leave `generation.logits` as `None`.
 
-    **Streaming not supported**: when ``ModelOption.STREAM=True``, logit
-    scores are not available and ``mot.generation.logits`` will be ``None``.
+    **Streaming not supported**: when `ModelOption.STREAM=True`, logit
+    scores are not available and `mot.generation.logits` will be `None`.
 
-    See also ``ModelOption.RAW_LOGITS`` for unprocessed LM-head output.
+    See also `ModelOption.RAW_LOGITS` for unprocessed LM-head output.
     """
 
     RAW_LOGITS = "@@@raw_logits@@@"
-    """When `True`, request per-token raw logits (``output_logits``).
+    """When `True`, request per-token raw logits (`output_logits`).
 
     These are the raw, unprocessed logits straight from the LM head —
-    the model's actual output *before* any ``LogitsProcessor`` transforms
+    the model's actual output *before* any `LogitsProcessor` transforms
     (temperature, top-k/top-p, repetition penalty, etc.).
-    Exposed on ``mot.generation.raw_logits`` as a tuple of 1-D tensors of
-    shape ``(vocab_size,)``, one per generated token.
+    Exposed on `mot.generation.raw_logits` as a tuple of 1-D tensors of
+    shape `(vocab_size,)`, one per generated token.
 
     Only supported by the HuggingFace local backend.
 
-    **Streaming not supported**: when ``ModelOption.STREAM=True``, raw
-    logits are not available and ``mot.generation.raw_logits`` will be ``None``.
+    **Streaming not supported**: when `ModelOption.STREAM=True`, raw
+    logits are not available and `mot.generation.raw_logits` will be `None`.
 
-    See also ``ModelOption.LOGITS`` for processor-transformed scores.
+    See also `ModelOption.LOGITS` for processor-transformed scores.
     """
 
     @staticmethod

--- a/mellea/backends/ollama.py
+++ b/mellea/backends/ollama.py
@@ -73,28 +73,28 @@ class OllamaModelBackend(FormatterBackend):
 
     Args:
         model_id (str | ModelIdentifier): Ollama model ID. If a
-            ``ModelIdentifier`` is passed, its ``ollama_name`` attribute must
+            `ModelIdentifier` is passed, its `ollama_name` attribute must
             be set.
         formatter (ChatFormatter | None): Formatter for rendering components.
-            Defaults to ``TemplateFormatter``.
+            Defaults to `TemplateFormatter`.
         base_url (str | None): Ollama server endpoint; defaults to
-            ``env(OLLAMA_HOST)`` or ``http://localhost:11434``.
+            `env(OLLAMA_HOST)` or `http://localhost:11434`.
         model_options (dict | None): Default model options for generation requests.
         timeout (float | None): Per-operation HTTP timeout in seconds (connect,
             read, write, pool). Defaults to 300 s. For streaming requests this
             bounds the wait between consecutive chunks; for non-streaming requests
-            it bounds total time-to-response. Pass ``None`` to use the upstream
-            ``ollama`` SDK default (no timeout).
+            it bounds total time-to-response. Pass `None` to use the upstream
+            `ollama` SDK default (no timeout).
 
     Attributes:
         to_mellea_model_opts_map (dict): Mapping from Ollama-specific option names
-            to Mellea ``ModelOption`` sentinel keys.
-        from_mellea_model_opts_map (dict): Mapping from Mellea ``ModelOption``
+            to Mellea `ModelOption` sentinel keys.
+        from_mellea_model_opts_map (dict): Mapping from Mellea `ModelOption`
             sentinel keys to Ollama-specific option names.
 
     Raises:
-        ValueError: If ``model_id`` is a ``ModelIdentifier`` with no ``ollama_name`` set.
-        ConnectionError: If the Ollama server is not running at ``base_url``.
+        ValueError: If `model_id` is a `ModelIdentifier` with no `ollama_name` set.
+        ConnectionError: If the Ollama server is not running at `base_url`.
         OSError: If the model cannot be pulled from the Ollama library.
     """
 
@@ -328,9 +328,9 @@ class OllamaModelBackend(FormatterBackend):
         model_options: dict | None = None,
         tool_calls: bool = False,
     ) -> tuple[ModelOutputThunk[C], Context]:
-        """Generate a completion for ``action`` given ``ctx`` via the Ollama chat API.
+        """Generate a completion for `action` given `ctx` via the Ollama chat API.
 
-        Delegates to ``generate_from_chat_context``. Only chat contexts are supported.
+        Delegates to `generate_from_chat_context`. Only chat contexts are supported.
 
         Args:
             action (Component[C] | CBlock): The component or content block to generate
@@ -340,12 +340,12 @@ class OllamaModelBackend(FormatterBackend):
                 structured/constrained output decoding.
             model_options (dict | None): Per-call model options that override the
                 backend's defaults.
-            tool_calls (bool): If ``True``, expose available tools to the model and
+            tool_calls (bool): If `True`, expose available tools to the model and
                 parse tool-call responses.
 
         Returns:
             tuple[ModelOutputThunk[C], Context]: A thunk holding the (lazy) model output
-                and an updated context that includes ``action`` and the new output.
+                and an updated context that includes `action` and the new output.
         """
         assert ctx.is_chat_context, (
             "The ollama backend only supports chat-like contexts."
@@ -374,7 +374,7 @@ class OllamaModelBackend(FormatterBackend):
     ) -> ModelOutputThunk[C]:
         """Generate a new completion from the provided context using this backend's formatter.
 
-        Treats the ``Context`` as a chat history and uses the ``ollama.Client.chat()``
+        Treats the `Context` as a chat history and uses the `ollama.Client.chat()`
         interface to generate a completion. Returns a thunk that lazily resolves
         the model output.
 
@@ -385,7 +385,7 @@ class OllamaModelBackend(FormatterBackend):
             _format (type[BaseModelSubclass] | None): Optional Pydantic model class for
                 structured output decoding.
             model_options (dict | None): Per-call model options.
-            tool_calls (bool): If ``True``, expose available tools and parse responses.
+            tool_calls (bool): If `True`, expose available tools and parse responses.
 
         Returns:
             ModelOutputThunk[C]: A thunk holding the (lazy) model output.
@@ -574,15 +574,15 @@ class OllamaModelBackend(FormatterBackend):
                 `usage` is the aggregate token-usage dict for the batch (or `None`
                 when no request reported usage).
 
-                If Ollama returns an empty done response (``response=""``,
-                ``done=True``, no thinking content) for an action, that thunk
-                soft-fails: it has ``value=""`` and ``thunk.error`` carries the
-                ``RuntimeError`` describing the cause. Other actions in the
+                If Ollama returns an empty done response (`response=""`,
+                `done=True`, no thinking content) for an action, that thunk
+                soft-fails: it has `value=""` and `thunk.error` carries the
+                `RuntimeError` describing the cause. Other actions in the
                 batch are unaffected.
 
         Note:
-            Requests are awaited with ``asyncio.gather`` (all-or-nothing): if any
-            request raises (e.g. ``ollama.ResponseError`` or a connection error),
+            Requests are awaited with `asyncio.gather` (all-or-nothing): if any
+            request raises (e.g. `ollama.ResponseError` or a connection error),
             that exception propagates to the caller and no list is returned, even
             for requests that completed successfully.
         """

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1111,8 +1111,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             conversation (list[dict]): The chat conversation sent to the model,
                 used for logging.
             thinking: The reasoning value passed to the model: a string level
-                (``"low"``, ``"medium"``, ``"high"``) for explicit effort strings,
-                ``True``/``False`` for the bool toggle, or ``None`` if reasoning
+                (`"low"`, `"medium"`, `"high"`) for explicit effort strings,
+                `True`/`False` for the bool toggle, or `None` if reasoning
                 was not enabled.
             seed: The random seed used during generation, or `None`.
             _format: The structured output format class used during generation, if any.

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -350,8 +350,8 @@ class AudioUrlBlock(CBlock):
         """Initialize AudioUrlBlock with a URL string and declared format.
 
         Raises:
-            ValueError: If ``value`` does not look like a URL (does not start
-                with ``http://`` or ``https://``), or if ``format`` is empty.
+            ValueError: If `value` does not look like a URL (does not start
+                with `http://` or `https://`), or if `format` is empty.
         """
         if not value.startswith(("http://", "https://")):
             raise ValueError(
@@ -1840,9 +1840,9 @@ def get_audio_from_component(c: Component) -> None | list[AudioBlock | AudioUrlB
         c: The `Component` whose `audio` attribute is inspected.
 
     Returns:
-        A non-empty list of ``AudioBlock`` or ``AudioUrlBlock`` objects if the
-        component has an ``audio`` attribute with at least one element;
-        ``None`` otherwise.
+        A non-empty list of `AudioBlock` or `AudioUrlBlock` objects if the
+        component has an `audio` attribute with at least one element;
+        `None` otherwise.
     """
     if hasattr(c, "audio"):
         audio = c.audio  # type: ignore

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -45,7 +45,7 @@ def load_transformers_lora(local_or_remote_path: str) -> tuple:
     pass it a LoRA adapter's config, but that auto-loading is very broken as of 8/2025.
     Workaround powers activate!
 
-    Device selection mirrors ``LocalHFBackend``: CUDA → MPS → CPU. The returned model
+    Device selection mirrors `LocalHFBackend`: CUDA → MPS → CPU. The returned model
     is already on that device; callers do not need to move it.
 
     Only works if `transformers` and `peft` are installed.
@@ -117,7 +117,7 @@ class _GuidanceLogitsProcessor:
     def __call__(
         self, batch_input_ids: torch.Tensor, batch_scores: torch.Tensor
     ) -> torch.Tensor:
-        """Apply the grammar's allowed-token bitmask to ``batch_scores`` in place."""
+        """Apply the grammar's allowed-token bitmask to `batch_scores` in place."""
         # Guaranteed to be imported by class __init__.
         import llguidance
         import llguidance.torch

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -27,10 +27,10 @@ DEFAULT_CHUNK_TIMEOUT: float = 120.0
 
 This value applies to every chunk including the first (time-to-first-token).
 Slow local inference (large models on CPU, heavily queued servers) can take
-well over 60 s before producing the first token — set ``ModelOption.STREAM_TIMEOUT``
-to a higher value or ``None`` for those deployments.
+well over 60 s before producing the first token — set `ModelOption.STREAM_TIMEOUT`
+to a higher value or `None` for those deployments.
 
-This timeout only activates when the backend returns an ``AsyncIterator`` (i.e.
+This timeout only activates when the backend returns an `AsyncIterator` (i.e.
 streaming responses). Non-streaming coroutines that resolve to a plain response
 object bypass the per-chunk loop entirely and are unaffected by this value.
 """
@@ -46,20 +46,20 @@ async def send_to_queue(
 
     Args:
         co: A coroutine or async iterator producing the backend response.
-        aqueue: The async queue to send results to. A sentinel ``None`` is appended on
-            normal completion; an exception instance (including ``TimeoutError``) is
+        aqueue: The async queue to send results to. A sentinel `None` is appended on
+            normal completion; an exception instance (including `TimeoutError`) is
             appended on error. A timeout does **not** append a trailing sentinel — the
             exception item is the stream terminator.
         chunk_timeout: Maximum seconds to wait for each chunk from the backend iterator,
             including the first (time-to-first-token). Only applies when the backend
-            response is an ``AsyncIterator``; non-streaming coroutines are unaffected.
-            If no chunk arrives within this window a ``TimeoutError`` is forwarded to
-            the queue and the stream is aborted. ``None`` disables the timeout.
-            Defaults to ``DEFAULT_CHUNK_TIMEOUT`` (120 s). Note that ``0`` sets the
-            deadline to "now" and aborts immediately — use ``None`` to disable.
+            response is an `AsyncIterator`; non-streaming coroutines are unaffected.
+            If no chunk arrives within this window a `TimeoutError` is forwarded to
+            the queue and the stream is aborted. `None` disables the timeout.
+            Defaults to `DEFAULT_CHUNK_TIMEOUT` (120 s). Note that `0` sets the
+            deadline to "now" and aborts immediately — use `None` to disable.
 
     Raises:
-        TimeoutError: Re-raised verbatim when the backend itself raises ``TimeoutError``
+        TimeoutError: Re-raised verbatim when the backend itself raises `TimeoutError`
             (i.e. the timeout did not originate from *this* function's per-chunk guard).
             Stream-guard timeouts are forwarded into *aqueue* rather than raised.
     """

--- a/mellea/plugins/hooks/session.py
+++ b/mellea/plugins/hooks/session.py
@@ -62,8 +62,8 @@ class SessionCleanupPayload(MelleaBasePayload):
         context: The `Context` at the time of cleanup (observe-only).
 
         interaction_count: Number of model-interaction turns committed during
-            the session (each ``self.ctx = ...`` assignment in ``MelleaSession``
-            counts as one). Reset to 0 by ``MelleaSession.reset()``. Stable
+            the session (each `self.ctx = ...` assignment in `MelleaSession`
+            counts as one). Reset to 0 by `MelleaSession.reset()`. Stable
             under any context-compaction strategy.
 
         exception: The exception that triggered cleanup, or `None` for normal

--- a/mellea/stdlib/components/adapter_based_component/__init__.py
+++ b/mellea/stdlib/components/adapter_based_component/__init__.py
@@ -1,14 +1,14 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""``AdapterBasedComponent`` — the user-facing component class for adapter-backed capabilities.
+"""`AdapterBasedComponent` — the user-facing component class for adapter-backed capabilities.
 
-``AdapterBasedComponent`` is the project term for a component whose behaviour is
+`AdapterBasedComponent` is the project term for a component whose behaviour is
 provided by a fine-tuned adapter (LoRA / aLoRA) rather than the base model. It
 is currently implemented as an alias for
 :class:`~mellea.stdlib.components.intrinsic.Intrinsic`; the alias allows
 downstream code to migrate to the new name as the rest of Epic #929 is merged. The
-old import path ``mellea.stdlib.components.intrinsic`` continues to work.
+old import path `mellea.stdlib.components.intrinsic` continues to work.
 """
 
 from ..intrinsic import Intrinsic as AdapterBasedComponent

--- a/mellea/stdlib/components/docs/richdocument.py
+++ b/mellea/stdlib/components/docs/richdocument.py
@@ -40,25 +40,25 @@ from ..mobject import MObject, Query, Transform
 class RichDocument(Component[str]):
     """A document wrapper that exposes content to a language model as Markdown.
 
-    The two canonical ways to create a ``RichDocument``:
+    The two canonical ways to create a `RichDocument`:
 
     * **From a file** — use :meth:`from_document_file` to convert a PDF,
       Markdown, DOCX, or other [Docling-supported format](https://ds4sd.github.io/docling/)
-      into a ``RichDocument``.  Set ``do_ocr=False`` for text-based PDFs to
+      into a `RichDocument`.  Set `do_ocr=False` for text-based PDFs to
       skip downloading OCR model weights.
     * **From a saved JSON** — use :meth:`load` to restore a document previously
       saved with :meth:`save`.
 
-    Passing a ``DoclingDocument`` directly to the constructor is intended for
-    advanced use (e.g. when you already hold a ``DoclingDocument`` produced by
-    your own Docling pipeline).  If you pass any other type a ``TypeError`` is
+    Passing a `DoclingDocument` directly to the constructor is intended for
+    advanced use (e.g. when you already hold a `DoclingDocument` produced by
+    your own Docling pipeline).  If you pass any other type a `TypeError` is
     raised immediately.
 
     Args:
         doc (DoclingDocument): The underlying Docling document to wrap.
 
     Raises:
-        TypeError: If *doc* is not a ``DoclingDocument`` instance.
+        TypeError: If *doc* is not a `DoclingDocument` instance.
     """
 
     def __init__(self, doc: DoclingDocument):
@@ -174,11 +174,11 @@ class RichDocument(Component[str]):
         * PDF pipeline options (image scaling, picture extraction, OCR) are
           always configured internally. For non-PDF formats Docling ignores
           these options, so they have no effect on Markdown or DOCX conversion.
-        * ``do_ocr=True`` (the default) causes Docling to download OCR model
+        * `do_ocr=True` (the default) causes Docling to download OCR model
           weights on the *first* call, which can be several hundred MB. Pass
-          ``do_ocr=False`` for text-based PDFs or any format that does not
+          `do_ocr=False` for text-based PDFs or any format that does not
           require OCR to avoid this download.
-        * Remote URLs (e.g. ``"https://arxiv.org/pdf/…"``) are accepted by
+        * Remote URLs (e.g. `"https://arxiv.org/pdf/…"`) are accepted by
           Docling but require network access and may be slow or fail if the
           remote is unavailable.
         * On Apple Silicon, Docling's auto-selected accelerator is MPS, but
@@ -191,7 +191,7 @@ class RichDocument(Component[str]):
             source (str | Path | DocumentStream): Path, URL, or stream for the
                 source document.
             do_ocr (bool): Whether to run OCR on the document. Defaults to
-                ``True``. Set to ``False`` for text-based PDFs or when you want
+                `True`. Set to `False` for text-based PDFs or when you want
                 to avoid downloading OCR model weights.
 
         Returns:

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -158,7 +158,7 @@ def call_intrinsic(
     method is called on the raw output string before returning.  The contract validates
     required fields and raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`
     on contract-breaking deltas; forward-compatible additions (extra optional fields) do
-    not raise.  When *io_contract* is ``None`` the raw ``json.loads`` result is returned.
+    not raise.  When *io_contract* is `None` the raw `json.loads` result is returned.
 
     Args:
         intrinsic_name (str): Capability name of the adapter function
@@ -168,16 +168,16 @@ def call_intrinsic(
         kwargs (dict | None): Extra keyword arguments forwarded to the
             adapter function's input template.
         model_options (dict | None): Model options that override defaults.
-            Adapter functions default to ``TEMPERATURE: 0.0`` for deterministic
-            output; pass ``TEMPERATURE`` here to override it.
+            Adapter functions default to `TEMPERATURE: 0.0` for deterministic
+            output; pass `TEMPERATURE` here to override it.
         io_contract (IOContract | None): Output contract to validate and parse the
-            raw model output.  When ``None``, ``json.loads`` is used directly.
+            raw model output.  When `None`, `json.loads` is used directly.
 
     Returns:
         dict[str, object]: Parsed (and optionally validated) JSON output from the adapter function.
 
     Raises:
-        ValueError: When the model output is ``None`` or is not valid JSON.
+        ValueError: When the model output is `None` or is not valid JSON.
         AdapterSchemaMismatchError: When *io_contract* is provided and the
             model output is missing a required field.
     """

--- a/mellea/stdlib/components/intrinsic/core.py
+++ b/mellea/stdlib/components/intrinsic/core.py
@@ -27,7 +27,7 @@ def check_certainty(
         context: Chat context containing user question and assistant answer.
         backend: Backend instance that supports LoRA/aLoRA adapters.
         model_options: Optional model-level overrides forwarded to the backend
-            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            (e.g. `{ModelOption.MAX_NEW_TOKENS: 64}`). When `None`, defaults
             apply.
 
     Returns:
@@ -57,7 +57,7 @@ def requirement_check(
         backend: Backend instance that supports LoRA/aLoRA adapters.
         requirement: Set of requirements to satisfy.
         model_options: Optional model-level overrides forwarded to the backend
-            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            (e.g. `{ModelOption.MAX_NEW_TOKENS: 64}`). When `None`, defaults
             apply.
 
     Returns:
@@ -65,7 +65,7 @@ def requirement_check(
 
     Raises:
         AdapterSchemaMismatchError: If the adapter output does not match the
-            expected ``{"requirement_check": {"score": <float>}}`` contract, or
+            expected `{"requirement_check": {"score": <float>}}` contract, or
             if the score is not a finite number in the range 0.0-1.0.
     """
     result_json = call_intrinsic(
@@ -124,7 +124,7 @@ def find_context_attributions(
             a user query.
         backend (AdapterMixin): Backend that supports intrinsic adapters.
         model_options: Optional model-level overrides forwarded to the backend
-            (e.g. ``{ModelOption.MAX_NEW_TOKENS: 64}``). When ``None``, defaults
+            (e.g. `{ModelOption.MAX_NEW_TOKENS: 64}`). When `None`, defaults
             apply.
 
     Returns:

--- a/mellea/stdlib/components/intrinsic/rag.py
+++ b/mellea/stdlib/components/intrinsic/rag.py
@@ -30,11 +30,11 @@ from ._util import _resolve_question, _resolve_response, call_intrinsic
 
 
 class _ListContract(IOContract):
-    """Validate list-of-dicts adapter output and wrap it under key ``"items"``.
+    """Validate list-of-dicts adapter output and wrap it under key `"items"`.
 
     Each item in the list is checked for the declared required keys.  The
-    validated list is returned wrapped in ``{"items": [...]}`` so that
-    :func:`call_intrinsic` can always return a plain ``dict``.
+    validated list is returned wrapped in `{"items": [...]}` so that
+    :func:`call_intrinsic` can always return a plain `dict`.
 
     Args:
         name: Adapter capability name; included in
@@ -58,8 +58,8 @@ class _ListContract(IOContract):
             raw (str): Raw JSON string from the model.
 
         Returns:
-            dict[str, object]: ``{"items": [list of validated dicts]}``.
-                An empty list parses to ``{"items": []}``.
+            dict[str, object]: `{"items": [list of validated dicts]}`.
+                An empty list parses to `{"items": []}`.
 
         Raises:
             ValueError: When *raw* is not valid JSON, is not a JSON array, or
@@ -172,7 +172,7 @@ def check_answerability(
     Adapter function that checks whether the question in the last user turn of a
     chat can be answered by a provided set of RAG documents.
 
-    Output contract — required key: ``answerability``.  Missing the key raises
+    Output contract — required key: `answerability`.  Missing the key raises
     :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
     keys in the model output do not raise (forward-compatible).
 
@@ -187,16 +187,16 @@ def check_answerability(
         backend: Backend instance that supports adding the LoRA or aLoRA adapters
             for answerability checks.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
-        A string value of either ``"answerable"`` or ``"unanswerable"``.
+        A string value of either `"answerable"` or `"unanswerable"`.
 
     Raises:
         ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
-            ``answerability`` field.
+            `answerability` field.
     """
     question, context = _resolve_question(question, context, backend)
     result = call_intrinsic(
@@ -223,7 +223,7 @@ def rewrite_question(
     Adapter function that rewrites the question in the next user turn into a
     self-contained query that can be passed to the retriever.
 
-    Output contract — required key: ``rewritten_question``.  Missing the key
+    Output contract — required key: `rewritten_question`.  Missing the key
     raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`;
     extra optional keys do not raise (forward-compatible).
 
@@ -234,8 +234,8 @@ def rewrite_question(
         context: Chat context containing the conversation thus far.
         backend: Backend instance that supports adding the LoRA or aLoRA adapters.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
         Rewritten version of `question`.
@@ -243,7 +243,7 @@ def rewrite_question(
     Raises:
         ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
-            ``rewritten_question`` field.
+            `rewritten_question` field.
     """
     question, context = _resolve_question(question, context, backend)
     result = call_intrinsic(
@@ -270,7 +270,7 @@ def clarify_query(
     based on the retrieved documents and conversation context, and generates an
     appropriate clarification question if needed.
 
-    Output contract — required key: ``clarification``.  Missing the key raises
+    Output contract — required key: `clarification`.  Missing the key raises
     :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
     keys do not raise (forward-compatible).
 
@@ -284,17 +284,17 @@ def clarify_query(
         backend: Backend instance that supports the adapters that implement
             this adapter function.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
-        Clarification question string (e.g., ``"Do you mean A or B?"``), or
-        the string ``"CLEAR"`` if no clarification is needed.
+        Clarification question string (e.g., `"Do you mean A or B?"`), or
+        the string `"CLEAR"` if no clarification is needed.
 
     Raises:
         ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
-            ``clarification`` field.
+            `clarification` field.
     """
     question, context = _resolve_question(question, context, backend)
     result = call_intrinsic(
@@ -322,9 +322,9 @@ def find_citations(
     Adapter function that finds sentences in RAG documents that support sentences
     in a potential assistant response to a user question.
 
-    Output contract — each record must contain: ``response_begin``,
-    ``response_end``, ``response_text``, ``citation_doc_id``, ``citation_begin``,
-    ``citation_end``, ``citation_text``.  A record missing any of these keys
+    Output contract — each record must contain: `response_begin`,
+    `response_end`, `response_text`, `citation_doc_id`, `citation_begin`,
+    `citation_end`, `citation_text`.  A record missing any of these keys
     raises :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra
     optional keys do not raise (forward-compatible).
 
@@ -342,13 +342,13 @@ def find_citations(
         backend: Backend that supports one of the adapters that implements this
             adapter function.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
-        List of records with fields ``response_begin``, ``response_end``,
-        ``response_text``, ``citation_doc_id``, ``citation_begin``,
-        ``citation_end``, ``citation_text``.  Begin and end offsets are
+        List of records with fields `response_begin`, `response_end`,
+        `response_text`, `citation_doc_id`, `citation_begin`,
+        `citation_end`, `citation_text`.  Begin and end offsets are
         character offsets into their respective UTF-8 strings.
 
     Raises:
@@ -393,10 +393,10 @@ def check_context_relevance(
     the answer to a user's question. Does not consider the context in which the
     question was asked.
 
-    This helper uses a Granite 4.0 adapter (``ibm-granite/granite-4.0-micro``) and
+    This helper uses a Granite 4.0 adapter (`ibm-granite/granite-4.0-micro`) and
     is not available for Granite 4.1 models.
 
-    Output contract — required key: ``context_relevance``.  Missing the key raises
+    Output contract — required key: `context_relevance`.  Missing the key raises
     :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
     keys do not raise (forward-compatible).
 
@@ -409,17 +409,17 @@ def check_context_relevance(
         backend: Backend instance that supports the adapters that implement this
             adapter function.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
         Context relevance judgement as one of the following strings:
-        ``"relevant"``, ``"irrelevant"``, or ``"partially relevant"``.
+        `"relevant"`, `"irrelevant"`, or `"partially relevant"`.
 
     Raises:
         ValueError: When the model output is not valid JSON.
         AdapterSchemaMismatchError: When the model output is missing the required
-            ``context_relevance`` field.
+            `context_relevance` field.
     """
     warnings.warn(
         "check_context_relevance() is deprecated and will be removed in a future "
@@ -456,12 +456,12 @@ def flag_hallucinated_content(
     user question are faithful to the retrieved document snippets. Sentences that do
     not align with the retrieved snippets are flagged as potential hallucinations.
 
-    The ``faithfulness`` field in each record is a string label (e.g.
-    ``"faithful"``, ``"hallucinated"``); coercion to a boolean is the caller's
+    The `faithfulness` field in each record is a string label (e.g.
+    `"faithful"`, `"hallucinated"`); coercion to a boolean is the caller's
     responsibility.
 
-    Output contract — each record must contain: ``response_begin``,
-    ``response_end``, ``response_text``, ``faithfulness``, ``explanation``.  A
+    Output contract — each record must contain: `response_begin`,
+    `response_end`, `response_text`, `faithfulness`, `explanation`.  A
     record missing any of these keys raises
     :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`; extra optional
     keys do not raise (forward-compatible).
@@ -477,12 +477,12 @@ def flag_hallucinated_content(
         backend: Backend instance that supports the adapters that implement this
             adapter function.
         model_options: Optional model-option overrides (e.g.
-            ``{"temperature": 0.1}``).  Merged on top of the adapter default
-            (``temperature=0.0``).
+            `{"temperature": 0.1}`).  Merged on top of the adapter default
+            (`temperature=0.0`).
 
     Returns:
-        List of records with fields ``response_begin``, ``response_end``,
-        ``response_text``, ``faithfulness``, ``explanation``.
+        List of records with fields `response_begin`, `response_end`,
+        `response_text`, `faithfulness`, `explanation`.
 
     Raises:
         ValueError: When the model output is not valid JSON.

--- a/mellea/stdlib/components/react.py
+++ b/mellea/stdlib/components/react.py
@@ -36,10 +36,10 @@ def _mellea_finalize_tool(answer: str) -> str:
 
 
 def pin_react_initiator(components: list[Component | CBlock]) -> int:
-    """A ``PinPredicate`` that pins everything up to and including the first ``ReactInitiator``.
+    """A `PinPredicate` that pins everything up to and including the first `ReactInitiator`.
 
     Plug it into any compactor in :mod:`mellea.stdlib.context` that takes a
-    ``pin_predicate`` (e.g. :class:`WindowCompactor`,
+    `pin_predicate` (e.g. :class:`WindowCompactor`,
     :class:`ThresholdCompactor`'s inner compactor) so the react goal and
     tool registration survive compaction:
 
@@ -51,7 +51,7 @@ def pin_react_initiator(components: list[Component | CBlock]) -> int:
         )
         result, _ = await react(goal=..., context=ctx, ...)
 
-    Returns ``0`` when no ``ReactInitiator`` is found, so a context that
+    Returns `0` when no `ReactInitiator` is found, so a context that
     has not yet been seeded with a react goal compacts as if there were
     no prefix.
     """
@@ -66,19 +66,19 @@ def react_summary_prompt(
 ) -> str:
     """Build a research-flavoured summary prompt for :class:`LLMSummarizeCompactor`.
 
-    Returns a template with a ``{conversation}`` placeholder that
+    Returns a template with a `{conversation}` placeholder that
     :class:`LLMSummarizeCompactor` fills in at compaction time. Pass the
-    react goal via ``goal=`` to anchor the summarisation around the
-    objective; with ``goal=None`` the ``GOAL:`` line is omitted.
+    react goal via `goal=` to anchor the summarisation around the
+    objective; with `goal=None` the `GOAL:` line is omitted.
 
-    Pass ``max_tokens_hint=N`` to inject a soft length-cap bullet
+    Pass `max_tokens_hint=N` to inject a soft length-cap bullet
     ("Be at most ~N tokens") into the summarizer's instructions. The hint
     is a plan-time anchor for the model — combine it with a hard
-    ``max_tokens`` API arg on the summarizer's LLM call to enforce.
-    ``max_tokens_hint=None`` (default) or non-positive values omit the
+    `max_tokens` API arg on the summarizer's LLM call to enforce.
+    `max_tokens_hint=None` (default) or non-positive values omit the
     bullet, so the prompt is byte-identical to the un-hinted form.
 
-    Curly braces in ``goal`` are escaped so :meth:`str.format` (used by the
+    Curly braces in `goal` are escaped so :meth:`str.format` (used by the
     compactor) preserves them as literal characters.
 
     Example::

--- a/mellea/stdlib/context/compactor.py
+++ b/mellea/stdlib/context/compactor.py
@@ -148,7 +148,7 @@ class Compactor(Protocol):
     `compact()` is generic in `T` (a `Context` subtype) so concrete
     compactors can narrow their input/output type — for example a
     chat-only compactor overrides the method as
-    ``def compact(self, ctx: ChatContext, *, backend=None) -> ChatContext``.
+    `def compact(self, ctx: ChatContext, *, backend=None) -> ChatContext`.
 
     The protocol is sync. Compactors that need to perform a backend call
     (e.g. :class:`LLMSummarizeCompactor`) hide the async work behind the sync

--- a/mellea/stdlib/frameworks/react.py
+++ b/mellea/stdlib/frameworks/react.py
@@ -51,21 +51,21 @@ async def react(
         model_options: additional model options, which will upsert into the model/backend's defaults.
         tools: the list of tools to use
         loop_budget: the number of steps allowed; use -1 for unlimited
-        compactor: optional sync ``Compactor`` invoked once per turn after the
+        compactor: optional sync `Compactor` invoked once per turn after the
             tool observation. Use this for strategies that should fire at turn
             boundaries rather than on every component append (per-add
-            compaction is configured on ``context`` itself). Compose with
+            compaction is configured on `context` itself). Compose with
             :func:`mellea.stdlib.components.react.pin_react_initiator` to
             preserve the goal across compactions. Compactors that need to
-            call the backend (e.g. ``LLMSummarizeCompactor``) hide the async
-            work behind their sync ``compact`` method internally.
+            call the backend (e.g. `LLMSummarizeCompactor`) hide the async
+            work behind their sync `compact` method internally.
 
-            The ``Compactor`` protocol is generic in ``T`` bound to
-            ``Context``, so a compactor that returns a non-chat ``Context``
-            (e.g. ``SimpleContext``) type-checks here but breaks the
-            ``ChatContext`` assumptions the next ``aact`` call relies on.
-            Custom compactors used with ``react`` must return a
-            ``ChatContext``.
+            The `Compactor` protocol is generic in `T` bound to
+            `Context`, so a compactor that returns a non-chat `Context`
+            (e.g. `SimpleContext`) type-checks here but breaks the
+            `ChatContext` assumptions the next `aact` call relies on.
+            Custom compactors used with `react` must return a
+            `ChatContext`.
 
     Returns:
         A (ModelOutputThunk, Context) if `return_sampling_results` is `False`, else returns a `SamplingResult`.

--- a/mellea/stdlib/requirements/python_reqs.py
+++ b/mellea/stdlib/requirements/python_reqs.py
@@ -272,31 +272,31 @@ class PythonExecutionReq(Requirement):
     Extracts the highest-scoring Python code block from the model's last output
     and validates or executes it according to the configured execution tier.
 
-    Use ``execution_tier`` to select behavior by intent:
+    Use `execution_tier` to select behavior by intent:
 
-    - ``"static"`` (default) — parse and import-check only, no execution.
-    - ``"local_unsafe"`` — subprocess execution, no policy restrictions.
-    - ``"local"`` — subprocess execution with a declared capability policy.
-    - ``"docker_unsafe"`` — Docker-isolated execution, no policy restrictions.
-    - ``"docker"`` — Docker-isolated execution with a declared capability policy.
+    - `"static"` (default) — parse and import-check only, no execution.
+    - `"local_unsafe"` — subprocess execution, no policy restrictions.
+    - `"local"` — subprocess execution with a declared capability policy.
+    - `"docker_unsafe"` — Docker-isolated execution, no policy restrictions.
+    - `"docker"` — Docker-isolated execution with a declared capability policy.
 
     Args:
-        execution_tier (str): One of ``"static"``, ``"local_unsafe"``, ``"local"``,
-            ``"docker_unsafe"``, or ``"docker"``.  Defaults to ``"static"``.
+        execution_tier (str): One of `"static"`, `"local_unsafe"`, `"local"`,
+            `"docker_unsafe"`, or `"docker"`.  Defaults to `"static"`.
         policy (CapabilityPolicy | None): Override the tier's default policy.
-            Ignored for ``"static"`` and unsafe tiers unless explicitly provided.
+            Ignored for `"static"` and unsafe tiers unless explicitly provided.
         allowed_imports (list[str] | None): Allowlist of importable top-level
-            modules.  ``None`` allows any import.
+            modules.  `None` allows any import.
         max_output_chars (int | None): Maximum allowed stdout size in characters.
             None = no size check (default). When set, adds output size validation
             in the same execution pass, avoiding the double-execution cost of using
             OutputSizeLimit. Only enforced for tiers that execute code (local_unsafe,
             local, docker_unsafe, docker); static tier skips output check.
-        timeout (int | None): Deprecated.  Pass ``policy=CapabilityPolicy(timeout=N)``
+        timeout (int | None): Deprecated.  Pass `policy=CapabilityPolicy(timeout=N)`
             instead.  When provided, overrides the policy timeout.
         allow_unsafe_execution (bool): Deprecated.  Use
-            ``execution_tier="local_unsafe"`` instead.
-        use_sandbox (bool): Deprecated.  Use ``execution_tier="docker"`` instead.
+            `execution_tier="local_unsafe"` instead.
+        use_sandbox (bool): Deprecated.  Use `execution_tier="docker"` instead.
 
     Attributes:
         validation_fn (Callable[[Context], ValidationResult]): The validation

--- a/mellea/stdlib/requirements/python_tools.py
+++ b/mellea/stdlib/requirements/python_tools.py
@@ -127,7 +127,7 @@ class OutputSizeLimit(Requirement):
 
     Args:
         limit_chars: Maximum allowed output size in characters. Defaults to 10,000.
-        execution_tier: Execution environment tier. Defaults to ``"static"``
+        execution_tier: Execution environment tier. Defaults to `"static"`
             (no execution; output limit not enforced).
         policy: Optional CapabilityPolicy to override tier defaults.
         allowed_imports: Whitelist of importable top-level modules. None allows all.
@@ -231,15 +231,15 @@ class ImportRestrictions(Requirement):
     provided, all imports are blocked. If None is provided, all imports are accepted.
 
     ⚠️ **Not a Security Boundary**: This is a static AST-based guidance check,
-    not a security control. It only detects static import statements (``import x``
-    and ``from x import y``) and does NOT detect dynamic imports such as:
-    - ``__import__("subprocess")``
-    - ``importlib.import_module("socket")``
-    - ``exec("import urllib")``
-    - ``eval("import os")``
+    not a security control. It only detects static import statements (`import x`
+    and `from x import y`) and does NOT detect dynamic imports such as:
+    - `__import__("subprocess")`
+    - `importlib.import_module("socket")`
+    - `exec("import urllib")`
+    - `eval("import os")`
 
     For real isolation from untrusted code, combine this requirement with
-    ``execution_tier="docker"`` and a restrictive ``CapabilityPolicy``.
+    `execution_tier="docker"` and a restrictive `CapabilityPolicy`.
     The execution environment sandbox provides the actual security boundary,
     not the import allowlist.
 

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -32,24 +32,24 @@ class LLMaJRequirement(Requirement):
 
 
 def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
-    """Convert a ``requirement-check`` adapter output string to a boolean result.
+    """Convert a `requirement-check` adapter output string to a boolean result.
 
-    Parses the JSON output produced by the ``requirement-check`` adapter and
-    returns ``True`` when the score exceeds 0.5.
+    Parses the JSON output produced by the `requirement-check` adapter and
+    returns `True` when the score exceeds 0.5.
 
     Args:
         x: Adapter output string or CBlock containing JSON with the contract
-            ``{"requirement_check": {"score": <float>}}``.
+            `{"requirement_check": {"score": <float>}}`.
 
     Returns:
-        ``True`` if the extracted score exceeds 0.5, ``False`` otherwise.
+        `True` if the extracted score exceeds 0.5, `False` otherwise.
 
     Raises:
-        json.JSONDecodeError: If ``x`` is not valid JSON.
+        json.JSONDecodeError: If `x` is not valid JSON.
         AdapterSchemaMismatchError: If the parsed output does not contain the
-            expected ``requirement_check.score`` structure, or if the score is
+            expected `requirement_check.score` structure, or if the score is
             not a finite number in the range 0.0-1.0.  Callers that previously
-            treated ``False`` as "requirement not met" must now catch this error
+            treated `False` as "requirement not met" must now catch this error
             separately.
     """
     output = str(x)
@@ -83,12 +83,12 @@ def requirement_check_to_bool(x: CBlock | ModelOutputThunk | str) -> bool:
 class ALoraRequirement(Requirement, Intrinsic):
     """A requirement validated by an ALoRA adapter; falls back to LLM-as-a-Judge only on generation error.
 
-    If the adapter is unavailable (e.g. cannot be loaded), ``mellea`` uses
+    If the adapter is unavailable (e.g. cannot be loaded), `mellea` uses
     LLMaJ for that requirement instead.  That is the only case where LLMaJ
     will be used.
 
     If the adapter generates output but the output **fails schema validation**
-    (``requirement_check_to_bool`` raises ``AdapterSchemaMismatchError``), the
+    (`requirement_check_to_bool` raises `AdapterSchemaMismatchError`), the
     exception propagates to the caller — it is not caught and does not trigger
     the LLMaJ fallback.  This is intentional: schema drift should surface
     loudly rather than silently return a wrong result.
@@ -96,10 +96,10 @@ class ALoraRequirement(Requirement, Intrinsic):
     Args:
         description (str): Human-readable requirement description.
         intrinsic_name (str | None): Name of the ALoRA intrinsic to use.
-            Defaults to ``"requirement-check"``.
+            Defaults to `"requirement-check"`.
 
     Attributes:
-        use_aloras (bool): Always ``True``; this class always attempts to use
+        use_aloras (bool): Always `True`; this class always attempts to use
             ALoRA adapters for validation.
     """
 

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -76,7 +76,7 @@ def _get_sampling_result(
     """Aggregate per-iteration slices into a SamplingResult.
 
     Picks the first successful slice as the result; falls back to
-    ``select_from_failure`` over the collected slices when no slice succeeded.
+    `select_from_failure` over the collected slices when no slice succeeded.
     """
     sample_generations: list[ComputedModelOutputThunk] = []
     sample_validations: list[list[tuple[Requirement, ValidationResult]]] = []

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -331,10 +331,10 @@ class MelleaSession:
     def ctx(self, value: Context) -> None:
         """Replace the context and count this as one interaction.
 
-        Every model-interaction code path in this class assigns to ``self.ctx``
+        Every model-interaction code path in this class assigns to `self.ctx`
         with the post-interaction context, so each setter call is exactly one
-        interaction. Lifecycle paths that swap the context wholesale (``reset``,
-        ``_auto_bind_model``) write to ``self._ctx`` directly to bypass this
+        interaction. Lifecycle paths that swap the context wholesale (`reset`,
+        `_auto_bind_model`) write to `self._ctx` directly to bypass this
         counter.
         """
         self._ctx = value

--- a/mellea/stdlib/tools/interpreter.py
+++ b/mellea/stdlib/tools/interpreter.py
@@ -1136,11 +1136,11 @@ def python_tool(
         `artifact_export_paths` emits a `RuntimeWarning` and yields
         `result.artifacts == []`.
 
-        **Local tiers are always unenforced.** ``CapabilityPolicy`` boolean
-        restrictions (``network_access``, ``subprocess_execution``, etc.)
-        are declarative-only on ``"local"`` and ``"local_unsafe"`` — this
+        **Local tiers are always unenforced.** `CapabilityPolicy` boolean
+        restrictions (`network_access`, `subprocess_execution`, etc.)
+        are declarative-only on `"local"` and `"local_unsafe"` — this
         applies to both explicitly passed policies *and* the default
-        ``LOCAL_POLICY`` used by ``tier="local"``.  Use a docker tier for
+        `LOCAL_POLICY` used by `tier="local"`.  Use a docker tier for
         real process isolation.
 
     When the executed code imports `matplotlib`, `matplotlib.use('Agg')` is

--- a/mellea/stdlib/tools/shell.py
+++ b/mellea/stdlib/tools/shell.py
@@ -3,18 +3,18 @@
 
 """Bash shell command execution tool and execution environments for agentic workflows.
 
-Provides ``BashEnvironment`` (abstract base for bash execution) and two concrete
-implementations: ``StaticBashEnvironment`` (parse and safety-check only, no execution)
-and ``_LocalBashEnvironment`` (subprocess execution in the current shell). All
+Provides `BashEnvironment` (abstract base for bash execution) and two concrete
+implementations: `StaticBashEnvironment` (parse and safety-check only, no execution)
+and `_LocalBashEnvironment` (subprocess execution in the current shell). All
 environments enforce a conservative safety denylist (sudo, rm -rf, git push --force,
 system paths, interactive shells). Write operations may also be constrained by
-``working_dir`` and ``allowed_paths``.
+`working_dir` and `allowed_paths`.
 
-The top-level ``bash_executor`` (recommended entry point) executes commands locally
+The top-level `bash_executor` (recommended entry point) executes commands locally
 with denylist safety checks. Bash executor runs with access to the host environment;
 isolation must be provided by the application layer (containers, VMs).
 
-The function is ready to be wrapped as a ``MelleaTool`` instance for ReACT or
+The function is ready to be wrapped as a `MelleaTool` instance for ReACT or
 other agentic loops.
 
 Security note: The denylist covers inline code execution (e.g., bash -c, python -e) and
@@ -689,14 +689,14 @@ class BashEnvironment(ABC):
             addition to passing the default dangerous-path checks.
         working_dir (str | None): Optional directory restriction for write
             operations. This is a host path where the command executes. When
-            specified, writes must remain within this directory or ``/tmp``.
+            specified, writes must remain within this directory or `/tmp`.
         timeout (int): Maximum number of seconds to allow command execution.
 
     Note:
-        Subclass ``StaticBashEnvironment`` returns ``success=True, skipped=True``
+        Subclass `StaticBashEnvironment` returns `success=True, skipped=True`
         to indicate that validation passed but the command was intentionally not
-        executed (analysis-only mode). Consumers that branch on ``success`` should
-        check ``skipped`` first to handle this state correctly.
+        executed (analysis-only mode). Consumers that branch on `success` should
+        check `skipped` first to handle this state correctly.
 
     """
 
@@ -715,14 +715,14 @@ class BashEnvironment(ABC):
         """Parse and validate a command before execution.
 
         The shared validation step performs argv parsing, rejects dangerous shell
-        constructs, applies path safety checks, and enforces ``allowed_paths`` and
-        ``working_dir`` restrictions for write operations.
+        constructs, applies path safety checks, and enforces `allowed_paths` and
+        `working_dir` restrictions for write operations.
 
         Args:
             command: The bash command string to validate.
 
         Returns:
-            Either the validated argv list or a skipped ``ExecutionResult``
+            Either the validated argv list or a skipped `ExecutionResult`
             describing why validation failed.
         """
         try:
@@ -840,10 +840,10 @@ class BashEnvironment(ABC):
 class StaticBashEnvironment(BashEnvironment):
     """Safe environment that validates but does not execute bash commands.
 
-    Returns ``success=True, skipped=True`` when validation passes (command is
+    Returns `success=True, skipped=True` when validation passes (command is
     syntactically valid and passes all safety checks), indicating the command
     would be safe to execute but this environment intentionally does not run it.
-    Returns ``success=False, skipped=True`` when validation fails (safety check
+    Returns `success=False, skipped=True` when validation fails (safety check
     rejection or parse error).
     """
 
@@ -854,8 +854,8 @@ class StaticBashEnvironment(BashEnvironment):
             command (str): The bash command to validate.
 
         Returns:
-            ExecutionResult: Result with ``skipped=True`` and parsed argv in
-            ``analysis_result`` on success, or a safety-check failure on rejection.
+            ExecutionResult: Result with `skipped=True` and parsed argv in
+            `analysis_result` on success, or a safety-check failure on rejection.
         """
         validated = self._validate_command(command)
         if isinstance(validated, ExecutionResult):
@@ -988,9 +988,9 @@ def bash_executor(
             to passing the default dangerous-path checks).
 
     Returns:
-        An ``ExecutionResult`` with stdout, stderr, and success flag. If the
-        command was rejected for safety reasons, ``skipped=True`` and
-        ``skip_message`` contains the reason.
+        An `ExecutionResult` with stdout, stderr, and success flag. If the
+        command was rejected for safety reasons, `skipped=True` and
+        `skip_message` contains the reason.
 
     Examples:
         Basic execution:

--- a/mellea/telemetry/logging.py
+++ b/mellea/telemetry/logging.py
@@ -99,7 +99,7 @@ def get_otlp_log_handler() -> Any:
     """Get an OTLP logging handler for Python's logging module.
 
     The logger provider is initialised on the first call so that environment
-    variables set after module import (e.g. ``MELLEA_LOGS_OTLP``) are
+    variables set after module import (e.g. `MELLEA_LOGS_OTLP`) are
     respected without requiring a module reload.
 
     Returns:

--- a/test/backends/conftest.py
+++ b/test/backends/conftest.py
@@ -16,7 +16,7 @@ def mock_ollama_backend():
 
     No live Ollama server or pulled model is required. The returned backend has
     real client objects replaced with MagicMocks, so subsequent tests can set
-    attributes such as ``backend._async_client.chat`` to control behaviour.
+    attributes such as `backend._async_client.chat` to control behaviour.
 
     Usage::
 

--- a/test/backends/test_audio_openai_unit.py
+++ b/test/backends/test_audio_openai_unit.py
@@ -3,9 +3,9 @@
 
 """Unit tests for audio payload shape on OpenAI-compatible backends (mocked).
 
-Verifies that `AudioBlock` is correctly serialised into the ``input_audio``
+Verifies that `AudioBlock` is correctly serialised into the `input_audio`
 content-part format that OpenAI Chat Completions expects, without requiring a
-live server.  Mirrors the tier-2 structural tests in ``test_vision_ollama.py``.
+live server.  Mirrors the tier-2 structural tests in `test_vision_ollama.py`.
 """
 
 import base64
@@ -100,7 +100,7 @@ def mocked_openai_session():
 def test_audio_block_in_instruct_payload_shape(
     mocked_openai_session: tuple, audio_block: AudioBlock
 ):
-    """AudioBlock is serialised as an ``input_audio`` content part in the outgoing payload."""
+    """AudioBlock is serialised as an `input_audio` content part in the outgoing payload."""
     session, _ = mocked_openai_session
 
     session.instruct("Transcribe this audio.", audio=[audio_block], strategy=None)

--- a/test/backends/test_discriminated_union_tools.py
+++ b/test/backends/test_discriminated_union_tools.py
@@ -4,13 +4,13 @@
 """End-to-end tests for discriminated-union tool parameters.
 
 Covers issue #989: a tool parameter typed as a Pydantic discriminated union
-``Annotated[A | B, Field(discriminator="kind")]`` (with or without ``| None``)
-must not collapse to ``{"type": "string"}``. The schema produced by
-``convert_function_to_ollama_tool`` is consumed by every backend
+`Annotated[A | B, Field(discriminator="kind")]` (with or without `| None`)
+must not collapse to `{"type": "string"}`. The schema produced by
+`convert_function_to_ollama_tool` is consumed by every backend
 (Ollama, OpenAI, Watsonx, HuggingFace, LiteLLM), so the union structure must
-be preserved and the OAS-3 ``discriminator`` keyword must be stripped from
+be preserved and the OAS-3 `discriminator` keyword must be stripped from
 the output (the JSON Schema subset accepted by tool-calling APIs does not
-include it; the ``Literal`` tag fields carry the discriminator signal).
+include it; the `Literal` tag fields carry the discriminator signal).
 """
 
 import json
@@ -71,7 +71,7 @@ def act_optional(
 
 
 def _pet_schema(func) -> dict:
-    """Convert ``func`` and return the ``pet`` parameter schema."""
+    """Convert `func` and return the `pet` parameter schema."""
     tool = convert_function_to_ollama_tool(func)
     assert tool.function is not None
     assert tool.function.parameters is not None
@@ -79,10 +79,10 @@ def _pet_schema(func) -> dict:
 
 
 def _has_branch(schema: dict, kind_value: str, *, must_have: set[str]) -> bool:
-    """Check that ``schema`` contains an inlined ``anyOf`` branch for ``kind_value``.
+    """Check that `schema` contains an inlined `anyOf` branch for `kind_value`.
 
-    After the fix lands the output schema must contain ``anyOf`` only, never
-    ``oneOf`` — accepting ``oneOf`` here would silently mask a regression of
+    After the fix lands the output schema must contain `anyOf` only, never
+    `oneOf` — accepting `oneOf` here would silently mask a regression of
     the discriminator-flattening pre-pass.
     """
     branches = schema.get("anyOf", [])
@@ -119,9 +119,9 @@ class TestDiscriminatedUnionSchema:
         )
 
     def test_required_union_strips_discriminator_keyword(self):
-        """OAS-3 ``discriminator`` is rejected by Ollama / OpenAI strict mode.
+        """OAS-3 `discriminator` is rejected by Ollama / OpenAI strict mode.
 
-        The ``Literal`` constraint on ``kind`` already carries the tag signal,
+        The `Literal` constraint on `kind` already carries the tag signal,
         so the OAS keyword adds no semantic value but is actively harmful.
         """
         pet = _pet_schema(act)
@@ -130,7 +130,7 @@ class TestDiscriminatedUnionSchema:
         )
 
     def test_required_union_no_dangling_refs(self):
-        """No ``$ref`` should leak into the output for the issue reproducer."""
+        """No `$ref` should leak into the output for the issue reproducer."""
         rendered = json.dumps(_pet_schema(act))
         assert "$ref" not in rendered, f"unresolved $ref in tool schema: {rendered}"
 
@@ -164,9 +164,9 @@ class TestDiscriminatedUnionSchema:
         )
 
     def test_optional_union_strips_discriminator_keyword(self):
-        """The Optional variant must also drop the OAS-3 ``discriminator``.
+        """The Optional variant must also drop the OAS-3 `discriminator`.
 
-        The required variant strips it via the top-level ``oneOf`` path; the
+        The required variant strips it via the top-level `oneOf` path; the
         optional variant strips it implicitly when the wrapper sub-schema is
         replaced by its expanded branches. Asserted explicitly so a refactor
         that re-introduces the wrapper does not slip past silently.
@@ -201,12 +201,12 @@ class TestDiscriminatedUnionSchema:
         )
 
     def test_non_discriminated_optional_unchanged(self):
-        """Non-discriminated ``Optional[Email]`` must still flow through unchanged.
+        """Non-discriminated `Optional[Email]` must still flow through unchanged.
 
         Regression guard: the new pre-pass must be a no-op for plain
-        ``$ref`` + ``| None`` shapes that the existing inliner already
+        `$ref` + `| None` shapes that the existing inliner already
         handles. Pydantic emits this as
-        ``{"anyOf": [{"$ref": "..."}, {"type": "null"}]}`` — no ``oneOf``
+        `{"anyOf": [{"$ref": "..."}, {"type": "null"}]}` — no `oneOf`
         in any sub-schema, so the pre-pass should not activate.
         """
 
@@ -235,7 +235,7 @@ class TestDiscriminatedUnionSchema:
 
 
 class TestDiscriminatedUnionValidation:
-    """``validate_tool_arguments`` must round-trip a valid discriminated payload."""
+    """`validate_tool_arguments` must round-trip a valid discriminated payload."""
 
     def test_strict_accepts_valid_dog(self):
         """A correctly-shaped dog dict should pass strict validation."""
@@ -258,7 +258,7 @@ class TestDiscriminatedUnionValidation:
             validate_tool_arguments(mt, {"pet": "just a string"}, strict=True)
 
     def test_strict_rejects_missing_discriminator(self):
-        """A dict without the ``kind`` discriminator must be rejected."""
+        """A dict without the `kind` discriminator must be rejected."""
         mt = MelleaTool.from_callable(act)
         with pytest.raises(ValidationError):
             validate_tool_arguments(mt, {"pet": {"name": "Rex"}}, strict=True)

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -12,7 +12,7 @@ happen to read self._tokenizer.chat_template.  The fixture sets that attribute t
 known Jinja string, bypassing __init__ (and therefore model loading) entirely.
 
 torch must be importable because importing LocalHFBackend triggers the top-level
-``import torch`` in huggingface.py.  Install mellea[hf] to satisfy this requirement.
+`import torch` in huggingface.py.  Install mellea[hf] to satisfy this requirement.
 """
 
 import logging
@@ -353,9 +353,9 @@ def test_generate_filter_drops_template_only_reasoning_kwargs(
     """Chat-template variables specific to non-Granite models must also be dropped.
 
     These variables are referenced by the chat templates of models shipped in
-    ``mellea/backends/model_ids.py`` (Qwen3, Llama 3.x/4, gpt-oss, etc.) but are
-    NOT accepted by ``transformers``' ``generate``. If forwarded through, they
-    would raise ``TypeError`` at inference time.
+    `mellea/backends/model_ids.py` (Qwen3, Llama 3.x/4, gpt-oss, etc.) but are
+    NOT accepted by `transformers`' `generate`. If forwarded through, they
+    would raise `TypeError` at inference time.
     """
     template_only_kwargs = [
         "enable_thinking",  # Qwen3
@@ -377,9 +377,9 @@ def test_generate_filter_drops_template_only_reasoning_kwargs(
 
 
 def test_for_generate_false_skips_filter(plain_backend: LocalHFBackend) -> None:
-    """``for_generate=False`` skips the generate-kwargs filter.
+    """`for_generate=False` skips the generate-kwargs filter.
 
-    This is the path used by ``_filter_for_chat_template`` — chat-template
+    This is the path used by `_filter_for_chat_template` — chat-template
     variables must survive the rename step so the chat-template allowlist can
     examine them.
     """
@@ -395,7 +395,7 @@ def test_generate_kwargs_allowlist_no_chat_template_only_overlap() -> None:
 
     This is the regression guard for the bug class fixed in this change: if a
     Jinja variable referenced by one of the templates in
-    ``mellea/backends/model_ids.py`` is *also* a real ``generate()`` kwarg name,
+    `mellea/backends/model_ids.py` is *also* a real `generate()` kwarg name,
     the allowlist would let it leak through and we'd need a different mechanism
     (an explicit denylist or a per-call-site decision). Today there is no
     overlap, and this test will fail loudly the day that changes.
@@ -428,11 +428,11 @@ def test_generate_kwargs_allowlist_no_chat_template_only_overlap() -> None:
 
 
 def test_generate_kwargs_allowlist_includes_known_generate_kwargs() -> None:
-    """Common ``generate()`` kwargs Mellea relies on must be in the allowlist.
+    """Common `generate()` kwargs Mellea relies on must be in the allowlist.
 
     A canary against an upstream rename or removal of a kwarg that Mellea
-    forwards from caller-supplied ``model_options``. Mellea-injected kwargs
-    (``stopping_criteria``, ``streamer``, etc.) are passed explicitly at the
+    forwards from caller-supplied `model_options`. Mellea-injected kwargs
+    (`stopping_criteria`, `streamer`, etc.) are passed explicitly at the
     call sites and don't need to be in this set, but generation-tuning kwargs
     that callers customize do.
     """

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -891,7 +891,7 @@ async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
 ):
     """_generate_from_intrinsic raises ValueError when ctx contains image/audio blocks.
 
-    The guard on the intrinsic path passes ``action=None`` and scans only the context;
+    The guard on the intrinsic path passes `action=None` and scans only the context;
     this test exercises that branch directly.
     """
     backend = _make_intrinsic_backend_stub(stub_backend)

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -3,9 +3,9 @@
 
 """Unit tests for LiteLLMBackend mot.thinking population.
 
-Covers the vLLM case where the wire key is ``"reasoning"`` instead of
-``"reasoning_content"``, and the case where LiteLLM has already normalised
-it to ``"reasoning_content"`` (so both keys are exercised).
+Covers the vLLM case where the wire key is `"reasoning"` instead of
+`"reasoning_content"`, and the case where LiteLLM has already normalised
+it to `"reasoning_content"` (so both keys are exercised).
 """
 
 import pytest
@@ -133,9 +133,9 @@ async def test_processing_non_streaming_empty_reasoning_content_does_not_fall_ba
 ):
     """Empty-string reasoning_content wins — does not fall back to reasoning key.
 
-    Validates that the is-None guard (not ``or``) is used: an empty-string
-    ``reasoning_content`` chunk is preserved as-is, not silently replaced by the
-    fallback ``reasoning`` value.
+    Validates that the is-None guard (not `or`) is used: an empty-string
+    `reasoning_content` chunk is preserved as-is, not silently replaced by the
+    fallback `reasoning` value.
     """
     mot = _fresh_mot()
     msg = Message(content="Paris", role="assistant")
@@ -212,7 +212,7 @@ async def test_processing_streaming_empty_reasoning_content_does_not_fall_back(
 ):
     """Streaming: empty-string reasoning_content wins — does not fall back to reasoning key.
 
-    Validates that the is-None guard (not ``or``) is used in the streaming branch too.
+    Validates that the is-None guard (not `or`) is used in the streaming branch too.
     """
     mot = _fresh_mot()
     delta = Delta(content="")

--- a/test/backends/test_model_options.py
+++ b/test/backends/test_model_options.py
@@ -98,7 +98,7 @@ def test_model_option_replace_with_conflicts():
 
 
 def test_model_option_sentinels_are_unique():
-    """All ``@@@``-prefixed sentinel values on ModelOption must be distinct."""
+    """All `@@@`-prefixed sentinel values on ModelOption must be distinct."""
     sentinel_values = [
         v
         for v in vars(ModelOption).values()

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -27,12 +27,12 @@ def _ensure_model_warm() -> None:
 
     The conftest warms models when transitioning *into* the ollama test group, but
     that warm-up does not fire when this file is run in isolation (e.g.
-    ``pytest test/backends/test_ollama.py``). Without this fixture the first test
+    `pytest test/backends/test_ollama.py`). Without this fixture the first test
     in such a run fires concurrent requests against a cold model, triggering the
     Ollama load-race that returns empty responses (see #599 and
     https://github.com/ollama/ollama/issues/16326).
 
-    ``keep_alive=-1`` pins the model in memory until the conftest module-boundary
+    `keep_alive=-1` pins the model in memory until the conftest module-boundary
     eviction fires at the end of this test file.
     """
     _model = IBM_GRANITE_4_1_3B.ollama_name

--- a/test/backends/test_openai_intrinsics.py
+++ b/test/backends/test_openai_intrinsics.py
@@ -4,7 +4,7 @@
 """E2E tests for intrinsics on the OpenAI backend with a Granite Switch model.
 
 Starts a vLLM server hosting a Granite Switch model, creates an OpenAIBackend with
-``embedded_adapters=True``, and runs each intrinsic that has matching test data
+`embedded_adapters=True`, and runs each intrinsic that has matching test data
 through the full generation path.
 """
 
@@ -65,7 +65,7 @@ SWITCH_MODEL_ID = os.environ.get(
 def vllm_switch_process():
     """Module-scoped vLLM process serving a Granite Switch model.
 
-    If ``VLLM_SWITCH_TEST_BASE_URL`` is set the server is assumed to be running
+    If `VLLM_SWITCH_TEST_BASE_URL` is set the server is assumed to be running
     externally and no subprocess is started.
     """
     if os.environ.get("VLLM_SWITCH_TEST_BASE_URL"):
@@ -218,7 +218,7 @@ def _get_matching_combos(backend: OpenAIBackend) -> dict[str, YamlJsonCombo]:
 def _build_chat_context(input_json: dict) -> ChatContext:
     """Build a ChatContext from the raw input JSON used by intrinsics tests.
 
-    Parses messages and attaches any documents from ``extra_body.documents``
+    Parses messages and attaches any documents from `extra_body.documents`
     to the last user message.
     """
     ctx = ChatContext()

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -3,10 +3,10 @@
 
 """Unit tests for the OpenAI backend intrinsic generation path — no server required.
 
-Mocks the OpenAI async client to verify that ``_generate_from_intrinsic`` correctly:
-- injects ``intrinsic_name`` into ``chat_template_kwargs``
-- applies the ``IntrinsicsResultProcessor`` to the raw response
-- forwards ``temperature`` and ``seed`` from model options
+Mocks the OpenAI async client to verify that `_generate_from_intrinsic` correctly:
+- injects `intrinsic_name` into `chat_template_kwargs`
+- applies the `IntrinsicsResultProcessor` to the raw response
+- forwards `temperature` and `seed` from model options
 - user-provided model options override io.yaml parameter defaults
 - all applicable model options (MAX_NEW_TOKENS, SYSTEM_PROMPT, etc.) are forwarded
 - raises when no adapter is registered or streaming is requested

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -223,7 +223,7 @@ def _vllm_chat_completion(reasoning: str, content: str | None) -> ChatCompletion
 
 
 async def test_processing_captures_vllm_reasoning_field(backend):
-    """Non-streaming: mot.thinking captures the raw ``reasoning`` key from vLLM."""
+    """Non-streaming: mot.thinking captures the raw `reasoning` key from vLLM."""
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     chunk = _vllm_chat_completion(reasoning="2 + 2 equals 4.", content="4")
     # Sanity check: the SDK object does not expose reasoning_content
@@ -236,7 +236,7 @@ async def test_processing_captures_vllm_reasoning_field(backend):
 
 
 async def test_processing_vllm_reasoning_with_null_content(backend):
-    """Non-streaming: reasoning is captured even when ``content`` is null."""
+    """Non-streaming: reasoning is captured even when `content` is null."""
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     chunk = _vllm_chat_completion(reasoning="some thinking", content=None)
 
@@ -247,7 +247,7 @@ async def test_processing_vllm_reasoning_with_null_content(backend):
 
 
 async def test_processing_streaming_captures_vllm_reasoning_field(backend):
-    """Streaming: per-chunk ``reasoning`` deltas accumulate into mot.thinking."""
+    """Streaming: per-chunk `reasoning` deltas accumulate into mot.thinking."""
     mot: ModelOutputThunk = ModelOutputThunk(value=None)
     chunk_a = ChatCompletionChunk.model_validate(
         {
@@ -292,9 +292,9 @@ async def test_processing_streaming_captures_vllm_reasoning_field(backend):
 
 
 async def test_processing_reasoning_content_still_used(backend):
-    """Regression guard: the pre-existing ``reasoning_content`` path is preserved.
+    """Regression guard: the pre-existing `reasoning_content` path is preserved.
 
-    Some providers surface the trace as ``reasoning_content`` on the message
+    Some providers surface the trace as `reasoning_content` on the message
     object itself. The fix must not regress that path in favour of the raw-dict
     fallback.
     """
@@ -322,7 +322,7 @@ async def test_processing_reasoning_content_still_used(backend):
 
 
 async def test_processing_reasoning_content_takes_precedence_over_reasoning(backend):
-    """reasoning_content attribute wins when both it and raw ``reasoning`` are present."""
+    """reasoning_content attribute wins when both it and raw `reasoning` are present."""
     message = ChatCompletionMessage.model_validate(
         {
             "role": "assistant",

--- a/test/backends/test_reasoning_replay.py
+++ b/test/backends/test_reasoning_replay.py
@@ -9,10 +9,10 @@ through each backend's conversation-construction path:
 
 - reasoning is **stripped** on a plain follow-up turn, and
 - **round-tripped** when the prior assistant turn issued a tool call
-  (detected by that assistant message's own ``tool_calls`` field).
+  (detected by that assistant message's own `tool_calls` field).
 
-The provider ``create``/``acompletion`` call is mocked, so no endpoint is
-required. A separate CI-skipped e2e test (``test_reasoning_replay_e2e.py``)
+The provider `create`/`acompletion` call is mocked, so no endpoint is
+required. A separate CI-skipped e2e test (`test_reasoning_replay_e2e.py`)
 verifies the same behaviour against a real reasoning model.
 """
 

--- a/test/backends/test_reasoning_replay_e2e.py
+++ b/test/backends/test_reasoning_replay_e2e.py
@@ -4,7 +4,7 @@
 """Live multi-turn reasoning-replay verification against a real thinking model.
 
 This is the "quick verification after the fact" for issue #1201: the mechanical
-strip/round-trip plumbing is unit-tested in ``test_reasoning_replay.py`` without
+strip/round-trip plumbing is unit-tested in `test_reasoning_replay.py` without
 a model; this module confirms the same behaviour holds against a real reasoning
 endpoint, and pins the one empirical unknown — which side of the tool-call
 contract the served model lands on.
@@ -12,11 +12,11 @@ contract the served model lands on.
 Model-agnostic by design. Configure via environment variables (skipped entirely
 when unset, so it never runs in default CI):
 
-- ``MELLEA_REASONING_TEST_BASE_URL`` — OpenAI-compatible endpoint, e.g.
-  ``http://localhost:8000/v1`` (vLLM) or ``http://localhost:11434/v1`` (Ollama).
-- ``MELLEA_REASONING_TEST_MODEL`` — served model id. Defaults to a Granite
+- `MELLEA_REASONING_TEST_BASE_URL` — OpenAI-compatible endpoint, e.g.
+  `http://localhost:8000/v1` (vLLM) or `http://localhost:11434/v1` (Ollama).
+- `MELLEA_REASONING_TEST_MODEL` — served model id. Defaults to a Granite
   reasoning model; point it at Qwen3 / DeepSeek-R1 / etc. to verify those.
-- ``MELLEA_REASONING_TEST_API_KEY`` — optional; defaults to ``"ollama"``.
+- `MELLEA_REASONING_TEST_API_KEY` — optional; defaults to `"ollama"`.
 
 Run directly (bypasses the default marker filter):
 

--- a/test/backends/test_schema_helpers.py
+++ b/test/backends/test_schema_helpers.py
@@ -169,10 +169,10 @@ class TestIsComplexAnyof:
     def test_anyof_with_oneof_branch_is_complex(self):
         """anyOf containing a oneOf branch (Optional discriminated union) is complex.
 
-        Pydantic emits ``Annotated[Cat | Dog, Field(discriminator="kind")] | None``
-        as ``{"anyOf": [{"discriminator": {...}, "oneOf": [$refs]}, {"type": "null"}]}``.
-        Without descending into ``oneOf`` we drop the union structure and ship
-        ``{"type": "string"}`` to the backend (issue #989).
+        Pydantic emits `Annotated[Cat | Dog, Field(discriminator="kind")] | None`
+        as `{"anyOf": [{"discriminator": {...}, "oneOf": [$refs]}, {"type": "null"}]}`.
+        Without descending into `oneOf` we drop the union structure and ship
+        `{"type": "string"}` to the backend (issue #989).
         """
         schema = {
             "anyOf": [

--- a/test/backends/test_stop_sequences_unit.py
+++ b/test/backends/test_stop_sequences_unit.py
@@ -27,7 +27,7 @@ def _make_openai_backend() -> OpenAIBackend:
 
 @pytest.mark.parametrize("context", ["chats", "completions"])
 def test_openai_stop_sequences_round_trip(context):
-    """Native ``stop`` -> sentinel -> ``stop`` for both chat and completions."""
+    """Native `stop` -> sentinel -> `stop` for both chat and completions."""
     backend = _make_openai_backend()
     is_chat = context == "chats"
     stops = ["END", "</s>"]
@@ -115,7 +115,7 @@ def _make_watsonx_backend():
     "is_chat,native_key", [(True, "stop"), (False, "stop_sequences")]
 )
 def test_watsonx_stop_sequences_round_trip(is_chat, native_key):
-    """Native -> sentinel -> native for both chat (``stop``) and completions (``stop_sequences``)."""
+    """Native -> sentinel -> native for both chat (`stop`) and completions (`stop_sequences`)."""
     backend = _make_watsonx_backend()
     stops = ["END", "</s>"]
 
@@ -171,8 +171,8 @@ async def test_watsonx_processing_streaming_captures_reasoning_content():
 def _make_hf_backend_stub():
     """Construct a LocalHFBackend without loading a model.
 
-    Bypasses ``__init__`` because the real constructor downloads weights. We only
-    need ``from_mellea_model_opts_map`` for the round-trip mapping check.
+    Bypasses `__init__` because the real constructor downloads weights. We only
+    need `from_mellea_model_opts_map` for the round-trip mapping check.
     """
     pytest.importorskip("transformers")
     from mellea.backends.huggingface import LocalHFBackend

--- a/test/backends/test_watsonx_multimodal_unit.py
+++ b/test/backends/test_watsonx_multimodal_unit.py
@@ -4,8 +4,8 @@
 """Unit tests verifying WatsonxAIBackend rejects image and audio inputs.
 
 Watsonx does not support image or audio inputs.  These tests confirm that
-passing ``ImageBlock``, ``ImageUrlBlock``, ``AudioBlock``, or ``AudioUrlBlock``
-raises ``ValueError`` before any network call is made, rather than silently
+passing `ImageBlock`, `ImageUrlBlock`, `AudioBlock`, or `AudioUrlBlock`
+raises `ValueError` before any network call is made, rather than silently
 dropping the data.
 """
 

--- a/test/cli/test_fix_async.py
+++ b/test/cli/test_fix_async.py
@@ -1463,7 +1463,7 @@ class TestUserWrittenPatternDetection:
         assert len(locs) == 0
 
     def test_from_stdlib_import_session_detected(self):
-        """``from mellea.stdlib import session`` should enable session detection."""
+        """`from mellea.stdlib import session` should enable session detection."""
         src = _dedent("""\
             from mellea.stdlib import session
             async def main():
@@ -1476,7 +1476,7 @@ class TestUserWrittenPatternDetection:
         assert locs[0].call_style == "session"
 
     def test_bare_import_mellea_detected(self):
-        """``import mellea`` + session method call should be detected."""
+        """`import mellea` + session method call should be detected."""
         src = _dedent("""\
             import mellea
             m = mellea.start_session()

--- a/test/cli/test_fix_genstub.py
+++ b/test/cli/test_fix_genstub.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the ``m fix genslots`` CLI tool."""
+"""Tests for the `m fix genslots` CLI tool."""
 
 import textwrap
 from pathlib import Path

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -257,8 +257,8 @@ BACKEND_MARKERS: dict[str, str] = {
 }
 """Single source of truth for backend marker names and descriptions.
 
-Add new backends here — ``pytest_configure`` registers them automatically.
-Keep ``pyproject.toml`` ``[tool.pytest.ini_options].markers`` in sync.
+Add new backends here — `pytest_configure` registers them automatically.
+Keep `pyproject.toml` `[tool.pytest.ini_options].markers` in sync.
 """
 
 
@@ -728,8 +728,8 @@ def aggressive_cleanup():
 async def register_acceptance_sets(request):
     """Register all acceptance plugin sets (logging, sequential, concurrent, fandf).
 
-    Usage: mark your test with ``@pytest.mark.plugins`` and request this fixture,
-    or rely on the autouse ``auto_register_acceptance_sets`` fixture below.
+    Usage: mark your test with `@pytest.mark.plugins` and request this fixture,
+    or rely on the autouse `auto_register_acceptance_sets` fixture below.
     """
     plugins_disabled = request.config.getoption(
         "--disable-default-mellea-plugins", default=False
@@ -756,7 +756,7 @@ async def register_acceptance_sets(request):
 
 @pytest.fixture(autouse=True, scope="session")
 async def auto_register_acceptance_sets(request):
-    """Auto-register acceptance plugin sets for all tests by default; disable when ``--disable-default-mellea-plugins`` is passed on the CLI."""
+    """Auto-register acceptance plugin sets for all tests by default; disable when `--disable-default-mellea-plugins` is passed on the CLI."""
     disable_plugins = request.config.getoption(
         "--disable-default-mellea-plugins", default=False
     )

--- a/test/core/test_base.py
+++ b/test/core/test_base.py
@@ -844,7 +844,7 @@ async def test_cancel_generation_propagates_outer_cancellation() -> None:
 
     When cancel_generation() is awaiting self._gen.generate and the *cancel_generation*
     task is itself cancelled from outside, cur.cancelling() > 0 and the
-    CancelledError must propagate — not be swallowed by the bare ``pass`` path.
+    CancelledError must propagate — not be swallowed by the bare `pass` path.
     """
     import asyncio
 

--- a/test/decompose/test_decompose.py
+++ b/test/decompose/test_decompose.py
@@ -1,10 +1,10 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ``cli/decompose/decompose.py`` run flow.
+"""Tests for `cli/decompose/decompose.py` run flow.
 
 This module validates prompt loading, argument forwarding, template selection,
-output writing, multi-job behavior, and cleanup behavior for the ``run`` command.
+output writing, multi-job behavior, and cleanup behavior for the `run` command.
 """
 
 from pathlib import Path
@@ -85,7 +85,7 @@ def write_input_file(tmp_path: Path, content: str, name: str = "input.txt") -> s
 
 @pytest.fixture
 def patch_jinja(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch Jinja objects used by ``run``."""
+    """Patch Jinja objects used by `run`."""
     monkeypatch.setattr("cli.decompose.decompose.Environment", DummyEnvironment)
     monkeypatch.setattr(
         "cli.decompose.decompose.FileSystemLoader", lambda *args, **kwargs: None
@@ -146,7 +146,7 @@ class TestRunSuccess:
         patch_validate_filename: None,
         patch_logging: Mock,
     ) -> None:
-        """Input file mode forwards args to ``pipeline.decompose``."""
+        """Input file mode forwards args to `pipeline.decompose`."""
         input_file = write_input_file(tmp_path, "Summarize document.")
         captured: dict[str, Any] = {}
 
@@ -184,7 +184,7 @@ class TestRunSuccess:
         patch_validate_filename: None,
         patch_logging: Mock,
     ) -> None:
-        """Interactive mode reads prompt and sends ``None`` input vars."""
+        """Interactive mode reads prompt and sends `None` input vars."""
         captured: dict[str, Any] = {}
 
         def fake_decompose(**kwargs: Any) -> DecompPipelineResult:
@@ -213,7 +213,7 @@ class TestRunSuccess:
         patch_validate_filename: None,
         patch_logging: Mock,
     ) -> None:
-        """``latest`` resolves to the last declared enum version."""
+        """`latest` resolves to the last declared enum version."""
         input_file = write_input_file(tmp_path, "Test")
         requested_templates: list[str] = []
         environment = Mock()
@@ -366,7 +366,7 @@ class TestRunFailures:
         patch_validate_filename: None,
         patch_logging: Mock,
     ) -> None:
-        """Exceptions from ``pipeline.decompose`` are propagated."""
+        """Exceptions from `pipeline.decompose` are propagated."""
         input_file = write_input_file(tmp_path, "fail")
 
         def raise_inference_error(**kwargs: Any) -> DecompPipelineResult:
@@ -389,7 +389,7 @@ class TestRunFailures:
         patch_validate_filename: None,
         patch_logging: Mock,
     ) -> None:
-        """Invalid ``out_dir`` fails before pipeline call."""
+        """Invalid `out_dir` fails before pipeline call."""
         input_file = write_input_file(tmp_path, "Test prompt")
 
         decompose_mock = Mock(return_value=make_decomp_result())

--- a/test/formatters/granite/test_intrinsics_canned_output.py
+++ b/test/formatters/granite/test_intrinsics_canned_output.py
@@ -5,12 +5,12 @@
 
 These tests exercise the full output-processing pipeline (JSON parsing,
 transformation rules, float-rounding comparison) against pre-recorded model
-outputs stored in ``testdata/``.  They require **no GPU, no network, and no
+outputs stored in `testdata/`.  They require **no GPU, no network, and no
 model downloads** — only a local YAML config file and the three JSON artifacts
 per scenario (canned input, model output, expected result).
 
 Scenarios that need a YAML config from HuggingFace Hub are skipped unless the
-YAML has been previously cached locally or a ``config_dict`` is embedded here.
+YAML has been previously cached locally or a `config_dict` is embedded here.
 """
 
 import copy

--- a/test/formatters/granite/test_intrinsics_formatters.py
+++ b/test/formatters/granite/test_intrinsics_formatters.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 __doc__ = """
-Tests of code under ``mellea.formatters.granite``
+Tests of code under `mellea.formatters.granite`
 """
 
 # Standard
@@ -80,12 +80,12 @@ def _substitute_root(
 
     Args:
         child_path: A path that is a descendant of a known root.
-        old_root: Root directory that is an ancestor of ``child_path``.
-        new_root: Root directory to substitute for ``old_root``.
+        old_root: Root directory that is an ancestor of `child_path`.
+        new_root: Root directory to substitute for `old_root`.
 
     Returns:
-        A version of ``child_path`` in which the prefix corresponding to
-        ``old_root`` has been replaced with ``new_root``.
+        A version of `child_path` in which the prefix corresponding to
+        `old_root` has been replaced with `new_root`.
     """
     # Resolve paths to handle symlinks, relative components, and other corner cases
     child_path = child_path.resolve()
@@ -128,18 +128,18 @@ class YamlJsonCombo(pydantic.BaseModel):
     short_name: str
     """Short name for the test scenario, for printing to the logs."""
     yaml_file: pathlib.Path | None = None
-    """Location of local YAML file, or ``None`` to download from remote repo.
+    """Location of local YAML file, or `None` to download from remote repo.
     If the file is downloaded, the validator for this field will update this field
     automatically."""
     inputs_file: pathlib.Path
     """Location of local JSON input file."""
     arguments_file: pathlib.Path | None = None
-    """Location of local JSON file of arguments, or ``None`` if no arguments."""
+    """Location of local JSON file of arguments, or `None` if no arguments."""
     task: str | None = None
-    """Name of target task, used for loading adapters. ``None`` means no adapter and
+    """Name of target task, used for loading adapters. `None` means no adapter and
     no inference tests."""
     is_alora: bool = False
-    """``True`` to use the activated LoRA variant of the model for inference tests."""
+    """`True` to use the activated LoRA variant of the model for inference tests."""
     repo_id: str = _RAG_INTRINSICS_REPO_NAME
     """Repo on Hugging Face Hub from which the adapter for this intrinsic should be
     loaded."""
@@ -151,7 +151,7 @@ class YamlJsonCombo(pydantic.BaseModel):
     def revision(self) -> str:
         """Pinned commit SHA for this combo's repo.
 
-        Resolved from ``_REPO_PINNED_SHAS`` so every combo for a given repo
+        Resolved from `_REPO_PINNED_SHAS` so every combo for a given repo
         downloads against the same revision, letting huggingface_hub's cache
         coalesce all per-test snapshot_download calls into one materialization
         per repo per pytest session.
@@ -365,7 +365,7 @@ def _yaml_json_combo(request: pytest.FixtureRequest) -> YamlJsonCombo:
     """Pytest fixture that allows us to run a given test case repeatedly with multiple
     different combinations of IO configuration and chat completion request.
 
-    Uses the files in ``testdata/input_json`` and ``testdata/input_yaml``.
+    Uses the files in `testdata/input_json` and `testdata/input_yaml`.
 
     Returns test configuration.
     """
@@ -380,7 +380,7 @@ def _yaml_json_combo_no_alora(request: pytest.FixtureRequest) -> YamlJsonCombo:
     different combinations of IO configuration and chat completion request. Ignores
     model configs that use the aLoRA variant of the model.
 
-    Uses the files in ``testdata/input_json`` and ``testdata/input_yaml``.
+    Uses the files in `testdata/input_json` and `testdata/input_yaml`.
 
     Returns tuple of short name, YAML file, JSON file, model directory, and
     arguments file.

--- a/test/formatters/granite/test_openai_compat.py
+++ b/test/formatters/granite/test_openai_compat.py
@@ -3,9 +3,9 @@
 
 """Unit tests verifying OpenAI SDK compatibility of ChatCompletion objects.
 
-These tests ensure that ``ChatCompletion`` Pydantic models serialise to dicts
+These tests ensure that `ChatCompletion` Pydantic models serialise to dicts
 that pass OpenAI Python SDK request validation.  The SDK client is pointed at a
-bogus URL so that the expected failure is ``APIConnectionError`` (network),
+bogus URL so that the expected failure is `APIConnectionError` (network),
 **not** a Pydantic/type validation error.  No network access is required.
 """
 

--- a/test/package/test_dependency_isolation.py
+++ b/test/package/test_dependency_isolation.py
@@ -3,7 +3,7 @@
 
 """Tests that verify each optional dependency group installs and imports correctly in isolation.
 
-Each test uses ``uv run --isolated`` to create a throwaway environment with only the
+Each test uses `uv run --isolated` to create a throwaway environment with only the
 specified extra installed, then runs a generated Python script to verify that:
 1. Expected imports succeed
 2. Optional imports that need other extras fail or degrade gracefully
@@ -122,10 +122,10 @@ TESTED_EXTRAS = {
 
 
 def _parse_optional_dependency_groups() -> set[str]:
-    """Parse ``pyproject.toml`` and return the set of optional-dependency group names.
+    """Parse `pyproject.toml` and return the set of optional-dependency group names.
 
     Returns:
-        set[str]: The group names defined in ``pyproject.toml`` (e.g. ``{"hf", ...}``).
+        set[str]: The group names defined in `pyproject.toml` (e.g. `{"hf", ...}`).
     """
     pyproject = PROJECT_ROOT / "pyproject.toml"
     with open(pyproject, "rb") as f:
@@ -141,11 +141,11 @@ def _normalize_exclude(exclude: set[str] | str = "") -> set[str]:
 
 
 def _backend_fail_imports(exclude: set[str] | str = "") -> list[tuple[str, str]]:
-    """Return ``(import_stmt, extra_name)`` pairs for backends expected to fail.
+    """Return `(import_stmt, extra_name)` pairs for backends expected to fail.
 
-    Collects import statements from all ``BACKEND_EXTRAS`` except those in ``exclude``.
+    Collects import statements from all `BACKEND_EXTRAS` except those in `exclude`.
     Each tuple pairs the import statement with the extra name so the checker
-    script can verify the ``ImportError`` contains a ``mellea[<extra>]`` hint.
+    script can verify the `ImportError` contains a `mellea[<extra>]` hint.
 
     Args:
         exclude (set[str] | str): Backend extras to omit (their imports are
@@ -153,7 +153,7 @@ def _backend_fail_imports(exclude: set[str] | str = "") -> list[tuple[str, str]]
             an empty string to include all backends.
 
     Returns:
-        list[tuple[str, str]]: Pairs of ``(import_statement, extra_name)``.
+        list[tuple[str, str]]: Pairs of `(import_statement, extra_name)`.
     """
     extras = BACKEND_EXTRAS - _normalize_exclude(exclude)
     return [(stmt, name) for name in sorted(extras) for stmt in IMPORTS[name]]
@@ -166,21 +166,21 @@ def _build_check_script(
 ) -> str:
     """Build a self-contained Python script that tests imports and prints failures.
 
-    The generated script attempts each import statement literally (no ``exec``),
-    checks module-level flags via ``importlib``, and raises ``SystemExit`` with
+    The generated script attempts each import statement literally (no `exec`),
+    checks module-level flags via `importlib`, and raises `SystemExit` with
     a newline-delimited failure summary if anything is wrong.
 
     Args:
         should_succeed (list[str]): Import statements that must execute without error.
         should_fail (list[tuple[str, str]]): Tuples of
-            ``(import_statement, extra_name)`` — the import must raise
-            ``ImportError`` and the message must contain ``mellea[<extra_name>]``.
+            `(import_statement, extra_name)` — the import must raise
+            `ImportError` and the message must contain `mellea[<extra_name>]`.
         flag_checks (list[tuple[str, str, bool]]): Tuples of
-            ``(module_path, attribute_name, expected_value)`` for boolean flag
-            assertions (e.g. ``("mellea.telemetry.tracing", "_OTEL_AVAILABLE", True)``).
+            `(module_path, attribute_name, expected_value)` for boolean flag
+            assertions (e.g. `("mellea.telemetry.tracing", "_OTEL_AVAILABLE", True)`).
 
     Returns:
-        str: A complete Python script suitable for ``python -c``.
+        str: A complete Python script suitable for `python -c`.
     """
     lines = ["import importlib", "failures = []", ""]
 
@@ -231,25 +231,25 @@ def _run_check(
 ) -> None:
     """Build and run an import check script in an isolated uv environment.
 
-    Creates a throwaway environment via ``uv run --isolated --no-project``,
+    Creates a throwaway environment via `uv run --isolated --no-project`,
     installs mellea (with the given extra if provided), and executes the
     generated checker script. Fails the current pytest test if any check
     doesn't pass.
 
     Args:
         extra (str | None): The optional-dependency extra to install
-            (e.g. ``"hf"``). Pass ``None`` to install core mellea only.
+            (e.g. `"hf"`). Pass `None` to install core mellea only.
         should_succeed (list[str]): Import statements that must execute without error.
         should_fail (list[tuple[str, str]]): Tuples of
-            ``(import_statement, extra_name)`` — must raise ``ImportError``
-            with ``mellea[<extra_name>]`` in the message.
+            `(import_statement, extra_name)` — must raise `ImportError`
+            with `mellea[<extra_name>]` in the message.
         flag_checks (list[tuple[str, str, bool]]): Tuples of
-            ``(module_path, attribute_name, expected_value)`` for boolean flag
+            `(module_path, attribute_name, expected_value)` for boolean flag
             assertions.
 
     Raises:
-        ValueError: If any import statement appears in both ``should_succeed``
-            and ``should_fail``.
+        ValueError: If any import statement appears in both `should_succeed`
+            and `should_fail`.
     """
     fail_stmts = {stmt for stmt, _ in should_fail}
     overlap = set(should_succeed) & fail_stmts
@@ -294,11 +294,11 @@ def _run_isolated_script(extra: str | None, script: str, error_prefix: str) -> N
 def _inverted_flag_checks(extra: str) -> list[tuple[str, str, bool]]:
     """Return flag checks for the given extra with inverted expected values.
 
-    Used in core-only testing to assert that feature flags are ``False`` when
+    Used in core-only testing to assert that feature flags are `False` when
     the extra is not installed.
 
     Args:
-        extra (str): Key into ``FLAG_CHECKS`` (e.g. ``"telemetry"``). If the
+        extra (str): Key into `FLAG_CHECKS` (e.g. `"telemetry"`). If the
             key is absent, an empty list is returned.
 
     Returns:
@@ -489,16 +489,16 @@ def test_all_extras_have_tests() -> None:
 def _run_script_raw(script: str) -> subprocess.CompletedProcess:
     """Run a checker script with the current Python interpreter and return the result.
 
-    Unlike ``_run_check``, this does **not** use ``uv run --isolated`` — it
-    executes directly with ``sys.executable``, making it suitable for fast
+    Unlike `_run_check`, this does **not** use `uv run --isolated` — it
+    executes directly with `sys.executable`, making it suitable for fast
     self-tests of the checker script logic.
 
     Args:
-        script (str): A complete Python script (as returned by ``_build_check_script``).
+        script (str): A complete Python script (as returned by `_build_check_script`).
 
     Returns:
-        subprocess.CompletedProcess: The completed process with ``stdout``,
-            ``stderr``, and ``returncode``.
+        subprocess.CompletedProcess: The completed process with `stdout`,
+            `stderr`, and `returncode`.
     """
     return subprocess.run(
         [sys.executable, "-c", script], capture_output=True, text=True, timeout=30

--- a/test/plugins/conftest.py
+++ b/test/plugins/conftest.py
@@ -14,8 +14,8 @@ async def _restore_plugins_after_package(request):
 
     Plugin tests freely shut down the manager for isolation.  This package-scoped
     fixture captures whether plugins were active at the start and restores them in
-    teardown so that test modules collected *after* ``test/plugins/`` still see the
-    session-scoped acceptance sets registered by ``auto_register_acceptance_sets``.
+    teardown so that test modules collected *after* `test/plugins/` still see the
+    session-scoped acceptance sets registered by `auto_register_acceptance_sets`.
     """
     plugins_disabled = request.config.getoption(
         "--disable-default-mellea-plugins", default=False

--- a/test/plugins/test_blocking.py
+++ b/test/plugins/test_blocking.py
@@ -4,9 +4,9 @@
 """Tests for blocking behavior and PluginViolationError.
 
 Covers:
-- ``block()`` helper: return shape and field population
-- ``invoke_hook`` raising ``PluginViolationError`` when a plugin blocks (default behavior)
-- Calling the underlying ``PluginManager.invoke_hook`` with ``violations_as_exceptions=False``
+- `block()` helper: return shape and field population
+- `invoke_hook` raising `PluginViolationError` when a plugin blocks (default behavior)
+- Calling the underlying `PluginManager.invoke_hook` with `violations_as_exceptions=False`
   to inspect the raw result without raising
 - Priority ordering: a blocking plugin at priority=1 stops downstream plugins at priority=100
 """
@@ -38,9 +38,9 @@ def _payload(**kwargs) -> SessionPreInitPayload:
 async def _invoke_no_raise(payload: SessionPreInitPayload):
     """Call the underlying ContextForge PluginManager directly with violations_as_exceptions=False.
 
-    Mellea's ``invoke_hook`` wrapper always raises ``PluginViolationError`` on a block.
-    To observe the raw ``PluginResult`` without raising, we bypass the wrapper and call
-    ``PluginManager.invoke_hook`` directly.
+    Mellea's `invoke_hook` wrapper always raises `PluginViolationError` on a block.
+    To observe the raw `PluginResult` without raising, we bypass the wrapper and call
+    `PluginManager.invoke_hook` directly.
     """
     pm = ensure_plugin_manager()
     ctx = build_global_context()
@@ -61,7 +61,7 @@ async def _invoke_no_raise(payload: SessionPreInitPayload):
 
 
 class TestBlockHelper:
-    """Unit tests for the ``block()`` convenience helper."""
+    """Unit tests for the `block()` convenience helper."""
 
     def test_block_basic_returns_non_continue_plugin_result(self) -> None:
         result = block("something went wrong")
@@ -98,7 +98,7 @@ class TestBlockHelper:
 
 
 class TestModifyHelper:
-    """Unit tests for the ``modify()`` convenience helper."""
+    """Unit tests for the `modify()` convenience helper."""
 
     def test_modify_returns_continue_processing_true(self) -> None:
         payload = _payload()

--- a/test/plugins/test_execution_modes.py
+++ b/test/plugins/test_execution_modes.py
@@ -7,18 +7,18 @@ Execution order: SEQUENTIAL → TRANSFORM → AUDIT → CONCURRENT → FIRE_AND_
 
 behavior summary
 -----------------
-- ``mode=SEQUENTIAL`` (default): serial, chained. Can block and modify payloads.
+- `mode=SEQUENTIAL` (default): serial, chained. Can block and modify payloads.
 
-- ``mode=TRANSFORM``: serial, chained. Can modify payloads but cannot block — blocking
+- `mode=TRANSFORM`: serial, chained. Can modify payloads but cannot block — blocking
   results are suppressed.
 
-- ``mode=AUDIT``: serial, observe-only. Cannot block or modify — violations are logged
+- `mode=AUDIT`: serial, observe-only. Cannot block or modify — violations are logged
   and payload modifications are discarded.
 
-- ``mode=CONCURRENT``: parallel, fail-fast. Can block but cannot modify — payload
+- `mode=CONCURRENT`: parallel, fail-fast. Can block but cannot modify — payload
   modifications are discarded to avoid non-deterministic races.
 
-- ``mode=FIRE_AND_FORGET``: background ``asyncio.create_task``. Cannot block or modify.
+- `mode=FIRE_AND_FORGET`: background `asyncio.create_task`. Cannot block or modify.
   Receives an isolated snapshot.
 """
 

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -1539,8 +1539,8 @@ class TestGenerationPostCallObserveOnly:
 class _MockLazyBackend(Backend):
     """Backend that returns a real lazy (uncomputed) ModelOutputThunk.
 
-    The MOT must be materialized via ``avalue()``/``astream()``, exercising
-    the ``_on_computed`` callback path.
+    The MOT must be materialized via `avalue()`/`astream()`, exercising
+    the `_on_computed` callback path.
     """
 
     model_id = "mock-lazy-model"

--- a/test/plugins/test_internal_tool_hook_skip.py
+++ b/test/plugins/test_internal_tool_hook_skip.py
@@ -4,8 +4,8 @@
 """Tests for control-flow tool signalling on tool hook payloads.
 
 Verifies that TOOL_PRE_INVOKE and TOOL_POST_INVOKE hooks always fire for all
-tools (including framework-internal ones like ``final_answer``), and that the
-``is_control_flow`` field is correctly populated so plugins can decide their
+tools (including framework-internal ones like `final_answer`), and that the
+`is_control_flow` field is correctly populated so plugins can decide their
 own policy.
 """
 

--- a/test/plugins/test_policy_enforcement.py
+++ b/test/plugins/test_policy_enforcement.py
@@ -3,8 +3,8 @@
 
 """End-to-end tests for payload policy enforcement through invoke_hook.
 
-The plugin manager applies ``HookPayloadPolicy`` after each plugin returns:
-only changes to ``writable_fields`` are accepted; all other mutations are
+The plugin manager applies `HookPayloadPolicy` after each plugin returns:
+only changes to `writable_fields` are accepted; all other mutations are
 silently discarded.  Hooks absent from the policy table are observe-only
 and reject every modification attempt.
 """
@@ -282,7 +282,7 @@ class TestPayloadChaining:
 
 
 class TestReturnNoneIsNoop:
-    """A plugin that returns ``None`` must leave the payload entirely unchanged."""
+    """A plugin that returns `None` must leave the payload entirely unchanged."""
 
     async def test_none_return_preserves_original_payload(self) -> None:
         @hook("session_pre_init", priority=10)

--- a/test/plugins/test_scoping.py
+++ b/test/plugins/test_scoping.py
@@ -28,7 +28,7 @@ def _payload() -> SessionPreInitPayload:
 
 
 class TestSessionScopedPlugins:
-    """Plugins registered via ``register(..., session_id=sid)``."""
+    """Plugins registered via `register(..., session_id=sid)`."""
 
     async def test_fires_while_session_active(self) -> None:
         invocations = []

--- a/test/plugins/test_unregister.py
+++ b/test/plugins/test_unregister.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the ``unregister()`` public API."""
+"""Tests for the `unregister()` public API."""
 
 from typing import Any
 

--- a/test/predicates.py
+++ b/test/predicates.py
@@ -3,7 +3,7 @@
 
 """Reusable test predicates for resource-gated test skipping.
 
-These return ``pytest.mark.skipif`` decorators that test authors apply directly.
+These return `pytest.mark.skipif` decorators that test authors apply directly.
 Each predicate encapsulates a specific availability check so that:
 
 - Test authors specify *exactly* what their test needs (not a vague tier).
@@ -45,9 +45,9 @@ _IS_APPLE_SILICON = sys.platform == "darwin" and platform.machine() == "arm64"
 def _apple_silicon_vram_gb() -> float:
     """Conservative usable GPU memory estimate for Apple Silicon.
 
-    Metal's ``recommendedMaxWorkingSetSize`` is a static device property
+    Metal's `recommendedMaxWorkingSetSize` is a static device property
     (~75% of total RAM) that does not account for current system load.
-    We use ``min(total * 0.75, total - 16)`` to leave headroom for the OS
+    We use `min(total * 0.75, total - 16)` to leave headroom for the OS
     and desktop applications, which typically consume 8-16 GB on a loaded
     developer machine.
     """
@@ -76,7 +76,7 @@ def _gpu_vram_gb() -> float:
     """Return usable GPU VRAM in GB, or 0 if unavailable.
 
     On Apple Silicon: uses a conservative heuristic based on total unified
-    memory rather than Metal's static ``recommendedMaxWorkingSetSize``.
+    memory rather than Metal's static `recommendedMaxWorkingSetSize`.
     On CUDA: reports device 0 total memory via torch.
     """
     if _IS_APPLE_SILICON:
@@ -95,7 +95,7 @@ def require_gpu(*, min_vram_gb: int | None = None):
     """Skip unless a GPU is available, optionally with minimum VRAM.
 
     Args:
-        min_vram_gb: Minimum VRAM in GB.  When ``None``, any GPU suffices.
+        min_vram_gb: Minimum VRAM in GB.  When `None`, any GPU suffices.
     """
     if os.environ.get("_MELLEA_SKIP_RESOURCE_CHECKS"):
         return pytest.mark.skipif(False, reason="")
@@ -219,7 +219,7 @@ def require_nltk_data():
 def require_package(package: str):
     """Skip unless *package* is importable.
 
-    For simple cases, ``pytest.importorskip(package)`` at module level is
+    For simple cases, `pytest.importorskip(package)` at module level is
     equivalent and more idiomatic.  This predicate is useful when you want
     a decorator rather than a module-level call::
 

--- a/test/stdlib/components/intrinsic/test_core.py
+++ b/test/stdlib/components/intrinsic/test_core.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests of the code in ``mellea.stdlib.intrinsics.core``"""
+"""Tests of the code in `mellea.stdlib.intrinsics.core`"""
 
 import gc
 import json
@@ -63,7 +63,7 @@ def _read_input_json(file_name: str):
     """Read test data from JSON and convert to a ChatContext.
 
     Returns the context and the raw JSON data (for accessing extra fields
-    like ``requirement``).
+    like `requirement`).
     """
     with open(DATA_ROOT / "input_json" / file_name, encoding="utf-8") as f:
         json_data = json.load(f)

--- a/test/stdlib/components/intrinsic/test_guardian.py
+++ b/test/stdlib/components/intrinsic/test_guardian.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests of the code in ``mellea.stdlib.components.intrinsic.guardian``"""
+"""Tests of the code in `mellea.stdlib.components.intrinsic.guardian`"""
 
 import gc
 import json
@@ -50,9 +50,9 @@ def _backend():
 def _read_guardian_input(file_name: str) -> tuple[ChatContext, list[Document]]:
     """Read test input and return a (ChatContext, documents) pair.
 
-    Builds the context from ``messages`` and extracts any documents stored
-    under ``extra_body.documents`` so callers can pass them via the
-    ``documents=`` keyword argument.
+    Builds the context from `messages` and extracts any documents stored
+    under `extra_body.documents` so callers can pass them via the
+    `documents=` keyword argument.
     """
     with open(DATA_ROOT / "input_json" / file_name, encoding="utf-8") as f:
         json_data = json.load(f)

--- a/test/stdlib/components/intrinsic/test_guardian_documents.py
+++ b/test/stdlib/components/intrinsic/test_guardian_documents.py
@@ -3,7 +3,7 @@
 
 """Unit tests for guardian adapter functions that require no model.
 
-Covers: ``documents=`` kwarg on factuality_detection/factuality_correction,
+Covers: `documents=` kwarg on factuality_detection/factuality_correction,
 and the policy_guardrails XOR validation logic.
 """
 

--- a/test/stdlib/components/intrinsic/test_rag.py
+++ b/test/stdlib/components/intrinsic/test_rag.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests of the code in ``mellea.stdlib.intrinsics.rag``"""
+"""Tests of the code in `mellea.stdlib.intrinsics.rag`"""
 
 import gc
 import json
@@ -99,8 +99,8 @@ def _read_output_json(file_name: str):
     to Mellea types.
 
     By convention, canned outputs hold the contents of
-    ``<completion>["choices"][0]["message"]["content"]``,
-    where ``<completion>`` is a JSON chat completion after post-processing.
+    `<completion>["choices"][0]["message"]["content"]`,
+    where `<completion>` is a JSON chat completion after post-processing.
     """
     with open(DATA_ROOT / "output_json" / file_name, encoding="utf-8") as f:
         json_data = json.load(f)
@@ -111,10 +111,10 @@ def _dump_output_json(file_name: str, to_write):
     """Shared code for dumping a test's generated JSON data.
 
     Dump the Python data structures that will be compared against canned
-    JSON output files. Outputs go to the local directory ``test_output``.
+    JSON output files. Outputs go to the local directory `test_output`.
 
     If you are sure the current output is correct, you can use this output to update
-    the contents of the ``testdata`` directory.
+    the contents of the `testdata` directory.
     """
     target_path = TEST_OUTPUT_ROOT / "output_json" / file_name
     if not os.path.exists(target_path.parent):

--- a/test/stdlib/components/intrinsic/test_rag_contracts.py
+++ b/test/stdlib/components/intrinsic/test_rag_contracts.py
@@ -3,12 +3,12 @@
 
 """Unit tests for IOContract validation in rag.py (Epic #929 Phase 1).
 
-Tests the ``parse()`` method of each IOContract subclass directly — no backend,
+Tests the `parse()` method of each IOContract subclass directly — no backend,
 no GPU, no model download required.  Two tests per helper:
 
-- ``test_<helper>_contract_enforced`` — output missing a required field raises
+- `test_<helper>_contract_enforced` — output missing a required field raises
   :class:`~mellea.backends.adapters.AdapterSchemaMismatchError`.
-- ``test_<helper>_forward_compat`` — output containing an extra optional field
+- `test_<helper>_forward_compat` — output containing an extra optional field
   does *not* raise.
 """
 

--- a/test/stdlib/frameworks/test_react_framework.py
+++ b/test/stdlib/frameworks/test_react_framework.py
@@ -366,7 +366,7 @@ def test_react_summary_prompt_max_tokens_hint_word_estimate_scales():
 
 @pytest.mark.asyncio
 async def test_react_invokes_per_turn_compactor():
-    """The ``compactor=`` hook runs once per turn after the tool observation."""
+    """The `compactor=` hook runs once per turn after the tool observation."""
     search = _make_tool("search", "found it")
     backend = ScriptedBackend(
         [

--- a/test/stdlib/test_compactor.py
+++ b/test/stdlib/test_compactor.py
@@ -1,7 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the ``Compactor`` protocol, ``WindowCompactor``, ``ThresholdCompactor``."""
+"""Tests for the `Compactor` protocol, `WindowCompactor`, `ThresholdCompactor`."""
 
 from __future__ import annotations
 
@@ -690,11 +690,11 @@ class TestLLMSummarizeCompactor:
         self, scripted_summary_backend
     ):
         """Component subclasses that aren't Message/ToolMessage/ModelOutputThunk
-        emit a ``<TypeName[: content]>`` marker instead of the default object repr."""
+        emit a `<TypeName[: content]>` marker instead of the default object repr."""
         from mellea.core import Component
 
         class _CustomMarker(Component):
-            """Component without a ``content`` attribute."""
+            """Component without a `content` attribute."""
 
             def parts(self):  # type: ignore[override]
                 return []

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -100,8 +100,8 @@ async def _feed_tokens(mot: ModelOutputThunk, response: str, token_size: int) ->
 class StreamingMockBackend(Backend):
     """Test double that streams a fixed response one token at a time.
 
-    ``token_size`` controls how many characters constitute one token.
-    Validation calls (via ``stream_validate`` / ``validate``) are delegated
+    `token_size` controls how many characters constitute one token.
+    Validation calls (via `stream_validate` / `validate`) are delegated
     to the requirements themselves — this backend does not perform any real
     inference.
     """
@@ -159,7 +159,7 @@ class AlwaysUnknownReq(Requirement):
 class FailAfterWordsReq(Requirement):
     """Returns 'fail' once the cumulative word count reaches *threshold*.
 
-    Each call to ``stream_validate`` receives a single chunk (delta) from the
+    Each call to `stream_validate` receives a single chunk (delta) from the
     chunking strategy; the running total is maintained on the instance.
     """
 
@@ -769,8 +769,8 @@ async def test_cancel_generation_invoked_on_fail() -> None:
 
 @pytest.mark.asyncio
 async def test_cancelled_flag_reflects_cancellation_state() -> None:
-    """The ``cancelled`` property on ModelOutputThunk distinguishes an early-exit
-    cancellation from a normal completion and propagates through ``as_thunk``."""
+    """The `cancelled` property on ModelOutputThunk distinguishes an early-exit
+    cancellation from a normal completion and propagates through `as_thunk`."""
 
     # Early exit → cancelled is True, is_computed True, propagates through as_thunk.
     fail_response = "word " * 50
@@ -952,10 +952,10 @@ async def test_acomplete_surfaces_exception_without_astream() -> None:
 async def test_external_task_cancellation_releases_consumers() -> None:
     """External cancellation of the orchestration task must still set _done.
 
-    If the finally cleanup itself contains an ``await`` (e.g. awaiting a
+    If the finally cleanup itself contains an `await` (e.g. awaiting a
     terminator put into the chunk queue), CancelledError re-raises at that
-    await and ``_done.set()`` never runs — any consumer blocked on
-    ``acomplete()`` hangs forever. The cleanup must therefore end with
+    await and `_done.set()` never runs — any consumer blocked on
+    `acomplete()` hangs forever. The cleanup must therefore end with
     synchronous operations only.
     """
     response = "word " * 200  # long enough that streaming is still in progress
@@ -994,10 +994,10 @@ async def test_external_task_cancellation_releases_consumers() -> None:
 async def test_external_cancellation_acomplete_raise_once() -> None:
     """Raise-once contract holds for the task-fallback path on external cancel.
 
-    CancelledError bypasses the orchestrator's ``except Exception`` handler,
-    so ``_orchestration_exception`` is never set. ``acomplete()`` surfaces the
-    cancel via ``self._orchestration_task.exception()`` instead — and that
-    branch must also flip ``_exception_surfaced`` so a second ``acomplete()``
+    CancelledError bypasses the orchestrator's `except Exception` handler,
+    so `_orchestration_exception` is never set. `acomplete()` surfaces the
+    cancel via `self._orchestration_task.exception()` instead — and that
+    branch must also flip `_exception_surfaced` so a second `acomplete()`
     call does not raise the same exception twice.
     """
     response = "word " * 200
@@ -1628,10 +1628,10 @@ async def test_cancelled_task_sets_completed_false() -> None:
     never set, guaranteeing the orchestrator is suspended at astream()
     when the task is cancelled.
 
-    Requires ``await asyncio.sleep(0)`` before ``cancel()`` — see inline
+    Requires `await asyncio.sleep(0)` before `cancel()` — see inline
     comment.  Python 3.12's C Task implementation skips the coroutine body
     entirely (including finally blocks) when cancelled before the first
-    ``coro.send(None)``.
+    `coro.send(None)`.
     """
     gate = asyncio.Event()  # never set — feed task blocks indefinitely
     feed_task: asyncio.Task[None] | None = None

--- a/tooling/docs-autogen/audit_coverage.py
+++ b/tooling/docs-autogen/audit_coverage.py
@@ -274,9 +274,9 @@ _GENERATOR_RETURN_PATTERNS = re.compile(
 def _check_member(member, full_path: str, short_threshold: int) -> list[dict]:
     """Return quality issues for a single class or function member.
 
-    Each returned dict has keys: ``path``, ``kind``, ``detail``, ``file``, ``line``.
-    ``file`` is the absolute source path; ``line`` is the 1-based line number of the
-    symbol definition (the ``def`` / ``class`` keyword line).
+    Each returned dict has keys: `path`, `kind`, `detail`, `file`, `line`.
+    `file` is the absolute source path; `line` is the 1-based line number of the
+    symbol definition (the `def` / `class` keyword line).
     """
     issues: list[dict] = []
     _raw_file = getattr(member, "filepath", None)
@@ -774,14 +774,14 @@ def _gha_file_annotation(
 ) -> None:
     """Emit a GitHub Actions annotation anchored to a specific file and line.
 
-    When ``file`` and ``line`` are provided the annotation appears inline in the
+    When `file` and `line` are provided the annotation appears inline in the
     PR diff view, making it immediately obvious which symbol needs fixing.
 
     Args:
-        level: Annotation level — ``"error"``, ``"warning"``, or ``"notice"``.
+        level: Annotation level — `"error"`, `"warning"`, or `"notice"`.
         title: Short label shown in bold in the annotation.
         message: Body text for the annotation.
-        file: Repo-relative file path (e.g. ``mellea/core/base.py``).
+        file: Repo-relative file path (e.g. `mellea/core/base.py`).
         line: 1-based line number of the symbol definition.
     """
     for s in (message, title, file):
@@ -801,8 +801,8 @@ _GHA_ANNOTATIONS_PER_KIND = 10
 def _print_quality_report(issues: list[dict], *, fail_on_quality: bool = False) -> None:
     """Print a grouped quality report to stdout and emit GHA annotations.
 
-    When running in GitHub Actions (``GITHUB_ACTIONS=true``), each issue is
-    also emitted as a file-level annotation (``::error`` or ``::warning``)
+    When running in GitHub Actions (`GITHUB_ACTIONS=true`), each issue is
+    also emitted as a file-level annotation (`::error` or `::warning`)
     anchored to the source line, so they appear inline in the PR diff.
 
     GitHub Actions caps inline diff annotations at roughly 10 per step; issues
@@ -810,15 +810,15 @@ def _print_quality_report(issues: list[dict], *, fail_on_quality: bool = False) 
     in the full job log and in the JSON artifact).  To ensure every check
     category gets at least one visible annotation, this function emits at most
     :data:`_GHA_ANNOTATIONS_PER_KIND` annotations per kind and prints a
-    ``"... and N more"`` notice for the remainder.  The complete list is always
+    `"... and N more"` notice for the remainder.  The complete list is always
     written to the job log regardless of the GHA cap.
 
     Args:
         issues: List of issue dicts from :func:`audit_docstring_quality`.
-            Each dict must have keys: ``path``, ``kind``, ``detail``,
-            ``file``, ``line``.
-        fail_on_quality: When ``True`` annotations are emitted as ``error``
-            (red); otherwise as ``warning`` (yellow).
+            Each dict must have keys: `path`, `kind`, `detail`,
+            `file`, `line`.
+        fail_on_quality: When `True` annotations are emitted as `error`
+            (red); otherwise as `warning` (yellow).
     """
     by_kind: dict[str, list[dict]] = {}
     for issue in issues:

--- a/tooling/docs-autogen/decorate_api_mdx.py
+++ b/tooling/docs-autogen/decorate_api_mdx.py
@@ -98,16 +98,16 @@ _ICON_PX_RE = re.compile(
 def normalize_icon_size(content: str) -> str:
     """Replace mdxify's hardcoded pixel icon sizes with em units.
 
-    mdxify emits ``style="width: 14px; height: 14px;"`` on source-link Icon
+    mdxify emits `style="width: 14px; height: 14px;"` on source-link Icon
     components.  Inline styles take priority over the stylesheet, so the icon
-    renders at a fixed 14 px regardless of heading level.  Swapping to ``em``
+    renders at a fixed 14 px regardless of heading level.  Swapping to `em`
     units lets the icon scale with the surrounding heading font-size.
 
     Args:
         content: MDX file content.
 
     Returns:
-        Content with pixel icon dimensions replaced by ``0.85em``.
+        Content with pixel icon dimensions replaced by `0.85em`.
     """
     return _ICON_PX_RE.sub(r"\g<1>width: 0.85em; height: 0.85em;\g<2>", content)
 
@@ -122,7 +122,7 @@ _RST_DOUBLE_BACKTICK_RE = re.compile(r"``([^`]+)``")
 def normalize_rst_backticks(content: str) -> str:
     """Convert RST-style double-backtick literals to single-backtick Markdown.
 
-    Replaces ``Symbol`` with `Symbol` in MDX prose (outside fenced code blocks).
+    Replaces `Symbol` with `Symbol` in MDX prose (outside fenced code blocks).
     This prevents add_cross_references from generating malformed link syntax such
     as `[`Backend`](url)` where the link is wrapped in an extra code span and
     renders as raw text rather than a clickable link.
@@ -131,7 +131,7 @@ def normalize_rst_backticks(content: str) -> str:
         content: MDX file content
 
     Returns:
-        Content with ``x`` replaced by `x` outside code fences
+        Content with `x` replaced by `x` outside code fences
     """
     lines = content.splitlines(keepends=True)
     result = []

--- a/tooling/docs-autogen/generate-ast.py
+++ b/tooling/docs-autogen/generate-ast.py
@@ -404,20 +404,20 @@ def remove_empty_mdx_files() -> None:
 
 
 def _imported_submodules(init_path: Path) -> set[str] | None:
-    """Return submodule names explicitly imported via relative imports in ``__init__.py``.
+    """Return submodule names explicitly imported via relative imports in `__init__.py`.
 
     Uses AST parsing (no import) so it is safe to call during doc generation.
 
-    A ``__init__.py`` that does ``from .ollama import OllamaModelBackend`` imports
-    from the ``ollama`` submodule, making it part of the package's public surface
-    even if the module name does not appear in ``__all__``.
+    A `__init__.py` that does `from .ollama import OllamaModelBackend` imports
+    from the `ollama` submodule, making it part of the package's public surface
+    even if the module name does not appear in `__all__`.
 
     Args:
-        init_path: Path to the ``__init__.py`` file to parse.
+        init_path: Path to the `__init__.py` file to parse.
 
     Returns:
-        Set of submodule names imported via ``from .name import ...``, or ``None``
-        when the file cannot be parsed.  An empty set means the ``__init__.py``
+        Set of submodule names imported via `from .name import ...`, or `None`
+        when the file cannot be parsed.  An empty set means the `__init__.py`
         exists but contains no relative imports — caller should treat the module
         as indeterminate and keep it.
     """
@@ -447,28 +447,28 @@ _CONFIRMED_INTERNAL_MODULES: frozenset[str] = frozenset()
 def remove_internal_modules(source_root: Path) -> None:
     """Remove MDX files for submodules that are not part of the package's public API.
 
-    ``mdxify --all`` generates documentation for every reachable submodule,
+    `mdxify --all` generates documentation for every reachable submodule,
     regardless of whether the package author intends it to be public.  This step
     enforces the Python convention: a submodule is public when its parent
-    ``__init__.py`` explicitly imports from it (``from .name import ...``).
-    Submodules that are never imported in the parent ``__init__.py`` are internal
+    `__init__.py` explicitly imports from it (`from .name import ...`).
+    Submodules that are never imported in the parent `__init__.py` are internal
     implementation details and are removed from the staging output.
 
     **Conservative rules:**
 
-    * If the parent ``__init__.py`` cannot be parsed → keep (safe default).
-    * If the parent ``__init__.py`` contains *no* relative imports → keep
+    * If the parent `__init__.py` cannot be parsed → keep (safe default).
+    * If the parent `__init__.py` contains *no* relative imports → keep
       (cannot determine intent; typical for packages where submodules are
       accessed via their full dotted path rather than re-exported).
-    * Package index files (``__init__.mdx`` renamed to ``<pkg>.mdx``) are
-      identified by ``stem == parent_dir_name`` and are never filtered.
+    * Package index files (`__init__.mdx` renamed to `<pkg>.mdx`) are
+      identified by `stem == parent_dir_name` and are never filtered.
 
-    A hardcoded ``_CONFIRMED_INTERNAL_MODULES`` set catches known internals in
-    packages where the parent ``__init__.py`` imports nothing (indeterminate
-    case).  These should eventually be renamed with a ``_`` prefix in source.
+    A hardcoded `_CONFIRMED_INTERNAL_MODULES` set catches known internals in
+    packages where the parent `__init__.py` imports nothing (indeterminate
+    case).  These should eventually be renamed with a `_` prefix in source.
 
     Args:
-        source_root: Root of the source repo (contains ``mellea/`` and ``cli/``).
+        source_root: Root of the source repo (contains `mellea/` and `cli/`).
     """
     print("-" * 30, flush=True)
     print(

--- a/tooling/docs-autogen/generate_cli_reference.py
+++ b/tooling/docs-autogen/generate_cli_reference.py
@@ -4,11 +4,11 @@
 
 """Generate a CLI reference page from Typer command metadata.
 
-Imports the ``cli.m`` Typer application, introspects its Click command tree,
-and emits a single Markdown reference page (``reference/cli.md``) documenting
+Imports the `cli.m` Typer application, introspects its Click command tree,
+and emits a single Markdown reference page (`reference/cli.md`) documenting
 every command, its flags, defaults, and descriptions.
 
-Structured docstring sections (``Prerequisites:``, ``See Also:``) in command
+Structured docstring sections (`Prerequisites:`, `See Also:`) in command
 functions are extracted and rendered as admonitions and cross-links.
 
 Run via::
@@ -43,8 +43,8 @@ _RST_BACKTICK_RE = re.compile(r"``([^`]+)``")
 def _parse_docstring_sections(docstring: str | None) -> dict[str, str]:
     """Parse a Google-style docstring into named sections.
 
-    Returns a dict with keys ``"summary"``, ``"body"``, and any structured
-    section names found (e.g. ``"Prerequisites"``, ``"See Also"``).
+    Returns a dict with keys `"summary"`, `"body"`, and any structured
+    section names found (e.g. `"Prerequisites"`, `"See Also"`).
     """
     if not docstring:
         return {"summary": "", "body": ""}
@@ -80,7 +80,7 @@ def _parse_docstring_sections(docstring: str | None) -> dict[str, str]:
 
 
 def _parse_see_also(see_also_text: str) -> list[tuple[str, str]]:
-    """Parse ``See Also`` entries into ``(kind, path)`` tuples.
+    """Parse `See Also` entries into `(kind, path)` tuples.
 
     Expected format::
 
@@ -138,7 +138,7 @@ def _slug_to_title(slug: str) -> str:
 
 
 def _get_click_app():
-    """Import and return the Click command tree for the ``m`` CLI."""
+    """Import and return the Click command tree for the `m` CLI."""
     try:
         import typer.main
 
@@ -155,13 +155,13 @@ def _get_click_app():
 def _parse_two_column_block(content: str) -> list[tuple[str, str]] | None:
     """Parse a Click-style two-column aligned block into (name, description) pairs.
 
-    Click authors sometimes format ``\\b`` blocks as a fixed-width two-column
+    Click authors sometimes format `\\b` blocks as a fixed-width two-column
     table (name left-aligned, description right-aligned with consistent padding)
-    for legible ``--help`` output.  This function detects that format and returns
-    ``(name, description)`` pairs so the generator can emit a proper markdown
+    for legible `--help` output.  This function detects that format and returns
+    `(name, description)` pairs so the generator can emit a proper markdown
     table instead of a raw code fence.
 
-    Returns ``None`` if the content does not match the two-column pattern.
+    Returns `None` if the content does not match the two-column pattern.
 
     Example input::
 
@@ -203,17 +203,17 @@ def _parse_two_column_block(content: str) -> list[tuple[str, str]] | None:
 
 
 def _extract_verbatim_blocks(help_text: str) -> list[str]:
-    """Extract Click ``\\b`` verbatim blocks from help text.
+    """Extract Click `\\b` verbatim blocks from help text.
 
-    Click uses the backspace character (``\\x08``, written as ``\\b`` in Python
+    Click uses the backspace character (`\\x08`, written as `\\b` in Python
     source string literals) as a marker to prevent paragraph rewrapping in
-    ``--help`` output.  The generator must extract these blocks independently
+    `--help` output.  The generator must extract these blocks independently
     because the section parser buries them inside whatever named section
-    (e.g. ``Raises``) happens to precede them, and that section is never
+    (e.g. `Raises`) happens to precede them, and that section is never
     rendered.
 
     Returns a list of stripped block strings (first line is typically the
-    block title, e.g. ``"Modes:"``, followed by indented content lines).
+    block title, e.g. `"Modes:"`, followed by indented content lines).
     """
     # In memory the docstring contains actual \x08 chars; split on them.
     parts = re.split(r"\x08\s*\n", help_text)
@@ -246,7 +246,7 @@ def _format_type(param: click.Parameter) -> str:
 
 
 def _format_flags(param: click.Parameter) -> str:
-    """Format parameter flags (e.g. ``--backend, -b``)."""
+    """Format parameter flags (e.g. `--backend, -b`)."""
     is_arg = isinstance(param, click.Argument)
     if is_arg:
         name = param.name or ""

--- a/tooling/docs-autogen/test_cli_reference.py
+++ b/tooling/docs-autogen/test_cli_reference.py
@@ -17,7 +17,7 @@ import pytest
 
 @pytest.fixture(scope="module")
 def click_app():
-    """Import and return the Click command tree for the ``m`` CLI."""
+    """Import and return the Click command tree for the `m` CLI."""
     import typer.main
 
     from cli.m import cli
@@ -239,10 +239,10 @@ def test_no_mdx_or_framework_specific_syntax(generated_md):
 def test_verbatim_blocks_rendered(generated_md):
     """Click \\b verbatim blocks must appear in the generated docs.
 
-    ``m fix async`` and ``m fix genslots`` contain \\b-delimited sections
+    `m fix async` and `m fix genslots` contain \\b-delimited sections
     (Modes, Best practices, Detection notes, Rewrites) that are visible in
-    ``--help`` output.  These were previously silently dropped because they
-    appear after ``Raises:`` in the docstring, which the generator never
+    `--help` output.  These were previously silently dropped because they
+    appear after `Raises:` in the docstring, which the generator never
     renders.  They should now appear correctly formatted.
     """
     assert "**Modes:**" in generated_md, "fix async Modes block missing"
@@ -256,7 +256,7 @@ def test_verbatim_blocks_rendered(generated_md):
 def test_bullet_blocks_not_in_code_fence(generated_md):
     """Bullet-list \\b blocks must render as markdown lists, not code fences.
 
-    Best practices / Detection notes / Rewrites start with ``- `` items and
+    Best practices / Detection notes / Rewrites start with `- ` items and
     should be plain markdown bullets so they render properly in the browser,
     not as monospace preformatted blocks.
     """

--- a/tooling/docs-autogen/test_validate.py
+++ b/tooling/docs-autogen/test_validate.py
@@ -14,6 +14,7 @@ from validate import (
     validate_examples_catalogue,
     validate_internal_links,
     validate_mdx_syntax,
+    validate_rst_docstrings,
     validate_source_links,
     validate_stale_files,
 )
@@ -131,6 +132,208 @@ def test_validate_internal_links_external_ignored():
         error_count, errors = validate_internal_links(docs_dir)
         assert error_count == 0
         assert len(errors) == 0
+
+
+def test_validate_rst_docstrings_detects_multiline_markup():
+    """Test RST literal detection across docstring lines."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            'def example():\n    """Use ``multi-line\n    value`` in prose."""\n',
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["file"] == "source/example.py"
+        assert errors[0]["line"] == 2
+
+
+def test_validate_rst_docstrings_detects_embedded_backticks():
+    """Test RST literal detection when its content contains backticks."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            'def example():\n    """Avoid ``value with `inner` marker`` in prose."""\n',
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["line"] == 2
+
+
+def test_validate_rst_docstrings_detects_attribute_descriptions():
+    """Test attribute, explicit module, and field documentation strings."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            '__doc__ = "Module uses ``literal``."\n'
+            'SETTING = "value"\n'
+            '"""Setting uses ``literal``."""\n'
+            "\n"
+            "class Options:\n"
+            '    field: str = Field(description="Field uses ``literal``.")\n'
+            "\n"
+            "    def __init__(self):\n"
+            '        self.value = "value"\n'
+            '        """Value uses ``literal``."""\n',
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 4
+        assert [error["line"] for error in errors] == [1, 3, 6, 10]
+
+
+def test_validate_rst_docstrings_handles_explicit_doc_scopes():
+    """Test explicit documentation assignments without matching local fixtures."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            "class Documented:\n"
+            "    pass\n"
+            "\n"
+            'Documented.__doc__ = "Class uses ``literal``."\n'
+            "\n"
+            "def fixture():\n"
+            '    __doc__ = "Runtime ``fixture`` input."\n'
+            "    return __doc__\n",
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["line"] == 4
+
+
+def test_validate_rst_docstrings_reports_source_line_for_escaped_newline():
+    """Test line reporting uses source text rather than the decoded string value."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            'def example():\n    """Before \\n``literal`` on one source line."""\n',
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["line"] == 2
+
+
+def test_validate_rst_docstrings_reports_source_line_for_concatenated_literal():
+    """Test line reporting across implicitly concatenated string literals."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            "def example():\n"
+            "    (\n"
+            '        "Before "\n'
+            '        "``literal`` in prose."\n'
+            "    )\n",
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["line"] == 4
+
+
+def test_validate_rst_docstrings_reports_source_line_for_split_literal():
+    """Test line reporting when RST markup spans concatenated string tokens."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            "def example():\n"
+            "    (\n"
+            '        "Before "\n'
+            '        "``literal "\n'
+            '        "continued`` in prose."\n'
+            "    )\n",
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 1
+        assert errors[0]["line"] == 4
+
+
+def test_validate_rst_docstrings_ignores_non_docstrings_and_fences():
+    """Test that only prose outside fenced blocks is validated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_dir = Path(tmpdir) / "source"
+        source_dir.mkdir()
+        (source_dir / "example.py").write_text(
+            'TEXT = "Use ``literal`` as fixture input"\n'
+            "\n"
+            "def example():\n"
+            '    """Show a fenced fixture.\n'
+            "\n"
+            "    ```python\n"
+            '    value = "``literal``"\n'
+            "    ```\n"
+            "\n"
+            "    ~~~~text\n"
+            "    ``tilde literal``\n"
+            "    ~~~~\n"
+            "\n"
+            "    ````text\n"
+            "    ```\n"
+            "    ``long fence literal``\n"
+            "    ```\n"
+            "    ````\n"
+            '    """\n'
+            '    return "``literal``"\n'
+            "\n"
+            "def direct_fence():\n"
+            '    """```text\n'
+            "    ``direct fence literal``\n"
+            "    ```\n"
+            '    """\n'
+            "\n"
+            "def escaped_fence():\n"
+            '    """```text\\n``escaped fence literal``\\n```"""\n'
+            "\n"
+            "def concatenated_fixture():\n"
+            "    (\n"
+            '        "Safe "\n'
+            "        # ``comment fixture``\n"
+            '        "documentation."\n'
+            "    )\n",
+            encoding="utf-8",
+        )
+
+        error_count, errors = validate_rst_docstrings(source_dir)
+
+        assert error_count == 0
+        assert errors == []
+
+
+@pytest.mark.parametrize("source_root", ["mellea", "cli", "test", "docs", "tooling"])
+def test_repository_docstrings_use_markdown_backticks(source_root):
+    """Test that repository documentation strings follow Markdown style."""
+    repo_root = Path(__file__).resolve().parents[2]
+
+    error_count, errors = validate_rst_docstrings(repo_root / source_root)
+
+    details = "\n".join(
+        f"{error['file']}:{error['line']}: {error['message']}" for error in errors
+    )
+    assert error_count == 0, details
 
 
 def test_validate_stale_files_clean():

--- a/tooling/docs-autogen/validate.py
+++ b/tooling/docs-autogen/validate.py
@@ -13,10 +13,13 @@ Performs comprehensive validation checks on generated MDX files:
 """
 
 import argparse
+import ast
+import io
 import json
 import os
 import re
 import sys
+import tokenize
 from pathlib import Path
 
 _IN_GHA = os.environ.get("GITHUB_ACTIONS") == "true"
@@ -131,11 +134,11 @@ def validate_source_links(docs_dir: Path, version: str) -> tuple[int, list[dict]
 
     Args:
         docs_dir: Directory containing MDX files.
-        version: Expected version string in links (e.g., ``"0.5.0"``).
+        version: Expected version string in links (e.g., `"0.5.0"`).
 
     Returns:
         Tuple of (error_count, errors) where each error dict has keys
-        ``file``, ``line``, and ``message``.
+        `file`, `line`, and `message`.
     """
     errors: list[dict] = []
     expected_repo = "ibm-granite/mellea"
@@ -197,7 +200,7 @@ def validate_mdx_syntax(docs_dir: Path) -> tuple[int, list[dict]]:
     """Validate MDX syntax in generated documentation files.
 
     Checks for unclosed code fences, unescaped curly braces inside code
-    blocks, missing frontmatter, and a missing ``title`` field.
+    blocks, missing frontmatter, and a missing `title` field.
 
     Args:
         docs_dir: Directory containing MDX files.
@@ -345,14 +348,166 @@ def validate_anchor_collisions(docs_dir: Path) -> tuple[int, list[dict]]:
     return len(errors), errors
 
 
-def validate_rst_docstrings(source_dir: Path) -> tuple[int, list[dict]]:
-    """Scan Python source files for RST double-backtick notation in docstrings.
+def _documentation_string_nodes(tree: ast.AST) -> list[ast.Constant]:
+    """Return standard and attribute documentation strings from a syntax tree."""
+    results: list[ast.Constant] = []
+    seen: set[tuple[int, int, int | None, int | None]] = set()
 
-    RST-style ``Symbol`` double-backtick markup interacts badly with the
-    add_cross_references step: the regex matches the inner single-backtick
-    boundary and generates a broken link wrapped in an extra code span, e.g.
-    ``Backend`` → `[`Backend`](url)` which Mintlify renders as raw text
-    rather than a clickable link.
+    def add(candidate: ast.AST | None) -> None:
+        if not isinstance(candidate, ast.Constant) or not isinstance(
+            candidate.value, str
+        ):
+            return
+        location = (
+            candidate.lineno,
+            candidate.col_offset,
+            candidate.end_lineno,
+            candidate.end_col_offset,
+        )
+        if location not in seen:
+            seen.add(location)
+            results.append(candidate)
+
+    containers = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    for container in ast.walk(tree):
+        if not isinstance(container, containers) or not container.body:
+            continue
+
+        first_statement = container.body[0]
+        if isinstance(first_statement, ast.Expr):
+            add(first_statement.value)
+
+        supports_attribute_docstrings = isinstance(
+            container, (ast.Module, ast.ClassDef)
+        ) or (
+            isinstance(container, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and container.name == "__init__"
+        )
+        if not supports_attribute_docstrings:
+            continue
+
+        for assignment, following in zip(container.body, container.body[1:]):
+            if not isinstance(following, ast.Expr):
+                continue
+            target = None
+            if isinstance(assignment, ast.Assign) and len(assignment.targets) == 1:
+                target = assignment.targets[0]
+            elif isinstance(assignment, ast.AnnAssign):
+                target = assignment.target
+            if isinstance(target, (ast.Name, ast.Attribute)):
+                add(following.value)
+
+    for container in ast.walk(tree):
+        if not isinstance(container, (ast.Module, ast.ClassDef)):
+            continue
+        for statement in container.body:
+            if isinstance(statement, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == "__doc__"
+                for target in statement.targets
+            ):
+                add(statement.value)
+            elif isinstance(statement, ast.AnnAssign) and isinstance(
+                statement.target, ast.Name
+            ):
+                if statement.target.id == "__doc__":
+                    add(statement.value)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Attribute) and target.attr == "__doc__"
+            for target in node.targets
+        ):
+            add(node.value)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Attribute):
+            if node.target.attr == "__doc__":
+                add(node.value)
+        elif isinstance(node, ast.Call):
+            is_field = (
+                isinstance(node.func, ast.Name) and node.func.id == "Field"
+            ) or (isinstance(node.func, ast.Attribute) and node.func.attr == "Field")
+            if is_field:
+                for keyword in node.keywords:
+                    if keyword.arg == "description":
+                        add(keyword.value)
+
+    return sorted(results, key=lambda node: (node.lineno, node.col_offset))
+
+
+def _unfenced_prose_segments(content: str) -> list[tuple[int, str]]:
+    """Return offsets and prose segments outside Markdown code fences."""
+    segments: list[tuple[int, str]] = []
+    fence: tuple[str, int] | None = None
+    offset = 0
+    segment_start = 0
+    for line in content.splitlines(keepends=True):
+        stripped = line.lstrip()
+        marker_match = re.match(r"(?P<marker>`{3,}|~{3,})", stripped)
+        if fence is None and marker_match:
+            if segment_start < offset:
+                segments.append((segment_start, content[segment_start:offset]))
+            marker = marker_match.group("marker")
+            fence = (marker[0], len(marker))
+        elif fence is not None and marker_match:
+            marker = marker_match.group("marker")
+            remainder = stripped[len(marker) :].strip()
+            if marker[0] == fence[0] and len(marker) >= fence[1] and not remainder:
+                fence = None
+                segment_start = offset + len(line)
+        offset += len(line)
+    if fence is None and segment_start < len(content):
+        segments.append((segment_start, content[segment_start:]))
+    return segments
+
+
+def _source_match_lines(
+    content: str,
+    node: ast.Constant,
+    decoded_content: str,
+    decoded_matches: list[re.Match[str]],
+) -> list[int | None]:
+    """Map decoded documentation matches to their original source lines."""
+    source_segment = ast.get_source_segment(content, node)
+    if source_segment is None:
+        return [None] * len(decoded_matches)
+
+    delimiter_pattern = re.compile(r"(?<!`)``(?!`)")
+    decoded_delimiters = list(delimiter_pattern.finditer(decoded_content))
+    delimiter_indexes = {
+        delimiter.start(): index for index, delimiter in enumerate(decoded_delimiters)
+    }
+    source_lines: list[int] = []
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(f"({source_segment})").readline)
+        for token_info in tokens:
+            if token_info.type != tokenize.STRING:
+                continue
+            for delimiter in delimiter_pattern.finditer(token_info.string):
+                line = (
+                    node.lineno
+                    + token_info.start[0]
+                    - 1
+                    + token_info.string[: delimiter.start()].count("\n")
+                )
+                source_lines.append(line)
+    except (IndentationError, tokenize.TokenError):
+        return [None] * len(decoded_matches)
+
+    if len(source_lines) != len(decoded_delimiters):
+        return [None] * len(decoded_matches)
+    return [
+        source_lines[index]
+        if (index := delimiter_indexes.get(match.start())) is not None
+        else None
+        for match in decoded_matches
+    ]
+
+
+def validate_rst_docstrings(source_dir: Path) -> tuple[int, list[dict]]:
+    """Scan Python documentation strings for RST inline-literal markup.
+
+    RST inline literals interact badly with the `add_cross_references` step:
+    the inner single-backtick boundary can produce a link wrapped in an extra
+    code span, which renders as raw text rather than a clickable link.
 
     Args:
         source_dir: Root of the Python source tree to scan (e.g. repo/mellea).
@@ -361,22 +516,42 @@ def validate_rst_docstrings(source_dir: Path) -> tuple[int, list[dict]]:
         Tuple of (error_count, errors).
     """
     errors: list[dict] = []
-    pattern = re.compile(r"``([A-Za-z][^`]*)``")
+    pattern = re.compile(r"(?<!`)``(?!`)(.+?)(?<!`)``(?!`)", re.DOTALL)
 
     for py_file in sorted(source_dir.rglob("*.py")):
         try:
             content = py_file.read_text(encoding="utf-8")
-        except Exception:
+            tree = ast.parse(content, filename=str(py_file))
+        except (OSError, SyntaxError, UnicodeError):
             continue
-        rel = str(py_file.relative_to(source_dir.parent))
-        for line_num, line in enumerate(content.splitlines(), 1):
-            if pattern.search(line):
+
+        rel = py_file.relative_to(source_dir.parent).as_posix()
+        for docstring_node in _documentation_string_nodes(tree):
+            docstring = docstring_node.value
+            if not isinstance(docstring, str):
+                continue
+            decoded_matches = list(pattern.finditer(docstring))
+            source_lines = _source_match_lines(
+                content, docstring_node, docstring, decoded_matches
+            )
+            prose_match_offsets = {
+                segment_offset + match.start()
+                for segment_offset, prose in _unfenced_prose_segments(docstring)
+                for match in pattern.finditer(prose)
+            }
+            for match, source_line in zip(decoded_matches, source_lines):
+                if match.start() not in prose_match_offsets:
+                    continue
+                line_num = source_line or (
+                    docstring_node.lineno + docstring[: match.start()].count("\n")
+                )
+                literal = match.group(0).replace("\n", " ")
                 errors.append(
                     _err(
                         rel,
                         line_num,
-                        f"RST double-backtick notation — use single backticks for "
-                        f"Markdown/MDX compatibility: {line.strip()[:100]}",
+                        "RST double-backtick notation — use single backticks for "
+                        f"Markdown/MDX compatibility: {literal[:100]}",
                     )
                 )
 
@@ -390,7 +565,7 @@ def validate_stale_files(docs_root: Path) -> tuple[int, list[dict]]:
     accumulates during doc rewrites and should not ship in a release.
 
     Args:
-        docs_root: The ``docs/`` directory (parent of ``docs/docs/``).
+        docs_root: The `docs/` directory (parent of `docs/docs/`).
 
     Returns:
         Tuple of (error_count, errors).
@@ -418,12 +593,12 @@ def validate_stale_files(docs_root: Path) -> tuple[int, list[dict]]:
 def validate_examples_catalogue(docs_root: Path) -> tuple[int, list[dict]]:
     """Check that every example directory is listed in the examples index page.
 
-    Scans ``docs/examples/`` for subdirectories that contain at least one
-    ``.py`` file and verifies each directory name appears in the catalogue
-    table in ``docs/docs/examples/index.md``.
+    Scans `docs/examples/` for subdirectories that contain at least one
+    `.py` file and verifies each directory name appears in the catalogue
+    table in `docs/docs/examples/index.md`.
 
     Args:
-        docs_root: The ``docs/`` directory (parent of ``docs/docs/``).
+        docs_root: The `docs/` directory (parent of `docs/docs/`).
 
     Returns:
         Tuple of (error_count, errors).
@@ -467,13 +642,13 @@ def validate_examples_catalogue(docs_root: Path) -> tuple[int, list[dict]]:
 def validate_doc_imports(docs_dir: Path) -> tuple[int, list[dict]]:
     """Verify that mellea imports in documentation code blocks still resolve.
 
-    Parses fenced Python code blocks in static docs for ``from mellea.X import Y``
-    and ``import mellea.X`` statements, then checks whether each module and symbol
-    exists at import time.  Optional-dependency failures (``ImportError`` whose
+    Parses fenced Python code blocks in static docs for `from mellea.X import Y`
+    and `import mellea.X` statements, then checks whether each module and symbol
+    exists at import time.  Optional-dependency failures (`ImportError` whose
     message mentions a third-party package) are silently skipped.
 
     Args:
-        docs_dir: The ``docs/docs/`` directory containing static documentation.
+        docs_dir: The `docs/docs/` directory containing static documentation.
 
     Returns:
         Tuple of (error_count, errors).
@@ -670,8 +845,8 @@ def _print_check_errors(label: str, errors: list[dict], gha_budget: list[int]) -
 
     Args:
         label: Human-readable check name shown in the section header.
-        errors: List of error dicts with keys ``file``, ``line``, ``message``.
-        gha_budget: Single-element list ``[remaining_annotations]``; decremented
+        errors: List of error dicts with keys `file`, `line`, `message`.
+        gha_budget: Single-element list `[remaining_annotations]`; decremented
             in-place as annotations are emitted.
     """
     if not errors:


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1446

## Description
Normalize RST-style double-backtick inline literals to Markdown single backticks across Python documentation strings so they render consistently in IDE hovers, `help()`, raw source views, and generated API docs.

Strengthen `validate_rst_docstrings()` to inspect documentation strings through the Python AST, including standard and attribute docstrings, explicit `__doc__` assignments, and `Field(description=...)`. The validator handles multiline and embedded-backtick spans, ignores fenced examples and non-docstring fixtures, reports source-accurate line numbers, and now runs as a repository-wide CI regression check across `mellea`, `cli`, `test`, `docs`, and `tooling`.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Local validation:
- `uv run pytest tooling/docs-autogen/test_validate.py -k "validate_rst_docstrings or repository_docstrings" -q` (13 passed)
- `uv run pytest tooling/docs-autogen/test_validate.py::test_repository_docstrings_use_markdown_backticks` (5 passed)
- `uv run ruff format --check .` (728 files already formatted)
- `uv run ruff check .`
- `uv run --no-sync python .github/scripts/check_license_headers.py --check` (565 files passed)
- `uv run poe apidocs` (136 modules generated, 0 failures)
- `git diff --check origin/main...HEAD`

`uv run pre-commit run --all-files` was also attempted. `uv-lock`, `codespell`, docs markdownlint, and generated-MDX validation passed. The local Windows hook environment could not launch the SPDX and Ruff system hooks because their configured executable names were unavailable; the equivalent standalone checks above passed. The full mypy hook reported missing optional dependencies and stubs in the local environment.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
