### PR TITLE
fix(stdlib): resolve postponed annotations in generative stub signature

### DIFF
--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -215,7 +215,7 @@ def describe_function(func: Callable) -> FunctionDict:
     """
     return {
         "name": func.__name__,
-        "signature": str(inspect.signature(func)),
+        "signature": str(inspect.signature(func, eval_str=True)),
         "docstring": inspect.getdoc(func),
     }
 
@@ -233,7 +233,7 @@ def get_argument(func: Callable, key: str, val: Any) -> Argument:
     Returns:
         Argument: an argument object representing the given parameter.
     """
-    sig = inspect.signature(func)
+    sig = inspect.signature(func, eval_str=True)
     param = sig.parameters.get(key)
     if param and param.annotation is not inspect.Parameter.empty:
         param_type = param.annotation

--- a/test/stdlib/components/_pep563_fixtures.py
+++ b/test/stdlib/components/_pep563_fixtures.py
@@ -1,0 +1,29 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures with postponed annotations (PEP 563), used by test_genstub_unit.py.
+
+Kept in a separate module because `from __future__ import annotations` is a
+module-level switch — isolating it here keeps the rest of the test suite on
+normal (resolved) annotations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Requirement:
+    """A single extracted requirement."""
+
+    id: str
+    text: str
+
+
+def extract_requirements(product_description: str) -> list[Requirement]:
+    """Extract requirements from a product description."""
+
+
+def greet(name: str) -> str:
+    """Say hello."""

--- a/test/stdlib/components/test_genstub_unit.py
+++ b/test/stdlib/components/test_genstub_unit.py
@@ -65,11 +65,16 @@ def test_describe_function_no_docstring():
 
 
 def test_describe_function_resolves_postponed_annotations():
-    # Regression test for issue #1476: `from __future__ import annotations`
-    # made `describe_function` render literal annotation strings (e.g.
+    # Regression test: `from __future__ import annotations` made
+    # `describe_function` render literal annotation strings (e.g.
     # "(product_description: 'str') -> 'list[Requirement]'") instead of the
     # resolved types, corrupting the prompt sent to the model.
     from test.stdlib.components._pep563_fixtures import extract_requirements
+
+    # Guard the precondition: if the fixture module ever drops its
+    # `from __future__ import annotations`, this test would otherwise keep
+    # passing without exercising postponed annotations at all.
+    assert extract_requirements.__annotations__["return"] == "list[Requirement]"
 
     result = describe_function(extract_requirements)
     assert "'str'" not in result["signature"]
@@ -103,11 +108,14 @@ def test_get_argument_int_value_not_quoted():
 
 
 def test_get_argument_string_value_quoted_under_postponed_annotations():
-    # Regression test for issue #1476: under `from __future__ import
-    # annotations`, `param.annotation` was the literal string "str" rather
-    # than the `str` type, so the `is str` check failed and string arguments
-    # were rendered unquoted in the prompt.
+    # Regression test: under `from __future__ import annotations`,
+    # `param.annotation` was the literal string "str" rather than the `str`
+    # type, so the `is str` check failed and string arguments were rendered
+    # unquoted in the prompt.
     from test.stdlib.components._pep563_fixtures import greet
+
+    # Guard the precondition: same reasoning as above.
+    assert greet.__annotations__["name"] == "str"
 
     arg = get_argument(greet, "name", "Alice")
     assert arg._argument_dict["value"] == '"Alice"'

--- a/test/stdlib/components/test_genstub_unit.py
+++ b/test/stdlib/components/test_genstub_unit.py
@@ -26,6 +26,7 @@ from mellea.stdlib.components.genstub import (
     get_argument,
 )
 from mellea.stdlib.requirements.requirement import reqify
+from test.stdlib.components._pep563_fixtures import extract_requirements, greet
 
 # --- describe_function ---
 
@@ -69,8 +70,6 @@ def test_describe_function_resolves_postponed_annotations():
     # `describe_function` render literal annotation strings (e.g.
     # "(product_description: 'str') -> 'list[Requirement]'") instead of the
     # resolved types, corrupting the prompt sent to the model.
-    from test.stdlib.components._pep563_fixtures import extract_requirements
-
     # Guard the precondition: if the fixture module ever drops its
     # `from __future__ import annotations`, this test would otherwise keep
     # passing without exercising postponed annotations at all.
@@ -112,8 +111,6 @@ def test_get_argument_string_value_quoted_under_postponed_annotations():
     # `param.annotation` was the literal string "str" rather than the `str`
     # type, so the `is str` check failed and string arguments were rendered
     # unquoted in the prompt.
