### PR TITLE
feat!: emit per-chunk streaming span events on backend spans

### DIFF
--- a/docs/docs/observability/telemetry.md
+++ b/docs/docs/observability/telemetry.md
@@ -34,6 +34,7 @@ All telemetry is configured via environment variables:
 | `MELLEA_TRACES_OTLP` | Enable OTLP span exporter | `false` |
 | `MELLEA_TRACES_CONSOLE` | Print traces to console (debugging) | `false` |
 | `MELLEA_TRACES_CONTENT` | Capture prompt/response content on spans (may include PII) | `false` |
+| `MELLEA_GENERATION_CHUNK_EVENTS` | Emit a `chunk_processed` span event per streamed chunk on backend spans | `false` |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace-specific OTLP endpoint (overrides general) | none |
 
 ### Metrics variables

--- a/docs/docs/observability/tracing.md
+++ b/docs/docs/observability/tracing.md
@@ -239,7 +239,7 @@ Mellea also adds context-specific attributes to backend spans:
 | `mellea.tool_calls_enabled` | Whether tool calling is enabled |
 | `mellea.num_actions` | Number of actions in batch (for `generate_from_raw`) |
 
-When `MELLEA_EMIT_CHUNK_EVENTS=true`, backend spans also record a `chunk_processed`
+When `MELLEA_GENERATION_CHUNK_EVENTS=true`, backend spans also record a `chunk_processed`
 span event per streamed chunk, carrying its index and added text length. This is
 opt-in and off by default, since a long response produces one event per chunk.
 

--- a/docs/docs/observability/tracing.md
+++ b/docs/docs/observability/tracing.md
@@ -239,6 +239,10 @@ Mellea also adds context-specific attributes to backend spans:
 | `mellea.tool_calls_enabled` | Whether tool calling is enabled |
 | `mellea.num_actions` | Number of actions in batch (for `generate_from_raw`) |
 
+When `MELLEA_EMIT_CHUNK_EVENTS=true`, backend spans also record a `chunk_processed`
+span event per streamed chunk, carrying its index and added text length. This is
+opt-in and off by default, since a long response produces one event per chunk.
+
 ### Span hierarchy
 
 Backend spans nest inside application spans:

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -23,6 +23,7 @@ import binascii
 import datetime
 import enum
 import logging
+import os
 import threading
 from collections import OrderedDict
 from collections.abc import Callable, Coroutine, Iterable, Mapping
@@ -49,6 +50,15 @@ from PIL import Image as PILImage
 
 from ..plugins.manager import has_plugins, invoke_hook
 from ..plugins.types import HookType
+
+
+def _emit_chunk_events_enabled() -> bool:
+    """Whether `MELLEA_EMIT_CHUNK_EVENTS` opts into per-chunk `generation_event` hooks."""
+    return os.getenv("MELLEA_EMIT_CHUNK_EVENTS", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
 
 
 class CBlock:
@@ -751,6 +761,9 @@ class _GenerationState:
         chunk_size: Minimum number of chunks to stream at a single time.
         first_chunk_received: Whether the first streamed chunk has arrived
             (gates time-to-first-byte recording).
+        processed_chunk_index: Monotonic index of the next streamed chunk to be
+            processed, incremented once per chunk folded into the value across the
+            repeated `astream()` calls of one generation.
         generate: The task driving generation. Linked to `generate_type`.
         generate_type: Determines which functions can resolve the thunk's value.
         generate_extra: Auxiliary generation task; currently only used by hf.
@@ -770,6 +783,7 @@ class _GenerationState:
     queue: asyncio.Queue = field(default_factory=lambda: asyncio.Queue(maxsize=20))
     chunk_size: int = 3
     first_chunk_received: bool = False
+    processed_chunk_index: int = 0
     generate: asyncio.Task[None] | None = None
     generate_type: GenerateType = GenerateType.NONE
     generate_extra: asyncio.Task[Any] | None = None
@@ -852,6 +866,16 @@ class ModelOutputThunk(Generic[S]):
                 datetime.datetime.now() - self._gen.start
             ).total_seconds() * 1000
             self._gen.first_chunk_received = True
