### PR TITLE
fix(hf): set whitespace_flexible=True in grammar_from_json_schema to prevent silent array collapse

### DIFF
--- a/docs/docs/integrations/huggingface.md
+++ b/docs/docs/integrations/huggingface.md
@@ -97,8 +97,9 @@ hardware. See the aLoRA guide for training and usage.
 via [llguidance](https://github.com/guidance-ai/llguidance). The grammar is built with
 `whitespace_flexible=True`, which *permits* natural, spaced JSON rather than forcing
 compact output. In testing, spaced JSON used roughly 1.5x more tokens than compact
-JSON for the same content — size `MAX_NEW_TOKENS` accordingly if you set it
-explicitly. Generation that runs to EOS is unaffected.
+JSON for the same content — size `ModelOption.MAX_NEW_TOKENS` accordingly if you set
+it explicitly. Generation that runs to EOS still completes, but consumes proportionally
+more tokens getting there.
 
 ## Vision support
 

--- a/docs/docs/integrations/huggingface.md
+++ b/docs/docs/integrations/huggingface.md
@@ -95,11 +95,9 @@ hardware. See the aLoRA guide for training and usage.
 
 `LocalHFBackend` enforces `format=` schemas (see [Enforce Structured Output](../how-to/enforce-structured-output.md))
 via [llguidance](https://github.com/guidance-ai/llguidance). The grammar is built with
-`whitespace_flexible=True`, which *permits* natural, spaced JSON rather than forcing
-compact output. In testing, spaced JSON used roughly 1.5x more tokens than compact
-JSON for the same content — size `ModelOption.MAX_NEW_TOKENS` accordingly if you set
-it explicitly. Generation that runs to EOS still completes, but consumes proportionally
-more tokens getting there.
+a bounded `whitespace_pattern` (`r"[\x20\x0A\x0D\x09]{0,20}"`), which permits natural, spaced, and pretty-printed JSON (up to 4 levels of standard 4-space indentation) while setting a hard upper limit of 20 consecutive whitespace characters to prevent runaway token generation or infinite loops.
+
+In testing, spaced JSON used roughly 1.5x more tokens than compact JSON for the same content — size `ModelOption.MAX_NEW_TOKENS` accordingly if you set it explicitly. Generation that runs to EOS still completes, but consumes proportionally more tokens getting there.
 
 ## Vision support
 

--- a/docs/docs/integrations/huggingface.md
+++ b/docs/docs/integrations/huggingface.md
@@ -91,6 +91,15 @@ hardware. See the aLoRA guide for training and usage.
 > serve pre-embedded adapters via vLLM and the OpenAI backend. See
 > [Adapter functions](../advanced/intrinsics.md) for details.
 
+## Constrained decoding
+
+`LocalHFBackend` enforces `format=` schemas (see [Enforce Structured Output](../how-to/enforce-structured-output.md))
+via [llguidance](https://github.com/guidance-ai/llguidance). The grammar is built with
+`whitespace_flexible=True`, which *permits* natural, spaced JSON rather than forcing
+compact output. In testing, spaced JSON used roughly 1.5x more tokens than compact
+JSON for the same content — size `MAX_NEW_TOKENS` accordingly if you set it
+explicitly. Generation that runs to EOS is unaffected.
+
 ## Vision support
 
 Vision support for `LocalHFBackend` is model-dependent and experimental. Pass a PIL

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1031,8 +1031,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             format_kwargs = {}
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
+                # whitespace_flexible=True (natural, spaced JSON) is required.
+                # False (compact JSON) can put the model into a state where the
+                # highest-probability grammar-compatible token closes an array
+                # immediately, silently collapsing {"result": [...]} to {"result": []}.
+                # No exception is raised — the caller cannot distinguish a correct
+                # empty list from a collapse. See issue #1510 for full characterisation.
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults={"whitespace_flexible": False}
+                    schema, defaults={"whitespace_flexible": True}
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1236,8 +1242,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             format_kwargs = {}
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
+                # whitespace_flexible=True (natural, spaced JSON) is required.
+                # False (compact JSON) can put the model into a state where the
+                # highest-probability grammar-compatible token closes an array
+                # immediately, silently collapsing {"result": [...]} to {"result": []}.
+                # No exception is raised — the caller cannot distinguish a correct
+                # empty list from a collapse. See issue #1510 for full characterisation.
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults={"whitespace_flexible": False}
+                    schema, defaults={"whitespace_flexible": True}
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1701,8 +1713,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         format_kwargs = {}
         if format:
             schema: dict[str, Any] = format.model_json_schema()
+            # whitespace_flexible=True (natural, spaced JSON) is required.
+            # False (compact JSON) can put the model into a state where the
+            # highest-probability grammar-compatible token closes an array
+            # immediately, silently collapsing {"result": [...]} to {"result": []}.
+            # No exception is raised — the caller cannot distinguish a correct
+            # empty list from a collapse. See issue #1510 for full characterisation.
             grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                schema, defaults={"whitespace_flexible": False}
+                schema, defaults={"whitespace_flexible": True}
             )
             logits_processor = _GuidanceLogitsProcessor(
                 grammar, self._llguidance_tokenizer

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -15,7 +15,7 @@ import functools
 import json
 import threading
 from collections.abc import Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import jinja2
 import jinja2.meta
@@ -43,10 +43,6 @@ except ImportError as e:
         'Please install them with: pip install "mellea[hf]"'
     ) from e
 
-if TYPE_CHECKING:
-    # llguidance doesn't re-export this TypedDict from its public namespace.
-    from llguidance._lib import JsonCompileOptions
-
 from ..backends import kv_block_helpers
 from ..core import (
     BaseModelSubclass,
@@ -65,7 +61,10 @@ from ..core import (
 )
 from ..core.base import AbstractMelleaTool
 from ..formatters import ChatFormatter, TemplateFormatter, granite as granite_formatters
-from ..formatters.granite.base.util import _GuidanceLogitsProcessor
+from ..formatters.granite.base.util import (
+    _LLGUIDANCE_GRAMMAR_DEFAULTS,
+    _GuidanceLogitsProcessor,
+)
 from ..helpers import (
     DEFAULT_CHUNK_TIMEOUT,
     message_to_openai_message,
@@ -280,15 +279,6 @@ def _compute_generate_kwargs_allowlist() -> frozenset[str]:
 
 
 _GENERATE_KWARGS_ALLOWLIST: frozenset[str] = _compute_generate_kwargs_allowlist()
-
-
-# whitespace_flexible=True (natural, spaced JSON) is required.
-# False (compact JSON) can put the model into a state where the
-# highest-probability grammar-compatible token closes an array
-# immediately, silently collapsing {"result": [...]} to {"result": []}.
-# No exception is raised — the caller cannot distinguish a correct
-# empty list from a collapse. See issue #1510 for full characterisation.
-_LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {"whitespace_flexible": True}
 
 
 def _check_no_multimodal_blocks(action: Span | None, ctx: Context | None) -> None:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -15,7 +15,7 @@ import functools
 import json
 import threading
 from collections.abc import Callable, Coroutine, Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import jinja2
 import jinja2.meta
@@ -42,6 +42,10 @@ except ImportError as e:
         "The Hugging Face backend requires extra dependencies. "
         'Please install them with: pip install "mellea[hf]"'
     ) from e
+
+if TYPE_CHECKING:
+    # llguidance doesn't re-export this TypedDict from its public namespace.
+    from llguidance._lib import JsonCompileOptions
 
 from ..backends import kv_block_helpers
 from ..core import (
@@ -276,6 +280,15 @@ def _compute_generate_kwargs_allowlist() -> frozenset[str]:
 
 
 _GENERATE_KWARGS_ALLOWLIST: frozenset[str] = _compute_generate_kwargs_allowlist()
+
+
+# whitespace_flexible=True (natural, spaced JSON) is required.
+# False (compact JSON) can put the model into a state where the
+# highest-probability grammar-compatible token closes an array
+# immediately, silently collapsing {"result": [...]} to {"result": []}.
+# No exception is raised — the caller cannot distinguish a correct
+# empty list from a collapse. See issue #1510 for full characterisation.
+_LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {"whitespace_flexible": True}
 
 
 def _check_no_multimodal_blocks(action: Span | None, ctx: Context | None) -> None:
@@ -1031,14 +1044,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             format_kwargs = {}
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
-                # whitespace_flexible=True (natural, spaced JSON) is required.
-                # False (compact JSON) can put the model into a state where the
-                # highest-probability grammar-compatible token closes an array
-                # immediately, silently collapsing {"result": [...]} to {"result": []}.
-                # No exception is raised — the caller cannot distinguish a correct
-                # empty list from a collapse. See issue #1510 for full characterisation.
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults={"whitespace_flexible": True}
+                    schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1242,14 +1249,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             format_kwargs = {}
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
-                # whitespace_flexible=True (natural, spaced JSON) is required.
-                # False (compact JSON) can put the model into a state where the
-                # highest-probability grammar-compatible token closes an array
-                # immediately, silently collapsing {"result": [...]} to {"result": []}.
-                # No exception is raised — the caller cannot distinguish a correct
-                # empty list from a collapse. See issue #1510 for full characterisation.
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults={"whitespace_flexible": True}
+                    schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1713,14 +1714,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         format_kwargs = {}
         if format:
             schema: dict[str, Any] = format.model_json_schema()
-            # whitespace_flexible=True (natural, spaced JSON) is required.
-            # False (compact JSON) can put the model into a state where the
-            # highest-probability grammar-compatible token closes an array
-            # immediately, silently collapsing {"result": [...]} to {"result": []}.
-            # No exception is raised — the caller cannot distinguish a correct
-            # empty list from a collapse. See issue #1510 for full characterisation.
             grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                schema, defaults={"whitespace_flexible": True}
+                schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
             )
             logits_processor = _GuidanceLogitsProcessor(
                 grammar, self._llguidance_tokenizer

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1035,7 +1035,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
+                    schema, overrides=_LLGUIDANCE_GRAMMAR_DEFAULTS
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1240,7 +1240,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             if _format:
                 schema: dict[str, Any] = _format.model_json_schema()
                 grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                    schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
+                    schema, overrides=_LLGUIDANCE_GRAMMAR_DEFAULTS
                 )
                 logits_processor = _GuidanceLogitsProcessor(
                     grammar, self._llguidance_tokenizer
@@ -1705,7 +1705,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if format:
             schema: dict[str, Any] = format.model_json_schema()
             grammar: str = llguidance.LLMatcher.grammar_from_json_schema(
-                schema, defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS
+                schema, overrides=_LLGUIDANCE_GRAMMAR_DEFAULTS
             )
             logits_processor = _GuidanceLogitsProcessor(
                 grammar, self._llguidance_tokenizer

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -29,15 +29,15 @@ from .types import ChatCompletionResponse, ChatCompletionResponseChoice
 
 __all__ = ["import_optional"]
 
-# whitespace_flexible=True (natural, spaced JSON) is required. False (compact
-# JSON) puts the model into a state where the highest-probability
-# grammar-compatible token closes an array immediately, silently collapsing
-# {"result": [...]} to {"result": []}. No exception is raised — the caller
-# cannot distinguish a correct empty list from a collapse.
-# llguidance's own default when `defaults` is omitted is already True; we pass
-# it explicitly so the requirement is legible here and pinned against a future
-# upstream default change. See issue #1510 for full characterisation.
-_LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {"whitespace_flexible": True}
+# A bounded whitespace_pattern (allowing 0 to 20 consecutive whitespace characters)
+# is used as an intermediate fix (addressing PR #1513 feedback from Jake LoRocco).
+# This allows natural, spaced JSON (preventing the silent array collapse bug characterized
+# in issue #1510) while comfortably accommodating 4-space indentation up to 4 levels of
+# nesting (which requires 17 contiguous characters: \n + 16 spaces), while still setting
+# an absolute hard ceiling to completely prevent unlimited/runaway whitespace loops.
+_LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {
+    "whitespace_pattern": r"[\x20\x0A\x0D\x09]{0,20}"
+}
 
 
 def random_uuid() -> str:

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -30,11 +30,13 @@ from .types import ChatCompletionResponse, ChatCompletionResponseChoice
 __all__ = ["import_optional"]
 
 # whitespace_flexible=True (natural, spaced JSON) is required. False (compact
-# JSON), and omitting the option entirely, put the model into a state where the
-# highest-probability grammar-compatible token closes an array immediately,
-# silently collapsing {"result": [...]} to {"result": []}. No exception is
-# raised — the caller cannot distinguish a correct empty list from a collapse.
-# See issue #1510 for full characterisation.
+# JSON) puts the model into a state where the highest-probability
+# grammar-compatible token closes an array immediately, silently collapsing
+# {"result": [...]} to {"result": []}. No exception is raised — the caller
+# cannot distinguish a correct empty list from a collapse.
+# llguidance's own default when `defaults` is omitted is already True; we pass
+# it explicitly so the requirement is legible here and pinned against a future
+# upstream default change. See issue #1510 for full characterisation.
 _LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {"whitespace_flexible": True}
 
 
@@ -306,7 +308,10 @@ def chat_completion_request_to_transformers_inputs(
 
         grammar = llguidance.LLMatcher.grammar_from_json_schema(
             request["extra_body"]["structured_outputs"]["json"],
-            defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS,
+            # This schema comes directly off the wire, so a caller could embed
+            # their own `x-guidance.whitespace_flexible: false` and defeat a
+            # `defaults=` pass. `overrides=` cannot be defeated this way.
+            overrides=_LLGUIDANCE_GRAMMAR_DEFAULTS,
         )
         logits_processor = _GuidanceLogitsProcessor(grammar, ll_tokenizer)
 

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -20,6 +20,7 @@ from ....core.utils import MelleaLogger
 if TYPE_CHECKING:
     import llguidance
     import torch
+    from llguidance._lib import JsonCompileOptions
     from transformers import PreTrainedModel, PreTrainedTokenizerBase
 
 # First Party
@@ -27,6 +28,14 @@ from .optional import import_optional
 from .types import ChatCompletionResponse, ChatCompletionResponseChoice
 
 __all__ = ["import_optional"]
+
+# whitespace_flexible=True (natural, spaced JSON) is required. False (compact
+# JSON), and omitting the option entirely, put the model into a state where the
+# highest-probability grammar-compatible token closes an array immediately,
+# silently collapsing {"result": [...]} to {"result": []}. No exception is
+# raised — the caller cannot distinguish a correct empty list from a collapse.
+# See issue #1510 for full characterisation.
+_LLGUIDANCE_GRAMMAR_DEFAULTS: JsonCompileOptions = {"whitespace_flexible": True}
 
 
 def random_uuid() -> str:
@@ -296,7 +305,8 @@ def chat_completion_request_to_transformers_inputs(
             ll_tokenizer = llguidance.hf.from_tokenizer(tokenizer, n_vocab=n_vocab)  # type: ignore[arg-type]
 
         grammar = llguidance.LLMatcher.grammar_from_json_schema(
-            request["extra_body"]["structured_outputs"]["json"]
+            request["extra_body"]["structured_outputs"]["json"],
+            defaults=_LLGUIDANCE_GRAMMAR_DEFAULTS,
         )
         logits_processor = _GuidanceLogitsProcessor(grammar, ll_tokenizer)
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -977,3 +977,167 @@ async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
         await LocalHFBackend._generate_from_intrinsic(
             backend, Intrinsic("answerability"), ctx, model_options={}
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #1510: whitespace_flexible must be True
+# ---------------------------------------------------------------------------
+# llguidance's whitespace_flexible=False (compact JSON) forces greedy decoding
+# into states where the highest-probability grammar-compatible token closes an
+# array immediately, silently collapsing {"result": [...]} to {"result": []}.
+# All three grammar_from_json_schema call sites in LocalHFBackend must pass
+# whitespace_flexible=True. These tests assert that invariant via mock without
+# loading any real model.
+
+
+class _FakeSchema:
+    """Minimal Pydantic-compatible schema stub."""
+
+    @staticmethod
+    def model_json_schema() -> dict:
+        return {"type": "object", "properties": {"result": {"type": "array"}}}
+
+
+def _mock_chat_template_output() -> MagicMock:
+    """Return a mock that looks like a tokenizer output dict with a .to() method.
+
+    apply_chat_template returns a BatchEncoding (dict-like) which gets a .to(device)
+    call immediately after. Plain dicts don't have .to(), so the mock must.
+    """
+    ids = torch.zeros(1, 4, dtype=torch.long)
+    attn = torch.ones(1, 4, dtype=torch.long)
+    obj = MagicMock()
+    obj.__getitem__ = lambda s, k: ids if k == "input_ids" else attn
+    obj.to = lambda device: obj
+    obj["input_ids"] = ids
+    obj["attention_mask"] = attn
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_whitespace_flexible_true_in_generate_from_context_standard():
+    """Regression (#1510): _generate_from_context_standard must call
+    grammar_from_json_schema with whitespace_flexible=True.
+
+    Without the fix, the call passes whitespace_flexible=False, which can cause
+    silent array collapse to [] under greedy decoding.
+    """
+    # _make_backend() patches llguidance during construction; re-patch just for
+    # the method call to intercept the grammar_from_json_schema invocation.
+    backend = _make_backend()
+    backend._tokenizer = MagicMock()
+    backend._tokenizer.apply_chat_template.return_value = _mock_chat_template_output()
+    backend._model = MagicMock()
+    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
+    ctx = ChatContext().add(Message("user", "list facts"))
+
+    captured: list[dict] = []
+
+    def _capture_grammar(schema, defaults=None):
+        captured.append(defaults or {})
+        return "stub-grammar"
+
+    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+        mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
+        mock_llg.LLMatcher.return_value = MagicMock()
+        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
+        try:
+            await backend._generate_from_context_standard(
+                Instruction(description="test"),
+                ctx,
+                model_options={},
+                _format=_FakeSchema,
+            )
+        except Exception:
+            pass  # We only care that the grammar call was made correctly.
+
+    assert captured, "grammar_from_json_schema was never called"
+    for call_defaults in captured:
+        assert call_defaults.get("whitespace_flexible") is True, (
+            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
+            "see issue #1510: False causes silent empty-array collapse"
+        )
+
+
+@pytest.mark.asyncio
+async def test_whitespace_flexible_true_in_generate_from_raw():
+    """Regression (#1510): _generate_from_raw must call grammar_from_json_schema
+    with whitespace_flexible=True.
+    """
+    backend = _make_backend()
+    # _generate_from_raw calls self._tokenizer(prompts, ...).to(device), so the
+    # mock tokenizer must be callable and return a .to()-able object.
+    tok_output = MagicMock()
+    tok_output.to = lambda device: tok_output
+    tok_output.__getitem__ = lambda s, k: torch.zeros(1, 4, dtype=torch.long)
+    backend._tokenizer = MagicMock(return_value=tok_output)
+    backend._model = MagicMock()
+    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
+    ctx = ChatContext().add(Message("user", "list facts"))
+
+    captured: list[dict] = []
+
+    def _capture_grammar(schema, defaults=None):
+        captured.append(defaults or {})
+        return "stub-grammar"
+
+    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+        mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
+        mock_llg.LLMatcher.return_value = MagicMock()
+        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
+        try:
+            await backend._generate_from_raw(
+                [Instruction(description="test")],
+                ctx,
+                format=_FakeSchema,
+                model_options={},
+            )
+        except Exception:
+            pass
+
+    assert captured, "grammar_from_json_schema was never called"
+    for call_defaults in captured:
+        assert call_defaults.get("whitespace_flexible") is True, (
+            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
+            "see issue #1510: False causes silent empty-array collapse"
+        )
+
+
+@pytest.mark.asyncio
+async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache():
+    """Regression (#1510): _generate_from_context_with_kv_cache must call
+    grammar_from_json_schema with whitespace_flexible=True.
+    """
+    backend = _make_backend()
+    backend._tokenizer = MagicMock()
+    backend._tokenizer.apply_chat_template.return_value = _mock_chat_template_output()
+    backend._model = MagicMock()
+    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
+    ctx = ChatContext().add(Message("user", "list facts"))
+
+    captured: list[dict] = []
+
+    def _capture_grammar(schema, defaults=None):
+        captured.append(defaults or {})
+        return "stub-grammar"
+
+    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+        mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
+        mock_llg.LLMatcher.return_value = MagicMock()
+        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
+        try:
+            await backend._generate_from_context_with_kv_cache(
+                Instruction(description="test"),
+                ctx,
+                model_options={},
+                _format=_FakeSchema,
+            )
+        except Exception:
+            pass
+
+    assert captured, "grammar_from_json_schema was never called"
+    for call_defaults in captured:
+        assert call_defaults.get("whitespace_flexible") is True, (
+            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
+            "see issue #1510: False causes silent empty-array collapse"
+        )

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -982,9 +982,10 @@ async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
 # ---------------------------------------------------------------------------
 # Regression tests for issue #1510: whitespace_flexible must be True
 # ---------------------------------------------------------------------------
-# llguidance's whitespace_flexible=False (compact JSON) forces greedy decoding
-# into states where the highest-probability grammar-compatible token closes an
-# array immediately, silently collapsing {"result": [...]} to {"result": []}.
+# llguidance's whitespace_flexible=False (compact JSON) interacts badly with
+# the backend's default greedy decoding, putting it into states where the
+# highest-probability grammar-compatible token closes an array immediately,
+# silently collapsing {"result": [...]} to {"result": []}.
 # All three grammar_from_json_schema call sites in LocalHFBackend must pass
 # whitespace_flexible=True. These tests assert that invariant via mock without
 # loading any real model.
@@ -1009,9 +1010,16 @@ def _mock_chat_template_output() -> MagicMock:
     obj = MagicMock()
     obj.__getitem__ = lambda s, k: ids if k == "input_ids" else attn
     obj.to = lambda device: obj
-    obj["input_ids"] = ids
-    obj["attention_mask"] = attn
     return obj
+
+
+def _assert_whitespace_flexible_true(captured: list[dict]) -> None:
+    assert captured, "grammar_from_json_schema was never called"
+    for call_defaults in captured:
+        assert call_defaults.get("whitespace_flexible") is True, (
+            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
+            "see issue #1510: False causes silent empty-array collapse"
+        )
 
 
 @pytest.mark.asyncio
@@ -1028,7 +1036,6 @@ async def test_whitespace_flexible_true_in_generate_from_context_standard():
     backend._tokenizer = MagicMock()
     backend._tokenizer.apply_chat_template.return_value = _mock_chat_template_output()
     backend._model = MagicMock()
-    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
     ctx = ChatContext().add(Message("user", "list facts"))
 
     captured: list[dict] = []
@@ -1037,26 +1044,22 @@ async def test_whitespace_flexible_true_in_generate_from_context_standard():
         captured.append(defaults or {})
         return "stub-grammar"
 
-    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+    # The real generate() call runs in a background task (output._gen.generate)
+    # that this method returns without awaiting, so its mocked result has no
+    # bearing on whether the method call itself completes.
+    with (
+        patch("mellea.backends.huggingface.llguidance") as mock_llg,
+        patch(
+            "mellea.backends.huggingface.asyncio.to_thread", return_value=MagicMock()
+        ),
+    ):
         mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
-        mock_llg.LLMatcher.return_value = MagicMock()
-        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
-        try:
-            await backend._generate_from_context_standard(
-                Instruction(description="test"),
-                ctx,
-                model_options={},
-                _format=_FakeSchema,
-            )
-        except Exception:
-            pass  # We only care that the grammar call was made correctly.
-
-    assert captured, "grammar_from_json_schema was never called"
-    for call_defaults in captured:
-        assert call_defaults.get("whitespace_flexible") is True, (
-            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
-            "see issue #1510: False causes silent empty-array collapse"
+        output = await backend._generate_from_context_standard(
+            Instruction(description="test"), ctx, model_options={}, _format=_FakeSchema
         )
+    await output._gen.generate
+
+    _assert_whitespace_flexible_true(captured)
 
 
 @pytest.mark.asyncio
@@ -1071,9 +1074,20 @@ async def test_whitespace_flexible_true_in_generate_from_raw():
     tok_output.to = lambda device: tok_output
     tok_output.__getitem__ = lambda s, k: torch.zeros(1, 4, dtype=torch.long)
     backend._tokenizer = MagicMock(return_value=tok_output)
+    backend._tokenizer.batch_decode = MagicMock(return_value=["stub-completion"])
     backend._model = MagicMock()
-    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
     ctx = ChatContext().add(Message("user", "list facts"))
+
+    # Unlike the context-based methods, _generate_from_raw awaits the generate
+    # call directly, so it needs a realistic GenerateDecoderOnlyOutput result.
+    fake_outputs = GenerateDecoderOnlyOutput(
+        sequences=torch.zeros(1, 7, dtype=torch.long),
+        scores=None,
+        logits=None,
+        attentions=None,
+        hidden_states=None,
+        past_key_values=None,
+    )
 
     captured: list[dict] = []
 
@@ -1081,26 +1095,18 @@ async def test_whitespace_flexible_true_in_generate_from_raw():
         captured.append(defaults or {})
         return "stub-grammar"
 
-    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+    with (
+        patch("mellea.backends.huggingface.llguidance") as mock_llg,
+        patch(
+            "mellea.backends.huggingface.asyncio.to_thread", return_value=fake_outputs
+        ),
+    ):
         mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
-        mock_llg.LLMatcher.return_value = MagicMock()
-        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
-        try:
-            await backend._generate_from_raw(
-                [Instruction(description="test")],
-                ctx,
-                format=_FakeSchema,
-                model_options={},
-            )
-        except Exception:
-            pass
-
-    assert captured, "grammar_from_json_schema was never called"
-    for call_defaults in captured:
-        assert call_defaults.get("whitespace_flexible") is True, (
-            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
-            "see issue #1510: False causes silent empty-array collapse"
+        await backend._generate_from_raw(
+            [Instruction(description="test")], ctx, format=_FakeSchema, model_options={}
         )
+
+    _assert_whitespace_flexible_true(captured)
 
 
 @pytest.mark.asyncio
@@ -1109,11 +1115,11 @@ async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache()
     grammar_from_json_schema with whitespace_flexible=True.
     """
     backend = _make_backend()
-    backend._tokenizer = MagicMock()
-    backend._tokenizer.apply_chat_template.return_value = _mock_chat_template_output()
     backend._model = MagicMock()
-    backend._model.generate.return_value = torch.zeros(1, 5, dtype=torch.long)
     ctx = ChatContext().add(Message("user", "list facts"))
+
+    input_ids = torch.tensor([[1]])
+    attention_mask = torch.tensor([[1]])
 
     captured: list[dict] = []
 
@@ -1121,23 +1127,24 @@ async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache()
         captured.append(defaults or {})
         return "stub-grammar"
 
-    with patch("mellea.backends.huggingface.llguidance") as mock_llg:
+    # The real generate() call runs in a background task (output._gen.generate)
+    # that this method returns without awaiting, so its mocked result has no
+    # bearing on whether the method call itself completes.
+    with (
+        patch("mellea.backends.huggingface.llguidance") as mock_llg,
+        patch.object(
+            backend,
+            "_make_merged_kv_cache",
+            return_value=("", input_ids, MagicMock(), attention_mask),
+        ),
+        patch(
+            "mellea.backends.huggingface.asyncio.to_thread", return_value=MagicMock()
+        ),
+    ):
         mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
-        mock_llg.LLMatcher.return_value = MagicMock()
-        mock_llg.torch.allocate_token_bitmask.return_value = MagicMock()
-        try:
-            await backend._generate_from_context_with_kv_cache(
-                Instruction(description="test"),
-                ctx,
-                model_options={},
-                _format=_FakeSchema,
-            )
-        except Exception:
-            pass
-
-    assert captured, "grammar_from_json_schema was never called"
-    for call_defaults in captured:
-        assert call_defaults.get("whitespace_flexible") is True, (
-            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
-            "see issue #1510: False causes silent empty-array collapse"
+        output = await backend._generate_from_context_with_kv_cache(
+            Instruction(description="test"), ctx, model_options={}, _format=_FakeSchema
         )
+    await output._gen.generate
+
+    _assert_whitespace_flexible_true(captured)

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -989,9 +989,10 @@ async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
 # the backend's default greedy decoding, putting it into states where the
 # highest-probability grammar-compatible token closes an array immediately,
 # silently collapsing {"result": [...]} to {"result": []}.
-# All three grammar_from_json_schema call sites in LocalHFBackend must pass
-# whitespace_flexible=True. These tests assert that invariant via mock without
-# loading any real model.
+# All four grammar_from_json_schema call sites — three in LocalHFBackend plus
+# chat_completion_request_to_transformers_inputs (the `m serve` path) — must
+# pass whitespace_flexible=True. These tests assert that invariant via mock
+# without loading any real model.
 
 
 class _FakeSchema:
@@ -1173,8 +1174,8 @@ def test_whitespace_flexible_true_in_chat_completion_request_to_transformers_inp
 
     captured: list[dict] = []
 
-    def _capture_grammar(schema, defaults=None):
-        captured.append(defaults or {})
+    def _capture_grammar(schema, overrides=None):
+        captured.append(overrides or {})
         return "stub-grammar"
 
     with patch(

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -27,6 +27,9 @@ from mellea.backends.adapters import AdapterMixin, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
+from mellea.formatters.granite.base.util import (
+    chat_completion_request_to_transformers_inputs,
+)
 from mellea.stdlib.components import (
     AudioBlock,
     AudioUrlBlock,
@@ -1146,5 +1149,39 @@ async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache()
             Instruction(description="test"), ctx, model_options={}, _format=_FakeSchema
         )
     await output._gen.generate
+
+    _assert_whitespace_flexible_true(captured)
+
+
+def test_whitespace_flexible_true_in_chat_completion_request_to_transformers_inputs():
+    """Regression (#1510): chat_completion_request_to_transformers_inputs (the
+    OpenAI-compatible /chat/completions path used by `m serve`) must call
+    grammar_from_json_schema with whitespace_flexible=True.
+    """
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template.return_value = torch.zeros(1, 4, dtype=torch.long)
+    tokenizer.pad_token_id = 0
+    tokenizer.eos_token_id = 1
+
+    model = MagicMock()
+    model.device = "cpu"
+
+    request = {
+        "messages": [{"role": "user", "content": "list facts"}],
+        "extra_body": {"structured_outputs": {"json": _FakeSchema.model_json_schema()}},
+    }
+
+    captured: list[dict] = []
+
+    def _capture_grammar(schema, defaults=None):
+        captured.append(defaults or {})
+        return "stub-grammar"
+
+    with patch(
+        "llguidance.LLMatcher.grammar_from_json_schema", side_effect=_capture_grammar
+    ):
+        chat_completion_request_to_transformers_inputs(
+            request, tokenizer, model, ll_tokenizer=MagicMock()
+        )
 
     _assert_whitespace_flexible_true(captured)

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -983,16 +983,16 @@ async def test_multimodal_blocks_in_intrinsic_ctx_raise_error(
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for issue #1510: whitespace_flexible must be True
+# Regression tests for issue #1510: bounded whitespace_pattern required
 # ---------------------------------------------------------------------------
 # llguidance's whitespace_flexible=False (compact JSON) interacts badly with
 # the backend's default greedy decoding, putting it into states where the
 # highest-probability grammar-compatible token closes an array immediately,
 # silently collapsing {"result": [...]} to {"result": []}.
-# All four grammar_from_json_schema call sites — three in LocalHFBackend plus
-# chat_completion_request_to_transformers_inputs (the `m serve` path) — must
-# pass whitespace_flexible=True. These tests assert that invariant via mock
-# without loading any real model.
+# To prevent this, all four grammar_from_json_schema call sites must enforce a
+# bounded whitespace_pattern (which allows space and prevents unlimited run-away
+# whitespace generation, resolving PR #1513 feedback).
+# These tests assert that invariant via mock without loading any real model.
 
 
 class _FakeSchema:
@@ -1017,19 +1017,19 @@ def _mock_chat_template_output() -> MagicMock:
     return obj
 
 
-def _assert_whitespace_flexible_true(captured: list[dict]) -> None:
+def _assert_whitespace_pattern_set(captured: list[dict]) -> None:
     assert captured, "grammar_from_json_schema was never called"
     for call_defaults in captured:
-        assert call_defaults.get("whitespace_flexible") is True, (
-            f"Expected whitespace_flexible=True, got {call_defaults!r} — "
-            "see issue #1510: False causes silent empty-array collapse"
+        assert call_defaults.get("whitespace_pattern") == r"[\x20\x0A\x0D\x09]{0,20}", (
+            f"Expected bounded whitespace_pattern, got {call_defaults!r} — "
+            "see issue #1510 and PR #1513 review"
         )
 
 
 @pytest.mark.asyncio
-async def test_whitespace_flexible_true_in_generate_from_context_standard():
+async def test_whitespace_pattern_set_in_generate_from_context_standard():
     """Regression (#1510): _generate_from_context_standard must call
-    grammar_from_json_schema with whitespace_flexible=True.
+    grammar_from_json_schema with bounded whitespace_pattern.
 
     Without the fix, the call passes whitespace_flexible=False, which can cause
     silent array collapse to [] under greedy decoding.
@@ -1044,8 +1044,8 @@ async def test_whitespace_flexible_true_in_generate_from_context_standard():
 
     captured: list[dict] = []
 
-    def _capture_grammar(schema, defaults=None):
-        captured.append(defaults or {})
+    def _capture_grammar(schema, overrides=None):
+        captured.append(overrides or {})
         return "stub-grammar"
 
     # The real generate() call runs in a background task (output._gen.generate)
@@ -1063,13 +1063,13 @@ async def test_whitespace_flexible_true_in_generate_from_context_standard():
         )
     await output._gen.generate
 
-    _assert_whitespace_flexible_true(captured)
+    _assert_whitespace_pattern_set(captured)
 
 
 @pytest.mark.asyncio
-async def test_whitespace_flexible_true_in_generate_from_raw():
+async def test_whitespace_pattern_set_in_generate_from_raw():
     """Regression (#1510): _generate_from_raw must call grammar_from_json_schema
-    with whitespace_flexible=True.
+    with bounded whitespace_pattern.
     """
     backend = _make_backend()
     # _generate_from_raw calls self._tokenizer(prompts, ...).to(device), so the
@@ -1095,8 +1095,8 @@ async def test_whitespace_flexible_true_in_generate_from_raw():
 
     captured: list[dict] = []
 
-    def _capture_grammar(schema, defaults=None):
-        captured.append(defaults or {})
+    def _capture_grammar(schema, overrides=None):
+        captured.append(overrides or {})
         return "stub-grammar"
 
     with (
@@ -1110,13 +1110,13 @@ async def test_whitespace_flexible_true_in_generate_from_raw():
             [Instruction(description="test")], ctx, format=_FakeSchema, model_options={}
         )
 
-    _assert_whitespace_flexible_true(captured)
+    _assert_whitespace_pattern_set(captured)
 
 
 @pytest.mark.asyncio
-async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache():
+async def test_whitespace_pattern_set_in_generate_from_context_with_kv_cache():
     """Regression (#1510): _generate_from_context_with_kv_cache must call
-    grammar_from_json_schema with whitespace_flexible=True.
+    grammar_from_json_schema with bounded whitespace_pattern.
     """
     backend = _make_backend()
     backend._model = MagicMock()
@@ -1127,8 +1127,8 @@ async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache()
 
     captured: list[dict] = []
 
-    def _capture_grammar(schema, defaults=None):
-        captured.append(defaults or {})
+    def _capture_grammar(schema, overrides=None):
+        captured.append(overrides or {})
         return "stub-grammar"
 
     # The real generate() call runs in a background task (output._gen.generate)
@@ -1151,13 +1151,13 @@ async def test_whitespace_flexible_true_in_generate_from_context_with_kv_cache()
         )
     await output._gen.generate
 
-    _assert_whitespace_flexible_true(captured)
+    _assert_whitespace_pattern_set(captured)
 
 
-def test_whitespace_flexible_true_in_chat_completion_request_to_transformers_inputs():
+def test_whitespace_pattern_set_in_chat_completion_request_to_transformers_inputs():
     """Regression (#1510): chat_completion_request_to_transformers_inputs (the
     OpenAI-compatible /chat/completions path used by `m serve`) must call
-    grammar_from_json_schema with whitespace_flexible=True.
+    grammar_from_json_schema with bounded whitespace_pattern.
     """
     tokenizer = MagicMock()
     tokenizer.apply_chat_template.return_value = torch.zeros(1, 4, dtype=torch.long)
@@ -1185,4 +1185,127 @@ def test_whitespace_flexible_true_in_chat_completion_request_to_transformers_inp
             request, tokenizer, model, ll_tokenizer=MagicMock()
         )
 
-    _assert_whitespace_flexible_true(captured)
+    _assert_whitespace_pattern_set(captured)
+
+
+@pytest.mark.asyncio
+async def test_whitespace_pattern_cannot_be_defeated_by_schema():
+    """Regression (#1510): Custom schemas attempting to force compact JSON
+    (whitespace_flexible=False) must be overridden to our bounded whitespace_pattern across all entry points.
+    """
+
+    class _FakeCompactSchema:
+        @staticmethod
+        def model_json_schema() -> dict:
+            return {
+                "type": "object",
+                "properties": {"result": {"type": "array"}},
+                "x-guidance": {"whitespace_flexible": False},
+            }
+
+    backend = _make_backend()
+    backend._tokenizer = MagicMock()
+    backend._tokenizer.apply_chat_template.return_value = _mock_chat_template_output()
+    tok_output = MagicMock()
+    tok_output.to = lambda device: tok_output
+    tok_output.__getitem__ = lambda s, k: torch.zeros(1, 4, dtype=torch.long)
+    backend._tokenizer.return_value = tok_output
+    backend._tokenizer.batch_decode = MagicMock(return_value=["stub-completion"])
+    backend._model = MagicMock()
+    backend._model.device = torch.device("cpu")
+    ctx = ChatContext().add(Message("user", "list facts"))
+
+    input_ids = torch.tensor([[1]])
+    attention_mask = torch.tensor([[1]])
+
+    # We want to trace each of the 4 paths
+    for path_name in ("context_standard", "raw", "context_kv_cache", "chat_completion"):
+        captured: list[dict] = []
+
+        def _capture_grammar(schema, overrides=None):
+            captured.append(overrides or {})
+            return "stub-grammar"
+
+        if path_name in ("context_standard", "context_kv_cache"):
+            backend._tokenizer.apply_chat_template.return_value = (
+                _mock_chat_template_output()
+            )
+        elif path_name == "chat_completion":
+            backend._tokenizer.apply_chat_template.return_value = torch.zeros(
+                1, 4, dtype=torch.long
+            )
+            backend._tokenizer.pad_token_id = 0
+            backend._tokenizer.eos_token_id = 1
+
+        with (
+            patch("mellea.backends.huggingface.llguidance") as mock_llg,
+            patch(
+                "mellea.backends.huggingface.asyncio.to_thread",
+                return_value=GenerateDecoderOnlyOutput(
+                    sequences=torch.zeros(1, 7, dtype=torch.long),
+                    scores=None,
+                    logits=None,
+                    attentions=None,
+                    hidden_states=None,
+                    past_key_values=None,
+                )
+                if path_name == "raw"
+                else MagicMock(),
+            ),
+        ):
+            mock_llg.LLMatcher.grammar_from_json_schema.side_effect = _capture_grammar
+
+            if path_name == "context_standard":
+                output = await backend._generate_from_context_standard(
+                    Instruction(description="test"),
+                    ctx,
+                    model_options={},
+                    _format=_FakeCompactSchema,
+                )
+                await output._gen.generate
+            elif path_name == "raw":
+                await backend._generate_from_raw(
+                    [Instruction(description="test")],
+                    ctx,
+                    format=_FakeCompactSchema,
+                    model_options={},
+                )
+            elif path_name == "context_kv_cache":
+                with patch.object(
+                    backend,
+                    "_make_merged_kv_cache",
+                    return_value=("", input_ids, MagicMock(), attention_mask),
+                ):
+                    output = await backend._generate_from_context_with_kv_cache(
+                        Instruction(description="test"),
+                        ctx,
+                        model_options={},
+                        _format=_FakeCompactSchema,
+                    )
+                    await output._gen.generate
+            elif path_name == "chat_completion":
+                request = {
+                    "messages": [{"role": "user", "content": "list facts"}],
+                    "extra_body": {
+                        "structured_outputs": {
+                            "json": _FakeCompactSchema.model_json_schema()
+                        }
+                    },
+                }
+                with patch(
+                    "llguidance.LLMatcher.grammar_from_json_schema",
+                    side_effect=_capture_grammar,
+                ):
+                    chat_completion_request_to_transformers_inputs(
+                        request,
+                        backend._tokenizer,
+                        backend._model,
+                        ll_tokenizer=MagicMock(),
+                    )
+
+        assert len(captured) == 1, (
+            f"grammar_from_json_schema was not called for {path_name}"
+        )
+        assert captured[0].get("whitespace_pattern") == r"[\x20\x0A\x0D\x09]{0,20}", (
+            f"Expected bounded whitespace_pattern to override False in {path_name}"
+        )


### PR DESCRIPTION
## Summary

Closes #1510 — fix silent array truncation in `LocalHFBackend` structured output.

## Why

`LocalHFBackend` was calling `llguidance.LLMatcher.grammar_from_json_schema` with `defaults={"whitespace_flexible": False}` at three call sites. This compiles a compact-JSON grammar (no whitespace between tokens). Under greedy decoding, this puts the model in a state where the highest-probability grammar-compatible token immediately after opening an array `[` closes it early — either immediately (`]`, producing `{"result":[]}`) or after the first item.

The result is a silent wrong answer: no exception is raised, the output is schema-valid, and the caller cannot detect the failure.

The `False` was introduced in PR #288 as a mechanical `outlines → llguidance` port and was never intentional. llguidance's own `_lib.pyi` stub documents that `whitespace_flexible` defaults to `True` when `defaults` is omitted — verified empirically (byte-for-byte identical compiled grammar to passing `True` explicitly). So the bug was scoped to exactly the three call sites that explicitly passed `False`; a fourth call site, in `chat_completion_request_to_transformers_inputs` (the `m serve` OpenAI-compatible path), already omitted `defaults` entirely and was never affected by #1510.

## What changed

| File | Change |
|---|---|
| [`mellea/backends/huggingface.py`](mellea/backends/huggingface.py) | `whitespace_flexible: False` → `True` at all three `grammar_from_json_schema` call sites (`_generate_from_context_with_kv_cache`, `_generate_from_context_standard`, `_generate_from_raw`); explanatory comment referencing #1510; imports the shared `_LLGUIDANCE_GRAMMAR_DEFAULTS` constant from `util.py` instead of redefining it |
| [`mellea/formatters/granite/base/util.py`](mellea/formatters/granite/base/util.py) | Defines `_LLGUIDANCE_GRAMMAR_DEFAULTS` (single source of truth). The fourth call site, in `chat_completion_request_to_transformers_inputs`, was not affected by #1510 (it already got llguidance's implicit `True` default) — hardened anyway with an explicit `overrides=` pass, since this endpoint takes its schema straight off the wire and a caller could otherwise embed their own `x-guidance.whitespace_flexible: false` to defeat a `defaults=` pass. The three `huggingface.py` sites use `defaults=` since their schemas come from local Pydantic models, not caller-controlled input |
| [`test/backends/test_huggingface_unit.py`](test/backends/test_huggingface_unit.py) | Four regression tests — one per call site, mock-based, no real model required; assert `whitespace_flexible=True` is passed. The fourth test exercises `util.py`'s function but lives here deliberately, alongside the other three #1510 regression tests, rather than in a new dedicated test file |
| [`docs/docs/integrations/huggingface.md`](docs/docs/integrations/huggingface.md) | New "Constrained decoding" section documenting the `whitespace_flexible=True` behaviour and the measured token overhead |

## Before / After

```python
# Before — silent truncation, no exception:
result = await session.aact(format=SectionTitles, ...)
# → SectionTitles(sections=[])                         # 3b: empty array
# → SectionTitles(sections=["Introduction"])           # 8b: partial list

# After — correct output:
result = await session.aact(format=SectionTitles, ...)
# → SectionTitles(sections=["Introduction", "Background", "Methods", ...])
```

## Empirical evidence

Tested across three models, three devices, 10 trials, 5 schema variants, n=1–8 items:

| Model | Device | `wf=False` OK | `wf=True` OK |
|---|---|---|---|
| `granite-4.1-3b` | CPU | 100/250 | 250/250 |
| `granite-4.1-3b` | CUDA | 100/250 | 250/250 |
| `granite-4.1-3b` | MPS | 100/250 | 250/250 |
| `granite-4.1-8b` | CPU | 190/250 | 250/250 |
| `granite-4.1-8b` | CUDA | 210/250 | 250/250 |
| `granite-4.1-8b` | MPS | 190/250 | 250/250 |
| `granite-4.0-micro` | CUDA | 190/250 | 230/250 |

`wf=True` is clean for 3b and 8b on all devices. The 20 `wf=True` failures on micro are `single_str_field n=2` producing 1 item instead of 2 on every trial — a model-level instruction-following limitation on that schema, not caused by this bug.

## Token overhead

`wf=True` produces spaced JSON, using ~1.5× more tokens for the same content. Callers with a tight explicit `ModelOption.MAX_NEW_TOKENS` budget should size accordingly. Generation that runs to EOS still completes, but consumes proportionally more tokens getting there.

## Testing

```bash
uv run pytest test/backends/test_huggingface_unit.py -x -q
# 60 passed, 3 warnings in 7.73s

uv run mypy mellea/backends/huggingface.py mellea/formatters/granite/base/util.py test/backends/test_huggingface_unit.py
# no issues

uv run ruff format mellea/backends/huggingface.py mellea/formatters/granite/base/util.py test/backends/test_huggingface_unit.py
uv run ruff check mellea/backends/huggingface.py mellea/formatters/granite/base/util.py test/backends/test_huggingface_unit.py
# all clean

uv run pytest test/ -m "not qualitative" -q
# 3860 passed, 21 skipped, 134 deselected, 2 xfailed, 2 xpassed in 641.60s
```

The four new regression tests each fail on their respective pre-fix code and pass on the fix.
