### PR TITLE
fix: feed tool results to open ai compat providers as role tool with id

### DIFF
--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -331,15 +331,18 @@ def message_to_openai_message(
     # Tool-result turns: spec-strict OpenAI-compatible providers require a
     # `role: "tool"` message to reference the assistant's originating tool call
     # via `tool_call_id` (issue #1389). Emit it when the ToolMessage carries a
-    # provider-supplied id. Duck-type on `_tool` to avoid importing ToolMessage
-    # (circular import) and to leave plain `role="tool"` Messages, and ids-less
-    # parses (e.g. Hugging Face raw-string tool calls), untouched. The optional
-    # `name` field is deliberately omitted: it is a legacy carryover from
-    # `role: "function"`, not part of the OpenAI tool-message schema, and is not
-    # required to satisfy the result-turn contract.
-    tool_call = getattr(msg, "_tool", None)
-    if tool_call is not None and getattr(tool_call, "tool_call_id", None) is not None:
-        result["tool_call_id"] = tool_call.tool_call_id
+    # provider-supplied id. The import is deferred (like `extract_model_tool_requests`
+    # above) purely to keep it out of module load; narrowing on `ToolMessage`
+    # leaves plain `role="tool"` Messages, and id-less parses (e.g. Hugging Face
+    # raw-string tool calls), untouched. The optional `name` field is deliberately
+    # omitted: it is a legacy carryover from `role: "function"`, not part of the
+    # OpenAI tool-message schema, and is not required to satisfy the result-turn
+    # contract. Gate on truthiness (matching `build_tool_calls` below) so an empty
+    # id is treated as absent.
+    from ..stdlib.components import ToolMessage
+
+    if isinstance(msg, ToolMessage) and msg._tool.tool_call_id:
+        result["tool_call_id"] = msg._tool.tool_call_id
 
     if replay_reasoning and msg.thinking:
         result["reasoning_content"] = msg.thinking
@@ -431,11 +434,14 @@ def build_tool_calls(output: ModelOutputThunk) -> list[ToolCallDict] | None:
     assert output.tool_calls is not None
     tool_calls: list[ToolCallDict] = []
     for model_tool_call in output.tool_calls:
-        # Reuse the provider-supplied call id so the replayed assistant turn and
-        # its tool-result turn (which reads the same id via `_tool.tool_call_id`)
+        # Reuse the provider-supplied call id when one exists so a downstream
+        # tool-result turn (which reads the same id via `_tool.tool_call_id`) can
         # reference the same call — spec-strict providers reject a mismatch
-        # (issue #1389). Fall back to a fabricated id only when the backend
-        # exposed none (e.g. raw-string tool parsing).
+        # (issue #1389). The live case is `cli/serve` forwarding an upstream id
+        # back downstream; on the openai/litellm paths the assistant turn's tool
+        # calls come straight from the provider payload rather than through here.
+        # Fall back to a fabricated id only when no id was supplied (e.g.
+        # raw-string tool parsing).
         tool_call_id = model_tool_call.tool_call_id or f"call_{uuid.uuid4().hex[:24]}"
 
         # Serialize arguments to JSON with str fallback for non-serializable types

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -267,10 +267,9 @@ def message_to_openai_message(
         present alongside tool calls, both keys are included. For a `ToolMessage`
         (a tool-result turn) whose originating `ModelToolCall` carries a
         provider-supplied id, the dict also carries `"tool_call_id"` (matching the
-        assistant tool call) and the tool `"name"`, as spec-strict
-        OpenAI-compatible providers require on `role: "tool"` messages. When
-        `replay_reasoning` is `True` and reasoning is present, the dict also
-        carries a `"reasoning_content"` field.
+        assistant tool call), as spec-strict OpenAI-compatible providers require
+        on `role: "tool"` messages. When `replay_reasoning` is `True` and
+        reasoning is present, the dict also carries a `"reasoning_content"` field.
 
     Raises:
         ValueError: If the message contains an `AudioUrlBlock`. The OpenAI Chat
@@ -331,17 +330,16 @@ def message_to_openai_message(
 
     # Tool-result turns: spec-strict OpenAI-compatible providers require a
     # `role: "tool"` message to reference the assistant's originating tool call
-    # via `tool_call_id` (issue #1389). Emit it — plus the optional `name` — when
-    # the ToolMessage carries a provider-supplied id. Duck-type on `_tool` to
-    # avoid importing ToolMessage (circular import) and to leave plain
-    # `role="tool"` Messages, and ids-less parses (e.g. Hugging Face raw-string
-    # tool calls), untouched.
+    # via `tool_call_id` (issue #1389). Emit it when the ToolMessage carries a
+    # provider-supplied id. Duck-type on `_tool` to avoid importing ToolMessage
+    # (circular import) and to leave plain `role="tool"` Messages, and ids-less
+    # parses (e.g. Hugging Face raw-string tool calls), untouched. The optional
+    # `name` field is deliberately omitted: it is a legacy carryover from
+    # `role: "function"`, not part of the OpenAI tool-message schema, and is not
+    # required to satisfy the result-turn contract.
     tool_call = getattr(msg, "_tool", None)
     if tool_call is not None and getattr(tool_call, "tool_call_id", None) is not None:
         result["tool_call_id"] = tool_call.tool_call_id
-        name = getattr(msg, "name", None)
-        if name is not None:
-            result["name"] = name
 
     if replay_reasoning and msg.thinking:
         result["reasoning_content"] = msg.thinking
@@ -433,8 +431,12 @@ def build_tool_calls(output: ModelOutputThunk) -> list[ToolCallDict] | None:
     assert output.tool_calls is not None
     tool_calls: list[ToolCallDict] = []
     for model_tool_call in output.tool_calls:
-        # Generate a unique ID for this tool call
-        tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
+        # Reuse the provider-supplied call id so the replayed assistant turn and
+        # its tool-result turn (which reads the same id via `_tool.tool_call_id`)
+        # reference the same call — spec-strict providers reject a mismatch
+        # (issue #1389). Fall back to a fabricated id only when the backend
+        # exposed none (e.g. raw-string tool parsing).
+        tool_call_id = model_tool_call.tool_call_id or f"call_{uuid.uuid4().hex[:24]}"
 
         # Serialize arguments to JSON with str fallback for non-serializable types
         args_json = json.dumps(model_tool_call.args, default=str)

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -264,7 +264,11 @@ def message_to_openai_message(
         images or audio, `"content"` is a list of content-part dicts; otherwise
         is a plain string. For tool-only assistant turns, `"content"` is `None`
         and `"tool_calls"` carries the structured call list. When content is
-        present alongside tool calls, both keys are included. When
+        present alongside tool calls, both keys are included. For a `ToolMessage`
+        (a tool-result turn) whose originating `ModelToolCall` carries a
+        provider-supplied id, the dict also carries `"tool_call_id"` (matching the
+        assistant tool call) and the tool `"name"`, as spec-strict
+        OpenAI-compatible providers require on `role: "tool"` messages. When
         `replay_reasoning` is `True` and reasoning is present, the dict also
         carries a `"reasoning_content"` field.
 
@@ -324,6 +328,20 @@ def message_to_openai_message(
         result["tool_calls"] = tool_calls
         if msg.images is None and not content:
             result["content"] = None
+
+    # Tool-result turns: spec-strict OpenAI-compatible providers require a
+    # `role: "tool"` message to reference the assistant's originating tool call
+    # via `tool_call_id` (issue #1389). Emit it — plus the optional `name` — when
+    # the ToolMessage carries a provider-supplied id. Duck-type on `_tool` to
+    # avoid importing ToolMessage (circular import) and to leave plain
+    # `role="tool"` Messages, and ids-less parses (e.g. Hugging Face raw-string
+    # tool calls), untouched.
+    tool_call = getattr(msg, "_tool", None)
+    if tool_call is not None and getattr(tool_call, "tool_call_id", None) is not None:
+        result["tool_call_id"] = tool_call.tool_call_id
+        name = getattr(msg, "name", None)
+        if name is not None:
+            result["name"] = name
 
     if replay_reasoning and msg.thinking:
         result["reasoning_content"] = msg.thinking

--- a/test/helpers/test_openai_compatible_helpers.py
+++ b/test/helpers/test_openai_compatible_helpers.py
@@ -612,6 +612,36 @@ class TestBuildToolCalls:
         assert "2024-01-15" in args["timestamp"]
         assert args["amount"] == "123.45"
 
+    def test_reuses_provider_tool_call_id(self):
+        """The provider-supplied id is reused so it matches the result turn (issue #1389)."""
+        tool = _make_tool("get_weather")
+        tool_call = ModelToolCall(
+            name="get_weather",
+            func=tool,
+            args={"location": "Dallas"},
+            tool_call_id="call_provider_xyz",
+        )
+        output = ModelOutputThunk(value="", tool_calls=[tool_call])
+
+        result = build_tool_calls(output)
+
+        assert result is not None
+        assert result[0]["id"] == "call_provider_xyz"
+
+    def test_fabricates_id_when_provider_id_absent(self):
+        """Falls back to a generated id only when the backend exposed none."""
+        tool = _make_tool("get_weather")
+        tool_call = ModelToolCall(
+            name="get_weather", func=tool, args={"location": "Dallas"}
+        )  # tool_call_id defaults to None
+        output = ModelOutputThunk(value="", tool_calls=[tool_call])
+
+        result = build_tool_calls(output)
+
+        assert result is not None
+        assert result[0]["id"].startswith("call_")
+        assert result[0]["id"] != "call_"
+
 
 def _make_tool_message(
     content: str = "sunny in Dallas",
@@ -638,13 +668,18 @@ class TestToolMessageSerialization:
     """Tool results must round-trip as role='tool' with a matching tool_call_id (issue #1389)."""
 
     def test_tool_message_serializes_tool_call_id(self):
-        """A ToolMessage with a provider id emits role='tool', tool_call_id, and name."""
+        """A ToolMessage with a provider id emits role='tool' and tool_call_id."""
         msg = _make_tool_message()
         result = message_to_openai_message(msg)
         assert result["role"] == "tool"
         assert result["content"] == "sunny in Dallas"
         assert result["tool_call_id"] == "call_abc123"
-        assert result["name"] == "get_weather"
+
+    def test_tool_message_omits_name(self):
+        """`name` is not emitted: it is a legacy field outside the OpenAI tool-message schema."""
+        msg = _make_tool_message()
+        result = message_to_openai_message(msg)
+        assert "name" not in result
 
     def test_tool_message_without_id_omits_tool_call_id(self):
         """A ToolMessage lacking a provider id (e.g. HF raw parsing) omits the key."""
@@ -667,6 +702,25 @@ class TestToolMessageSerialization:
         assert result == {"role": "user", "content": "hello"}
         assert "tool_call_id" not in result
         assert "name" not in result
+
+    def test_tool_message_conforms_to_openai_schema(self):
+        """The serialised tool message matches the OpenAI SDK's tool-message schema.
+
+        Validates the output against the `openai` SDK's own
+        `ChatCompletionToolMessageParam`: every key we emit is a field the SDK
+        declares for a tool message (`role`, `content`, `tool_call_id`), and the
+        required fields are present and JSON-serialisable. No extra keys are
+        sent, so a spec-strict provider has nothing to reject. Skips if `openai`
+        is absent.
+        """
+        openai_types = pytest.importorskip("openai.types.chat")
+        declared = set(openai_types.ChatCompletionToolMessageParam.__annotations__)
+
+        result = message_to_openai_message(_make_tool_message())
+
+        assert {"role", "content", "tool_call_id"} <= set(result)
+        assert set(result) <= declared  # no keys beyond the declared schema
+        assert json.loads(json.dumps(result)) == result
 
 
 if __name__ == "__main__":

--- a/test/helpers/test_openai_compatible_helpers.py
+++ b/test/helpers/test_openai_compatible_helpers.py
@@ -689,6 +689,13 @@ class TestToolMessageSerialization:
         assert result["content"] == "sunny in Dallas"
         assert "tool_call_id" not in result
 
+    def test_tool_message_with_empty_id_omits_tool_call_id(self):
+        """An empty-string provider id is treated as absent (truthiness gate)."""
+        msg = _make_tool_message(tool_call_id="")
+        result = message_to_openai_message(msg)
+        assert result["role"] == "tool"
+        assert "tool_call_id" not in result
+
     def test_plain_message_role_tool_has_no_tool_call_id(self):
         """A plain Message (not a ToolMessage) with role='tool' is unaffected."""
         msg = Message(role="tool", content="raw tool text")

--- a/test/helpers/test_openai_compatible_helpers.py
+++ b/test/helpers/test_openai_compatible_helpers.py
@@ -26,7 +26,7 @@ from mellea.helpers.openai_compatible_helpers import (
     message_to_openai_message,
     messages_to_docs,
 )
-from mellea.stdlib.components import Document, Message
+from mellea.stdlib.components import Document, Message, ToolMessage
 
 # Minimal valid 1x1 white PNG
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -611,6 +611,62 @@ class TestBuildToolCalls:
         assert isinstance(args["timestamp"], str)
         assert "2024-01-15" in args["timestamp"]
         assert args["amount"] == "123.45"
+
+
+def _make_tool_message(
+    content: str = "sunny in Dallas",
+    *,
+    tool_call_id: str | None = "call_abc123",
+    name: str = "get_weather",
+) -> ToolMessage:
+    """Build a ToolMessage whose underlying ModelToolCall carries a tool_call_id."""
+    tool = _make_tool(name)
+    model_tool_call = ModelToolCall(
+        name=name, func=tool, args={"location": "Dallas"}, tool_call_id=tool_call_id
+    )
+    return ToolMessage(
+        role="tool",
+        content=content,
+        tool_output=content,
+        name=name,
+        args={"location": "Dallas"},
+        tool=model_tool_call,
+    )
+
+
+class TestToolMessageSerialization:
+    """Tool results must round-trip as role='tool' with a matching tool_call_id (issue #1389)."""
+
+    def test_tool_message_serializes_tool_call_id(self):
+        """A ToolMessage with a provider id emits role='tool', tool_call_id, and name."""
+        msg = _make_tool_message()
+        result = message_to_openai_message(msg)
+        assert result["role"] == "tool"
+        assert result["content"] == "sunny in Dallas"
+        assert result["tool_call_id"] == "call_abc123"
+        assert result["name"] == "get_weather"
+
+    def test_tool_message_without_id_omits_tool_call_id(self):
+        """A ToolMessage lacking a provider id (e.g. HF raw parsing) omits the key."""
+        msg = _make_tool_message(tool_call_id=None)
+        result = message_to_openai_message(msg)
+        assert result["role"] == "tool"
+        assert result["content"] == "sunny in Dallas"
+        assert "tool_call_id" not in result
+
+    def test_plain_message_role_tool_has_no_tool_call_id(self):
+        """A plain Message (not a ToolMessage) with role='tool' is unaffected."""
+        msg = Message(role="tool", content="raw tool text")
+        result = message_to_openai_message(msg)
+        assert result == {"role": "tool", "content": "raw tool text"}
+
+    def test_regular_message_unaffected(self):
+        """Ordinary user messages carry no tool_call_id or name keys."""
+        msg = Message(role="user", content="hello")
+        result = message_to_openai_message(msg)
+        assert result == {"role": "user", "content": "hello"}
+        assert "tool_call_id" not in result
+        assert "name" not in result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1389

## Description
<!-- What does this PR do and why? -->
Feed tool results back to OpenAI-compatible providers as role: "tool" messages with a matching tool_call_id, instead of as user text.

Spec-strict providers may still mishandle the result prior to this change (as a string).

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