+
+    async def _emit_event(self, event_name: str, **data: Any) -> None:
+        """Fire a `generation_event` hook named `event_name` carrying `data`, if any plugin subscribes."""
+        if has_plugins(HookType.GENERATION_EVENT):
+            from ..plugins.hooks.generation import GenerationEventPayload
+
+            event_payload = GenerationEventPayload(
+                generation_id=self._call.generation_id, event_name=event_name, data=data
+            )
+            await invoke_hook(HookType.GENERATION_EVENT, event_payload)
 
     async def cancel_generation(self, error: Exception | None = None) -> None:
         """Cancel an in-progress streaming generation, drain the queue, and fire the `generation_error` hook.
@@ -1153,9 +1177,18 @@ class ModelOutputThunk(Generic[S]):
 
             raise chunks[-1]
 
+        emit_chunk_events = self.generation.streaming and _emit_chunk_events_enabled()
         for chunk in chunks:
             assert self._gen.process is not None
+            prev_len = len(self._underlying_value or "")
             await self._gen.process(self, chunk)
+            if emit_chunk_events:
+                await self._emit_event(
+                    "chunk_processed",
+                    chunk_index=self._gen.processed_chunk_index,
+                    chunk_len=len(self._underlying_value or "") - prev_len,
+                )
+            self._gen.processed_chunk_index += 1
 
         if do_set_computed:
             assert self._underlying_value is not None

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1170,7 +1170,7 @@ class ModelOutputThunk(Generic[S]):
             raise chunks[-1]
 
         emit_chunk_events = self.generation.streaming and _parse_bool_env(
-            os.getenv("MELLEA_EMIT_CHUNK_EVENTS", ""), default=False
+            os.getenv("MELLEA_GENERATION_CHUNK_EVENTS", ""), default=False
         )
         for chunk in chunks:
             assert self._gen.process is not None

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -50,15 +50,7 @@ from PIL import Image as PILImage
 
 from ..plugins.manager import has_plugins, invoke_hook
 from ..plugins.types import HookType
-
-
-def _emit_chunk_events_enabled() -> bool:
-    """Whether `MELLEA_EMIT_CHUNK_EVENTS` opts into per-chunk `generation_event` hooks."""
-    return os.getenv("MELLEA_EMIT_CHUNK_EVENTS", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-    )
+from .utils import _parse_bool_env
 
 
 class CBlock:
@@ -1177,16 +1169,18 @@ class ModelOutputThunk(Generic[S]):
 
             raise chunks[-1]
 
-        emit_chunk_events = self.generation.streaming and _emit_chunk_events_enabled()
+        emit_chunk_events = self.generation.streaming and _parse_bool_env(
+            os.getenv("MELLEA_EMIT_CHUNK_EVENTS", ""), default=False
+        )
         for chunk in chunks:
             assert self._gen.process is not None
-            prev_len = len(self._underlying_value or "")
+            prev_len = len(str(self._underlying_value or ""))
             await self._gen.process(self, chunk)
             if emit_chunk_events:
                 await self._emit_event(
                     "chunk_processed",
                     chunk_index=self._gen.processed_chunk_index,
-                    chunk_len=len(self._underlying_value or "") - prev_len,
+                    chunk_text_length=len(str(self._underlying_value or "")) - prev_len,
                 )
             self._gen.processed_chunk_index += 1
 

--- a/mellea/core/utils.py
+++ b/mellea/core/utils.py
@@ -69,9 +69,6 @@ try:
 except ImportError:
     _OTEL_AVAILABLE = False
 
-from ..telemetry import get_otlp_log_handler
-from ..telemetry.context import _CONTEXT_VARS as _telemetry_vars, MelleaContextFilter
-
 # ---------------------------------------------------------------------------
 # Per-task/coroutine context fields (safe for asyncio — each Task gets its own copy)
 # ---------------------------------------------------------------------------
@@ -426,6 +423,8 @@ class JsonFormatter(logging.Formatter):
         # MelleaContextFilter stamps these onto the record before formatters run; read
         # them back off the record here so they appear in JSON output.  Fall back to the
         # ContextVar directly so the formatter still works without the filter attached.
+        from ..telemetry.context import _CONTEXT_VARS as _telemetry_vars
+
         for key, var in _telemetry_vars.items():
             value = getattr(record, key, var.get())
             if value is not None:
@@ -577,6 +576,8 @@ def configure_logging(logger: logging.Logger) -> None:
     Args:
         logger: The `logging.Logger` to configure.
     """
+    from ..telemetry import get_otlp_log_handler
+
     enabled_raw = os.environ.get("MELLEA_LOGS_ENABLED")
     if not _parse_bool_env(enabled_raw or "", default=True):
         return
