### PR TITLE
fix: do not share session state across requests in m_serve examples

### DIFF
--- a/docs/examples/m_serve/README.md
+++ b/docs/examples/m_serve/README.md
@@ -112,14 +112,13 @@ from mellea import start_session
 from mellea.stdlib.sampling import RejectionSamplingStrategy
 from mellea.core import Requirement
 
-session = start_session()
-
 def serve(input: list[ChatMessage],
           requirements: list[str] | None = None,
           model_options: dict | None = None):
     """Main serving function - called by m serve."""
     message = input[-1].content
 
+    session = start_session()
     result = session.instruct(
         description=message,
         requirements=requirements or [],

--- a/docs/examples/m_serve/multimodal-audio/m_serve_example_multimodal_audio_granite.py
+++ b/docs/examples/m_serve/multimodal-audio/m_serve_example_multimodal_audio_granite.py
@@ -20,12 +20,10 @@ transcribed to plain text before reaching the chat model, only word-level
 content survives the pipeline — tone of voice, emotion, background sound,
 and speaker identity are not available to the chat model on this path.
 
-The session uses `ChatContext` so conversation history accumulates across
-turns: follow-up questions like "who sang it?" work without re-uploading
-the audio.  The serve function also honours caller-supplied `requirements`
-and `model_options`, and uses `session.ainstruct()` with a built-in
-`Requirement` to keep answers grounded in the transcript (tuned to the
-bundled "roses are red and violets are blue" audio sample).
+The serve function honors caller-supplied `requirements` and `model_options`,
+and uses `session.ainstruct()` with a built-in `Requirement` to keep answers
+grounded in the transcript (tuned to the bundled "roses are red and violets
+are blue" audio sample).
 
 Prerequisites:
     - Ollama running locally with both models pulled:
@@ -57,7 +55,6 @@ import httpx
 from mellea import start_session
 from mellea.core import AudioBlock, ModelOutputThunk, Requirement
 from mellea.serve import ChatMessage
-from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import simple_validate
 from mellea.stdlib.sampling import RejectionSamplingStrategy
 
@@ -66,10 +63,6 @@ _speech_model = os.environ.get(
     "GRANITE_SPEECH_MODEL", "hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M"
 )
 _chat_model = os.environ.get("GRANITE_CHAT_MODEL", "granite4.1:3b")
-
-# ChatContext accumulates conversation history across turns so follow-up
-# questions work without re-uploading the audio.
-chat_session = start_session(model_id=_chat_model, ctx=ChatContext())
 
 
 def _audio_block_to_bytes(block: AudioBlock) -> tuple[bytes, str]:
@@ -123,9 +116,7 @@ async def serve(
     Step 1: `hf.co/ibm-granite/granite-speech-4.1-2b-GGUF:Q4_K_M` transcribes the audio.
     Step 2: `granite4.1:3b` answers the user's text question, informed by the transcript.
 
-    The session retains conversation history across calls (via `ChatContext`),
-    so follow-up questions work without re-uploading audio.  Caller-supplied
-    `requirements` and `model_options` are forwarded to `ainstruct`.
+    Caller-supplied `requirements` and `model_options` are forwarded to `ainstruct`.
     """
     if not input:
         return ModelOutputThunk(value="No input provided")
@@ -171,6 +162,7 @@ async def serve(
         validation_fn=simple_validate(_has_two_transcript_colors),
     )
 
+    chat_session = start_session(model_id=_chat_model)
     result = await chat_session.ainstruct(
         description=prompt,
         requirements=[

--- a/docs/examples/m_serve/multimodal-audio/m_serve_example_multimodal_audio_llama_server.py
+++ b/docs/examples/m_serve/multimodal-audio/m_serve_example_multimodal_audio_llama_server.py
@@ -10,9 +10,7 @@ Unlike the Ollama version, llama-server with a multimodal Gemma checkpoint
 supports native audio-text-to-text: audio and text are sent together in a
 single request and the model responds in text.
 
-The session uses `ChatContext` so conversation history accumulates across
-turns: follow-up questions work without re-uploading audio.  Caller-supplied
-`requirements` and `model_options` are forwarded to `ainstruct`.
+Caller-supplied `requirements` and `model_options` are forwarded to `ainstruct`.
 
 Prerequisites:
     - llama-server running with an audio-capable Gemma checkpoint, e.g.:
@@ -48,23 +46,11 @@ from mellea import start_session
 from mellea.backends import ModelOption
 from mellea.core import AudioBlock, AudioUrlBlock, ModelOutputThunk, Requirement
 from mellea.serve import ChatMessage
-from mellea.stdlib.context import ChatContext
 from mellea.stdlib.sampling import RejectionSamplingStrategy
 
 _base_url = os.environ.get("LLAMA_SERVER_URL", "http://localhost:8088/v1")
 _api_key = os.environ.get("LLAMA_SERVER_API_KEY", "default")
 _model_id = os.environ.get("LLAMA_SERVER_MODEL", "gemma-4-12b-it-Q8_0.gguf")
-
-# ChatContext accumulates conversation history across turns so follow-up
-# questions work without re-uploading audio.
-session = start_session(
-    "openai",
-    model_id=_model_id,
-    base_url=_base_url,
-    api_key=_api_key,
-    ctx=ChatContext(),
-    model_options={ModelOption.MAX_NEW_TOKENS: 1000, "modalities": ["text"]},
-)
 
 
 async def serve(
@@ -74,9 +60,7 @@ async def serve(
 ) -> ModelOutputThunk:
     """Serve function that supports native audio-text-to-text via llama-server.
 
-    The session retains conversation history across calls (via `ChatContext`),
-    so follow-up questions work without re-uploading audio.  Caller-supplied
-    `requirements` and `model_options` are forwarded to `ainstruct`.
+    Caller-supplied `requirements` and `model_options` are forwarded to `ainstruct`.
     """
     if not input:
         return ModelOutputThunk(value="No input provided")
@@ -92,6 +76,13 @@ async def serve(
             "No audio provided. Please include an audio clip in your message."
         )
 
+    session = start_session(
+        "openai",
+        model_id=_model_id,
+        base_url=_base_url,
+        api_key=_api_key,
+        model_options={ModelOption.MAX_NEW_TOKENS: 1000, "modalities": ["text"]},
+    )
     result = await session.ainstruct(
         description=text,
         audio=audio_blocks,

--- a/docs/examples/m_serve/multimodal-image/client_multimodal_image.py
+++ b/docs/examples/m_serve/multimodal-image/client_multimodal_image.py
@@ -9,8 +9,8 @@ PORT = 8080
 
 client = openai.OpenAI(api_key="na", base_url=f"http://0.0.0.0:{PORT}/v1")
 
-# Create a simple 100x100 red square image (vision models need reasonable-sized images)
-img = Image.new("RGB", (100, 100), color="cyan")
+# Create a simple 100x100 green square image (vision models need reasonable-sized images)
+img = Image.new("RGB", (100, 100), color="green")
 img_io = BytesIO()
 img.save(img_io, "PNG")
 test_image_base64 = base64.b64encode(img_io.getvalue()).decode("utf-8")

--- a/docs/examples/m_serve/multimodal-image/m_serve_example_multimodal_image.py
+++ b/docs/examples/m_serve/multimodal-image/m_serve_example_multimodal_image.py
@@ -7,7 +7,7 @@ message objects and uses them with a vision model via Ollama's OpenAI-compatible
 
 Prerequisites:
     - Ollama running locally with a vision model pulled
-    - Run: ollama pull granite3.2-vision
+    - Run: ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M
 
 Usage:
     m serve docs/examples/m_serve/multimodal-image/m_serve_example_multimodal_image.py

--- a/docs/examples/m_serve/multimodal-image/m_serve_example_multimodal_image.py
+++ b/docs/examples/m_serve/multimodal-image/m_serve_example_multimodal_image.py
@@ -21,9 +21,9 @@ from typing import Any, cast
 from mellea import start_session
 from mellea.core import ModelOutputThunk
 from mellea.serve import ChatMessage
+from mellea.stdlib.context import ChatContext
 
-MODEL_ID = "granite3.2-vision"
-session = start_session(model_id=MODEL_ID)
+MODEL_ID = "hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M"
 
 # MODEL_ID = "llava"
 #
@@ -54,6 +54,7 @@ async def serve(
     last_message = input[-1]
     text = last_message.get_text_content() or "Describe this image"
     image_blocks = last_message.get_image_blocks()
+    session = start_session(model_id=MODEL_ID, ctx=ChatContext())
     result = session.chat(content=text, images=image_blocks)
 
     print(f"Result content: {result.content[:100] if result.content else 'None'}...")

--- a/docs/examples/m_serve/pii/pii_serve.py
+++ b/docs/examples/m_serve/pii/pii_serve.py
@@ -71,9 +71,6 @@ def pii_remove_validate(
         return "The Validation Failed"
 
 
-session = mellea.start_session(model_id=IBM_GRANITE_4_1_3B)
-
-
 def serve(
     input: list[ChatMessage],
     requirements: list[str] | None = None,
@@ -81,6 +78,7 @@ def serve(
 ) -> ModelOutputThunk | SamplingResult | str:
     """Simple serve example to do PII stuff."""
     message = input[-1].get_text_content()
+    session = mellea.start_session(model_id=IBM_GRANITE_4_1_3B)
     result = pii_remove_validate(
         session, message, requirements=requirements, model_options=model_options
     )

--- a/docs/examples/m_serve/response-format/m_serve_example_response_format.py
+++ b/docs/examples/m_serve/response-format/m_serve_example_response_format.py
@@ -20,9 +20,6 @@ from typing import Any
 import mellea
 from mellea.core import ModelOutputThunk
 from mellea.serve import ChatMessage
-from mellea.stdlib.context import ChatContext
-
-session = mellea.start_session(ctx=ChatContext())
 
 
 def serve(
@@ -45,7 +42,8 @@ def serve(
     message = input[-1].get_text_content() or "No message provided"
 
     # When format is provided (from json_schema response_format),
-    # pass it to instruct() to get structured output
+    # pass it to instruct() to get structured output.
+    session = mellea.start_session()
     result = session.instruct(
         description=message,
         requirements=requirements,  # type: ignore

--- a/docs/examples/m_serve/simple/m_serve_example_simple.py
+++ b/docs/examples/m_serve/simple/m_serve_example_simple.py
@@ -2,16 +2,11 @@
 
 """Example to run m serve."""
 
-from typing import Any
-
 import mellea
 from mellea.core import ModelOutputThunk, Requirement, SamplingResult
 from mellea.serve import ChatMessage
-from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import simple_validate
 from mellea.stdlib.sampling import RejectionSamplingStrategy
-
-session = mellea.start_session(ctx=ChatContext())
 
 
 def validate_hi_bob(email: str) -> bool:
@@ -42,6 +37,7 @@ def serve(
         *requirements,
     ]
 
+    session = mellea.start_session()
     result = session.instruct(
         description=message,  # type: ignore
         requirements=reqs,  # type: ignore

--- a/docs/examples/m_serve/streaming/m_serve_example_streaming.py
+++ b/docs/examples/m_serve/streaming/m_serve_example_streaming.py
@@ -10,8 +10,6 @@ from mellea.core import ComputedModelOutputThunk, ModelOutputThunk
 from mellea.serve import ChatMessage
 from mellea.stdlib.context import SimpleContext
 
-session = mellea.start_session(ctx=SimpleContext())
-
 
 async def serve(
     input: list[ChatMessage],
@@ -27,6 +25,7 @@ async def serve(
     message = input[-1].get_text_content()
     is_streaming = bool((model_options or {}).get(ModelOption.STREAM, False))
 
+    session = mellea.start_session(ctx=SimpleContext())
     if is_streaming:
         return await session.ainstruct(
             description=message,

--- a/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
+++ b/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
@@ -25,7 +25,6 @@ from mellea.core import ModelOutputThunk, Requirement
 from mellea.core.base import AbstractMelleaTool
 from mellea.formatters import TemplateFormatter
 from mellea.serve import ChatMessage
-from mellea.stdlib.context import ChatContext
 from mellea.stdlib.session import MelleaSession
 
 _ollama_host = os.environ.get("OLLAMA_HOST", "localhost:11434")
@@ -38,7 +37,6 @@ backend = OpenAIBackend(
     base_url=f"{_ollama_host}/v1",
     api_key="ollama",
 )
-session = MelleaSession(backend, ctx=ChatContext())
 
 
 class GetWeatherTool(AbstractMelleaTool):
@@ -233,6 +231,7 @@ def serve(
     # at the request level. Enforcing uses_tool(...) inside session.instruct()
     # caused noisy server-side failures when the model ignored the tool request
     # on a particular sample.
+    session = MelleaSession(backend)
     result = session.instruct(
         description=message,  # type: ignore
         requirements=[Requirement(req) for req in requirements],  # type: ignore
@@ -245,6 +244,7 @@ def serve(
 
 
 if __name__ == "__main__":
+    session = MelleaSession(backend)
     response = session.instruct(
         "What's the weather in Boston?",
         model_options={


### PR DESCRIPTION
Examples are holding the session across requests so that different client would share history.  This doesn't significantly affect the examples, but it's a bad pattern if the example influences real implementations.


Assisted-by: IBM Bob

# Pull Request

## Issue
Fixes #1444 

## Description
<!-- What does this PR do and why? -->


### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
