### PR TITLE
feat(telemetry): add sampling and validator tracing spans via hooks

### DIFF
--- a/docs/docs/how-to/debug-with-plugins.md
+++ b/docs/docs/how-to/debug-with-plugins.md
@@ -134,7 +134,7 @@ register([
 - Loop start: strategy, budget, requirement count
 - Each iteration: pass/fail count, failed requirement names
 - Repair events: when triggered, repair type, failed requirements
-- Loop end: success/failure, iterations used, final statistics
+- Loop end: success/failure/error, iterations used, final statistics
 
 ## Enabling multiple plugins together
 

--- a/docs/docs/observability/telemetry.md
+++ b/docs/docs/observability/telemetry.md
@@ -101,7 +101,7 @@ Enable tracing for full observability. Backend spans nest inside application spa
 session                  (mellea.application)
 ├── action               (mellea.application)
 │   ├── chat             (mellea.backend) [gen_ai.provider.name=ollama]
-│   └── requirement_validation  (mellea.application)
+│   └── validation       (mellea.application)
 └── action               (mellea.application)
     └── chat             (mellea.backend) [gen_ai.provider.name=openai]
 ```

--- a/docs/docs/observability/tracing.md
+++ b/docs/docs/observability/tracing.md
@@ -162,6 +162,36 @@ convention.
 | `mellea.tool.is_control_flow` | Whether the tool is framework control flow (e.g., `final_answer` in ReAct) |
 | `mellea.tool.arguments_hash` | Stable hash of the arguments; recorded independent of content capture, when the call has arguments |
 
+#### `sampling` span
+
+One per sampling loop, when a `m.act()`, `m.instruct()`, or `@generative` call
+runs with a sampling strategy. Wraps each attempt and closes when the loop
+produces a passing sample or exhausts its budget.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `mellea.strategy_type` | Sampling strategy class name (e.g., `RejectionSamplingStrategy`) |
+| `mellea.loop_budget` | Maximum iterations per subsample |
+| `mellea.requirement_count` | Number of requirements validated each iteration |
+| `mellea.sampling_success` | Whether at least one attempt passed all requirements |
+| `mellea.iterations_used` | Total iterations that completed across subsamples |
+| `mellea.failure_reason` | Human-readable reason when `mellea.sampling_success` is `false` |
+
+It also records an `iteration` span event per attempt and a `repair` span event
+per repair.
+
+#### `validation` span
+
+One per requirement-validation batch, wherever requirements are checked.
+
+| Attribute | Description |
+| --------- | ----------- |
+| `mellea.requirement_count` | Number of requirements validated |
+| `mellea.validation_passed` | Whether every requirement passed |
+| `mellea.passed_count` | Number of requirements that passed |
+| `mellea.failed_count` | Number of requirements that failed |
+| `mellea.failure_reasons` | List of failing requirements' reasons; recorded only when `MELLEA_TRACES_CONTENT=true` |
+
 #### `stream_with_chunking` span
 
 One per `stream_with_chunking()` run, wrapping the backend generation and any
@@ -221,19 +251,24 @@ start_session             (mellea.application)
 session                   (mellea.application)
 ├── action                (mellea.application)
 │   │                     [mellea.action_type=Instruction]
-│   ├── chat              (mellea.backend)
-│   │                     [gen_ai.provider.name=ollama]
-│   │                     [gen_ai.request.model=granite4.1:3b]
-│   │                     [gen_ai.usage.input_tokens=150]
-│   │                     [gen_ai.usage.output_tokens=42]
-│   └── requirement_validation  (mellea.application)
+│   └── sampling          (mellea.application)
+│       │                 [mellea.strategy_type=RejectionSamplingStrategy]
+│       ├── chat          (mellea.backend)
+│       │                 [gen_ai.provider.name=ollama]
+│       │                 [gen_ai.request.model=granite4.1:3b]
+│       │                 [gen_ai.usage.input_tokens=150]
+│       │                 [gen_ai.usage.output_tokens=42]
+│       └── validation    (mellea.application)
+│                         [mellea.requirement_count=2]
 ├── execute_tool search   (mellea.application)
 │                         [gen_ai.tool.name=search]
 │                         [mellea.tool.status=success]
-└── action                (mellea.application)
-    └── chat              (mellea.backend)
-                          [gen_ai.provider.name=openai]
-                          [gen_ai.request.model=gpt-4o]
+├── action                (mellea.application)
+│   └── chat              (mellea.backend)
+│                         [gen_ai.provider.name=openai]
+│                         [gen_ai.request.model=gpt-4o]
+└── validation            (mellea.application)   ← final m.validate() check
+                          [mellea.requirement_count=2]
 ```
 
 Tool execution happens after the generating call completes, so `execute_tool`
@@ -269,10 +304,11 @@ When you open a trace in your backend, look for these patterns:
 has accumulated many previous messages. Use
 [prefix caching](../advanced/prefix-caching-and-kv-blocks) to reduce cost.
 
-**Repeated `requirement_validation` spans beneath one `action`.** The value of
-`mellea.num_generate_logs` in the parent span tells you how many retries occurred.
-If the model keeps retrying, read the `mellea.response` attribute on each attempt to
-understand why validation is failing.
+**Repeated `validation` spans beneath one `sampling` span.** The model is
+retrying because requirements keep failing. Each `sampling` span records
+`mellea.iterations_used` (how many attempts ran); open a failing attempt's
+`validation` span and read `mellea.failure_reasons` to see why validation is
+failing (recorded as available when content capture is enabled).
 
 **Long gaps between spans.** A gap between the start of a backend `chat` span
 and the next application span usually indicates time spent waiting for the LLM.

--- a/mellea/plugins/builtin_debug/sampling.py
+++ b/mellea/plugins/builtin_debug/sampling.py
@@ -140,13 +140,18 @@ async def log_sampling_loop_end(
     """Log sampling completion with success status and attempt statistics.
 
     Args:
-        payload: SamplingLoopEndPayload with success, iterations_used, all_results, all_validations.
+        payload: SamplingLoopEndPayload with success, iterations_used, all_results,
+            all_validations, and exception (set when the loop raised).
         ctx: Plugin context for hook execution.
     """
     strategy = payload.strategy_name
     iterations = payload.iterations_used
     success = payload.success
     failure_reason = payload.failure_reason
+
+    if payload.exception is not None:
+        logger.info(f"[💥 SAMPLING-END] ERROR using {strategy}: {payload.exception!r}")
+        return
 
     if success:
         logger.info(

--- a/mellea/plugins/builtin_debug/validation.py
+++ b/mellea/plugins/builtin_debug/validation.py
@@ -73,9 +73,14 @@ async def log_validation_post_check(
     """Log validation results after requirements are checked.
 
     Args:
-        payload: ValidationPostCheckPayload with passed_count, failed_count, results.
+        payload: ValidationPostCheckPayload with passed_count, failed_count,
+            results, and exception (set when validation raised).
         ctx: Plugin context for hook execution.
     """
+    if payload.exception is not None:
+        logger.info(f"[💥 VALIDATION-POST-CHECK] ERROR: {payload.exception!r}")
+        return
+
     passed = payload.passed_count
     failed = payload.failed_count
     total = len(payload.requirements)

--- a/mellea/plugins/hooks/sampling.py
+++ b/mellea/plugins/hooks/sampling.py
@@ -14,6 +14,8 @@ class SamplingLoopStartPayload(MelleaBasePayload):
     """Payload for `sampling_loop_start` — when sampling strategy begins.
 
     Attributes:
+        sampling_id: UUID correlating the start/iteration/repair/end hooks for a
+            single sampling loop.
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
         action: The `Component` being sampled.
 
@@ -23,6 +25,7 @@ class SamplingLoopStartPayload(MelleaBasePayload):
         loop_budget: Maximum number of sampling iterations allowed (writable).
     """
 
+    sampling_id: str = ""
     strategy_name: str = ""
     action: Any = None
     context: Any = None
@@ -34,6 +37,7 @@ class SamplingIterationPayload(MelleaBasePayload):
     """Payload for `sampling_iteration` — after each sampling attempt.
 
     Attributes:
+        sampling_id: UUID correlating with the matching `sampling_loop_start`.
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
         iteration: 1-based iteration number within the sampling loop. There is no guarantee that
             iteration will be monotonically increasing when concurrency is enabled.
@@ -47,6 +51,7 @@ class SamplingIterationPayload(MelleaBasePayload):
         total_count: Total number of requirements evaluated.
     """
 
+    sampling_id: str = ""
     strategy_name: str = ""
     iteration: int = 0
     action: Any = None
@@ -61,6 +66,7 @@ class SamplingRepairPayload(MelleaBasePayload):
     """Payload for `sampling_repair` — when repair is invoked after validation failure.
 
     Attributes:
+        sampling_id: UUID correlating with the matching `sampling_loop_start`.
         repair_type: Kind of repair (strategy-dependent, e.g. `"rejection"`, `"template"`).
         failed_action: The `Component` that failed validation.
 
@@ -71,6 +77,7 @@ class SamplingRepairPayload(MelleaBasePayload):
         repair_iteration: 1-based iteration at which the repair was triggered.
     """
 
+    sampling_id: str = ""
     repair_type: str = ""
     failed_action: Any = None
     failed_result: Any = None
@@ -83,23 +90,31 @@ class SamplingRepairPayload(MelleaBasePayload):
 class SamplingLoopEndPayload(MelleaBasePayload):
     """Payload for `sampling_loop_end` — when sampling completes.
 
+    Fires on every completing path: success, budget exhaustion, and an
+    unhandled exception. `success` and `exception` together distinguish the
+    outcomes.
+
     Attributes:
+        sampling_id: UUID correlating with the matching `sampling_loop_start`.
         strategy_name: Class name of the sampling strategy (e.g. `"RejectionSamplingStrategy"`).
         success: `True` if at least one attempt passed all requirements.
         iterations_used: Total number of sampling iterations that completed. With concurrency
             enabled, this may be less than `loop_budget * concurrency_budget` if the strategy
-            exits early after a successful result.
+            exits early after a successful result. `0` on the exception path, regardless of
+            how many iterations ran before the loop raised.
         final_result: The selected `ModelOutputThunk` (best success or best failure).
         final_action: The `Component` that produced `final_result`.
 
         final_context: The `Context` associated with `final_result`.
 
         failure_reason: Human-readable reason when `success` is `False`.
+        exception: The exception raised by the loop, or `None` when it completed.
         all_results: List of `ModelOutputThunk` from every iteration.
         all_validations: Nested list — `all_validations[i]` is the list of
             `(Requirement, ValidationResult)` tuples for iteration *i*.
     """
 
+    sampling_id: str = ""
     strategy_name: str = ""
     success: bool = False
     iterations_used: int = 0
@@ -107,5 +122,6 @@ class SamplingLoopEndPayload(MelleaBasePayload):
     final_action: Any = None
     final_context: Any = None
     failure_reason: str | None = None
+    exception: BaseException | None = None
     all_results: list[Any] = []
     all_validations: list[list[tuple[Any, Any]]] = []

--- a/mellea/plugins/hooks/validation.py
+++ b/mellea/plugins/hooks/validation.py
@@ -14,6 +14,8 @@ class ValidationPreCheckPayload(MelleaBasePayload):
     """Payload for `validation_pre_check` — before requirement validation.
 
     Attributes:
+        validation_id: UUID correlating the pre/post hooks for a single
+            requirement-validation batch.
         requirements: List of `Requirement` instances to validate (writable).
         target: The `CBlock` being validated, or `None` when validating the full context.
 
@@ -22,6 +24,7 @@ class ValidationPreCheckPayload(MelleaBasePayload):
         model_options: Dict of model options for backend-based validators (writable).
     """
 
+    validation_id: str = ""
     requirements: list[Any] = []
     target: Any = None
     context: Any = None
@@ -31,16 +34,23 @@ class ValidationPreCheckPayload(MelleaBasePayload):
 class ValidationPostCheckPayload(MelleaBasePayload):
     """Payload for `validation_post_check` — after validation completes.
 
+    Fires on every completing path: a normal check (any pass/fail mix) and an
+    unhandled exception. On the exception path `results` and the counts are empty.
+
     Attributes:
+        validation_id: UUID correlating with the matching `validation_pre_check`.
         requirements: List of `Requirement` instances that were evaluated.
         results: List of `ValidationResult` instances (writable).
         all_validations_passed: `True` when every requirement passed (writable).
         passed_count: Number of requirements that passed.
         failed_count: Number of requirements that failed.
+        exception: The exception raised during validation, or `None` when it completed.
     """
 
+    validation_id: str = ""
     requirements: list[Any] = []
     results: list[Any] = []
     all_validations_passed: bool = False
     passed_count: int = 0
     failed_count: int = 0
+    exception: BaseException | None = None

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -1047,6 +1047,8 @@ async def avalidate(
     reqs = [reqs] if not isinstance(reqs, list) else reqs
     reqs = [Requirement(req) if type(req) is str else req for req in reqs]
 
+    validation_id = str(uuid.uuid4())
+
     if output is None:
         validation_target_ctx = context
     else:
@@ -1062,6 +1064,7 @@ async def avalidate(
         from ..plugins.hooks.validation import ValidationPreCheckPayload
 
         pre_payload = ValidationPreCheckPayload(
+            validation_id=validation_id,
             requirements=reqs,
             target=output,
             context=validation_target_ctx,
@@ -1082,40 +1085,47 @@ async def avalidate(
         )
         coroutines.append(val_result_co)
 
-    for val_result in await asyncio.gather(*coroutines):
-        rvs.append(val_result)
+    exception: BaseException | None = None
+    try:
+        for val_result in await asyncio.gather(*coroutines):
+            rvs.append(val_result)
 
-        # If the validator utilized a backend to generate a result, attach the corresponding
-        # info to the generate_logs list.
-        if generate_logs is not None:
-            if val_result.thunk is not None:
-                thunk = val_result.thunk
-                assert (
-                    thunk._generate_log is not None
-                )  # Cannot be None after generation.
-                generate_logs.append(thunk._generate_log)
-            else:
-                # We have to append None here so that the logs line-up.
-                # TODO: A better solution should be found for this edge case.
-                #       This is the only scenario where ValidationResults are supposed to line
-                #       up with GenerateLogs.
-                generate_logs.append(None)  # type: ignore
+            # If the validator utilized a backend to generate a result, attach the corresponding
+            # info to the generate_logs list.
+            if generate_logs is not None:
+                if val_result.thunk is not None:
+                    thunk = val_result.thunk
+                    assert (
+                        thunk._generate_log is not None
+                    )  # Cannot be None after generation.
+                    generate_logs.append(thunk._generate_log)
+                else:
+                    # We have to append None here so that the logs line-up.
+                    # TODO: A better solution should be found for this edge case.
+                    #       This is the only scenario where ValidationResults are supposed to line
+                    #       up with GenerateLogs.
+                    generate_logs.append(None)  # type: ignore
+    except BaseException as exc:
+        exception = exc
+        raise
+    finally:
+        # --- validation_post_check hook ---
+        if has_plugins(HookType.VALIDATION_POST_CHECK):
+            from ..plugins.hooks.validation import ValidationPostCheckPayload
 
-    # --- validation_post_check hook ---
-    if has_plugins(HookType.VALIDATION_POST_CHECK):
-        from ..plugins.hooks.validation import ValidationPostCheckPayload
-
-        post_payload = ValidationPostCheckPayload(
-            requirements=reqs,
-            results=rvs,
-            all_validations_passed=all(bool(r) for r in rvs),
-            passed_count=sum(1 for r in rvs if bool(r)),
-            failed_count=sum(1 for r in rvs if not bool(r)),
-        )
-        _, post_payload = await invoke_hook(
-            HookType.VALIDATION_POST_CHECK, post_payload, backend=backend
-        )
-        rvs = post_payload.results
+            post_payload = ValidationPostCheckPayload(
+                validation_id=validation_id,
+                requirements=reqs,
+                results=rvs,
+                all_validations_passed=exception is None and all(bool(r) for r in rvs),
+                passed_count=sum(1 for r in rvs if bool(r)),
+                failed_count=sum(1 for r in rvs if not bool(r)),
+                exception=exception,
+            )
+            _, post_payload = await invoke_hook(
+                HookType.VALIDATION_POST_CHECK, post_payload, backend=backend
+            )
+            rvs = post_payload.results
 
     return rvs
 

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -19,6 +19,7 @@ Sampling strategies control how Mellea handles validation failures during genera
 
 import abc
 import asyncio
+import uuid
 from collections.abc import AsyncGenerator, Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
@@ -259,12 +260,15 @@ class BaseSamplingStrategy(SamplingStrategy):
                 reqs += requirements
             reqs = list(set(reqs))
 
+            sampling_id = str(uuid.uuid4())
+
             # --- sampling_loop_start hook ---
             effective_loop_budget = self.loop_budget
             if has_plugins(HookType.SAMPLING_LOOP_START):
                 from ...plugins.hooks.sampling import SamplingLoopStartPayload
 
                 start_payload = SamplingLoopStartPayload(
+                    sampling_id=sampling_id,
                     strategy_name=type(self).__name__,
                     action=action,
                     context=context,
@@ -276,173 +280,195 @@ class BaseSamplingStrategy(SamplingStrategy):
                 )
                 effective_loop_budget = start_payload.loop_budget
 
-            # Hooks can override loop_budget but bypass the constructor's
-            # validation; reject non-positive values up front so the failure
-            # mode is a clear error rather than an empty-slices AssertionError.
-            if effective_loop_budget < 1:
-                raise ValueError(
-                    f"SAMPLING_LOOP_START hook returned non-positive loop_budget="
-                    f"{effective_loop_budget}; must be >= 1."
-                )
-
-            total_possible_generations = effective_loop_budget * self.concurrency_budget
-            progress_indicator = (
-                tqdm.tqdm(
-                    iterable=range(total_possible_generations),
-                    desc=f"{type(self).__name__}",
-                )
-                if show_progress
-                else None
-            )
-
-            # Create `concurrency_budget` concurrent generators that all generate up to the `loop_budget` number of generations.
-            generators: list[AsyncGenerator[_SamplingResultSlice[S], Any]] = [
-                self._subsample_iteration(
-                    subsample_index=idx,
-                    iterations=effective_loop_budget,
-                    action=action,
-                    context=context,
-                    backend=backend,
-                    requirements=reqs,
-                    validation_ctx=validation_ctx,
-                    format=format,
-                    model_options=model_options,
-                    tool_calls=tool_calls,
-                )
-                for idx in range(self.concurrency_budget)
-            ]
-
-            # Sentinel pushed by each producer when it exhausts its generator.
-            # Lets the consumer detect "all producers done" without racing
-            # queue.get() against a separate completion future.
-            _DONE = object()
-
-            async def _producer(
-                generator: AsyncGenerator[_SamplingResultSlice, Any],
-                queue: asyncio.Queue[_SamplingResultSlice | object],
-            ) -> None:
-                """Drain an async generator into a shared queue, then signal completion."""
-                try:
-                    async for item in generator:
-                        await queue.put(item)
-                finally:
-                    await queue.put(_DONE)
-
-            # Create the queue that the samples are consumed from.
-            slice_queue: asyncio.Queue[_SamplingResultSlice | object] = asyncio.Queue()
-            producer_tasks = [
-                # Use tasks to push to the queue so that we don't need to explicitly await each generator.
-                asyncio.create_task(_producer(gen, slice_queue))
-                for gen in generators
-            ]
-
-            slices: list[_SamplingResultSlice] = []
-            producer_results: list[Any] = []
-
-            # Keep track of the producers left. It's the easiest way to ensure we don't deadlock
-            # if the producers finish and queue is empty at the same time.
-            remaining_producers = len(producer_tasks)
+            exception: BaseException | None = None
             try:
-                while remaining_producers > 0:
-                    item = await slice_queue.get()
+                # Hooks can override loop_budget but bypass the constructor's
+                # validation; reject non-positive values up front so the failure
+                # mode is a clear error rather than an empty-slices AssertionError.
+                if effective_loop_budget < 1:
+                    raise ValueError(
+                        f"SAMPLING_LOOP_START hook returned non-positive loop_budget="
+                        f"{effective_loop_budget}; must be >= 1."
+                    )
 
-                    if item is _DONE:
-                        remaining_producers -= 1
-                        continue
-
-                    assert isinstance(item, _SamplingResultSlice)
-                    slices.append(item)
-
-                    if progress_indicator is not None:
-                        progress_indicator.update()
-
-                    if item.success:
-                        # Found a successful sample. Exit early.
-                        break
-            finally:
-                for t in producer_tasks:
-                    t.cancel()  # No-op if already done / cancelled.
-
-                # Wait for cancellations to settle so we don't leak tasks.
-                # Capture results so we can surface backend errors that would
-                # otherwise be swallowed when no slices made it through.
-                producer_results = await asyncio.gather(
-                    *producer_tasks, return_exceptions=True
+                total_possible_generations = (
+                    effective_loop_budget * self.concurrency_budget
+                )
+                progress_indicator = (
+                    tqdm.tqdm(
+                        iterable=range(total_possible_generations),
+                        desc=f"{type(self).__name__}",
+                    )
+                    if show_progress
+                    else None
                 )
 
-                # Drain anything queued before producers were cancelled.
-                while not slice_queue.empty():
+                # Create `concurrency_budget` concurrent generators that all generate up to the `loop_budget` number of generations.
+                generators: list[AsyncGenerator[_SamplingResultSlice[S], Any]] = [
+                    self._subsample_iteration(
+                        subsample_index=idx,
+                        iterations=effective_loop_budget,
+                        action=action,
+                        context=context,
+                        backend=backend,
+                        requirements=reqs,
+                        validation_ctx=validation_ctx,
+                        format=format,
+                        model_options=model_options,
+                        tool_calls=tool_calls,
+                        sampling_id=sampling_id,
+                    )
+                    for idx in range(self.concurrency_budget)
+                ]
+
+                # Sentinel pushed by each producer when it exhausts its generator.
+                # Lets the consumer detect "all producers done" without racing
+                # queue.get() against a separate completion future.
+                _DONE = object()
+
+                async def _producer(
+                    generator: AsyncGenerator[_SamplingResultSlice, Any],
+                    queue: asyncio.Queue[_SamplingResultSlice | object],
+                ) -> None:
+                    """Drain an async generator into a shared queue, then signal completion."""
                     try:
-                        item = slice_queue.get_nowait()
-                    except asyncio.QueueEmpty:
-                        break
-                    if item is _DONE:
-                        continue
-                    assert isinstance(item, _SamplingResultSlice)
-                    slices.append(item)
+                        async for item in generator:
+                            await queue.put(item)
+                    finally:
+                        await queue.put(_DONE)
+
+                # Create the queue that the samples are consumed from.
+                slice_queue: asyncio.Queue[_SamplingResultSlice | object] = (
+                    asyncio.Queue()
+                )
+                producer_tasks = [
+                    # Use tasks to push to the queue so that we don't need to explicitly await each generator.
+                    asyncio.create_task(_producer(gen, slice_queue))
+                    for gen in generators
+                ]
+
+                slices: list[_SamplingResultSlice] = []
+                producer_results: list[Any] = []
+
+                # Keep track of the producers left. It's the easiest way to ensure we don't deadlock
+                # if the producers finish and queue is empty at the same time.
+                remaining_producers = len(producer_tasks)
+                try:
+                    while remaining_producers > 0:
+                        item = await slice_queue.get()
+
+                        if item is _DONE:
+                            remaining_producers -= 1
+                            continue
+
+                        assert isinstance(item, _SamplingResultSlice)
+                        slices.append(item)
+
+                        if progress_indicator is not None:
+                            progress_indicator.update()
+
+                        if item.success:
+                            # Found a successful sample. Exit early.
+                            break
+                finally:
+                    for t in producer_tasks:
+                        t.cancel()  # No-op if already done / cancelled.
+
+                    # Wait for cancellations to settle so we don't leak tasks.
+                    # Capture results so we can surface backend errors that would
+                    # otherwise be swallowed when no slices made it through.
+                    producer_results = await asyncio.gather(
+                        *producer_tasks, return_exceptions=True
+                    )
+
+                    # Drain anything queued before producers were cancelled.
+                    while not slice_queue.empty():
+                        try:
+                            item = slice_queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                        if item is _DONE:
+                            continue
+                        assert isinstance(item, _SamplingResultSlice)
+                        slices.append(item)
+                        if progress_indicator is not None:
+                            progress_indicator.update()
+
                     if progress_indicator is not None:
-                        progress_indicator.update()
+                        progress_indicator.close()
 
-                if progress_indicator is not None:
-                    progress_indicator.close()
-
-            # If no slices made it through, surface the first non-cancellation
-            # exception from a producer rather than letting the empty-slices
-            # state crash later in SamplingResult with a misleading assertion.
-            for r in producer_results:
-                if isinstance(r, BaseException) and not isinstance(
-                    r, asyncio.CancelledError
-                ):
-                    flog.warning("A concurrent subsample raised an exception: %s", r)
-
-            if not slices:
+                # If no slices made it through, surface the first non-cancellation
+                # exception from a producer rather than letting the empty-slices
+                # state crash later in SamplingResult with a misleading assertion.
                 for r in producer_results:
                     if isinstance(r, BaseException) and not isinstance(
                         r, asyncio.CancelledError
                     ):
-                        raise r
+                        flog.warning(
+                            "A concurrent subsample raised an exception: %s", r
+                        )
 
-            s_result = _get_sampling_result(
-                slices=slices, select_from_failure=self.select_from_failure
-            )
+                if not slices:
+                    for r in producer_results:
+                        if isinstance(r, BaseException) and not isinstance(
+                            r, asyncio.CancelledError
+                        ):
+                            raise r
 
-            if s_result.success:
-                flog.info("Sampling was successful.")
-            else:
-                flog.info(
-                    f"Invoking select_from_failure after {len(s_result.sample_generations)} failed attempts."
+                s_result = _get_sampling_result(
+                    slices=slices, select_from_failure=self.select_from_failure
                 )
 
-            assert s_result.result_index < len(s_result.sample_generations), (
-                "The select_from_failure method did not return a valid result. It must return an index into failed_results."
-            )
-            assert s_result.result._generate_log is not None
-            s_result.result._generate_log.is_final_result = True
+                if s_result.success:
+                    flog.info("Sampling was successful.")
+                else:
+                    flog.info(
+                        f"Invoking select_from_failure after {len(s_result.sample_generations)} failed attempts."
+                    )
 
-            # --- sampling_loop_end hook (success or failure) ---
-            if has_plugins(HookType.SAMPLING_LOOP_END):
-                from ...plugins.hooks.sampling import SamplingLoopEndPayload
-
-                end_payload = SamplingLoopEndPayload(
-                    strategy_name=type(self).__name__,
-                    success=s_result.success,
-                    iterations_used=len(slices),
-                    final_result=s_result.result,
-                    final_action=s_result.result_action,
-                    final_context=s_result.result_ctx,
-                    all_results=list(s_result.sample_generations),
-                    all_validations=list(s_result.sample_validations),
-                    failure_reason=(
-                        None
-                        if s_result.success
-                        else f"Budget exhausted after {len(slices)} iterations"
-                    ),
+                assert s_result.result_index < len(s_result.sample_generations), (
+                    "The select_from_failure method did not return a valid result. It must return an index into failed_results."
                 )
-                await invoke_hook(
-                    HookType.SAMPLING_LOOP_END, end_payload, backend=backend
-                )
+                assert s_result.result._generate_log is not None
+                s_result.result._generate_log.is_final_result = True
 
-            return s_result
+                return s_result
+
+            except BaseException as exc:
+                exception = exc
+                raise
+            finally:
+                # --- sampling_loop_end hook ---
+                if has_plugins(HookType.SAMPLING_LOOP_END):
+                    from ...plugins.hooks.sampling import SamplingLoopEndPayload
+
+                    if exception is not None:
+                        end_payload = SamplingLoopEndPayload(
+                            sampling_id=sampling_id,
+                            strategy_name=type(self).__name__,
+                            success=False,
+                            exception=exception,
+                        )
+                    else:
+                        end_payload = SamplingLoopEndPayload(
+                            sampling_id=sampling_id,
+                            strategy_name=type(self).__name__,
+                            success=s_result.success,
+                            iterations_used=len(slices),
+                            final_result=s_result.result,
+                            final_action=s_result.result_action,
+                            final_context=s_result.result_ctx,
+                            all_results=list(s_result.sample_generations),
+                            all_validations=list(s_result.sample_validations),
+                            failure_reason=(
+                                None
+                                if s_result.success
+                                else f"Budget exhausted after {len(slices)} iterations"
+                            ),
+                        )
+                    await invoke_hook(
+                        HookType.SAMPLING_LOOP_END, end_payload, backend=backend
+                    )
 
     async def _subsample_iteration(
         self,
@@ -457,12 +483,14 @@ class BaseSamplingStrategy(SamplingStrategy):
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
         tool_calls: bool = False,
+        sampling_id: str = "",
     ) -> AsyncGenerator[_SamplingResultSlice[S], Any]:
         """Run one concurrent subsample: up to `iterations` generate/validate/repair attempts.
 
         Yields a :class:`_SamplingResultSlice` per attempt and ends early after the first successful slice.
         `subsample_index` (0-based) identifies this subsample within the parent `sample()` call; it is used to derive a
-        globally unique iteration counter for telemetry and hooks.
+        globally unique iteration counter for telemetry and hooks. `sampling_id` is passed through to the
+        iteration and repair hooks this subsample fires.
         """
         flog = MelleaLogger.get_logger()
         sampled_results: list[ComputedModelOutputThunk[S]] = []
@@ -525,6 +553,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                     from ...plugins.hooks.sampling import SamplingIterationPayload
 
                     iter_payload = SamplingIterationPayload(
+                        sampling_id=sampling_id,
                         strategy_name=type(self).__name__,
                         iteration=current_iteration,
                         action=next_action,
@@ -586,6 +615,7 @@ class BaseSamplingStrategy(SamplingStrategy):
                     from ...plugins.hooks.sampling import SamplingRepairPayload
 
                     repair_payload = SamplingRepairPayload(
+                        sampling_id=sampling_id,
                         repair_type=getattr(
                             self, "_get_repair_type", lambda: "unknown"
                         )(),

--- a/mellea/telemetry/metrics_plugins.py
+++ b/mellea/telemetry/metrics_plugins.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from mellea.plugins.hooks.validation import ValidationPostCheckPayload
 
 
-class TokenMetricsPlugin(Plugin, name="token_metrics", priority=50):
+class TokenMetricsPlugin(Plugin, name="token_metrics", priority=1050):
     """Records token usage metrics from generation outputs.
 
     This plugin hooks into the generation_post_call and
@@ -107,7 +107,7 @@ class TokenMetricsPlugin(Plugin, name="token_metrics", priority=50):
         )
 
 
-class LatencyMetricsPlugin(Plugin, name="latency_metrics", priority=51):
+class LatencyMetricsPlugin(Plugin, name="latency_metrics", priority=1051):
     """Records request duration and TTFB latency metrics from generation outputs.
 
     This plugin hooks into the generation_post_call and
@@ -167,7 +167,7 @@ class LatencyMetricsPlugin(Plugin, name="latency_metrics", priority=51):
         )
 
 
-class ErrorMetricsPlugin(Plugin, name="error_metrics", priority=52):
+class ErrorMetricsPlugin(Plugin, name="error_metrics", priority=1052):
     """Records LLM error counts from generation errors.
 
     This plugin hooks into the generation_error and generation_batch_error
@@ -244,7 +244,7 @@ class ErrorMetricsPlugin(Plugin, name="error_metrics", priority=52):
         )
 
 
-class CostMetricsPlugin(Plugin, name="cost_metrics", priority=53):
+class CostMetricsPlugin(Plugin, name="cost_metrics", priority=1053):
     """Records estimated request cost metrics from generation outputs.
 
     This plugin hooks into the generation_post_call and
@@ -325,7 +325,7 @@ class CostMetricsPlugin(Plugin, name="cost_metrics", priority=53):
             record_cost(cost=cost, model=model, provider=provider)
 
 
-class SamplingMetricsPlugin(Plugin, name="sampling_metrics", priority=54):
+class SamplingMetricsPlugin(Plugin, name="sampling_metrics", priority=1054):
     """Records sampling loop attempt and outcome metrics.
 
     Hooks into `sampling_iteration` to count attempts per strategy and
@@ -350,14 +350,18 @@ class SamplingMetricsPlugin(Plugin, name="sampling_metrics", priority=54):
     async def record_sampling_outcome(
         self, payload: SamplingLoopEndPayload, context: dict[str, Any]
     ) -> None:
-        """Record success or failure when the sampling loop ends.
+        """Record success or failure when the sampling loop ends, unless it raised.
+
+        A raised loop is not a sampling outcome, so it is skipped.
 
         Args:
-            payload: Contains strategy_name and success flag.
+            payload: Contains strategy_name, success flag, and exception.
             context: Plugin context (unused).
         """
         from mellea.telemetry.metrics import record_sampling_outcome
 
+        if payload.exception is not None:
+            return
         record_sampling_outcome(payload.strategy_name or "unknown", payload.success)
 
     @hook("streaming_end", mode=PluginMode.FIRE_AND_FORGET)
@@ -375,7 +379,7 @@ class SamplingMetricsPlugin(Plugin, name="sampling_metrics", priority=54):
         record_sampling_outcome("stream_with_chunking", payload.success)
 
 
-class RequirementMetricsPlugin(Plugin, name="requirement_metrics", priority=55):
+class RequirementMetricsPlugin(Plugin, name="requirement_metrics", priority=1055):
     """Records requirement validation check and failure metrics.
 
     Hooks into `validation_post_check` to count checks and failures per
@@ -386,10 +390,12 @@ class RequirementMetricsPlugin(Plugin, name="requirement_metrics", priority=55):
     async def record_requirement_metrics(
         self, payload: ValidationPostCheckPayload, context: dict[str, Any]
     ) -> None:
-        """Record validation checks and failures for each requirement.
+        """Record validation checks and failures for each requirement, unless it raised.
+
+        A raised validation has no results to count, so it is skipped.
 
         Args:
-            payload: Contains requirements list and corresponding results.
+            payload: Contains requirements list, corresponding results, and exception.
             context: Plugin context (unused).
         """
         from mellea.telemetry.metrics import (
@@ -397,6 +403,8 @@ class RequirementMetricsPlugin(Plugin, name="requirement_metrics", priority=55):
             record_requirement_failure,
         )
 
+        if payload.exception is not None:
+            return
         for req, result in zip(payload.requirements, payload.results):
             req_name = type(req).__name__
             record_requirement_check(req_name)
@@ -435,7 +443,7 @@ class RequirementMetricsPlugin(Plugin, name="requirement_metrics", priority=55):
                 record_requirement_failure(req_name, pvr.reason or "")
 
 
-class ToolMetricsPlugin(Plugin, name="tool_metrics", priority=56):
+class ToolMetricsPlugin(Plugin, name="tool_metrics", priority=1056):
     """Records tool invocation metrics.
 
     Hooks into `tool_post_invoke` to count tool calls by name and success/failure status.
@@ -463,7 +471,7 @@ class ToolMetricsPlugin(Plugin, name="tool_metrics", priority=56):
 
 
 class AdapterFunctionMetricsPlugin(
-    Plugin, name="adapter_function_metrics", priority=57
+    Plugin, name="adapter_function_metrics", priority=1057
 ):
     """Records adapter function invocation and phase-duration metrics.
 

--- a/mellea/telemetry/tracing.py
+++ b/mellea/telemetry/tracing.py
@@ -847,20 +847,17 @@ def start_streaming_span(
     )
 
 
-def add_streaming_event(
-    streaming_id: str, *, event_name: str, attributes: dict[str, Any]
-) -> None:
-    """Add an OTel span event to the in-flight `stream_with_chunking` span.
+def add_span_event(key: str, *, event_name: str, attributes: dict[str, Any]) -> None:
+    """Add an OTel span event to any in-flight application span.
 
-    Leaves the span in `_in_flight_spans` for a later `finish_streaming_span_*`
-    call to close.
+    Leaves the span in `_in_flight_spans` for a later `finish_*` call to close.
 
     Args:
-        streaming_id: Correlation key from the matching open call.
+        key: Correlation key from the matching open call.
         event_name: Span-event name.
         attributes: Span-event attributes; `None` values are skipped.
     """
-    entry = _in_flight_spans.get(streaming_id)
+    entry = _in_flight_spans.get(key)
     if entry is None:
         return
     span = entry[0]
@@ -945,6 +942,139 @@ def finish_streaming_span(
             exception=exception,
             description=failure_reason,
         )
+
+
+def start_sampling_span(
+    sampling_id: str,
+    *,
+    strategy_type: str | None,
+    loop_budget: int | None,
+    requirement_count: int | None,
+    attach_context: bool = True,
+) -> Span | None:
+    """Open the `sampling` span for a single sampling loop.
+
+    Iterations and repairs are recorded as span events on this span (see
+    `add_span_event`) rather than as child spans.
+
+    Args:
+        sampling_id: UUID correlating this loop across the sampling hooks.
+        strategy_type: Sampling strategy class name.
+        loop_budget: Maximum iterations per subsample.
+        requirement_count: Number of requirements validated each iteration.
+        attach_context: Whether to attach the span as the ambient OTel context.
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    return _start_application_span(
+        "sampling",
+        sampling_id,
+        {
+            "mellea.strategy_type": strategy_type,
+            "mellea.loop_budget": loop_budget,
+            "mellea.requirement_count": requirement_count,
+        },
+        attach_context=attach_context,
+    )
+
+
+def finish_sampling_span(
+    sampling_id: str,
+    *,
+    success: bool,
+    iterations_used: int | None = None,
+    failure_reason: str | None = None,
+    exception: BaseException | None = None,
+) -> None:
+    """End the `sampling` span.
+
+    Records the outcome attributes, or ERROR status with the exception when the
+    loop raised.
+
+    Args:
+        sampling_id: Correlation key from the matching open call.
+        success: `True` if at least one attempt passed all requirements.
+        iterations_used: Total iterations that completed across subsamples.
+        failure_reason: Reason recorded as `mellea.failure_reason` when
+            `success` is `False`.
+        exception: The exception that ended the loop, when one was raised.
+    """
+    if exception is None:
+        _finish_application_span_success(
+            sampling_id,
+            extra_attributes={
+                "mellea.sampling_success": success,
+                "mellea.iterations_used": iterations_used,
+                "mellea.failure_reason": failure_reason,
+            },
+        )
+    else:
+        _finish_application_span_error(sampling_id, exception=exception)
+
+
+def start_validation_span(
+    validation_id: str, *, requirement_count: int | None, attach_context: bool = True
+) -> Span | None:
+    """Open the `validation` span for a single requirement-validation batch.
+
+    Args:
+        validation_id: UUID correlating the pre/post validation hooks.
+        requirement_count: Number of requirements being validated.
+        attach_context: Whether to attach the span as the ambient OTel context.
+
+    Returns:
+        The span, or `None` if tracing is disabled.
+    """
+    return _start_application_span(
+        "validation",
+        validation_id,
+        {"mellea.requirement_count": requirement_count},
+        attach_context=attach_context,
+    )
+
+
+def finish_validation_span(
+    validation_id: str,
+    *,
+    all_validations_passed: bool | None = None,
+    passed_count: int | None = None,
+    failed_count: int | None = None,
+    failure_reasons: list[str] | None = None,
+    exception: BaseException | None = None,
+) -> None:
+    """End the `validation` span.
+
+    Records the outcome attributes, or ERROR status with the exception when the
+    check raised. `mellea.failure_reasons` is recorded only when content capture
+    is enabled, since a requirement's reason can echo model output.
+
+    Args:
+        validation_id: Correlation key from the matching open call.
+        all_validations_passed: `mellea.validation_passed`.
+        passed_count: `mellea.passed_count`.
+        failed_count: `mellea.failed_count`.
+        failure_reasons: One reason per failing requirement. Recorded as
+            `mellea.failure_reasons` only when content tracing is enabled.
+        exception: The exception that ended validation, when one was raised.
+    """
+    if exception is None:
+        reasons = (
+            [get_capture_content_value(r) for r in failure_reasons]
+            if failure_reasons and content_capture_enabled()
+            else None
+        )
+        _finish_application_span_success(
+            validation_id,
+            extra_attributes={
+                "mellea.validation_passed": all_validations_passed,
+                "mellea.passed_count": passed_count,
+                "mellea.failed_count": failed_count,
+                "mellea.failure_reasons": reasons,
+            },
+        )
+    else:
+        _finish_application_span_error(validation_id, exception=exception)
 
 
 __all__ = [

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -13,6 +13,9 @@ pipelines to automatically emit spans when tracing is enabled:
 - StreamingTracingPlugin: Emits an application-level orchestration span and
   per-chunk span events for `stream_with_chunking` runs.
 - ToolTracingPlugin: Emits an `execute_tool` span for every tool invocation.
+- SamplingTracingPlugin: Emits a `sampling` span per sampling loop, with a span
+  event per iteration and repair.
+- ValidationTracingPlugin: Emits a `validation` span per requirement-check batch.
 """
 
 from __future__ import annotations
@@ -44,6 +47,12 @@ if TYPE_CHECKING:
         GenerationPostCallPayload,
         GenerationPreCallPayload,
     )
+    from mellea.plugins.hooks.sampling import (
+        SamplingIterationPayload,
+        SamplingLoopEndPayload,
+        SamplingLoopStartPayload,
+        SamplingRepairPayload,
+    )
     from mellea.plugins.hooks.streaming import (
         StreamingEndPayload,
         StreamingEventPayload,
@@ -52,9 +61,13 @@ if TYPE_CHECKING:
         StreamingStartPayload,
     )
     from mellea.plugins.hooks.tool import ToolPostInvokePayload, ToolPreInvokePayload
+    from mellea.plugins.hooks.validation import (
+        ValidationPostCheckPayload,
+        ValidationPreCheckPayload,
+    )
 
 
-class BackendTracingPlugin(Plugin, name="backend_tracing", priority=40):
+class BackendTracingPlugin(Plugin, name="backend_tracing", priority=1040):
     """Emits Gen-AI semconv backend spans for every LLM generation.
 
     This plugin hooks into the generation pre-call, post-call, and error
@@ -181,7 +194,7 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=40):
         )
 
 
-class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
+class ComponentTracingPlugin(Plugin, name="component_tracing", priority=1041):
     """Emits application-level spans tracking component execution.
 
     This plugin hooks into component pre-execute, post-success, and
@@ -266,7 +279,7 @@ class ComponentTracingPlugin(Plugin, name="component_tracing", priority=41):
         finish_action_span_error(payload.action_id, exception=payload.error)
 
 
-class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
+class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=1042):
     """Emits the `stream_with_chunking` application span.
 
     `streaming_start` opens the span; `streaming_event` records a span event for
@@ -334,11 +347,11 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
             QuickCheckEvent,
             StreamingDoneEvent,
         )
-        from mellea.telemetry.tracing import add_streaming_event
+        from mellea.telemetry.tracing import add_span_event
 
         ev = payload.event
         if isinstance(ev, QuickCheckEvent):
-            add_streaming_event(
+            add_span_event(
                 payload.streaming_id,
                 event_name="quick_check",
                 attributes={
@@ -348,25 +361,25 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
                 },
             )
         elif isinstance(ev, ChunkEvent):
-            add_streaming_event(
+            add_span_event(
                 payload.streaming_id,
                 event_name="chunk",
                 attributes={"chunk_index": ev.chunk_index, "text_length": len(ev.text)},
             )
         elif isinstance(ev, StreamingDoneEvent):
-            add_streaming_event(
+            add_span_event(
                 payload.streaming_id,
                 event_name="streaming_done",
                 attributes={"full_text_length": len(ev.full_text)},
             )
         elif isinstance(ev, FullValidationEvent):
-            add_streaming_event(
+            add_span_event(
                 payload.streaming_id,
                 event_name="full_validation",
                 attributes={"passed": ev.passed, "requirement_count": len(ev.results)},
             )
         elif isinstance(ev, ErrorEvent):
-            add_streaming_event(
+            add_span_event(
                 payload.streaming_id,
                 event_name="error",
                 attributes={"exception_type": ev.exception_type, "detail": ev.detail},
@@ -379,9 +392,9 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
         """Record the `completed` span event and close the stream_with_chunking span."""
         if not payload.streaming_id:
             return
-        from mellea.telemetry.tracing import add_streaming_event, finish_streaming_span
+        from mellea.telemetry.tracing import add_span_event, finish_streaming_span
 
-        add_streaming_event(
+        add_span_event(
             payload.streaming_id,
             event_name="completed",
             attributes={
@@ -400,7 +413,7 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=42):
         )
 
 
-class ToolTracingPlugin(Plugin, name="tool_tracing", priority=43):
+class ToolTracingPlugin(Plugin, name="tool_tracing", priority=1043):
     """Emits an `execute_tool` span per tool invocation (pre/post lifecycle).
 
     `tool_pre_invoke` opens the span; `tool_post_invoke` closes it with success
@@ -452,10 +465,145 @@ class ToolTracingPlugin(Plugin, name="tool_tracing", priority=43):
             )
 
 
+class SamplingTracingPlugin(Plugin, name="sampling_tracing", priority=1044):
+    """Emits a `sampling` span per sampling loop.
+
+    `sampling_loop_start` opens the span; `sampling_iteration` and
+    `sampling_repair` record span events on it; `sampling_loop_end` closes it,
+    correlated across hooks via `sampling_id`.
+
+    Iterations and repairs are recorded as span events, not child spans.
+
+    All hooks run SEQUENTIAL so the OTel context token attached in loop_start
+    can be detached on the same task in loop_end.
+    """
+
+    @hook("sampling_loop_start")
+    async def on_loop_start(
+        self, payload: SamplingLoopStartPayload, context: dict[str, Any]
+    ) -> None:
+        """Open the sampling span for this loop."""
+        if not payload.sampling_id:
+            return
+        from mellea.telemetry.tracing import start_sampling_span
+
+        start_sampling_span(
+            payload.sampling_id,
+            strategy_type=payload.strategy_name or None,
+            loop_budget=payload.loop_budget,
+            requirement_count=len(payload.requirements),
+            attach_context=_CONTEXT_ATTACH_SUPPORTED,
+        )
+
+    @hook("sampling_iteration")
+    async def on_iteration(
+        self, payload: SamplingIterationPayload, context: dict[str, Any]
+    ) -> None:
+        """Record a span event for one sampling attempt."""
+        if not payload.sampling_id:
+            return
+        from mellea.telemetry.tracing import add_span_event
+
+        add_span_event(
+            payload.sampling_id,
+            event_name="iteration",
+            attributes={
+                "iteration": payload.iteration,
+                "all_validations_passed": payload.all_validations_passed,
+                "valid_count": payload.valid_count,
+                "total_count": payload.total_count,
+            },
+        )
+
+    @hook("sampling_repair")
+    async def on_repair(
+        self, payload: SamplingRepairPayload, context: dict[str, Any]
+    ) -> None:
+        """Record a span event for one repair."""
+        if not payload.sampling_id:
+            return
+        from mellea.telemetry.tracing import add_span_event
+
+        add_span_event(
+            payload.sampling_id,
+            event_name="repair",
+            attributes={
+                "repair_iteration": payload.repair_iteration,
+                "repair_type": payload.repair_type,
+                "failed_count": len(payload.failed_validations),
+            },
+        )
+
+    @hook("sampling_loop_end")
+    async def on_loop_end(
+        self, payload: SamplingLoopEndPayload, context: dict[str, Any]
+    ) -> None:
+        """Close the sampling span, ERROR only when the loop raised."""
+        if not payload.sampling_id:
+            return
+        from mellea.telemetry.tracing import finish_sampling_span
+
+        finish_sampling_span(
+            payload.sampling_id,
+            success=payload.success,
+            iterations_used=payload.iterations_used,
+            failure_reason=payload.failure_reason,
+            exception=payload.exception,
+        )
+
+
+class ValidationTracingPlugin(Plugin, name="validation_tracing", priority=1045):
+    """Emits a `validation` span per requirement-validation batch.
+
+    `validation_pre_check` opens the span; `validation_post_check` closes it,
+    correlated via `validation_id`.
+
+    All hooks run SEQUENTIAL so the OTel context token attached in pre_check
+    can be detached on the same task in post_check.
+    """
+
+    @hook("validation_pre_check")
+    async def on_pre_check(
+        self, payload: ValidationPreCheckPayload, context: dict[str, Any]
+    ) -> None:
+        """Open the validation span for this check."""
+        if not payload.validation_id:
+            return
+        from mellea.telemetry.tracing import start_validation_span
+
+        start_validation_span(
+            payload.validation_id,
+            requirement_count=len(payload.requirements),
+            attach_context=_CONTEXT_ATTACH_SUPPORTED,
+        )
+
+    @hook("validation_post_check")
+    async def on_post_check(
+        self, payload: ValidationPostCheckPayload, context: dict[str, Any]
+    ) -> None:
+        """Close the validation span, ERROR only when validation raised."""
+        if not payload.validation_id:
+            return
+        from mellea.telemetry.tracing import finish_validation_span
+
+        # One reason per failing requirement (results with no reason are skipped).
+        reasons = [r.reason for r in payload.results if not bool(r) and r.reason]
+        finish_validation_span(
+            payload.validation_id,
+            all_validations_passed=payload.all_validations_passed,
+            passed_count=payload.passed_count,
+            failed_count=payload.failed_count,
+            failure_reasons=reasons,
+            exception=payload.exception,
+        )
+
+
 # All tracing plugins to auto-register when tracing is enabled.
 _TRACING_PLUGIN_CLASSES = (
     BackendTracingPlugin,
     ComponentTracingPlugin,
     StreamingTracingPlugin,
     ToolTracingPlugin,
+    SamplingTracingPlugin,
+    ValidationTracingPlugin,
 )

--- a/test/plugins/test_all_payloads.py
+++ b/test/plugins/test_all_payloads.py
@@ -448,6 +448,7 @@ class TestGenerationPostCallPayload:
 class TestValidationPreCheckPayload:
     def test_defaults(self):
         payload = ValidationPreCheckPayload()
+        assert payload.validation_id == ""
         assert payload.requirements == []
         assert payload.target is None
         assert payload.context is None
@@ -500,11 +501,13 @@ class TestValidationPreCheckPayload:
 class TestValidationPostCheckPayload:
     def test_defaults(self):
         payload = ValidationPostCheckPayload()
+        assert payload.validation_id == ""
         assert payload.requirements == []
         assert payload.results == []
         assert payload.all_validations_passed is False
         assert payload.passed_count == 0
         assert payload.failed_count == 0
+        assert payload.exception is None
 
     def test_construction_with_values(self):
         reqs = [_SENTINEL_REQUIREMENT, _SENTINEL_REQUIREMENT]
@@ -571,6 +574,7 @@ class TestValidationPostCheckPayload:
 class TestSamplingLoopStartPayload:
     def test_defaults(self):
         payload = SamplingLoopStartPayload()
+        assert payload.sampling_id == ""
         assert payload.strategy_name == ""
         assert payload.action is None
         assert payload.context is None
@@ -620,6 +624,7 @@ class TestSamplingLoopStartPayload:
 class TestSamplingIterationPayload:
     def test_defaults(self):
         payload = SamplingIterationPayload()
+        assert payload.sampling_id == ""
         assert payload.iteration == 0
         assert payload.action is None
         assert payload.result is None
@@ -695,6 +700,7 @@ class TestSamplingIterationPayload:
 class TestSamplingRepairPayload:
     def test_defaults(self):
         payload = SamplingRepairPayload()
+        assert payload.sampling_id == ""
         assert payload.repair_type == ""
         assert payload.failed_action is None
         assert payload.failed_result is None
@@ -759,12 +765,14 @@ class TestSamplingRepairPayload:
 class TestSamplingLoopEndPayload:
     def test_defaults(self):
         payload = SamplingLoopEndPayload()
+        assert payload.sampling_id == ""
         assert payload.success is False
         assert payload.iterations_used == 0
         assert payload.final_result is None
         assert payload.final_action is None
         assert payload.final_context is None
         assert payload.failure_reason is None
+        assert payload.exception is None
         assert payload.all_results == []
         assert payload.all_validations == []
 

--- a/test/plugins/test_builtin_debug.py
+++ b/test/plugins/test_builtin_debug.py
@@ -458,6 +458,27 @@ class TestSamplingLoopEndPlugin:
         assert any("FAILED" in r.message for r in caplog.records)
         assert any("budget exceeded" in r.message for r in caplog.records)
 
+    async def test_sampling_loop_end_logs_error_on_exception(self, caplog) -> None:
+        """Loop end hook logs an ERROR line when the loop raised."""
+        register(log_sampling_loop_end)
+
+        payload = SamplingLoopEndPayload(
+            strategy_name="RejectionSampling",
+            success=False,
+            exception=RuntimeError("backend boom"),
+        )
+
+        with caplog.at_level(
+            logging.DEBUG, logger="mellea.plugins.builtin_debug.sampling"
+        ):
+            await invoke_hook(HookType.SAMPLING_LOOP_END, payload)
+
+        assert any("SAMPLING-END" in r.message for r in caplog.records)
+        assert any("ERROR" in r.message for r in caplog.records)
+        assert any("backend boom" in r.message for r in caplog.records)
+        # The routine-failure line is not emitted on the error path.
+        assert not any("FAILED" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # Validation plugin tests
@@ -565,6 +586,24 @@ class TestValidationPostCheckPlugin:
         assert any("VALIDATION-POST-CHECK" in r.message for r in caplog.records)
         assert any("MIXED RESULTS" in r.message for r in caplog.records)
         assert any("1/2 passed" in r.message for r in caplog.records)
+
+    async def test_validation_post_check_logs_error_on_exception(self, caplog) -> None:
+        """Post-check hook logs an ERROR line when validation raised."""
+        register(log_validation_post_check)
+
+        payload = ValidationPostCheckPayload(exception=RuntimeError("validator boom"))
+
+        with caplog.at_level(
+            logging.DEBUG, logger="mellea.plugins.builtin_debug.validation"
+        ):
+            await invoke_hook(HookType.VALIDATION_POST_CHECK, payload)
+
+        assert any("VALIDATION-POST-CHECK" in r.message for r in caplog.records)
+        assert any("ERROR" in r.message for r in caplog.records)
+        assert any("validator boom" in r.message for r in caplog.records)
+        # The routine-outcome lines are not emitted on the error path.
+        assert not any("PASSED" in r.message for r in caplog.records)
+        assert not any("MIXED" in r.message for r in caplog.records)
 
     async def test_validation_post_check_handles_result_mismatch(self, caplog) -> None:
         """Post-check hook detects mismatch between requirements and results."""

--- a/test/telemetry/test_metrics_plugins.py
+++ b/test/telemetry/test_metrics_plugins.py
@@ -814,6 +814,21 @@ async def test_sampling_plugin_records_failure_outcome(sampling_plugin):
 
 
 @pytest.mark.asyncio
+async def test_sampling_plugin_skips_outcome_on_exception(sampling_plugin):
+    """A raised loop records no outcome — a crash is not a sampling result."""
+    payload = SamplingLoopEndPayload(
+        strategy_name="RejectionSamplingStrategy",
+        success=False,
+        exception=RuntimeError("boom"),
+    )
+
+    with patch("mellea.telemetry.metrics.record_sampling_outcome") as mock_record:
+        await sampling_plugin.record_sampling_outcome(payload, {})
+
+        mock_record.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_sampling_plugin_records_streaming_success_outcome(sampling_plugin):
     """streaming_end with success=True records a `stream_with_chunking` success."""
     payload = StreamingEndPayload(streaming_id="sid", success=True)
@@ -933,6 +948,23 @@ async def test_requirement_plugin_failure_with_no_reason_uses_default(
         await requirement_plugin.record_requirement_metrics(payload, {})
 
         mock_fail.assert_called_once_with("_FakeReq", "LLM judgment")
+
+
+@pytest.mark.asyncio
+async def test_requirement_plugin_skips_on_exception(requirement_plugin):
+    """A raised validation records no checks — there are no results to count."""
+    payload = ValidationPostCheckPayload(
+        requirements=[_FakeReq()], exception=RuntimeError("boom")
+    )
+
+    with (
+        patch("mellea.telemetry.metrics.record_requirement_check") as mock_check,
+        patch("mellea.telemetry.metrics.record_requirement_failure") as mock_fail,
+    ):
+        await requirement_plugin.record_requirement_metrics(payload, {})
+
+        mock_check.assert_not_called()
+        mock_fail.assert_not_called()
 
 
 class _LengthRequirement:

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -46,8 +46,10 @@ from mellea.telemetry.tracing_plugins import (
     _CONTEXT_ATTACH_SUPPORTED,
     BackendTracingPlugin,
     ComponentTracingPlugin,
+    SamplingTracingPlugin,
     StreamingTracingPlugin,
     ToolTracingPlugin,
+    ValidationTracingPlugin,
 )
 from test.telemetry.conftest import reset_tracing_state
 
@@ -70,6 +72,16 @@ def streaming_plugin():
 @pytest.fixture
 def tool_plugin():
     return ToolTracingPlugin()
+
+
+@pytest.fixture
+def sampling_plugin():
+    return SamplingTracingPlugin()
+
+
+@pytest.fixture
+def validation_plugin():
+    return ValidationTracingPlugin()
 
 
 @pytest.fixture
@@ -1277,3 +1289,336 @@ async def test_tool_span_skips_without_id(tool_plugin, enabled_tracing):
             {},
         )
     fake_tracer.start_span.assert_not_called()
+
+
+# SamplingTracingPlugin tests
+
+
+@pytest.mark.asyncio
+async def test_sampling_loop_start_starts_span_and_stashes_by_id(
+    sampling_plugin, enabled_tracing
+):
+    from mellea.plugins.hooks.sampling import SamplingLoopStartPayload
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    payload = SamplingLoopStartPayload(
+        sampling_id="sid-1",
+        strategy_name="RejectionSamplingStrategy",
+        requirements=[object(), object()],
+        loop_budget=3,
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(payload, {})
+
+    fake_tracer.start_span.assert_called_once_with("sampling")
+    assert "sid-1" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.strategy_type"] == "RejectionSamplingStrategy"
+    assert attrs["mellea.loop_budget"] == 3
+    assert attrs["mellea.requirement_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sampling_loop_start_skips_without_id(sampling_plugin, enabled_tracing):
+    from mellea.plugins.hooks.sampling import SamplingLoopStartPayload
+
+    fake_tracer = MagicMock()
+
+    payload = SamplingLoopStartPayload(sampling_id="")
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(payload, {})
+
+    fake_tracer.start_span.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sampling_iteration_records_span_event(sampling_plugin, enabled_tracing):
+    from mellea.plugins.hooks.sampling import (
+        SamplingIterationPayload,
+        SamplingLoopStartPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    start = SamplingLoopStartPayload(sampling_id="sid-2", loop_budget=1)
+    iteration = SamplingIterationPayload(
+        sampling_id="sid-2",
+        iteration=2,
+        all_validations_passed=False,
+        valid_count=1,
+        total_count=2,
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(start, {})
+        await sampling_plugin.on_iteration(iteration, {})
+
+    fake_span.add_event.assert_called_once()
+    name, attrs = fake_span.add_event.call_args.args
+    assert name == "iteration"
+    assert attrs["iteration"] == 2
+    assert attrs["valid_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sampling_repair_records_span_event(sampling_plugin, enabled_tracing):
+    from mellea.plugins.hooks.sampling import (
+        SamplingLoopStartPayload,
+        SamplingRepairPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    start = SamplingLoopStartPayload(sampling_id="sid-3", loop_budget=2)
+    repair = SamplingRepairPayload(
+        sampling_id="sid-3",
+        repair_type="rejection",
+        repair_iteration=1,
+        failed_validations=[(object(), object())],
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(start, {})
+        await sampling_plugin.on_repair(repair, {})
+
+    name, attrs = fake_span.add_event.call_args.args
+    assert name == "repair"
+    assert attrs["repair_type"] == "rejection"
+    assert attrs["failed_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sampling_loop_end_finishes_span(sampling_plugin, enabled_tracing):
+    from mellea.plugins.hooks.sampling import (
+        SamplingLoopEndPayload,
+        SamplingLoopStartPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    start = SamplingLoopStartPayload(sampling_id="sid-4", loop_budget=2)
+    end = SamplingLoopEndPayload(
+        sampling_id="sid-4",
+        success=False,
+        iterations_used=2,
+        failure_reason="Budget exhausted after 2 iterations",
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(start, {})
+        await sampling_plugin.on_loop_end(end, {})
+
+    fake_span.end.assert_called_once()
+    assert "sid-4" not in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.sampling_success"] is False
+    assert attrs["mellea.iterations_used"] == 2
+    # A budget-exhausted loop is a routine outcome, not an error.
+    fake_span.set_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sampling_loop_end_marks_error_on_exception(
+    sampling_plugin, enabled_tracing
+):
+    from mellea.plugins.hooks.sampling import (
+        SamplingLoopEndPayload,
+        SamplingLoopStartPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    start = SamplingLoopStartPayload(sampling_id="sid-5", loop_budget=1)
+    end = SamplingLoopEndPayload(
+        sampling_id="sid-5", success=False, exception=RuntimeError("boom")
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await sampling_plugin.on_loop_start(start, {})
+        await sampling_plugin.on_loop_end(end, {})
+
+    fake_span.end.assert_called_once()
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    assert _attrs(fake_span)["error.type"] == "RuntimeError"
+
+
+# ValidationTracingPlugin tests
+
+
+class _PassResult:
+    reason = None
+
+    def __bool__(self) -> bool:
+        return True
+
+
+class _FailResult:
+    def __init__(self, reason: str = "constraint not met") -> None:
+        self.reason = reason
+
+    def __bool__(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_validation_pre_check_starts_span_and_stashes_by_id(
+    validation_plugin, enabled_tracing
+):
+    from mellea.plugins.hooks.validation import ValidationPreCheckPayload
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    payload = ValidationPreCheckPayload(
+        validation_id="vid-1", requirements=[object(), object(), object()]
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await validation_plugin.on_pre_check(payload, {})
+
+    fake_tracer.start_span.assert_called_once_with("validation")
+    assert "vid-1" in tracing._in_flight_spans
+    assert _attrs(fake_span)["mellea.requirement_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_validation_pre_check_skips_without_id(
+    validation_plugin, enabled_tracing
+):
+    from mellea.plugins.hooks.validation import ValidationPreCheckPayload
+
+    fake_tracer = MagicMock()
+
+    payload = ValidationPreCheckPayload(validation_id="")
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await validation_plugin.on_pre_check(payload, {})
+
+    fake_tracer.start_span.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_validation_post_check_finishes_span_with_counts(
+    validation_plugin, enabled_tracing, monkeypatch
+):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    monkeypatch.delenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False
+    )
+    from mellea.plugins.hooks.validation import (
+        ValidationPostCheckPayload,
+        ValidationPreCheckPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ValidationPreCheckPayload(validation_id="vid-2", requirements=[object()])
+    post = ValidationPostCheckPayload(
+        validation_id="vid-2",
+        requirements=[object(), object()],
+        results=[_PassResult(), _FailResult("output too short")],
+        all_validations_passed=False,
+        passed_count=1,
+        failed_count=1,
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await validation_plugin.on_pre_check(pre, {})
+        await validation_plugin.on_post_check(post, {})
+
+    fake_span.end.assert_called_once()
+    assert "vid-2" not in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.validation_passed"] is False
+    assert attrs["mellea.passed_count"] == 1
+    assert attrs["mellea.failed_count"] == 1
+    # Content capture disabled → failure reasons omitted.
+    assert "mellea.failure_reasons" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_validation_post_check_records_reasons_when_content_enabled(
+    validation_plugin, enabled_tracing, monkeypatch
+):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    from mellea.plugins.hooks.validation import (
+        ValidationPostCheckPayload,
+        ValidationPreCheckPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ValidationPreCheckPayload(validation_id="vid-3", requirements=[object()])
+    post = ValidationPostCheckPayload(
+        validation_id="vid-3",
+        requirements=[object()],
+        results=[_FailResult("output too short")],
+        all_validations_passed=False,
+        passed_count=0,
+        failed_count=1,
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await validation_plugin.on_pre_check(pre, {})
+        await validation_plugin.on_post_check(post, {})
+
+    # Only failing results contribute reasons, recorded as a list.
+    assert _attrs(fake_span)["mellea.failure_reasons"] == ["output too short"]
+
+
+@pytest.mark.asyncio
+async def test_validation_post_check_marks_error_on_exception(
+    validation_plugin, enabled_tracing
+):
+    from mellea.plugins.hooks.validation import (
+        ValidationPostCheckPayload,
+        ValidationPreCheckPayload,
+    )
+
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = ValidationPreCheckPayload(validation_id="vid-4", requirements=[object()])
+    post = ValidationPostCheckPayload(
+        validation_id="vid-4", exception=RuntimeError("boom")
+    )
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        await validation_plugin.on_pre_check(pre, {})
+        await validation_plugin.on_post_check(post, {})
+
+    fake_span.end.assert_called_once()
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    assert _attrs(fake_span)["error.type"] == "RuntimeError"

--- a/test/telemetry/test_tracing_sampling_validation.py
+++ b/test/telemetry/test_tracing_sampling_validation.py
@@ -1,0 +1,470 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sampling and validation tracing spans."""
+
+import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry", reason="opentelemetry not installed — install mellea[telemetry]"
+)
+pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from mellea.core.backend import Backend
+from mellea.core.base import GenerateLog, ModelOutputThunk, _CallInfo, _GenerationState
+from mellea.core.requirement import Requirement, ValidationResult
+from mellea.stdlib.components import Instruction
+from mellea.stdlib.context import SimpleContext
+from mellea.stdlib.sampling.base import RejectionSamplingStrategy
+from mellea.stdlib.session import start_session
+from mellea.telemetry import tracing
+from mellea.telemetry.tracing import (
+    add_span_event,
+    finish_sampling_span,
+    finish_validation_span,
+    start_sampling_span,
+    start_validation_span,
+)
+from mellea.telemetry.tracing_plugins import _CONTEXT_ATTACH_SUPPORTED
+from test.telemetry.conftest import reset_tracing_state
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def enabled_tracing(monkeypatch):
+    monkeypatch.setenv("MELLEA_TRACES_ENABLED", "true")
+    reset_tracing_state()
+    yield
+    reset_tracing_state()
+
+
+@pytest.fixture
+def disabled_tracing(monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_ENABLED", raising=False)
+    reset_tracing_state()
+    yield
+    reset_tracing_state()
+
+
+@pytest.fixture
+def span_exporter(enabled_tracing):
+    if tracing._tracer_provider is None:
+        pytest.skip("Telemetry not initialized")
+    exporter = InMemorySpanExporter()
+    tracing._tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter
+    exporter.clear()
+
+
+def _patch_app_tracer() -> tuple[MagicMock, MagicMock]:
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+    return fake_span, fake_tracer
+
+
+def _attrs(span: MagicMock) -> dict:
+    return {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+
+
+def _spans_by_name(exporter: InMemorySpanExporter) -> dict[str, Any]:
+    tracing._tracer_provider.force_flush()  # type: ignore[union-attr]
+    return {s.name: s for s in exporter.get_finished_spans()}
+
+
+class _MockBackend(Backend):
+    """Minimal backend that returns a faked ModelOutputThunk — no LLM API calls."""
+
+    model_id = "mock-model"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._model_id = "mock-model"
+        self._provider = "mock-provider"
+
+    async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
+        mot = MagicMock(spec=ModelOutputThunk)
+        mot._gen = _GenerationState()
+        mot._call = _CallInfo()
+        glog = GenerateLog()
+        glog.prompt = "mocked formatted prompt"
+        mot._generate_log = glog
+        mot.parsed_repr = None
+        mot._gen.start = datetime.datetime.now()
+
+        async def _avalue() -> str:
+            return "mocked output"
+
+        mot.avalue = _avalue
+        mot.value = "mocked output"
+        return mot, SimpleContext()
+
+    async def _generate_from_raw(self, actions: Any, ctx: Any, **kwargs: Any):
+        return [], None
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests (mock tracer)
+# ---------------------------------------------------------------------------
+
+
+def test_start_sampling_span_stamps_attrs_and_stashes(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_sampling_span(
+            "sid-1",
+            strategy_type="RejectionSamplingStrategy",
+            loop_budget=4,
+            requirement_count=2,
+        )
+
+    fake_tracer.start_span.assert_called_once_with("sampling")
+    assert "sid-1" in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.strategy_type"] == "RejectionSamplingStrategy"
+    assert attrs["mellea.loop_budget"] == 4
+    assert attrs["mellea.requirement_count"] == 2
+
+
+def test_add_span_event_records_event_on_in_flight_span(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_sampling_span(
+            "sid-ev", strategy_type="S", loop_budget=1, requirement_count=1
+        )
+        add_span_event(
+            "sid-ev",
+            event_name="iteration",
+            attributes={"iteration": 1, "all_validations_passed": True, "skip": None},
+        )
+
+    fake_span.add_event.assert_called_once()
+    name, attrs = fake_span.add_event.call_args.args
+    assert name == "iteration"
+    # None-valued attributes are filtered out.
+    assert attrs == {"iteration": 1, "all_validations_passed": True}
+
+
+def test_add_span_event_no_op_when_key_missing(enabled_tracing):
+    # Contract: unknown key → silent no-op (does not raise).
+    add_span_event("never-opened", event_name="iteration", attributes={"x": 1})
+    assert "never-opened" not in tracing._in_flight_spans
+
+
+def test_finish_sampling_span_success_stamps_outcome(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_sampling_span(
+            "sid-ok", strategy_type="S", loop_budget=1, requirement_count=1
+        )
+        finish_sampling_span("sid-ok", success=True, iterations_used=3)
+
+    fake_span.end.assert_called_once()
+    assert "sid-ok" not in tracing._in_flight_spans
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.sampling_success"] is True
+    assert attrs["mellea.iterations_used"] == 3
+
+
+def test_finish_sampling_span_failure_is_not_an_error(enabled_tracing):
+    # A budget-exhausted loop (success=False, no exception) is a routine
+    # outcome: the span closes with default status, not ERROR.
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_sampling_span(
+            "sid-fail", strategy_type="S", loop_budget=2, requirement_count=1
+        )
+        finish_sampling_span(
+            "sid-fail",
+            success=False,
+            iterations_used=2,
+            failure_reason="Budget exhausted after 2 iterations",
+        )
+
+    fake_span.record_exception.assert_not_called()
+    fake_span.set_status.assert_not_called()
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.sampling_success"] is False
+    assert attrs["mellea.failure_reason"] == "Budget exhausted after 2 iterations"
+
+
+def test_finish_sampling_span_exception_sets_error(enabled_tracing):
+    # Only a raised loop marks the span ERROR.
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_sampling_span(
+            "sid-exc", strategy_type="S", loop_budget=1, requirement_count=1
+        )
+        finish_sampling_span("sid-exc", success=False, exception=RuntimeError("boom"))
+
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    fake_span.end.assert_called_once()
+    assert "sid-exc" not in tracing._in_flight_spans
+    assert _attrs(fake_span)["error.type"] == "RuntimeError"
+
+
+def test_start_validation_span_stamps_requirement_count(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_validation_span("vid-1", requirement_count=3)
+
+    fake_tracer.start_span.assert_called_once_with("validation")
+    assert "vid-1" in tracing._in_flight_spans
+    assert _attrs(fake_span)["mellea.requirement_count"] == 3
+
+
+def test_finish_validation_span_records_counts_always(enabled_tracing, monkeypatch):
+    monkeypatch.delenv("MELLEA_TRACES_CONTENT", raising=False)
+    monkeypatch.delenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False
+    )
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_validation_span("vid-c", requirement_count=2)
+        finish_validation_span(
+            "vid-c",
+            all_validations_passed=False,
+            passed_count=1,
+            failed_count=1,
+            failure_reasons=["constraint not met"],
+        )
+
+    fake_span.end.assert_called_once()
+    attrs = _attrs(fake_span)
+    assert attrs["mellea.validation_passed"] is False
+    assert attrs["mellea.passed_count"] == 1
+    assert attrs["mellea.failed_count"] == 1
+    # Content capture disabled → failure reasons omitted.
+    assert "mellea.failure_reasons" not in attrs
+
+
+def test_finish_validation_span_records_reasons_when_content_enabled(
+    enabled_tracing, monkeypatch
+):
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_validation_span("vid-r", requirement_count=1)
+        finish_validation_span(
+            "vid-r",
+            all_validations_passed=False,
+            passed_count=0,
+            failed_count=1,
+            failure_reasons=["output too short"],
+        )
+
+    assert _attrs(fake_span)["mellea.failure_reasons"] == ["output too short"]
+
+
+def test_finish_validation_span_records_reasons_as_list(enabled_tracing, monkeypatch):
+    # Multiple failing requirements are recorded as a list, one entry each.
+    monkeypatch.setenv("MELLEA_TRACES_CONTENT", "true")
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_validation_span("vid-multi", requirement_count=2)
+        finish_validation_span(
+            "vid-multi",
+            all_validations_passed=False,
+            passed_count=0,
+            failed_count=2,
+            failure_reasons=["too short", "wrong tone"],
+        )
+
+    assert _attrs(fake_span)["mellea.failure_reasons"] == ["too short", "wrong tone"]
+
+
+def test_finish_validation_span_exception_marks_error(enabled_tracing):
+    fake_span, fake_tracer = _patch_app_tracer()
+    with patch(
+        "mellea.telemetry.tracing.get_application_tracer", return_value=fake_tracer
+    ):
+        start_validation_span("vid-exc", requirement_count=1)
+        finish_validation_span("vid-exc", exception=RuntimeError("boom"))
+
+    fake_span.record_exception.assert_called_once()
+    fake_span.set_status.assert_called_once()
+    fake_span.end.assert_called_once()
+    assert "vid-exc" not in tracing._in_flight_spans
+    assert _attrs(fake_span)["error.type"] == "RuntimeError"
+
+
+def test_helpers_silent_when_tracing_disabled(disabled_tracing):
+    # No tracer → helpers return None / no-op and stash nothing.
+    assert (
+        start_sampling_span("x", strategy_type="S", loop_budget=1, requirement_count=1)
+        is None
+    )
+    assert start_validation_span("y", requirement_count=1) is None
+    finish_sampling_span("x", success=True)
+    finish_validation_span("y")
+    add_span_event("x", event_name="iteration", attributes={"a": 1})
+    assert "x" not in tracing._in_flight_spans
+    assert "y" not in tracing._in_flight_spans
+
+
+# ---------------------------------------------------------------------------
+# Integration test (real hooks, mock backend)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_act_with_strategy_emits_sampling_and_validate_nesting(span_exporter):
+    """`m.act(strategy=...)` with a requirement emits `action > sampling > validate`.
+
+    Uses a mocked-transport `OllamaModelBackend` so the full generation
+    lifecycle fires — the `chat` span opens *and* closes before validation runs,
+    so the `validation` span nests directly under `sampling`. Parent-chain asserts
+    are gated on `_CONTEXT_ATTACH_SUPPORTED`.
+    """
+    import ollama
+
+    from mellea.backends.ollama import OllamaModelBackend
+
+    async def fake_chat(*args, **kwargs):
+        return ollama.ChatResponse(
+            model="test-model",
+            created_at=None,
+            message=ollama.Message(role="assistant", content="hi there"),
+            done=True,
+            eval_count=3,
+            prompt_eval_count=2,
+        )
+
+    mock_client = MagicMock()
+    mock_client.chat.side_effect = fake_chat
+
+    passing_req = Requirement(
+        "always ok", validation_fn=lambda _ctx: ValidationResult(True)
+    )
+
+    with (
+        patch.object(OllamaModelBackend, "_check_ollama_server", return_value=True),
+        patch.object(OllamaModelBackend, "_pull_ollama_model", return_value=True),
+        patch("mellea.backends.ollama.ollama.Client"),
+        patch("mellea.backends.ollama.ollama.AsyncClient", return_value=mock_client),
+        patch(
+            "mellea.stdlib.session.backend_name_to_class",
+            return_value=OllamaModelBackend,
+        ),
+    ):
+        with start_session("ollama", model_id="test-model") as m:
+            m.act(
+                Instruction(description="say hi"),
+                requirements=[passing_req],
+                strategy=RejectionSamplingStrategy(loop_budget=1),
+            )
+
+    by_name = _spans_by_name(span_exporter)
+    assert "sampling" in by_name, "sampling span not emitted"
+    assert "validation" in by_name, "validation span not emitted"
+    assert "action" in by_name
+
+    sampling_span = by_name["sampling"]
+    validate_span = by_name["validation"]
+    action_span = by_name["action"]
+
+    assert sampling_span.attributes is not None
+    assert (
+        sampling_span.attributes.get("mellea.strategy_type")
+        == "RejectionSamplingStrategy"
+    )
+    assert sampling_span.attributes.get("mellea.sampling_success") is True
+
+    if _CONTEXT_ATTACH_SUPPORTED:
+        assert sampling_span.parent is not None
+        assert sampling_span.parent.span_id == action_span.context.span_id, (
+            "sampling should nest under action"
+        )
+        assert validate_span.parent is not None
+        assert validate_span.parent.span_id == sampling_span.context.span_id, (
+            "validate should nest under sampling"
+        )
+    else:
+        session_span = by_name["session"]
+        assert sampling_span.parent is not None
+        assert sampling_span.parent.span_id == session_span.context.span_id, (
+            "sampling should collapse to session on Python <=3.11"
+        )
+        assert validate_span.parent is not None
+        assert validate_span.parent.span_id == session_span.context.span_id, (
+            "validate should collapse to session on Python <=3.11"
+        )
+
+
+@pytest.mark.integration
+def test_avalidate_raises_closes_validate_span_error(span_exporter):
+    """A validator that raises still closes the `validation` span (ERROR, no leak)."""
+    import asyncio
+
+    from mellea.stdlib.functional import avalidate
+
+    def _boom(_ctx):
+        raise RuntimeError("validator boom")
+
+    backend = _MockBackend()
+    req = Requirement("explodes", validation_fn=_boom)
+
+    with pytest.raises(RuntimeError, match="validator boom"):
+        asyncio.run(
+            avalidate(req, SimpleContext(), backend, output=ModelOutputThunk(value="x"))
+        )
+
+    # Span closed, not leaked, and marked ERROR.
+    assert not tracing._in_flight_spans
+    by_name = _spans_by_name(span_exporter)
+    assert "validation" in by_name
+    assert by_name["validation"].status.status_code.name == "ERROR"
+
+
+@pytest.mark.integration
+def test_sample_raises_closes_sampling_span_error(span_exporter):
+    """A backend that raises during sampling still closes the `sampling` span."""
+    import asyncio
+
+    class _RaisingBackend(_MockBackend):
+        async def _generate_from_context(self, action, ctx, **kwargs):
+            raise RuntimeError("backend boom")
+
+    with pytest.raises(RuntimeError, match="backend boom"):
+        asyncio.run(
+            RejectionSamplingStrategy(loop_budget=1).sample(
+                Instruction(description="hi"),
+                context=SimpleContext(),
+                backend=_RaisingBackend(),
+                requirements=[],
+            )
+        )
+
+    assert not tracing._in_flight_spans
+    by_name = _spans_by_name(span_exporter)
+    assert "sampling" in by_name
+    assert by_name["sampling"].status.status_code.name == "ERROR"


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1050

## Description
Adds `sampling` and `validation` tracing spans, emitted by two new plugins (`SamplingTracingPlugin`, `ValidationTracingPlugin`) that subscribe to the sampling and validation lifecycle hooks already dispatched by `BaseSamplingStrategy.sample()` and `avalidate()`.

#1050 also named the formatter, which is intentionally left out: it's a synchronous render step with no duration or place in the trace tree of its own, so it isn't a meaningful span. The data worth capturing from that path — the prompt template and its variables — is component-level information the formatter merely renders, and it belongs as attributes on the backend `chat` span, which is #1067's scope (`llm.prompt_template.*`).

Two new plugins in `mellea/telemetry/tracing_plugins.py`:

- **`SamplingTracingPlugin`** — emits a `sampling` application span per sampling loop, opened on `sampling_loop_start` and closed on `sampling_loop_end`. Each attempt and repair is recorded as a span event (`iteration` / `repair`) rather than a child span, so the markers stay on the one span alongside the backend `chat` spans the same calls emit.
- **`ValidationTracingPlugin`** — emits a `validation` application span per requirement-validation batch, opened on `validation_pre_check` and closed on `validation_post_check`.

Supporting changes:

- **Correlation ids**: added observe-only `sampling_id` / `validation_id` fields to the sampling and validation hook payloads, minted once at each dispatch site (`sample()` and `avalidate()`) so the paired open/close hooks correlate.
- **Span helpers** in `tracing.py`: `start`/`finish_sampling_span`, `start`/`finish_validation_span`, and a generic `add_span_event` (renamed from the streaming-specific `add_streaming_event`, now shared).
- **Error-path span closure**: `sample()` and `avalidate()` fire their end hook from a `try`/`finally` with an optional `exception` field, so a raised loop/check still closes its span. ERROR status is driven only by an exception — a routine budget-exhausted loop or failing check closes with default status. The metrics and `builtin_debug` plugins skip the outcome on the exception path.
- **Docs**: documented the `sampling` and `validation` spans and corrected the span-hierarchy diagrams in `tracing.md` / `telemetry.md` (they referenced a `requirement_validation` span that never existed — the real span is `validation`).

### Notes for reviewers

- Nesting is `session → action → sampling → {chat, validation}` on Python 3.12+; on ≤3.11 hook-attached spans collapse to `session` (same documented degradation as all existing tracing plugins).
- The `add_streaming_event` → `add_span_event` rename updates `StreamingTracingPlugin`'s call sites; no compat shim.
- The `sampling` span covers strategies that use the `BaseSamplingStrategy` loop. Strategies that override `sample()` with a custom loop (SOFAI, budget-forcing, majority-voting) don't emit it — that coupling is tracked as a follow-up in #1487, out of scope here.
- Telemetry plugin priorities moved from the 40s/50s into the 1040s/1050s so they run after user hooks and observe the final post-hook payload state (fixes sampling/validation spans reporting pre-mutation `loop_budget`/`requirement_count`). Relative order is unchanged: tracing (1040–1045) still precedes metrics (1050–1057).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