@@ -701,6 +702,8 @@ class MelleaLogger:
         Returns:
             Configured logger instance.
         """
+        from ..telemetry.context import MelleaContextFilter
+
         if MelleaLogger.logger is None:
             with _logger_lock:
                 # Second check inside the lock: another thread may have finished

--- a/mellea/plugins/hooks/generation.py
+++ b/mellea/plugins/hooks/generation.py
@@ -83,6 +83,27 @@ class GenerationErrorPayload(MelleaBasePayload):
     generation_id: str | None = None
 
 
+class GenerationEventPayload(MelleaBasePayload):
+    """Payload for `generation_event` — a milestone event during a single generation.
+
+    A generic carrier for events emitted mid-generation. Subscribers branch on
+    `event_name` and read the keys `data` carries for that event.
+
+    Attributes:
+        generation_id: Mellea-side hook correlation ID matching the corresponding
+            pre_call payload, distinct from the provider-assigned
+            `GenerationMetadata.response_id`. `None` when the firing site did not
+            generate one.
+        event_name: Identifies the event. Subscribers dispatch on this.
+        data: Values for this event, keyed by name. The keys present depend on
+            `event_name`.
+    """
+
+    generation_id: str | None = None
+    event_name: str = ""
+    data: dict[str, Any] = {}
+
+
 class GenerationBatchPreCallPayload(MelleaBasePayload):
     """Payload for `generation_batch_pre_call` — fires once before a batch generation request.
 

--- a/mellea/plugins/hooks/generation.py
+++ b/mellea/plugins/hooks/generation.py
@@ -89,6 +89,11 @@ class GenerationEventPayload(MelleaBasePayload):
     A generic carrier for events emitted mid-generation. Subscribers branch on
     `event_name` and read the keys `data` carries for that event.
 
+    Known events:
+        `chunk_processed`: emitted once per streamed chunk during `astream()`
+            (opt-in via `MELLEA_EMIT_CHUNK_EVENTS`). `data` keys:
+            `chunk_index` (int), `chunk_text_length` (int).
+
     Attributes:
         generation_id: Mellea-side hook correlation ID matching the corresponding
             pre_call payload, distinct from the provider-assigned
@@ -96,7 +101,7 @@ class GenerationEventPayload(MelleaBasePayload):
             generate one.
         event_name: Identifies the event. Subscribers dispatch on this.
         data: Values for this event, keyed by name. The keys present depend on
