### PR TITLE
fix: surface HF auth failures when loading switch adapters

### DIFF
--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -23,7 +23,7 @@ from typing import Literal, TypeAlias, TypeVar, cast
 
 import yaml
 
-from ...core import Backend, MelleaLogger
+from ...core import Backend
 from ...formatters.granite import intrinsics as intrinsics
 from ._core import Adapter as _AdapterCore, Identity, IOContract, WeightsBinding
 from .catalog import AdapterType, fetch_intrinsic_metadata
@@ -777,13 +777,12 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
         """
         try:
             import huggingface_hub
+            from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
         except ImportError as e:
             raise ImportError(
                 "huggingface_hub is required to download embedded adapter configs from "
                 'Hugging Face Hub. Please install it with: pip install "mellea[switch]"'
             ) from e
-
-        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
 
         try:
             local_root = huggingface_hub.snapshot_download(
@@ -797,9 +796,9 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
                 f"Could not access '{repo_id}' on Hugging Face Hub. If this is a "
                 "private or gated repository, authenticate first (run "
                 "`huggingface-cli login` or set the HF_TOKEN environment variable) "
-                "and confirm your account has been granted access to the repository."
+                "and confirm your account has been granted access to the repository. "
+                "Otherwise, the repository ID may be misspelled."
             )
-            MelleaLogger.get_logger().error(auth_hint)
             raise PermissionError(auth_hint) from e
 
         try:

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -23,7 +23,7 @@ from typing import Literal, TypeAlias, TypeVar, cast
 
 import yaml
 
-from ...core import Backend
+from ...core import Backend, MelleaLogger
 from ...formatters.granite import intrinsics as intrinsics
 from ._core import Adapter as _AdapterCore, Identity, IOContract, WeightsBinding
 from .catalog import AdapterType, fetch_intrinsic_metadata
@@ -767,8 +767,11 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
 
         Raises:
             ImportError: If `huggingface_hub` is not installed.
-            FileNotFoundError: If `adapter_index.json` is missing (delegated
-                from :meth:`from_model_directory`).
+            PermissionError: If the repository is private or gated and the
+                current Hugging Face credentials do not grant access.
+            FileNotFoundError: If the downloaded snapshot has no
+                `adapter_index.json` (wrong repo/revision, not a Granite Switch
+                model, or a stale cache).
             ValueError: If no adapters are found (delegated from
                 :meth:`from_model_directory`).
         """
@@ -780,16 +783,42 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
                 'Hugging Face Hub. Please install it with: pip install "mellea[switch]"'
             ) from e
 
-        local_root = huggingface_hub.snapshot_download(
-            repo_id=repo_id,
-            allow_patterns=["adapter_index.json", "io_configs/**"],
-            cache_dir=cache_dir,
-            revision=revision,
-        )
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+        try:
+            local_root = huggingface_hub.snapshot_download(
+                repo_id=repo_id,
+                allow_patterns=["adapter_index.json", "io_configs/**"],
+                cache_dir=cache_dir,
+                revision=revision,
+            )
+        except (GatedRepoError, RepositoryNotFoundError) as e:
+            auth_hint = (
+                f"Could not access '{repo_id}' on Hugging Face Hub. If this is a "
+                "private or gated repository, authenticate first (run "
+                "`huggingface-cli login` or set the HF_TOKEN environment variable) "
+                "and confirm your account has been granted access to the repository."
+            )
+            MelleaLogger.get_logger().error(auth_hint)
+            raise PermissionError(auth_hint) from e
+
         try:
             return EmbeddedIntrinsicAdapter.from_model_directory(
                 local_root, intrinsic_name=intrinsic_name
             )
+        except FileNotFoundError as e:
+            # snapshot_download succeeded but the index is absent: wrong
+            # repo/revision, a repo that isn't a Granite Switch model, or a
+            # stale cache. Replace the cryptic snapshot-cache path with a
+            # repo-scoped message that names authentication as one possible
+            # cause without asserting it.
+            raise FileNotFoundError(
+                f"adapter_index.json was not found in the downloaded snapshot of "
+                f"'{repo_id}'. Verify it is a Granite Switch model and that the "
+                f"revision '{revision}' is correct; if the repository is private "
+                "or gated, confirm you are authenticated (run "
+                "`huggingface-cli login` or set the HF_TOKEN environment variable)."
+            ) from e
         except ValueError as e:
             if intrinsic_name is not None:
                 raise ValueError(

--- a/test/backends/test_adapters/test_embedded_adapter.py
+++ b/test/backends/test_adapters/test_embedded_adapter.py
@@ -334,6 +334,51 @@ class TestFromHub:
             with pytest.raises(ImportError, match="huggingface_hub is required"):
                 EmbeddedIntrinsicAdapter.from_hub("some/repo")
 
+    @pytest.mark.parametrize(
+        "error_name", ["GatedRepoError", "RepositoryNotFoundError"]
+    )
+    def test_auth_error_raises_permission_error(self, error_name):
+        """Auth failures from snapshot_download become an actionable PermissionError."""
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+        class _FakeResponse:
+            headers: dict = {}
+            status_code = 403
+            url = "https://huggingface.co"
+            request = None
+
+        error_cls = {
+            "GatedRepoError": GatedRepoError,
+            "RepositoryNotFoundError": RepositoryNotFoundError,
+        }[error_name]
+        hf_error = error_cls("denied", response=_FakeResponse())
+
+        with patch("huggingface_hub.snapshot_download", side_effect=hf_error):
+            with pytest.raises(PermissionError, match="huggingface-cli login") as exc:
+                EmbeddedIntrinsicAdapter.from_hub("ibm-granite/private-switch")
+
+        # Original HF error is chained for debugging.
+        assert exc.value.__cause__ is hf_error
+
+    def test_missing_index_after_download_raises_clear_file_not_found(self, tmp_path):
+        """A snapshot without adapter_index.json raises a repo-scoped FileNotFoundError.
+
+        snapshot_download can return a path that lacks the index (wrong
+        repo/revision, not a Switch model, or a stale cache). The message names
+        the repo and lists auth as one possible cause, rather than leaking the
+        cryptic snapshot-cache path from from_model_directory.
+        """
+        with patch("huggingface_hub.snapshot_download", return_value=str(tmp_path)):
+            with pytest.raises(
+                FileNotFoundError, match=r"ibm-granite/some-switch"
+            ) as exc:
+                EmbeddedIntrinsicAdapter.from_hub("ibm-granite/some-switch")
+
+        # Not the raw cache-path error, and auth is offered as a possibility.
+        assert "huggingface-cli login" in str(exc.value)
+        # The original cryptic error is chained for debugging.
+        assert isinstance(exc.value.__cause__, FileNotFoundError)
+
 
 # ---- EmbeddedIntrinsicAdapter.from_source ----
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1500

## Description
Loading a Granite Switch adapter from a private or gated HF repo without credentials failed with a cryptic `FileNotFoundError` about a missing `adapter_index.json` in the snapshot cache. `EmbeddedIntrinsicAdapter.from_hub` now:

- Catches HF auth errors (`GatedRepoError` / `RepositoryNotFoundError`) and raises a `PermissionError` with guidance to run `huggingface-cli login` or set `HF_TOKEN`.
- When the download succeeds but the index is genuinely absent, raises a repo-scoped `FileNotFoundError` naming auth as one possible cause, instead of leaking the cache path.


### Testing
- [X] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
