### PR TITLE
fix: harden computed model output thunks

### DIFF
--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1382,12 +1382,20 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     ) -> ComputedModelOutputThunk[S]:
         """Convert a `ModelOutputThunk` into a `ComputedModelOutputThunk` via zero-copy reassignment.
 
-        `thunk is None` allocates a bare instance; this is the path taken by pickle's
-        default reconstruction (`cls.__new__(cls)`), which then restores `__dict__`
-        directly. A genuine no-arg call is caught in `__init__` (which pickle skips).
+        The whole computed invariant is validated here, *before* the class reassignment,
+        so a rejected `thunk` is left untouched as the plain `ModelOutputThunk` the caller
+        passed in.
+
+        `thunk is None` allocates a bare instance. Pickling a `ModelOutputThunk` or a
+        `ComputedModelOutputThunk` is not supported today — a generated thunk's `_gen`
+        holds asyncio tasks and backend-bound callbacks that cannot be pickled — but
+        pickle reconstructs via `cls.__new__(cls)`, so keeping this branch means adding
+        pickle support to the base class later needs no change here. A genuine no-arg call
+        is caught in `__init__` (which pickle skips).
 
         Raises:
             TypeError: If `thunk` is neither `None` nor a `ModelOutputThunk`.
+            ValueError: If `thunk` is not computed or has a `None` value.
         """
         if thunk is None:
             return object.__new__(cls)  # type: ignore[return-value]
@@ -1396,34 +1404,39 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
                 "ComputedModelOutputThunk requires a computed ModelOutputThunk; "
                 f"got {type(thunk).__name__}."
             )
+
+        # Validate before reassigning __class__ below. Reassigning first would leave a
+        # rejected thunk mutated into a ComputedModelOutputThunk whose is_computed()
+        # returns True while .value is None, and __setattr__ then blocks resetting
+        # _computed to repair it.
+        if not thunk._computed:
+            raise ValueError(
+                "ComputedModelOutputThunk requires a computed ModelOutputThunk; but ._computed is False."
+            )
+        if thunk.value is None:
+            raise ValueError("ComputedModelOutputThunk requires a non-None value.")
+
         thunk.__class__ = cls
         return thunk  # type: ignore[return-value]
 
-    def __init__(self, thunk: ModelOutputThunk[S] | None = None) -> None:
+    def __init__(self, thunk: ModelOutputThunk[S]) -> None:
         """A `ComputedModelOutputThunk` is a `ModelOutputThunk` that is guaranteed to be computed.
 
         Uses zero-copy class reassignment: calling `ComputedModelOutputThunk(thunk)` reassigns
         the thunk's `__class__` to `ComputedModelOutputThunk` without creating a new object.
+        The computed invariant is validated in `__new__`, which runs first.
 
         Raises:
             TypeError: If constructed with no `thunk` (the argument is mandatory).
-            ValueError: If `thunk` is not computed or has a `None` value.
         """
-        # Pickle restores state via __dict__ and never calls __init__, so reaching here
-        # with thunk=None means a genuine no-arg constructor call, which is invalid.
+        # `thunk` is mandatory, so a no-arg call raises TypeError before reaching here.
+        # An explicit `None` still arrives, having taken the bare-allocation branch in
+        # __new__ that exists for pickle's reconstruction path; reject it.
         if thunk is None:
             raise TypeError(
                 "ComputedModelOutputThunk() requires a computed ModelOutputThunk; "
                 "construct one as ComputedModelOutputThunk(thunk)."
             )
-
-        # `self` is `thunk` (zero-copy), already cast to ComputedModelOutputThunk.
-        if not self._computed:
-            raise ValueError(
-                "ComputedModelOutputThunk requires a computed ModelOutputThunk; but ._computed is False."
-            )
-        if self.value is None:
-            raise ValueError("ComputedModelOutputThunk requires a non-None value.")
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Enforce the computed invariant on every assignment.
@@ -1450,17 +1463,19 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
         """Shallow-copy, preserving the concrete computed subclass.
 
         Delegates field copying to `ModelOutputThunk.__copy__`, then re-casts the
-        base-class result back to `ComputedModelOutputThunk` so the copy keeps its type
-        and invariant instead of silently demoting to the base class.
+        base-class result back to `type(self)` so the copy keeps its type and invariant
+        instead of silently demoting to the base class. Only the class is preserved: the
+        delegate builds a plain `ModelOutputThunk`, so a subclass that adds fields of its
+        own still needs to override this.
         """
         copied = super().__copy__()
