### PR TITLE
fix: assign the result of Context.add in transform/atransform

### DIFF
--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -500,7 +500,7 @@ def transform(
                 f"the transform of {obj} with transformation description '{transformation}' resulted in a tool call with no generated arguments; consider calling the function `{chosen_tool._tool.name}` directly"
             )
 
-        new_ctx.add(chosen_tool)
+        new_ctx = new_ctx.add(chosen_tool)
         MelleaLogger.get_logger().info(
             "added a tool message from transform to the context"
         )
@@ -1279,7 +1279,7 @@ async def atransform(
                 f"the transform of {obj} with transformation description '{transformation}' resulted in a tool call with no generated arguments; consider calling the function `{chosen_tool._tool.name}` directly"
             )
 
-        new_ctx.add(chosen_tool)
+        new_ctx = new_ctx.add(chosen_tool)
         MelleaLogger.get_logger().info(
             "added a tool message from transform to the context"
         )

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image as PILImage
 
-from mellea.core import AudioBlock, ImageBlock, ModelToolCall
+from mellea.core import AudioBlock, Context, ImageBlock, ModelToolCall
 from mellea.stdlib.components import (
     Document,
     Instruction,
@@ -428,6 +428,17 @@ def _make_tool_message(name: str = "some_tool") -> ToolMessage:
     )
 
 
+def _assert_tool_message_persisted_after(
+    new_ctx: Context, prior_messages: list[Message], tool_message: ToolMessage
+) -> None:
+    """Assert `new_ctx` is exactly `prior_messages + [tool_message]`, by identity."""
+    result = new_ctx.as_list()
+    assert len(result) == len(prior_messages) + 1
+    for expected, actual in zip(prior_messages, result):
+        assert actual is expected
+    assert result[-1] is tool_message
+
+
 @patch("mellea.stdlib.functional._call_tools")
 @patch("mellea.stdlib.functional.act")
 def test_transform_persists_chosen_tool_message_in_context(mock_act, mock_call_tools):