-            `event_name`.
+            `event_name` (see Known events above).
     """
 
     generation_id: str | None = None

--- a/mellea/plugins/hooks/generation.py
+++ b/mellea/plugins/hooks/generation.py
@@ -91,7 +91,7 @@ class GenerationEventPayload(MelleaBasePayload):
 
     Known events:
         `chunk_processed`: emitted once per streamed chunk during `astream()`
-            (opt-in via `MELLEA_EMIT_CHUNK_EVENTS`). `data` keys:
+            (opt-in via `MELLEA_GENERATION_CHUNK_EVENTS`). `data` keys:
             `chunk_index` (int), `chunk_text_length` (int).
 
     Attributes:

--- a/mellea/plugins/policies.py
+++ b/mellea/plugins/policies.py
@@ -65,7 +65,7 @@ def _build_policies() -> dict[str, Any]:
         "generation_batch_pre_call": HookPayloadPolicy(
             writable_fields=frozenset({"model_options", "tool_calls", "format"})
         ),
-        # generation_post_call, generation_batch_post_call: observe-only
+        # generation_post_call, generation_batch_post_call, generation_event: observe-only
         # Validation
         "validation_pre_check": HookPayloadPolicy(
             writable_fields=frozenset({"requirements", "model_options"})

--- a/mellea/plugins/types.py
+++ b/mellea/plugins/types.py
@@ -55,6 +55,7 @@ class HookType(StrEnum):
     GENERATION_BATCH_PRE_CALL = "generation_batch_pre_call"
     GENERATION_BATCH_POST_CALL = "generation_batch_post_call"
     GENERATION_BATCH_ERROR = "generation_batch_error"
+    GENERATION_EVENT = "generation_event"
 
     # Validation
     VALIDATION_PRE_CHECK = "validation_pre_check"
@@ -106,6 +107,7 @@ def _build_hook_registry() -> dict[str, tuple[type, type]]:
         GenerationBatchPostCallPayload,
         GenerationBatchPreCallPayload,
         GenerationErrorPayload,
+        GenerationEventPayload,
         GenerationPostCallPayload,
         GenerationPreCallPayload,
     )
@@ -166,6 +168,7 @@ def _build_hook_registry() -> dict[str, tuple[type, type]]:
             GenerationBatchErrorPayload,
             PluginResult,
         ),
+        HookType.GENERATION_EVENT.value: (GenerationEventPayload, PluginResult),
         # Validation
         HookType.VALIDATION_PRE_CHECK.value: (ValidationPreCheckPayload, PluginResult),
         HookType.VALIDATION_POST_CHECK.value: (

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -156,8 +156,10 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=1040):
                 payload.generation_id,
                 event_name="chunk_processed",
                 attributes={
-                    "mellea.chunk_index": payload.data.get("chunk_index"),
-                    "mellea.chunk_text_length": payload.data.get("chunk_len"),
+                    "mellea.generation.chunk_index": payload.data.get("chunk_index"),
+                    "mellea.generation.chunk_text_length": payload.data.get(
+                        "chunk_len"
+                    ),
                 },
             )
 
@@ -379,34 +381,44 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=1042):
                 payload.streaming_id,
                 event_name="quick_check",
                 attributes={
-                    "chunk_index": ev.chunk_index,
-                    "passed": ev.passed,
-                    "requirement_count": len(ev.results),
+                    "mellea.streaming.chunk_index": ev.chunk_index,
+                    "mellea.validation.passed": ev.passed,
+                    "mellea.validation.requirement_count": len(ev.results),
                 },
             )
         elif isinstance(ev, ChunkEvent):
             add_span_event(
                 payload.streaming_id,
                 event_name="chunk",
-                attributes={"chunk_index": ev.chunk_index, "text_length": len(ev.text)},
+                attributes={
+                    "mellea.streaming.chunk_index": ev.chunk_index,
+                    "mellea.streaming.chunk_text_length": len(ev.text),
+                },
             )
         elif isinstance(ev, StreamingDoneEvent):
             add_span_event(
                 payload.streaming_id,
                 event_name="streaming_done",
-                attributes={"full_text_length": len(ev.full_text)},
+                attributes={"mellea.streaming.full_text_length": len(ev.full_text)},
             )
         elif isinstance(ev, FullValidationEvent):
             add_span_event(
                 payload.streaming_id,
                 event_name="full_validation",
-                attributes={"passed": ev.passed, "requirement_count": len(ev.results)},
+                attributes={
+                    "mellea.validation.passed": ev.passed,
+                    "mellea.validation.requirement_count": len(ev.results),
+                },
             )
         elif isinstance(ev, ErrorEvent):
+            # Not OTel's reserved `exception.*`: `detail` isn't always the plain message.
             add_span_event(
                 payload.streaming_id,
                 event_name="error",
-                attributes={"exception_type": ev.exception_type, "detail": ev.detail},
+                attributes={
+                    "mellea.error.type": ev.exception_type,
+                    "mellea.error.detail": ev.detail,
+                },
             )
 
     @hook("streaming_end")
@@ -422,8 +434,8 @@ class StreamingTracingPlugin(Plugin, name="streaming_tracing", priority=1042):
             payload.streaming_id,
             event_name="completed",
             attributes={
-                "success": payload.success,
-                "full_text_length": payload.full_text_length,
+                "mellea.streaming.success": payload.success,
+                "mellea.streaming.full_text_length": payload.full_text_length,
             },
         )
         finish_streaming_span(
@@ -532,10 +544,10 @@ class SamplingTracingPlugin(Plugin, name="sampling_tracing", priority=1044):
             payload.sampling_id,
             event_name="iteration",
             attributes={
-                "iteration": payload.iteration,
-                "all_validations_passed": payload.all_validations_passed,
-                "valid_count": payload.valid_count,
-                "total_count": payload.total_count,
+                "mellea.sampling.iteration": payload.iteration,
+                "mellea.sampling.all_validations_passed": payload.all_validations_passed,
+                "mellea.validation.valid_count": payload.valid_count,
+                "mellea.validation.requirement_count": payload.total_count,
             },
         )
 
@@ -552,9 +564,9 @@ class SamplingTracingPlugin(Plugin, name="sampling_tracing", priority=1044):
             payload.sampling_id,
             event_name="repair",
             attributes={
-                "repair_iteration": payload.repair_iteration,
-                "repair_type": payload.repair_type,
-                "failed_count": len(payload.failed_validations),
+                "mellea.sampling.repair_iteration": payload.repair_iteration,
+                "mellea.sampling.repair_type": payload.repair_type,
+                "mellea.validation.failed_count": len(payload.failed_validations),
             },
         )
 

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -158,7 +158,7 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=1040):
                 attributes={
                     "mellea.generation.chunk_index": payload.data.get("chunk_index"),
                     "mellea.generation.chunk_text_length": payload.data.get(
-                        "chunk_len"
+                        "chunk_text_length"
                     ),
                 },
             )

--- a/mellea/telemetry/tracing_plugins.py
+++ b/mellea/telemetry/tracing_plugins.py
@@ -7,7 +7,8 @@ This module contains plugins that hook into the generation and component
 pipelines to automatically emit spans when tracing is enabled:
 
 - BackendTracingPlugin: Emits Gen-AI semconv backend spans for every LLM
-  generation, on both chat and raw (batch) paths.
+  generation, on both chat and raw (batch) paths, plus mid-generation span
+  events from the generation_event hook.
 - ComponentTracingPlugin: Emits application-level spans tracking component
   execution.
 - StreamingTracingPlugin: Emits an application-level orchestration span and
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
         GenerationBatchPostCallPayload,
         GenerationBatchPreCallPayload,
         GenerationErrorPayload,
+        GenerationEventPayload,
         GenerationPostCallPayload,
         GenerationPreCallPayload,
     )
@@ -73,10 +75,13 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=1040):
     This plugin hooks into the generation pre-call, post-call, and error
     events on both the chat and raw (batch) paths to automatically emit one
     span per LLM call. Spans are started on pre-call and ended on post-call
-    or error, correlated across hooks via generation_id.
+    or error, correlated across hooks via generation_id. It also records
+    mid-generation span events from the `generation_event` hook onto the
+    in-flight span.
 
     All hooks run SEQUENTIAL so the OTel context token attached in pre-call
-    can be detached on the same task in post-call / error.
+    can be detached on the same task in post-call / error, and so
+    `generation_event` appends to the span before post-call ends it.
     """
 
     # --- Chat hooks ---