-    from test.stdlib.components._pep563_fixtures import greet
-
     # Guard the precondition: same reasoning as above.
     assert greet.__annotations__["name"] == "str"
 

--- a/test/stdlib/components/test_genstub_unit.py
+++ b/test/stdlib/components/test_genstub_unit.py
@@ -64,6 +64,23 @@ def test_describe_function_no_docstring():
     assert result["docstring"] is None
 
 
+def test_describe_function_resolves_postponed_annotations():
+    # Regression test for issue #1476: `from __future__ import annotations`
+    # made `describe_function` render literal annotation strings (e.g.
+    # "(product_description: 'str') -> 'list[Requirement]'") instead of the
+    # resolved types, corrupting the prompt sent to the model.
+    from test.stdlib.components._pep563_fixtures import extract_requirements
+
+    result = describe_function(extract_requirements)
+    assert "'str'" not in result["signature"]
+    assert "'list[Requirement]'" not in result["signature"]
+    assert "product_description: str" in result["signature"]
+    assert (
+        "list[test.stdlib.components._pep563_fixtures.Requirement]"
+        in result["signature"]
+    )
+
+
 # --- get_argument ---
 
 
@@ -83,6 +100,17 @@ def test_get_argument_int_value_not_quoted():
     arg = get_argument(fn, "count", 42)
     assert arg._argument_dict["value"] == 42
     assert "int" in str(arg._argument_dict["annotation"])
+
+
+def test_get_argument_string_value_quoted_under_postponed_annotations():
+    # Regression test for issue #1476: under `from __future__ import
+    # annotations`, `param.annotation` was the literal string "str" rather
+    # than the `str` type, so the `is str` check failed and string arguments
+    # were rendered unquoted in the prompt.
+    from test.stdlib.components._pep563_fixtures import greet
+
+    arg = get_argument(greet, "name", "Alice")
+    assert arg._argument_dict["value"] == '"Alice"'
 
 
 def test_get_argument_no_annotation_falls_back_to_runtime_type():


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1503

## Description

Under `from __future__ import annotations` (PEP 563 postponed annotations), `@generative` stub signatures were corrupted before being sent to the model.

- `describe_function()` used `inspect.signature(func)`, which renders postponed annotations as literal strings — `(product_description: str) -> list[Requirement]` became `(product_description: 'str') -> 'list[Requirement]'` in the prompt.
- `get_argument()` had the same issue at the parameter level: `param.annotation` was the string `"str"` rather than the type `str`, so the `param_type is str` check failed and string arguments were rendered unquoted (`value: Alice` instead of `value: "Alice"`).

Both are fixed by passing `eval_str=True` to `inspect.signature()`, which resolves the annotation strings back to real types — the same resolution `create_response_format()` already gets for free via `typing.get_type_hints()`.

**Why `eval_str=True` is safe here:** any annotation that would raise under `eval_str=True` (e.g. `TYPE_CHECKING`-only imports, forward references to not-yet-defined classes) already raises the identical `NameError` from the pre-existing `get_type_hints(func)` call in `create_response_format()`, which every `@generative`-decorated function goes through at decoration time. So this cannot break any function that could previously be decorated with `@generative` — it only changes which of two co-located calls raises first.

The two other `inspect.signature(func)` call sites in this file (`bind_function_arguments()` and `GenerativeStub.__init__`'s disallowed-param-name check) are deliberately left unchanged — neither inspects `.annotation`, so PEP 563 doesn't affect them, and adding `eval_str` there would only add a failure mode for no benefit.

**Follow-ups (out of scope here):**
- `mellea/backends/tools.py`'s `convert_function_to_ollama_tool` has the same root-cause bug for tool-schema generation from annotated functions — filed as #1507, fixed in #1509.
- No test currently exercises the full `@generative` → prompt-template chain under PEP 563 (the new tests call `describe_function`/`get_argument` directly); worth adding later.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Added `test/stdlib/components/_pep563_fixtures.py`, a fixture module with `from __future__ import annotations` (isolated in its own file since the import is a module-level directive), and two regression tests in `test/stdlib/components/test_genstub_unit.py` — each with a precondition guard on `__annotations__` so they can't pass vacuously if PEP 563 is later dropped from the fixture module.

`uv run python -m pytest test/stdlib/components/test_genstub_unit.py -v` — 33 passed. `uv run ruff format --check`, `uv run ruff check`, `uv run mypy` — all clean on the three changed files.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
