### PR TITLE
feat: add mellea version dunder

### DIFF
--- a/mellea/__init__.py
+++ b/mellea/__init__.py
@@ -3,14 +3,24 @@
 
 """Mellea."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from . import serve
 from .backends import model_ids
 from .stdlib.components.genstub import generative
 from .stdlib.session import MelleaSession, start_session
 from .stdlib.start_backend import start_backend
 
+try:
+    # Read the version from the installed package metadata so it stays in sync
+    # with the `version` field in pyproject.toml (no manual duplication).
+    __version__ = version("mellea")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 __all__ = [
     "MelleaSession",
+    "__version__",
     "generative",
     "model_ids",
     "serve",

--- a/test/package/test_version.py
+++ b/test/package/test_version.py
@@ -1,0 +1,26 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that the package-level `__version__` is exposed and stays in sync with pyproject.toml."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import mellea
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def test_version_attribute_exists():
+    """`mellea.__version__` is a non-empty string."""
+    assert isinstance(mellea.__version__, str)
+    assert mellea.__version__
+
+
+def test_version_matches_pyproject():
+    """The runtime `__version__` matches the `version` declared in pyproject.toml."""
+    with PYPROJECT.open("rb") as f:
+        pyproject = tomllib.load(f)
+    assert mellea.__version__ == pyproject["project"]["version"]


### PR DESCRIPTION
Assisted-by: CLAUDE:OPUS

# Pull Request

## Issue
Fixes https://github.com/generative-computing/mellea/issues/1114

## Description
Adds a version dunder. More and more packages are using the metadata import version utilized here so I think we should be good.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