@@ -136,6 +141,25 @@ class BackendTracingPlugin(Plugin, name="backend_tracing", priority=1040):
             exception=payload.exception,
             gen=gen,
         )
+
+    @hook("generation_event")
+    async def on_generation_event(
+        self, payload: GenerationEventPayload, context: dict[str, Any]
+    ) -> None:
+        """Record a span event on the in-flight backend span for one `generation_event`."""
+        if not payload.generation_id:
+            return
+        from mellea.telemetry.tracing import add_span_event
+
+        if payload.event_name == "chunk_processed":
+            add_span_event(
+                payload.generation_id,
+                event_name="chunk_processed",
+                attributes={
+                    "mellea.chunk_index": payload.data.get("chunk_index"),
+                    "mellea.chunk_text_length": payload.data.get("chunk_len"),
+                },
+            )
 
     # --- Batch hooks ---
 

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -121,13 +121,13 @@ async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch
     Uses a mocked Ollama client so no server is needed.  Verifies the core
     TracingPlugin invariant: the span must remain open for the full duration of
     streaming and close only once all chunks are consumed. `chunk_processed`
-    events are emitted only when `MELLEA_EMIT_CHUNK_EVENTS` is on; with the env
+    events are emitted only when `MELLEA_GENERATION_CHUNK_EVENTS` is on; with the env
     unset (the default) the span carries no such events.
     """
     if emit:
-        monkeypatch.setenv("MELLEA_EMIT_CHUNK_EVENTS", "true")
+        monkeypatch.setenv("MELLEA_GENERATION_CHUNK_EVENTS", "true")
     else:
-        monkeypatch.delenv("MELLEA_EMIT_CHUNK_EVENTS", raising=False)
+        monkeypatch.delenv("MELLEA_GENERATION_CHUNK_EVENTS", raising=False)
 
     async def fake_chat_stream(*args, **kwargs):
         for content in ["1", " 2", " 3"]:
@@ -190,11 +190,11 @@ async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch
     chunk_events = [e for e in backend_span.events if e.name == "chunk_processed"]
     if emit:
         assert chunk_events, (
-            "expected chunk_processed events with MELLEA_EMIT_CHUNK_EVENTS on"
+            "expected chunk_processed events with MELLEA_GENERATION_CHUNK_EVENTS on"
         )
     else:
         assert not chunk_events, (
-            "expected no chunk_processed events when MELLEA_EMIT_CHUNK_EVENTS is unset"
+            "expected no chunk_processed events when MELLEA_GENERATION_CHUNK_EVENTS is unset"
         )
 
 

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -114,15 +114,20 @@ def mocked_tracing_backend():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch):
+@pytest.mark.parametrize("emit", [True, False], ids=["emit_on", "emit_off_default"])
+async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch, emit):
     """Streaming backend call creates a chat span that closes after the stream completes.
 
     Uses a mocked Ollama client so no server is needed.  Verifies the core
     TracingPlugin invariant: the span must remain open for the full duration of