-        copied.__class__ = ComputedModelOutputThunk
+        copied.__class__ = type(self)
         return copied  # type: ignore[return-value]
 
     def __deepcopy__(self, memo: dict) -> ComputedModelOutputThunk[S]:
         """Deep-copy, preserving the concrete computed subclass (see `__copy__`)."""
         deepcopied = super().__deepcopy__(memo)
-        deepcopied.__class__ = ComputedModelOutputThunk
+        deepcopied.__class__ = type(self)
         return deepcopied  # type: ignore[return-value]
 
     async def avalue(self) -> str:

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1349,28 +1349,119 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
     Uses zero-copy class reassignment: calling `ComputedModelOutputThunk(thunk)` reassigns
     the thunk's `__class__` to `ComputedModelOutputThunk` without creating a new object.
 
+    The *computed invariant* is enforced on every assignment: the thunk can never be
+    mutated into an inconsistent state. Setting `_computed` to anything other than
+    `True` (it can never become uncomputed) or setting `_underlying_value`/`value` to
+    `None` or a non-`str` (the `.value -> str` contract must hold) raises `AttributeError`.
+    Invariant-*preserving* writes are allowed — a caller may replace the value with a
+    different computed string (see `mellea/stdlib/frameworks/react.py`, which swaps in a
+    tool's final answer) and a sampling strategy may finalize `parsed_repr`. This
+    guarantees `is_computed()` stays `True` and `.value` stays a non-`None` `str` for
+    the lifetime of the object.
+
+    Constructing without a `thunk` raises `TypeError` — the argument is mandatory.
+
     Args:
         thunk: A fully-computed `ModelOutputThunk` whose class will be reassigned.
     """
 
-    def __new__(cls, thunk: ModelOutputThunk[S]) -> ComputedModelOutputThunk[S]:
-        """Convert the ModelOutputThunk into a ComputedModelOutputThunk."""
+    # Fields guarded by the computed invariant. Each maps to a predicate a *new* value
+    # must satisfy; a rejected write raises AttributeError. The rule is "never made
+    # uncomputed or given an invalid value" — not "read-only": replacing the value with
+    # another valid computed string is allowed (react.py does this). `parsed_repr` is
+    # unguarded (a derived field finalized post-wrap). The guard is purely value-based,
+    # so it needs no "is-sealed" flag: at wrap time the base thunk is already computed
+    # with a str value, and the wrap itself writes no guarded field.
+    _INVARIANT_GUARDS: dict[str, Callable[[Any], bool]] = {
+        "_computed": lambda v: v is True,
+        "_underlying_value": lambda v: isinstance(v, str),
+    }
+
+    def __new__(
+        cls, thunk: ModelOutputThunk[S] | None = None
+    ) -> ComputedModelOutputThunk[S]:
+        """Convert a `ModelOutputThunk` into a `ComputedModelOutputThunk` via zero-copy reassignment.
+
+        `thunk is None` allocates a bare instance; this is the path taken by pickle's
+        default reconstruction (`cls.__new__(cls)`), which then restores `__dict__`
+        directly. A genuine no-arg call is caught in `__init__` (which pickle skips).
+
+        Raises:
+            TypeError: If `thunk` is neither `None` nor a `ModelOutputThunk`.
+        """
+        if thunk is None:
+            return object.__new__(cls)  # type: ignore[return-value]
+        if not isinstance(thunk, ModelOutputThunk):
+            raise TypeError(
+                "ComputedModelOutputThunk requires a computed ModelOutputThunk; "
+                f"got {type(thunk).__name__}."
+            )
         thunk.__class__ = cls
         return thunk  # type: ignore[return-value]
 
-    def __init__(self, thunk: ModelOutputThunk[S]) -> None:
+    def __init__(self, thunk: ModelOutputThunk[S] | None = None) -> None:
         """A `ComputedModelOutputThunk` is a `ModelOutputThunk` that is guaranteed to be computed.
 
         Uses zero-copy class reassignment: calling `ComputedModelOutputThunk(thunk)` reassigns
         the thunk's `__class__` to `ComputedModelOutputThunk` without creating a new object.
+
+        Raises:
+            TypeError: If constructed with no `thunk` (the argument is mandatory).
+            ValueError: If `thunk` is not computed or has a `None` value.
         """
-        # Call the underlying value. It's already been cast as a ComputedModelOutputThunk, so it's .is_computed() value is always True.
+        # Pickle restores state via __dict__ and never calls __init__, so reaching here
+        # with thunk=None means a genuine no-arg constructor call, which is invalid.
+        if thunk is None:
+            raise TypeError(
+                "ComputedModelOutputThunk() requires a computed ModelOutputThunk; "
+                "construct one as ComputedModelOutputThunk(thunk)."
+            )
+
+        # `self` is `thunk` (zero-copy), already cast to ComputedModelOutputThunk.
         if not self._computed:
             raise ValueError(
                 "ComputedModelOutputThunk requires a computed ModelOutputThunk; but ._computed is False."
             )
         if self.value is None:
             raise ValueError("ComputedModelOutputThunk requires a non-None value.")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Enforce the computed invariant on every assignment.
+
+        A guarded field (see `_INVARIANT_GUARDS`) may be reassigned only to a value that
+        keeps the thunk computed and its `.value` a valid `str`; unguarded fields
+        (`parsed_repr`, `_cancelled`, ...) are unrestricted. The `value` property setter
+        also routes here.
+
+        Raises:
+            AttributeError: If the assignment would violate the computed invariant
+                (uncompute the thunk, or set the value to `None`/non-`str`).
+        """
+        guard = self._INVARIANT_GUARDS.get(name)
+        if guard is not None and not guard(value):
+            raise AttributeError(
+                "cannot assign to this ComputedModelOutputThunk: the assignment "
+                "would violate the computed invariant (it must stay computed with a "
+                f"non-None str value; got {value!r})."
+            )
+        super().__setattr__(name, value)
+
+    def __copy__(self) -> ComputedModelOutputThunk[S]:
+        """Shallow-copy, preserving the concrete computed subclass.
+
+        Delegates field copying to `ModelOutputThunk.__copy__`, then re-casts the
+        base-class result back to `ComputedModelOutputThunk` so the copy keeps its type
+        and invariant instead of silently demoting to the base class.
+        """
+        copied = super().__copy__()
+        copied.__class__ = ComputedModelOutputThunk
+        return copied  # type: ignore[return-value]
+
+    def __deepcopy__(self, memo: dict) -> ComputedModelOutputThunk[S]:
+        """Deep-copy, preserving the concrete computed subclass (see `__copy__`)."""
+        deepcopied = super().__deepcopy__(memo)
+        deepcopied.__class__ = ComputedModelOutputThunk
+        return deepcopied  # type: ignore[return-value]
 
     async def avalue(self) -> str:
         """Return the value of the thunk. Use .value instead.
@@ -1407,7 +1498,11 @@ class ComputedModelOutputThunk(ModelOutputThunk[S]):
 
     @value.setter
     def value(self, v: str):
-        """Sets the value of the block."""
+        """Set the underlying value, enforcing the computed invariant.
+
+        Raises:
+            AttributeError: If `v` is not a `str`.
+        """
         self._underlying_value = v
 
     def is_computed(self) -> Literal[True]:

--- a/test/core/test_computed_model_output_thunk.py
+++ b/test/core/test_computed_model_output_thunk.py
@@ -4,7 +4,6 @@
 """Tests for ComputedModelOutputThunk."""
 
 import copy
-import pickle
 
 import pytest
 
@@ -37,14 +36,44 @@ def test_computed_thunk_requires_computed_thunk():
         ComputedModelOutputThunk(uncomputed_thunk)
 
 
-def test_computed_thunk_requires_value():
-    """Test that ComputedModelOutputThunk requires a non-None value."""
-    # Create a thunk that's computed but has None value (edge case)
+def _computed_thunk_with_none_value() -> ModelOutputThunk:
+    """A thunk that claims to be computed but holds a None value (edge case)."""
     base_thunk = ModelOutputThunk(value="test")
     base_thunk.value = None  # type: ignore
+    return base_thunk
 
+
+def test_computed_thunk_requires_value():
+    """Test that ComputedModelOutputThunk requires a non-None value."""
     with pytest.raises(ValueError, match="requires a non-None value"):
+        ComputedModelOutputThunk(_computed_thunk_with_none_value())
+
+
+@pytest.mark.parametrize(
+    "make_base_thunk",
+    [
+        pytest.param(lambda: ModelOutputThunk(value=None), id="uncomputed"),
+        pytest.param(_computed_thunk_with_none_value, id="none-value"),
+    ],
+)
+def test_rejected_wrap_leaves_input_thunk_unmutated(make_base_thunk):
+    """A rejected wrap must leave the caller's thunk as a plain ModelOutputThunk.
+
+    `__new__` reassigns `__class__` in place, so validating after that reassignment would
+    leave the input claiming `is_computed() is True` while `.value` is None — and the
+    guarded `__setattr__` would then block repairing it.
+    """
+    base_thunk = make_base_thunk()
+
+    with pytest.raises(ValueError):
         ComputedModelOutputThunk(base_thunk)
+
+    assert type(base_thunk) is ModelOutputThunk
+
+    # Still a plain thunk, so it remains repairable and wrappable.
+    base_thunk._computed = True
+    base_thunk.value = "repaired"
+    assert ComputedModelOutputThunk(base_thunk).value == "repaired"
 
 
 async def test_computed_thunk_avalue():
@@ -235,13 +264,13 @@ def test_copy_preserves_computed_subclass():
         cc._computed = False
 
 
-def test_pickle_roundtrip_preserves_computed_subclass():
-    """A pickled/unpickled computed thunk stays a sealed, computed ComputedModelOutputThunk."""
-    computed = ComputedModelOutputThunk(ModelOutputThunk(value="hello"))
-    restored = pickle.loads(pickle.dumps(computed))
+def test_copies_preserve_concrete_subclass():
+    """copy/deepcopy of a subclass return that subclass, not the base computed class."""
 
-    assert isinstance(restored, ComputedModelOutputThunk)
-    assert restored.is_computed()
-    assert restored.value == "hello"
-    with pytest.raises(AttributeError, match="computed invariant"):
-        restored.value = None  # type: ignore[assignment]
+    class _SubComputedThunk(ComputedModelOutputThunk):
+        pass
+
+    sub = _SubComputedThunk(ModelOutputThunk(value="hello"))
+
+    assert type(copy.copy(sub)) is _SubComputedThunk
+    assert type(copy.deepcopy(sub)) is _SubComputedThunk

--- a/test/core/test_computed_model_output_thunk.py
+++ b/test/core/test_computed_model_output_thunk.py
@@ -3,6 +3,9 @@
 
 """Tests for ComputedModelOutputThunk."""
 
+import copy
+import pickle
+
 import pytest
 
 from mellea.core import ComputedModelOutputThunk, ModelOutputThunk
@@ -135,3 +138,110 @@ def test_computed_thunk_zero_copy_identity():
     base_thunk = ModelOutputThunk(value="test output")
     computed_thunk = ComputedModelOutputThunk(base_thunk)
     assert computed_thunk is base_thunk
+
+
+def test_computed_thunk_no_arg_construction_rejected():
+    """Constructing without a thunk must raise; the argument is mandatory."""
+    with pytest.raises(TypeError):
+        ComputedModelOutputThunk()  # type: ignore[call-arg]
+
+
+def test_computed_thunk_non_thunk_arg_rejected():
+    """Passing a non-ModelOutputThunk must raise TypeError, not silently proceed."""
+    with pytest.raises(TypeError, match="requires a computed ModelOutputThunk"):
+        ComputedModelOutputThunk("not a thunk")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "field, bad_value",
+    [
+        ("_computed", False),
+        ("_computed", None),
+        ("_underlying_value", None),
+        ("_underlying_value", 123),
+        ("value", None),
+        ("value", 123),
+    ],
+)
+def test_computed_thunk_invariant_violating_writes_rejected(field, bad_value):
+    """Assignments that would uncompute the thunk or invalidate its value are rejected."""
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="original"))
+    with pytest.raises(AttributeError, match="computed invariant"):
+        setattr(computed, field, bad_value)
+    # The invariant still holds after the rejected write.
+    assert computed.value == "original"
+    assert computed.is_computed()
+
+
+def test_computed_thunk_value_may_be_replaced_with_valid_string():
+    """The value may be swapped for another valid computed string (react.py relies on this)."""
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="original"))
+    computed.value = "replaced"
+    assert computed.value == "replaced"
+    assert computed.is_computed()
+    # The private field route is equally allowed for a valid string.
+    computed._underlying_value = "again"
+    assert computed.value == "again"
+
+
+def test_computed_thunk_derived_and_status_fields_writable():
+    """Fields outside the invariant guard remain freely mutable after wrapping.
+
+    `parsed_repr` is finalized by sampling strategies (mellea/stdlib/sampling/base.py),
+    `_cancelled` is a status flag, and `thinking` is derived output — none are guarded.
+    """
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="ok"))
+    computed.thinking = "some reasoning"
+    computed.parsed_repr = "finalized"
+    computed._cancelled = True
+    assert computed.thinking == "some reasoning"
+    assert computed.parsed_repr == "finalized"
+    assert computed._cancelled is True
+
+
+def test_pre_wrap_value_edit_still_allowed():
+    """The guard must not engage on the still-plain ModelOutputThunk before wrapping.
+
+    Setting `.value` on the base thunk prior to wrapping must succeed (the existing
+    `test_computed_thunk_requires_value` flow relies on this).
+    """
+    base = ModelOutputThunk(value="original")
+    base.value = "edited"  # allowed: base thunk is not sealed
+    computed = ComputedModelOutputThunk(base)
+    assert computed.value == "edited"
+
+
+def test_deepcopy_preserves_computed_subclass():
+    """deepcopy of a computed thunk stays a sealed, computed ComputedModelOutputThunk."""
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="hello"))
+    dc = copy.deepcopy(computed)
+
+    assert isinstance(dc, ComputedModelOutputThunk)
+    assert dc.is_computed()
+    assert dc.value == "hello"
+    with pytest.raises(AttributeError, match="computed invariant"):
+        dc.value = None  # type: ignore[assignment]
+
+
+def test_copy_preserves_computed_subclass():
+    """copy.copy of a computed thunk stays a sealed, computed ComputedModelOutputThunk."""
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="hello"))
+    cc = copy.copy(computed)
+
+    assert isinstance(cc, ComputedModelOutputThunk)
+    assert cc.is_computed()
+    assert cc.value == "hello"
+    with pytest.raises(AttributeError, match="computed invariant"):
+        cc._computed = False
+
+
+def test_pickle_roundtrip_preserves_computed_subclass():
+    """A pickled/unpickled computed thunk stays a sealed, computed ComputedModelOutputThunk."""
+    computed = ComputedModelOutputThunk(ModelOutputThunk(value="hello"))
+    restored = pickle.loads(pickle.dumps(computed))
+
+    assert isinstance(restored, ComputedModelOutputThunk)
+    assert restored.is_computed()
+    assert restored.value == "hello"
+    with pytest.raises(AttributeError, match="computed invariant"):
+        restored.value = None  # type: ignore[assignment]

--- a/test/core/test_logger_plugin_hooks.py
+++ b/test/core/test_logger_plugin_hooks.py
@@ -29,8 +29,6 @@ import datetime
 # ---------------------------------------------------------------------------
 # Minimal mock backend (avoids real LLM calls)
 # ---------------------------------------------------------------------------
-from unittest.mock import MagicMock
-
 from mellea.core.backend import Backend
 from mellea.core.base import (
     CBlock,
@@ -38,8 +36,6 @@ from mellea.core.base import (
     GenerateLog,
     GenerateType,
     ModelOutputThunk,
-    _CallInfo,
-    _GenerationState,
 )
 from mellea.core.utils import (
     MelleaLogger,
@@ -60,20 +56,11 @@ class _MockBackend(Backend):
         self._provider: str = "mock-provider"
 
     async def _generate_from_context(self, action, ctx, **kwargs):
-        mot = MagicMock(spec=ModelOutputThunk)
-        mot._gen = _GenerationState()
-        mot._call = _CallInfo()
+        mot = ModelOutputThunk(value="mocked output")
         glog = GenerateLog()
         glog.prompt = "mocked prompt"
         mot._generate_log = glog
-        mot.parsed_repr = None
         mot._gen.start = datetime.datetime.now()
-
-        async def _avalue():
-            return "mocked output"
-
-        mot.avalue = _avalue
-        mot.value = "mocked output"
         return mot, SimpleContext()
 
     async def _generate_from_raw(self, actions, ctx, **kwargs):

--- a/test/plugins/test_hook_call_sites.py
+++ b/test/plugins/test_hook_call_sites.py
@@ -31,8 +31,6 @@ from mellea.core.base import (
     GenerateLog,
     GenerateType,
     ModelOutputThunk,
-    _CallInfo,
-    _GenerationState,
 )
 from mellea.core.requirement import Requirement, ValidationResult
 from mellea.plugins import HookType, PluginResult, hook, register
@@ -68,20 +66,11 @@ class _MockBackend(Backend):
         self._provider: str = "mock-provider"
 
     async def _generate_from_context(self, action, ctx, **kwargs):
-        mot = MagicMock(spec=ModelOutputThunk)
-        mot._gen = _GenerationState()
-        mot._call = _CallInfo()
+        mot = ModelOutputThunk(value="mocked output string")
         glog = GenerateLog()
         glog.prompt = "mocked formatted prompt"
         mot._generate_log = glog
-        mot.parsed_repr = None
         mot._gen.start = datetime.datetime.now()
-
-        async def _avalue():
-            return "mocked output"
-
-        mot.avalue = _avalue
-        mot.value = "mocked output string"  # SamplingResult requires a str .value
         # Return a new SimpleContext to mimic real context evolution
         new_ctx = SimpleContext()
         return mot, new_ctx

--- a/test/stdlib/sampling/test_sofai_graph_coloring.py
+++ b/test/stdlib/sampling/test_sofai_graph_coloring.py
@@ -153,20 +153,11 @@ def graph_coloring_requirement():
 
 
 def create_mock_mot(value: str) -> ModelOutputThunk:
-    """Create a mock ModelOutputThunk with given value."""
-    mot = MagicMock(spec=ModelOutputThunk)
-    mot.value = value
+    """Create a real, computed ModelOutputThunk with the given value."""
+    mot = ModelOutputThunk(value=value)
     mot.parsed_repr = value
-    mot._generate_log = MagicMock(spec=GenerateLog)
+    mot._generate_log = GenerateLog()
     mot._generate_log.is_final_result = False
-    # Required for Message._parse() to work correctly
-    mot.tool_calls = None
-    mot._meta = {}
-
-    async def mock_avalue():
-        return value
-
-    mot.avalue = mock_avalue
     return mot
 
 

--- a/test/telemetry/test_tracing_application.py
+++ b/test/telemetry/test_tracing_application.py
@@ -29,7 +29,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from mellea.core.backend import Backend
-from mellea.core.base import GenerateLog, ModelOutputThunk, _CallInfo, _GenerationState
+from mellea.core.base import GenerateLog, ModelOutputThunk
 from mellea.stdlib.components import Message
 from mellea.stdlib.context import SimpleContext
 from mellea.stdlib.session import MelleaSession, start_session
@@ -110,20 +110,11 @@ class _MockBackend(Backend):
         self._provider: str = "mock-provider"
 
     async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
-        mot = MagicMock(spec=ModelOutputThunk)
-        mot._gen = _GenerationState()
-        mot._call = _CallInfo()
+        mot = ModelOutputThunk(value="mocked output")
         glog = GenerateLog()
         glog.prompt = "mocked formatted prompt"
         mot._generate_log = glog
-        mot.parsed_repr = None
         mot._gen.start = datetime.datetime.now()
-
-        async def _avalue() -> str:
-            return "mocked output"
-
-        mot.avalue = _avalue
-        mot.value = "mocked output"
         return mot, SimpleContext()
 
     async def _generate_from_raw(self, actions: Any, ctx: Any, **kwargs: Any):

--- a/test/telemetry/test_tracing_sampling_validation.py
+++ b/test/telemetry/test_tracing_sampling_validation.py
@@ -18,7 +18,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from mellea.core.backend import Backend
-from mellea.core.base import GenerateLog, ModelOutputThunk, _CallInfo, _GenerationState
+from mellea.core.base import GenerateLog, ModelOutputThunk
 from mellea.core.requirement import Requirement, ValidationResult
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.context import SimpleContext
@@ -92,20 +92,11 @@ class _MockBackend(Backend):
         self._provider = "mock-provider"
 
     async def _generate_from_context(self, action: Any, ctx: Any, **kwargs: Any):
-        mot = MagicMock(spec=ModelOutputThunk)
-        mot._gen = _GenerationState()
-        mot._call = _CallInfo()
+        mot = ModelOutputThunk(value="mocked output")
         glog = GenerateLog()
         glog.prompt = "mocked formatted prompt"
         mot._generate_log = glog
-        mot.parsed_repr = None
         mot._gen.start = datetime.datetime.now()
-
-        async def _avalue() -> str:
-            return "mocked output"
-
-        mot.avalue = _avalue
-        mot.value = "mocked output"
         return mot, SimpleContext()
 
     async def _generate_from_raw(self, actions: Any, ctx: Any, **kwargs: Any):


### PR DESCRIPTION
Assisted-by: CLAUDE:OPUS

# Pull Request

## Issue
Fixes N/A; Some things I noticed with computed model output thunks

## Description
I hardened some of the assumptions around ComputedModelOutputThunks so that copy / deepcopy / pickling work better along with ensuring their main property (being computed) never gets unset (along with ensuring value never gets set to None as well).

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
