### PR TITLE
fix: repair broken dict-vs-string assertions in test_validate.py

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -136,7 +136,7 @@ jobs:
         run: >-
           uv run -m pytest -v --junit-xml=/tmp/pytest-results.xml
           test
-          tooling/docs-autogen/test_validate.py::test_repository_docstrings_use_markdown_backticks
+          tooling/docs-autogen/test_validate.py
       - name: Send failure message tests
         if: failure() # This step will only run if a previous step failed
         run: echo "Tests failed. Please verify that tests are working locally."

--- a/tooling/docs-autogen/test_validate.py
+++ b/tooling/docs-autogen/test_validate.py
@@ -48,7 +48,7 @@ def test_validate_source_links_fail():
         error_count, errors = validate_source_links(docs_dir, "0.5.0")
         assert error_count == 1
         assert len(errors) == 1
-        assert "Invalid source link" in errors[0]
+        assert "Invalid source link" in errors[0]["message"]
 
 
 def test_validate_mdx_syntax_pass():
@@ -74,7 +74,7 @@ def test_validate_mdx_syntax_missing_frontmatter():
 
         error_count, errors = validate_mdx_syntax(docs_dir)
         assert error_count == 1
-        assert "Missing frontmatter" in errors[0]
+        assert "Missing frontmatter" in errors[0]["message"]
 
 
 def test_validate_mdx_syntax_unclosed_code_block():
@@ -86,7 +86,7 @@ def test_validate_mdx_syntax_unclosed_code_block():
 
         error_count, errors = validate_mdx_syntax(docs_dir)
         assert error_count == 1
-        assert "Unclosed code block" in errors[0]
+        assert "Unclosed code block" in errors[0]["message"]
 
 
 def test_validate_internal_links_pass():
@@ -115,7 +115,7 @@ def test_validate_internal_links_broken():
 
         error_count, errors = validate_internal_links(docs_dir)
         assert error_count == 1
-        assert "Broken link" in errors[0]
+        assert "Broken link" in errors[0]["message"]
 
 
 def test_validate_internal_links_external_ignored():
@@ -356,7 +356,7 @@ def test_validate_stale_files_review_artifact():
 
         error_count, errors = validate_stale_files(docs_root)
         assert error_count == 1
-        assert "review artifact" in errors[0].lower()
+        assert "review artifact" in errors[0]["message"].lower()
 
 
 def test_validate_stale_files_superseded_index():
@@ -369,7 +369,7 @@ def test_validate_stale_files_superseded_index():
 
         error_count, errors = validate_stale_files(docs_root)
         assert error_count == 1
-        assert "superseded" in errors[0].lower()
+        assert "superseded" in errors[0]["message"].lower()
 
 
 def test_validate_stale_files_superseded_tutorial():
@@ -382,7 +382,7 @@ def test_validate_stale_files_superseded_tutorial():
 
         error_count, errors = validate_stale_files(docs_root)
         assert error_count == 1
-        assert "superseded" in errors[0].lower()
+        assert "superseded" in errors[0]["message"].lower()
 
 
 def test_validate_doc_imports_pass():
@@ -409,7 +409,7 @@ def test_validate_doc_imports_bad_symbol():
 
         error_count, errors = validate_doc_imports(docs_dir)
         assert error_count == 1
-        assert "symbol not found" in errors[0]
+        assert "symbol not found" in errors[0]["message"]
 
 
 def test_validate_doc_imports_skips_non_python_blocks():
@@ -509,7 +509,7 @@ def test_validate_examples_catalogue_missing():
 
         error_count, errors = validate_examples_catalogue(docs_root)
         assert error_count == 1
-        assert "unlisted_example" in errors[0]
+        assert "unlisted_example" in errors[0]["message"]
 
 
 def test_validate_examples_catalogue_skips_helper():


### PR DESCRIPTION
## Summary

- Nine tests in `tooling/docs-autogen/test_validate.py` asserted against `errors[0]` as if it were a string, but `_err()` returns a dict with `file`/`line`/`message` keys. Running the file directly raises `AttributeError` or fails the containment check outright — fixed each assertion to check `errors[0]["message"]`.
- `.github/workflows/quality.yml` pinned a single test node from this file rather than running the whole module, which is how these 9 failures went unnoticed by CI. Widened it to run the full file.

Fixes #1484

## Test plan

- [x] `uv run pytest tooling/docs-autogen/test_validate.py -v` — 34/34 pass (previously 9 failed)
- [x] `uv run ruff format` / `uv run ruff check` clean
- [x] `uv run mypy tooling/docs-autogen/test_validate.py` clean (note: `tooling/` is excluded from the project's mypy config, so this was already out of scope for the pre-commit gate)