-    streaming and close only once all chunks are consumed. With
-    `MELLEA_EMIT_CHUNK_EVENTS` on, the span also carries `chunk_processed` events.
+    streaming and close only once all chunks are consumed. `chunk_processed`
+    events are emitted only when `MELLEA_EMIT_CHUNK_EVENTS` is on; with the env
+    unset (the default) the span carries no such events.
     """
-    monkeypatch.setenv("MELLEA_EMIT_CHUNK_EVENTS", "true")
+    if emit:
+        monkeypatch.setenv("MELLEA_EMIT_CHUNK_EVENTS", "true")
+    else:
+        monkeypatch.delenv("MELLEA_EMIT_CHUNK_EVENTS", raising=False)
 
     async def fake_chat_stream(*args, **kwargs):
         for content in ["1", " 2", " 3"]:
@@ -183,9 +188,14 @@ async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch
     )
 
     chunk_events = [e for e in backend_span.events if e.name == "chunk_processed"]
-    assert chunk_events, (
-        "expected chunk_processed events with MELLEA_EMIT_CHUNK_EVENTS on"
-    )
+    if emit:
+        assert chunk_events, (
+            "expected chunk_processed events with MELLEA_EMIT_CHUNK_EVENTS on"
+        )
+    else:
+        assert not chunk_events, (
+            "expected no chunk_processed events when MELLEA_EMIT_CHUNK_EVENTS is unset"
+        )
 
 
 @pytest.mark.integration

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -187,14 +187,21 @@ async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch
         "the streaming delay, suggesting the span did not stay open for the full stream"
     )
 
-    chunk_events = [e for e in backend_span.events if e.name == "chunk_processed"]
+    chunk_events = [
+        (
+            e.attributes.get("mellea.generation.chunk_index"),
+            e.attributes.get("mellea.generation.chunk_text_length"),
+        )
+        for e in backend_span.events
+        if e.name == "chunk_processed"
+    ]
     if emit:
-        assert chunk_events, (
-            "expected chunk_processed events with MELLEA_GENERATION_CHUNK_EVENTS on"
+        assert chunk_events == [(0, 1), (1, 2), (2, 2), (3, 0)], (
+            "Chunk events should report (index, added_text_length) per chunk"
         )
     else:
         assert not chunk_events, (
-            "expected no chunk_processed events when MELLEA_GENERATION_CHUNK_EVENTS is unset"
+            "Chunk events should be absent when MELLEA_GENERATION_CHUNK_EVENTS is unset"
         )
 
 

--- a/test/telemetry/test_tracing_backend.py
+++ b/test/telemetry/test_tracing_backend.py
@@ -114,13 +114,15 @@ def mocked_tracing_backend():
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_streaming_span_creates_and_closes_span(span_exporter):
+async def test_streaming_span_creates_and_closes_span(span_exporter, monkeypatch):
     """Streaming backend call creates a chat span that closes after the stream completes.
 
     Uses a mocked Ollama client so no server is needed.  Verifies the core
     TracingPlugin invariant: the span must remain open for the full duration of
