### PR TITLE
fix: raise clear error when intrinsic context forwards no history

### DIFF
--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -140,6 +140,35 @@ def _resolve_response(
     return _extract_last_response(context)
 
 
+def _assert_context_forwards_history(intrinsic_name: str, context: ChatContext) -> None:
+    """Guard against contexts that forward no history to the model.
+
+    Adapter functions evaluate over a conversation, so the context must
+    linearize to at least one message. A `SimpleContext` (the `start_session`
+    default) always drops history — its `view_for_generation()` returns `[]`
+    even after messages are added — which downstream causes an opaque
+    `IndexError` inside `apply_chat_template` (issue #937). Fail early here
+    with an actionable message instead.
+
+    Args:
+        intrinsic_name: Capability name, included in the error message.
+        context: The context that will be forwarded to the backend.
+
+    Raises:
+        ValueError: When `context.view_for_generation()` is empty or `None`.
+    """
+    if not context.view_for_generation():
+        raise ValueError(
+            f"Intrinsic '{intrinsic_name}' received a context that forwards no "
+            "history to the model. Adapter functions evaluate over a "
+            "conversation, so the context must contain at least one message. "
+            "This usually means a SimpleContext was passed (the default for "
+            "`start_session`), which does not retain history. Use a ChatContext "
+            'instead, e.g. `start_session(..., context_type="chat")` or '
+            '`start_backend(..., context_type="chat")`.'
+        )
+
+
 def call_intrinsic(
     intrinsic_name: str,
     context: ChatContext,
@@ -177,10 +206,14 @@ def call_intrinsic(
         dict[str, object]: Parsed (and optionally validated) JSON output from the adapter function.
 
     Raises:
-        ValueError: When the model output is `None` or is not valid JSON.
+        ValueError: When *context* forwards no history to the model (e.g. a
+            `SimpleContext` was passed), or when the model output is `None` or
+            is not valid JSON.
         AdapterSchemaMismatchError: When *io_contract* is provided and the
             model output is missing a required field.
     """
+    _assert_context_forwards_history(intrinsic_name, context)
+
     # Ensure the adapter is registered; resolve_adapter creates it if absent.
     backend.resolve_adapter(intrinsic_name)
 

--- a/test/stdlib/components/intrinsic/test_util_unit.py
+++ b/test/stdlib/components/intrinsic/test_util_unit.py
@@ -11,9 +11,13 @@ discarded behind a hardcoded default) resurfacing.
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from mellea.backends.model_options import ModelOption
+from mellea.stdlib.components import Message
 from mellea.stdlib.components.intrinsic import _util
 from mellea.stdlib.context import ChatContext
+from mellea.stdlib.context.simple import SimpleContext
 
 
 def _fake_act_capturing(calls):
@@ -33,7 +37,7 @@ def test_call_intrinsic_caller_model_options_survive(monkeypatch):
     monkeypatch.setattr(_util.mfuncs, "act", _fake_act_capturing(calls))
 
     backend = MagicMock()
-    context = ChatContext()
+    context = ChatContext().add(Message("user", "hi"))
 
     _util.call_intrinsic(
         "answerability", context, backend, model_options={ModelOption.TEMPERATURE: 0.7}
@@ -51,7 +55,7 @@ def test_call_intrinsic_default_temperature_used_when_not_overridden(monkeypatch
     monkeypatch.setattr(_util.mfuncs, "act", _fake_act_capturing(calls))
 
     backend = MagicMock()
-    context = ChatContext()
+    context = ChatContext().add(Message("user", "hi"))
 
     _util.call_intrinsic("answerability", context, backend)
 
@@ -67,8 +71,39 @@ def test_call_intrinsic_resolves_adapter_before_acting(monkeypatch):
     monkeypatch.setattr(_util.mfuncs, "act", _fake_act_capturing(calls))
 
     backend = MagicMock()
-    context = ChatContext()
+    context = ChatContext().add(Message("user", "hi"))
 
     _util.call_intrinsic("answerability", context, backend)
 
     backend.resolve_adapter.assert_called_once_with("answerability")
+
+
+def test_call_intrinsic_rejects_context_with_no_history(monkeypatch):
+    """A SimpleContext forwards no history, so call_intrinsic must fail early (issue #937)."""
+    calls: list[dict | None] = []
+    monkeypatch.setattr(_util.mfuncs, "act", _fake_act_capturing(calls))
+
+    backend = MagicMock()
+    # SimpleContext.view_for_generation() is always [] even after add().
+    context = SimpleContext().add(Message("user", "hi"))
+
+    with pytest.raises(ValueError, match="forwards no history"):
+        _util.call_intrinsic("answerability", context, backend)
+
+    # The guard must fire before the backend is touched.
+    backend.resolve_adapter.assert_not_called()
+    assert calls == []
+
+
+def test_call_intrinsic_rejects_empty_chat_context(monkeypatch):
+    """An empty ChatContext also forwards nothing and must be rejected."""
+    calls: list[dict | None] = []
+    monkeypatch.setattr(_util.mfuncs, "act", _fake_act_capturing(calls))
+
+    backend = MagicMock()
+
+    with pytest.raises(ValueError, match="forwards no history"):
+        _util.call_intrinsic("answerability", ChatContext(), backend)
+
+    backend.resolve_adapter.assert_not_called()
+    assert calls == []


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #937 

## Description
 Calling an intrinsic (e.g. `check_answerability`) with a `SimpleContext` (the `start_session` default) crashed with an opaque `IndexError` from deep inside   `apply_chat_template`, because `SimpleContext` forwards no history and the intrinsic handed an empty conversation to the tokenizer.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