@@ -435,18 +446,23 @@ def test_transform_persists_chosen_tool_message_in_context(mock_act, mock_call_t
 
     `Context.add` is non-mutating (it returns a new context rather than
     mutating in place), so `new_ctx.add(chosen_tool)` as a bare statement
-    silently drops the tool message.
+    silently drops the tool message. Seed the context with a prior message
+    so the assertion can also catch an `add` that clobbers existing history
+    instead of appending to it, and confirm the tool message lands last.
     """
     from mellea.stdlib.functional import transform
 
-    ctx = ChatContext()
+    prior_message = Message("user", "prior")
+    ctx = ChatContext().add(prior_message)
+    # mock_act returns this same ctx unchanged, so transform() extends it directly;
+    # that's what makes asserting `result[0] is prior_message` meaningful below.
     mock_act.return_value = (MagicMock(), ctx)
     tool_message = _make_tool_message()
     mock_call_tools.return_value = [tool_message]
 
     _, new_ctx = transform(MObject(), "transform it", ctx, MagicMock())
 
-    assert tool_message in new_ctx.as_list()
+    _assert_tool_message_persisted_after(new_ctx, [prior_message], tool_message)
 
 
 @pytest.mark.asyncio
@@ -458,14 +474,17 @@ async def test_atransform_persists_chosen_tool_message_in_context(
     """Async counterpart of test_transform_persists_chosen_tool_message_in_context."""
     from mellea.stdlib.functional import atransform
 
-    ctx = ChatContext()
+    prior_message = Message("user", "prior")
+    ctx = ChatContext().add(prior_message)
+    # mock_aact returns this same ctx unchanged, so atransform() extends it directly;
+    # that's what makes asserting `result[0] is prior_message` meaningful below.
     mock_aact.return_value = (MagicMock(), ctx)
     tool_message = _make_tool_message()
     mock_acall_tools.return_value = [tool_message]
 
     _, new_ctx = await atransform(MObject(), "transform it", ctx, MagicMock())
 
-    assert tool_message in new_ctx.as_list()
+    _assert_tool_message_persisted_after(new_ctx, [prior_message], tool_message)
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -8,14 +8,20 @@ Covers image preprocessing plus chat()/instruct() forwarding of multimodal input
 
 import base64
 import io
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from PIL import Image as PILImage
 
-from mellea.core import AudioBlock, ImageBlock
-from mellea.stdlib.components import Document, Instruction, Message
-from mellea.stdlib.context import SimpleContext
+from mellea.core import AudioBlock, ImageBlock, ModelToolCall
+from mellea.stdlib.components import (
+    Document,
+    Instruction,
+    Message,
+    MObject,
+    ToolMessage,
+)
+from mellea.stdlib.context import ChatContext, SimpleContext
 from mellea.stdlib.functional import (
     _parse_and_clean_image_args,
     aact,
@@ -404,6 +410,62 @@ async def test_aact_no_raise_without_requirements():
     backend = _mock_backend_returning("ok")
     out, _ = await aact(CBlock("x"), SimpleContext(), backend, await_result=True)
     assert str(out) == "ok"
+
+
+# --- transform()/atransform() must persist the chosen tool message in context ---
+
+
+def _make_tool_message(name: str = "some_tool") -> ToolMessage:
+    """Return a real ToolMessage, as `_call_tools`/`_acall_tools` would produce."""
+    tool_call = ModelToolCall(name=name, func=MagicMock(), args={"arg": 1})
+    return ToolMessage(
+        role="tool",
+        content="tool result",
+        tool_output="tool result",
+        name=name,
+        args={"arg": 1},
+        tool=tool_call,
+    )
+
+
+@patch("mellea.stdlib.functional._call_tools")
+@patch("mellea.stdlib.functional.act")
+def test_transform_persists_chosen_tool_message_in_context(mock_act, mock_call_tools):
+    """The tool message transform() picks must survive in the returned Context.
+
+    `Context.add` is non-mutating (it returns a new context rather than
+    mutating in place), so `new_ctx.add(chosen_tool)` as a bare statement
+    silently drops the tool message.
+    """
+    from mellea.stdlib.functional import transform
+
+    ctx = ChatContext()
+    mock_act.return_value = (MagicMock(), ctx)
+    tool_message = _make_tool_message()
+    mock_call_tools.return_value = [tool_message]
+
+    _, new_ctx = transform(MObject(), "transform it", ctx, MagicMock())
+
+    assert tool_message in new_ctx.as_list()
+
+
+@pytest.mark.asyncio
+@patch("mellea.stdlib.functional._acall_tools", new_callable=AsyncMock)
+@patch("mellea.stdlib.functional.aact", new_callable=AsyncMock)
+async def test_atransform_persists_chosen_tool_message_in_context(
+    mock_aact, mock_acall_tools
+):
+    """Async counterpart of test_transform_persists_chosen_tool_message_in_context."""
+    from mellea.stdlib.functional import atransform
+
+    ctx = ChatContext()
+    mock_aact.return_value = (MagicMock(), ctx)
+    tool_message = _make_tool_message()
+    mock_acall_tools.return_value = [tool_message]
+
+    _, new_ctx = await atransform(MObject(), "transform it", ctx, MagicMock())
+
+    assert tool_message in new_ctx.as_list()
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -429,9 +429,18 @@ def _make_tool_message(name: str = "some_tool") -> ToolMessage:
 
 
 def _assert_tool_message_persisted_after(
-    new_ctx: Context, prior_messages: list[Message], tool_message: ToolMessage
+    prior_ctx: Context,
+    new_ctx: Context,
+    prior_messages: list[Message],
+    tool_message: ToolMessage,
 ) -> None:
-    """Assert `new_ctx` is exactly `prior_messages + [tool_message]`, by identity."""
+    """Assert `new_ctx` is exactly `prior_messages + [tool_message]`, by identity.
+
+    Also asserts `prior_ctx` (the context passed into transform/atransform,
+    which the mocked act/aact returns unchanged) still holds only
+    `prior_messages` — confirming `Context.add` did not mutate it in place.
+    """
+    assert prior_ctx.as_list() == prior_messages
     result = new_ctx.as_list()
     assert len(result) == len(prior_messages) + 1
     for expected, actual in zip(prior_messages, result):
@@ -454,15 +463,13 @@ def test_transform_persists_chosen_tool_message_in_context(mock_act, mock_call_t
 
     prior_message = Message("user", "prior")
     ctx = ChatContext().add(prior_message)
-    # mock_act returns this same ctx unchanged, so transform() extends it directly;
-    # that's what makes asserting `result[0] is prior_message` meaningful below.
     mock_act.return_value = (MagicMock(), ctx)
     tool_message = _make_tool_message()
     mock_call_tools.return_value = [tool_message]
 
     _, new_ctx = transform(MObject(), "transform it", ctx, MagicMock())
 
-    _assert_tool_message_persisted_after(new_ctx, [prior_message], tool_message)
+    _assert_tool_message_persisted_after(ctx, new_ctx, [prior_message], tool_message)
 
 
 @pytest.mark.asyncio
@@ -476,15 +483,13 @@ async def test_atransform_persists_chosen_tool_message_in_context(
 
     prior_message = Message("user", "prior")
     ctx = ChatContext().add(prior_message)
-    # mock_aact returns this same ctx unchanged, so atransform() extends it directly;
-    # that's what makes asserting `result[0] is prior_message` meaningful below.
     mock_aact.return_value = (MagicMock(), ctx)
     tool_message = _make_tool_message()
     mock_acall_tools.return_value = [tool_message]
 
     _, new_ctx = await atransform(MObject(), "transform it", ctx, MagicMock())
 
-    _assert_tool_message_persisted_after(new_ctx, [prior_message], tool_message)
+    _assert_tool_message_persisted_after(ctx, new_ctx, [prior_message], tool_message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1475

## Description
`transform()` and `atransform()` both call `new_ctx.add(chosen_tool)` as a bare statement. `Context.add` is non-mutating, so the returned context is discarded and the chosen tool message never reaches the context handed back to the caller — despite an info log claiming it was added.

Fix: assign the result at both call sites (`mellea/stdlib/functional.py:502` in `transform()`, `:1271` in `atransform()`).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.