-    streaming and close only once all chunks are consumed.
+    streaming and close only once all chunks are consumed. With
+    `MELLEA_EMIT_CHUNK_EVENTS` on, the span also carries `chunk_processed` events.
     """
+    monkeypatch.setenv("MELLEA_EMIT_CHUNK_EVENTS", "true")
 
     async def fake_chat_stream(*args, **kwargs):
         for content in ["1", " 2", " 3"]:
@@ -178,6 +180,11 @@ async def test_streaming_span_creates_and_closes_span(span_exporter):
     assert span_duration_s >= 0.1, (
         f"Span closed too early — duration {span_duration_s:.3f}s is shorter than "
         "the streaming delay, suggesting the span did not stay open for the full stream"
+    )
+
+    chunk_events = [e for e in backend_span.events if e.name == "chunk_processed"]
+    assert chunk_events, (
+        "expected chunk_processed events with MELLEA_EMIT_CHUNK_EVENTS on"
     )
 
 

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -211,8 +211,8 @@ async def test_event_records_chunk_processed_on_in_flight_span(
     assert len(events) == 1
     name, attrs = events[0]
     assert name == "chunk_processed"
-    assert attrs["mellea.chunk_index"] == 2
-    assert attrs["mellea.chunk_text_length"] == 5
+    assert attrs["mellea.generation.chunk_index"] == 2
+    assert attrs["mellea.generation.chunk_text_length"] == 5
     # The event does not close the span.
     fake_span.end.assert_not_called()
 
@@ -947,8 +947,8 @@ async def test_streaming_end_records_completed_event_then_closes_span(
     events = _events(fake_span)
     assert any(name == "completed" for name, _ in events)
     completed_attrs = next(attrs for name, attrs in events if name == "completed")
-    assert completed_attrs["success"] is True
-    assert completed_attrs["full_text_length"] == 11
+    assert completed_attrs["mellea.streaming.success"] is True
+    assert completed_attrs["mellea.streaming.full_text_length"] == 11
 
     attrs = _attrs(fake_span)
     assert attrs["mellea.full_text_length"] == 11
@@ -1028,11 +1028,11 @@ async def test_streaming_event_records_mid_stream_events(
     names = [name for name, _ in events]
     assert names == ["quick_check", "chunk", "streaming_done", "full_validation"]
     qc_attrs = events[0][1]
-    assert qc_attrs["chunk_index"] == 0
-    assert qc_attrs["passed"] is True
-    assert qc_attrs["requirement_count"] == 1
+    assert qc_attrs["mellea.streaming.chunk_index"] == 0
+    assert qc_attrs["mellea.validation.passed"] is True
+    assert qc_attrs["mellea.validation.requirement_count"] == 1
     chunk_attrs = events[1][1]
-    assert chunk_attrs["text_length"] == 5
+    assert chunk_attrs["mellea.streaming.chunk_text_length"] == 5
 
     # streaming_event never closes the span.
     fake_span.end.assert_not_called()
@@ -1054,8 +1054,8 @@ async def test_streaming_event_records_error_event(streaming_plugin, enabled_tra
     events = _events(fake_span)
     assert any(name == "error" for name, _ in events)
     error_attrs = next(attrs for name, attrs in events if name == "error")
-    assert error_attrs["exception_type"] == "ValueError"
-    assert error_attrs["detail"] == "boom"
+    assert error_attrs["mellea.error.type"] == "ValueError"
+    assert error_attrs["mellea.error.detail"] == "boom"
     fake_span.end.assert_not_called()
 
 
@@ -1417,8 +1417,8 @@ async def test_sampling_iteration_records_span_event(sampling_plugin, enabled_tr
     fake_span.add_event.assert_called_once()
     name, attrs = fake_span.add_event.call_args.args
     assert name == "iteration"
-    assert attrs["iteration"] == 2
-    assert attrs["valid_count"] == 1
+    assert attrs["mellea.sampling.iteration"] == 2
+    assert attrs["mellea.validation.valid_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -1447,8 +1447,8 @@ async def test_sampling_repair_records_span_event(sampling_plugin, enabled_traci
 
     name, attrs = fake_span.add_event.call_args.args
     assert name == "repair"
-    assert attrs["repair_type"] == "rejection"
-    assert attrs["failed_count"] == 1
+    assert attrs["mellea.sampling.repair_type"] == "rejection"
+    assert attrs["mellea.validation.failed_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -203,7 +203,7 @@ async def test_event_records_chunk_processed_on_in_flight_span(
     payload = GenerationEventPayload(
         generation_id="gid-ev",
         event_name="chunk_processed",
-        data={"chunk_index": 2, "chunk_len": 5},
+        data={"chunk_index": 2, "chunk_text_length": 5},
     )
     await backend_plugin.on_generation_event(payload, {})
 
@@ -231,7 +231,7 @@ async def test_event_skipped_when_span_not_in_flight(backend_plugin, enabled_tra
     payload = GenerationEventPayload(
         generation_id="gid-missing",
         event_name="chunk_processed",
-        data={"chunk_index": 0, "chunk_len": 1},
+        data={"chunk_index": 0, "chunk_text_length": 1},
     )
     await backend_plugin.on_generation_event(payload, {})
 

--- a/test/telemetry/test_tracing_plugins.py
+++ b/test/telemetry/test_tracing_plugins.py
@@ -25,6 +25,7 @@ from mellea.plugins.hooks.generation import (
     GenerationBatchPostCallPayload,
     GenerationBatchPreCallPayload,
     GenerationErrorPayload,
+    GenerationEventPayload,
     GenerationPostCallPayload,
     GenerationPreCallPayload,
 )
@@ -185,6 +186,56 @@ async def test_error_finishes_span_with_error_status(backend_plugin, enabled_tra
     attrs = _attrs(fake_span)
     assert attrs["error.type"] == "ValueError"
     assert "gid-err" not in tracing._in_flight_spans
+
+
+@pytest.mark.asyncio
+async def test_event_records_chunk_processed_on_in_flight_span(
+    backend_plugin, enabled_tracing
+):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = GenerationPreCallPayload(action=None, context=None, generation_id="gid-ev")
+    with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
+        await backend_plugin.on_pre_call(pre, {})
+
+    payload = GenerationEventPayload(
+        generation_id="gid-ev",
+        event_name="chunk_processed",
+        data={"chunk_index": 2, "chunk_len": 5},
+    )
+    await backend_plugin.on_generation_event(payload, {})
+
+    events = _events(fake_span)
+    assert len(events) == 1
+    name, attrs = events[0]
+    assert name == "chunk_processed"
+    assert attrs["mellea.chunk_index"] == 2
+    assert attrs["mellea.chunk_text_length"] == 5
+    # The event does not close the span.
+    fake_span.end.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_event_skipped_when_span_not_in_flight(backend_plugin, enabled_tracing):
+    fake_span = MagicMock()
+    fake_tracer = MagicMock()
+    fake_tracer.start_span.return_value = fake_span
+
+    pre = GenerationPreCallPayload(action=None, context=None, generation_id="gid-live")
+    with patch("mellea.telemetry.tracing.get_backend_tracer", return_value=fake_tracer):
+        await backend_plugin.on_pre_call(pre, {})
+
+    # Event for a different, non-in-flight id must not land on the live span.
+    payload = GenerationEventPayload(
+        generation_id="gid-missing",
+        event_name="chunk_processed",
+        data={"chunk_index": 0, "chunk_len": 1},
+    )
+    await backend_plugin.on_generation_event(payload, {})
+
+    fake_span.add_event.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issue
Fixes #1051

## Description
Adds streaming span events on the backend generation span (`chat` / `text_completion`), so per-chunk streaming cadence is visible on individual traces rather than only as aggregate metrics.

This introduces a reusable event path for backend spans:
- A generic `generation_event` hook (`GenerationEventPayload` carrying `event_name` + a `data` dict), fired via `ModelOutputThunk._emit_event`.
- A `BackendTracingPlugin.on_generation_event` handler that dispatches on `event_name` and records the event on the in-flight backend span via the existing `add_span_event`. Future backend-span events reuse this path.

Its first consumer is an opt-in `chunk_processed` event, emitted once per streamed chunk during `astream()` when `MELLEA_EMIT_CHUNK_EVENTS=true` (off by default, since a long response produces one event per chunk). It carries `mellea.generation.chunk_index` and `mellea.generation.chunk_text_length`.

Design notes:
- Core stays telemetry-agnostic: the emit site passes raw domain values by keyword; the OpenTelemetry attribute vocabulary lives only in the plugin.
- The gate is a core-side hook gate (`MELLEA_EMIT_CHUNK_EVENTS`), checked before the hook fires so the disabled path costs only an env read.
- The handler runs SEQUENTIAL so the event is appended before `on_post_call` ends the span.

Span event attribute keys across the tracing plugins are also namespaced (previously emitted bare, e.g. `chunk_index`), following `mellea.<origin>.<leaf>` where the origin names the subsystem the value comes from. **Note:** the streaming-span event attributes were previously released, so renaming them is a breaking change for existing trace queries.

Also fixes a latent import-layering bug this surfaced: `mellea/core/utils.py` imported `mellea.telemetry` at module scope, forming a `core → telemetry → core.base` cycle. Those imports are now lazy (function-local), which is behavior-preserving.

## Open question for review
`GenerationEventPayload` carries an untyped `data: dict` rather than a typed event class (contrast `StreamEvent`, which the streaming hook uses). This keeps core telemetry-agnostic and avoids a payload class per event type. The known `event_name` → `data` key contracts are documented in the `GenerationEventPayload` docstring. Still worth confirming before other subscribers depend on it: is the generic `data` dict the right call, or should backend events get a typed hierarchy?

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
