### PR TITLE
test(vision): activate Ollama vision e2e via Hugging Face GGUF pull

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -134,6 +134,9 @@ jobs:
               sleep 20
             done
           done
+          # The names below are what the tests match against; print them so a
+          # tag-name mismatch is diagnosable from the log alone.
+          ollama list
       - name: Run Tests
         id: tests
         env:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -128,11 +128,18 @@ jobs:
         # model is ever published to the Ollama library directly.
         run: |
           for model in granite4.1:3b hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M; do
+            pulled=false
             for i in 1 2 3 4 5; do
-              ollama pull "$model" && break
+              ollama pull "$model" && { pulled=true; break; }
               echo "Attempt $i to pull $model failed, retrying in 20s..."
               sleep 20
             done
+            # Without this the loop exits 0 after exhausting every attempt: the
+            # `&&` above puts the failure in a tested context, so `bash -e` does
+            # not fire, and the loop's status comes from `sleep`. The step would
+            # go green and the miss would surface 20 minutes later as a test
+            # failure instead of an infra one.
+            $pulled || { echo "::error::failed to pull $model after 5 attempts"; exit 1; }
           done
           # The names below are what the tests match against; print them so a
           # tag-name mismatch is diagnosable from the log alone.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -122,11 +122,17 @@ jobs:
       - name: Start serving ollama
         run: nohup ollama serve &
       - name: Pull models
+        # granite-vision-4.1 is not in the Ollama library, so it is pulled from
+        # IBM's official GGUF repo on Hugging Face (that build ships the mmproj
+        # projector Ollama needs for image input). Drop the hf.co prefix if the
+        # model is ever published to the Ollama library directly.
         run: |
-          for i in 1 2 3 4 5; do
-            ollama pull granite4.1:3b && break
-            echo "Attempt $i failed, retrying in 20s..."
-            sleep 20
+          for model in granite4.1:3b hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M; do
+            for i in 1 2 3 4 5; do
+              ollama pull "$model" && break
+              echo "Attempt $i to pull $model failed, retrying in 20s..."
+              sleep 20
+            done
           done
       - name: Run Tests
         id: tests

--- a/docs/docs/how-to/use-images-and-vision.md
+++ b/docs/docs/how-to/use-images-and-vision.md
@@ -11,8 +11,9 @@ Mellea supports multimodal input: pass images alongside your text prompt to any
 running.
 
 > **Backend note:** The default Ollama model (`granite4.1:3b`) does not support image
-> input. You must switch to a vision-capable model such as `granite-vision-4.1` or
-> `granite3.2-vision`. Not all backends support vision — see backend notes below.
+> input. You must switch to a vision-capable model such as `granite3.2-vision`, or
+> `granite-vision-4.1` via the Hugging Face tag shown below. Not all backends support
+> vision — see backend notes below.
 
 ---
 

--- a/docs/docs/how-to/use-images-and-vision.md
+++ b/docs/docs/how-to/use-images-and-vision.md
@@ -11,8 +11,8 @@ Mellea supports multimodal input: pass images alongside your text prompt to any
 running.
 
 > **Backend note:** The default Ollama model (`granite4.1:3b`) does not support image
-> input. You must switch to a vision-capable model such as `granite3.2-vision` or
-> `llava`. Not all backends support vision — see backend notes below.
+> input. You must switch to a vision-capable model such as `granite-vision-4.1` or
+> `granite3.2-vision`. Not all backends support vision — see backend notes below.
 
 ---
 
@@ -37,6 +37,40 @@ print(str(result))
 ```
 
 Other vision-capable Ollama models: `llava`, `llava-phi3`, `moondream`, `qwen2.5vl:7b`.
+
+### Granite Vision 4.1
+
+`granite-vision-4.1` is the current-generation Granite vision model. It is not in the
+Ollama library, so pull IBM's official GGUF build from Hugging Face instead — that
+build ships the `mmproj` projector Ollama needs for image input:
+
+```bash
+ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M
+```
+
+Reference it with the `IBM_GRANITE_VISION_4_1_4B` constant rather than typing the tag:
+
+```python
+# Requires: mellea, pillow
+# Returns: str
+from PIL import Image
+from mellea import start_session
+from mellea.backends import ModelOption, model_ids
+
+m = start_session(
+    model_id=model_ids.IBM_GRANITE_VISION_4_1_4B,
+    model_options={ModelOption.CONTEXT_WINDOW: 4096},
+)
+
+img = Image.open("photo.jpg")
+result = m.instruct("Is the subject in this image smiling?", images=[img])
+print(str(result))
+# Output will vary — LLM responses depend on model and temperature.
+```
+
+Setting `CONTEXT_WINDOW` explicitly is worth the line. Ollama otherwise allocates the
+model's full 131072-token window — close to 9 GB — for a request that needs a few
+thousand tokens. Capping it at 4096 brings that down to roughly 2.5 GB.
 
 ---
 

--- a/docs/docs/integrations/ollama.md
+++ b/docs/docs/integrations/ollama.md
@@ -88,6 +88,7 @@ ollama pull mistral:7b
 | `IBM_GRANITE_4_1_8B` | `granite4.1:8b` | Higher quality, ~5 GB. |
 | `IBM_GRANITE_3_3_8B` | `granite3.3:8b` | Higher quality, ~5 GB. |
 | `IBM_GRANITE_3_3_VISION_2B` | `ibm/granite3.3-vision:2b` | Vision model for image inputs. |
+| `IBM_GRANITE_VISION_4_1_4B` | `hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M` | Current-generation vision model, pulled from Hugging Face. |
 | `META_LLAMA_3_2_3B` | `llama3.2:3b` | Compact Llama model. |
 | `MISTRALAI_MISTRAL_0_3_7B` | `mistral:7b` | Mistral 7B. |
 | `QWEN3_8B` | `qwen3:8b` | Qwen3 8B. |
@@ -180,7 +181,14 @@ or `chat()` apply to that call only and take precedence.
 ## Vision models
 
 Ollama hosts vision-capable models. Use `IBM_GRANITE_3_3_VISION_2B` or any Ollama
-vision model via the OpenAI-compatible endpoint:
+vision model via the OpenAI-compatible endpoint.
+
+For the current-generation Granite vision model, use `IBM_GRANITE_VISION_4_1_4B`. It is
+not in the Ollama library, so pull IBM's official GGUF build from Hugging Face first —
+`ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M` — and cap
+`ModelOption.CONTEXT_WINDOW` (its full 131072-token window allocates close to 9 GB).
+See [Use Images and Vision Models](../how-to/use-images-and-vision.md) for a worked
+example.
 
 ```python
 # Requires: mellea, pillow

--- a/docs/docs/integrations/ollama.md
+++ b/docs/docs/integrations/ollama.md
@@ -88,6 +88,7 @@ ollama pull mistral:7b
 | `IBM_GRANITE_4_1_8B` | `granite4.1:8b` | Higher quality, ~5 GB. |
 | `IBM_GRANITE_3_3_8B` | `granite3.3:8b` | Higher quality, ~5 GB. |
 | `IBM_GRANITE_3_3_VISION_2B` | `ibm/granite3.3-vision:2b` | Vision model for image inputs. |
+| `IBM_GRANITE_VISION_4_1_4B` | `hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M` | Current-generation vision model, pulled from Hugging Face. |
 | `META_LLAMA_3_2_3B` | `llama3.2:3b` | Compact Llama model. |
 | `MISTRALAI_MISTRAL_0_3_7B` | `mistral:7b` | Mistral 7B. |
 | `QWEN3_8B` | `qwen3:8b` | Qwen3 8B. |
@@ -167,7 +168,14 @@ or `chat()` apply to that call only and take precedence.
 ## Vision models
 
 Ollama hosts vision-capable models. Use `IBM_GRANITE_3_3_VISION_2B` or any Ollama
-vision model via the OpenAI-compatible endpoint:
+vision model via the OpenAI-compatible endpoint.
+
+For the current-generation Granite vision model, use `IBM_GRANITE_VISION_4_1_4B`. It is
+not in the Ollama library, so pull IBM's official GGUF build from Hugging Face first —
+`ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M` — and cap
+`ModelOption.CONTEXT_WINDOW` (its full 131072-token window allocates close to 9 GB).
+See [Use Images and Vision Models](../how-to/use-images-and-vision.md) for a worked
+example.
 
 ```python
 # Requires: mellea, pillow

--- a/docs/examples/image_text_models/README.md
+++ b/docs/examples/image_text_models/README.md
@@ -55,7 +55,10 @@ response = m.chat(
 
 ## Supported Models
 
-- **Ollama**: granite-vision-4.1, granite3.2-vision, llava, bakllava, llava-phi3, moondream, qwen2.5vl:7b
+- **Ollama**: granite3.2-vision, llava, bakllava, llava-phi3, moondream,
+  qwen2.5vl:7b, and granite-vision-4.1 as
+  `hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M` (pulled from Hugging
+  Face rather than the Ollama library, so the full tag is required)
 - **OpenAI**: gpt-4-vision-preview, gpt-4o
 - **LiteLLM**: Various vision models through unified interface
 

--- a/docs/examples/image_text_models/README.md
+++ b/docs/examples/image_text_models/README.md
@@ -55,7 +55,7 @@ response = m.chat(
 
 ## Supported Models
 
-- **Ollama**: granite3.2-vision, llava, bakllava, llava-phi3, moondream, qwen2.5vl:7b
+- **Ollama**: granite-vision-4.1, granite3.2-vision, llava, bakllava, llava-phi3, moondream, qwen2.5vl:7b
 - **OpenAI**: gpt-4-vision-preview, gpt-4o
 - **LiteLLM**: Various vision models through unified interface
 
@@ -66,6 +66,10 @@ Pull a vision-capable model before running these examples:
 ```bash
 ollama pull granite3.2-vision    # ~2.4 GB — primary recommended model
 ollama pull qwen2.5vl:7b         # ~4.7 GB — used in vision_openai_examples.py
+
+# granite-vision-4.1 is the current-generation Granite vision model. It is not in
+# the Ollama library, so pull IBM's official GGUF build from Hugging Face:
+ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M   # ~3.3 GB
 ```
 
 ## Related Documentation

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -151,6 +151,16 @@ IBM_GRANITE_3_3_VISION_2B = ModelIdentifier(
     context_length=131072,
 )
 
+# Granite 4.1 Vision Model (4B). Not in the Ollama library; the `hf.co/...` tag
+# pulls IBM's official GGUF build (which ships the `mmproj` projector needed for
+# image input) straight from Hugging Face.
+IBM_GRANITE_VISION_4_1_4B = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-vision-4.1-4b",
+    ollama_name="hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M",
+    watsonx_name=None,
+    context_length=131072,
+)
+
 IBM_GRANITE_GUARDIAN_3_0_2B = ModelIdentifier(
     hf_model_name="ibm-granite/granite-guardian-3.0-2b",
     ollama_name="granite3-guardian:2b",

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -140,6 +140,16 @@ IBM_GRANITE_3_3_VISION_2B = ModelIdentifier(
     context_length=131072,
 )
 
+# Granite 4.1 Vision Model (4B). Not in the Ollama library; the `hf.co/...` tag
+# pulls IBM's official GGUF build (which ships the `mmproj` projector needed for
+# image input) straight from Hugging Face.
+IBM_GRANITE_VISION_4_1_4B = ModelIdentifier(
+    hf_model_name="ibm-granite/granite-vision-4.1-4b",
+    ollama_name="hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M",
+    watsonx_name=None,
+    context_length=131072,
+)
+
 IBM_GRANITE_GUARDIAN_3_0_2B = ModelIdentifier(
     hf_model_name="ibm-granite/granite-guardian-3.0-2b",
     ollama_name="granite3-guardian:2b",

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -9,10 +9,9 @@ Three tiers:
 2. **Structural payload** (unit, mocked) — verify mellea correctly embeds images
    into the Ollama conversation payload. The Ollama transport is mocked so no
    server or vision model is needed. Runs in CI unconditionally.
-3. **Dormant live e2e** (e2e, qualitative) — full round-trip against a real
-   vision-capable Ollama model. Skipped today because granite-vision-4.1 is not
-   yet in the Ollama library. Reactivates automatically once the model is pulled.
-   See #1187 for the activation checklist.
+3. **Live e2e** (e2e, qualitative) — full round-trip against a real
+   vision-capable Ollama model. Requires `granite-vision-4.1` to be pulled
+   locally; skipped with a pull command if it is not.
 """
 
 import base64
@@ -27,6 +26,7 @@ from PIL import Image
 
 from mellea import MelleaSession
 from mellea.backends import ModelOption
+from mellea.backends.model_ids import IBM_GRANITE_VISION_4_1_4B
 from mellea.core import (
     AudioBlock,
     AudioUrlBlock,
@@ -36,13 +36,18 @@ from mellea.core import (
 )
 from mellea.stdlib.components import Instruction, Message
 
-# Ollama name for the target vision model; bump to the model_ids constant once
-# IBM_GRANITE_VISION_4_1_4B is added to mellea/backends/model_ids.py.
-_VISION_MODEL = "granite-vision-4.1"
+# granite-vision-4.1 is not in the Ollama library, so the model is pulled from
+# IBM's official GGUF repo on Hugging Face. Match on the full tag rather than a
+# bare name so the check cannot be satisfied by an unrelated local alias.
+_VISION_MODEL = IBM_GRANITE_VISION_4_1_4B
+_VISION_MODEL_TAG = str(IBM_GRANITE_VISION_4_1_4B.ollama_name)
 _SKIP_REASON = (
-    f"Vision model {_VISION_MODEL!r} not available in Ollama — "
-    "see https://github.com/generative-computing/mellea/issues/1187"
+    f"Vision model not pulled locally — run `ollama pull {_VISION_MODEL_TAG}`"
 )
+
+# The model's full 131072-token context window loads ~9 GB for a job that needs a
+# few thousand tokens; capping it keeps the live tests near 2.5 GB.
+_VISION_CONTEXT_WINDOW = 4096
 
 
 # ── Shared image fixture ──────────────────────────────────────────────────────
@@ -294,18 +299,15 @@ def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Ima
     assert image_list[0] == str(image_block)
 
 
-# ── Tier 3: Dormant live e2e ──────────────────────────────────────────────────
+# ── Tier 3: Live e2e ──────────────────────────────────────────────────────────
 #
-# Full round-trip against a real vision-capable Ollama model.  Currently skipped
-# because granite-vision-4.1 is not yet in the Ollama library.
-#
-# To activate: ensure `ollama pull granite-vision-4.1` succeeds, then remove the
-# pytest.skip() call from vision_session below and add the model to the CI pull
-# step in .github/workflows/quality.yml.  See #1187 for the full checklist.
+# Full round-trip against a real vision-capable Ollama model.  CI pulls the model
+# in the "Pull models" step of .github/workflows/quality.yml; locally these skip
+# unless you have pulled it yourself (the skip message gives the command).
 
 
 def _ollama_vision_model_available() -> bool:
-    """Return True if _VISION_MODEL is present in the local Ollama model list."""
+    """Return True if the vision model tag is present in the local Ollama model list."""
     import requests
 
     host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
@@ -318,7 +320,7 @@ def _ollama_vision_model_available() -> bool:
         resp = requests.get(f"{base_url}/api/tags", timeout=5)
         resp.raise_for_status()
         pulled = {m.get("name", "") for m in resp.json().get("models", [])}
-        return any(_VISION_MODEL in name for name in pulled)
+        return any(name.startswith(_VISION_MODEL_TAG) for name in pulled)
     except Exception:
         return False
 
@@ -331,7 +333,12 @@ def vision_session():
     from mellea import start_session
 
     m = start_session(
-        "ollama", model_id=_VISION_MODEL, model_options={ModelOption.MAX_NEW_TOKENS: 5}
+        "ollama",
+        model_id=_VISION_MODEL,
+        model_options={
+            ModelOption.MAX_NEW_TOKENS: 5,
+            ModelOption.CONTEXT_WINDOW: _VISION_CONTEXT_WINDOW,
+        },
     )
     yield m
     del m
@@ -343,7 +350,7 @@ def vision_session():
 def test_vision_instruct_live_e2e(
     vision_session: MelleaSession, pil_image: Image.Image
 ):
-    """Live vision instruct round-trip; skips until granite-vision-4.1 lands on Ollama."""
+    """Live vision instruct round-trip against granite-vision-4.1."""
     image_block: ImageBlock | ImageUrlBlock = ImageBlock.from_pil_image(pil_image)
     instr = vision_session.instruct(
         "Is this image mainly blue? Answer yes or no.",
@@ -359,7 +366,7 @@ def test_vision_instruct_live_e2e(
 @pytest.mark.ollama
 @pytest.mark.qualitative
 def test_vision_chat_live_e2e(vision_session: MelleaSession, pil_image: Image.Image):
-    """Live vision chat round-trip; skips until granite-vision-4.1 lands on Ollama."""
+    """Live vision chat round-trip against granite-vision-4.1."""
     ct = vision_session.chat(
         "Is this image mainly blue? Answer yes or no.", images=[pil_image]
     )

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -9,9 +9,13 @@ Three tiers:
 2. **Structural payload** (unit, mocked) — verify mellea correctly embeds images
    into the Ollama conversation payload. The Ollama transport is mocked so no
    server or vision model is needed. Runs in CI unconditionally.
-3. **Live e2e** (e2e, qualitative) — full round-trip against a real
-   vision-capable Ollama model. Requires `granite-vision-4.1` to be pulled
-   locally; skipped with a pull command if it is not.
+3. **Live e2e** (e2e) — full round-trip against a real vision-capable Ollama
+   model. The assertions are structural (a thunk/message with non-empty content),
+   so these are `e2e` and not `qualitative`: no assertion here can be broken by
+   swapping the model version, and marking them `qualitative` would exclude them
+   from CI, where `CICD=1` skips that tier. Requires `granite-vision-4.1` to be
+   pulled; skipped locally with a pull command if it is not, and failed in CI,
+   where the workflow is responsible for pulling it.
 """
 
 import base64
@@ -306,8 +310,8 @@ def test_image_block_in_chat(mocked_session: MelleaSession, pil_image: Image.Ima
 # unless you have pulled it yourself (the skip message gives the command).
 
 
-def _ollama_vision_model_available() -> bool:
-    """Return True if the vision model tag is present in the local Ollama model list."""
+def _pulled_ollama_models() -> set[str]:
+    """Return the model names Ollama reports locally; empty if it is unreachable."""
     import requests
 
     host = os.environ.get("OLLAMA_HOST", "127.0.0.1")
@@ -319,15 +323,35 @@ def _ollama_vision_model_available() -> bool:
     try:
         resp = requests.get(f"{base_url}/api/tags", timeout=5)
         resp.raise_for_status()
-        pulled = {m.get("name", "") for m in resp.json().get("models", [])}
-        return any(name.startswith(_VISION_MODEL_TAG) for name in pulled)
+        return {m.get("name", "") for m in resp.json().get("models", [])}
     except Exception:
-        return False
+        return set()
+
+
+def _vision_model_pulled(pulled: set[str]) -> bool:
+    """Return True if the vision model tag is among the pulled model names.
+
+    Compared case-insensitively: Ollama has normalised the case of `hf.co/...` tags
+    differently across versions, and a case difference alone must not decide whether
+    the live tests run.
+    """
+    tag = _VISION_MODEL_TAG.casefold()
+    return any(name.casefold().startswith(tag) for name in pulled)
 
 
 @pytest.fixture
-def vision_session():
-    if not _ollama_vision_model_available():
+def vision_session(gh_run: int):
+    pulled = _pulled_ollama_models()
+    if not _vision_model_pulled(pulled):
+        if gh_run:
+            # CI pulls this model in the "Pull models" step, so a miss here is a real
+            # failure -- either the pull did not happen or Ollama reports the model
+            # under a name this check does not recognise. Skipping would hide both
+            # behind a green tick.
+            pytest.fail(
+                f"{_SKIP_REASON}\nOllama reported: "
+                f"{sorted(pulled) if pulled else '<no models / server unreachable>'}"
+            )
         pytest.skip(_SKIP_REASON)
 
     from mellea import start_session
@@ -346,7 +370,6 @@ def vision_session():
 
 @pytest.mark.e2e
 @pytest.mark.ollama
-@pytest.mark.qualitative
 def test_vision_instruct_live_e2e(
     vision_session: MelleaSession, pil_image: Image.Image
 ):
@@ -364,7 +387,6 @@ def test_vision_instruct_live_e2e(
 
 @pytest.mark.e2e
 @pytest.mark.ollama
-@pytest.mark.qualitative
 def test_vision_chat_live_e2e(vision_session: MelleaSession, pil_image: Image.Image):
     """Live vision chat round-trip against granite-vision-4.1."""
     ct = vision_session.chat(

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -329,25 +329,13 @@ def _pulled_ollama_models() -> set[str]:
 
 
 def _vision_model_pulled(pulled: set[str]) -> bool:
-    """Return True if the vision model tag is among the pulled model names.
-
-    Compared case-insensitively: Ollama has normalised the case of `hf.co/...` tags
-    differently across versions, and a case difference alone must not decide whether
-    the live tests run.
-    """
-    tag = _VISION_MODEL_TAG.casefold()
-    return any(name.casefold().startswith(tag) for name in pulled)
+    """Return True if the vision model tag is among the pulled model names."""
+    return any(name.startswith(_VISION_MODEL_TAG) for name in pulled)
 
 
-def test_vision_model_tag_match_ignores_case():
-    """Ollama has varied the case of `hf.co/...` tags, so matching must not depend on it."""
-    assert _vision_model_pulled({_VISION_MODEL_TAG})
-    assert _vision_model_pulled({_VISION_MODEL_TAG.lower()})
-    assert _vision_model_pulled({_VISION_MODEL_TAG.upper()})
-
-
-def test_vision_model_tag_match_rejects_other_models():
+def test_vision_model_tag_matches_the_pulled_tag():
     """Only the pinned tag counts; a bare alias could point at any model."""
+    assert _vision_model_pulled({_VISION_MODEL_TAG})
     assert not _vision_model_pulled(set())
     assert not _vision_model_pulled({"granite4.1:3b", "granite3.2-vision:latest"})
     assert not _vision_model_pulled({"granite-vision-4.1:latest"})

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -339,6 +339,20 @@ def _vision_model_pulled(pulled: set[str]) -> bool:
     return any(name.casefold().startswith(tag) for name in pulled)
 
 
+def test_vision_model_tag_match_ignores_case():
+    """Ollama has varied the case of `hf.co/...` tags, so matching must not depend on it."""
+    assert _vision_model_pulled({_VISION_MODEL_TAG})
+    assert _vision_model_pulled({_VISION_MODEL_TAG.lower()})
+    assert _vision_model_pulled({_VISION_MODEL_TAG.upper()})
+
+
+def test_vision_model_tag_match_rejects_other_models():
+    """Only the pinned tag counts; a bare alias could point at any model."""
+    assert not _vision_model_pulled(set())
+    assert not _vision_model_pulled({"granite4.1:3b", "granite3.2-vision:latest"})
+    assert not _vision_model_pulled({"granite-vision-4.1:latest"})
+
+
 @pytest.fixture
 def vision_session(gh_run: int):
     pulled = _pulled_ollama_models()

--- a/test/backends/test_vision_ollama.py
+++ b/test/backends/test_vision_ollama.py
@@ -44,7 +44,10 @@ from mellea.stdlib.components import Instruction, Message
 # IBM's official GGUF repo on Hugging Face. Match on the full tag rather than a
 # bare name so the check cannot be satisfied by an unrelated local alias.
 _VISION_MODEL = IBM_GRANITE_VISION_4_1_4B
-_VISION_MODEL_TAG = str(IBM_GRANITE_VISION_4_1_4B.ollama_name)
+# Asserted rather than coerced with str(): ollama_name is `str | None`, and
+# str(None) would silently make the tag the literal "None".
+assert IBM_GRANITE_VISION_4_1_4B.ollama_name is not None
+_VISION_MODEL_TAG = IBM_GRANITE_VISION_4_1_4B.ollama_name
 _SKIP_REASON = (
     f"Vision model not pulled locally — run `ollama pull {_VISION_MODEL_TAG}`"
 )
@@ -329,16 +332,19 @@ def _pulled_ollama_models() -> set[str]:
 
 
 def _vision_model_pulled(pulled: set[str]) -> bool:
-    """Return True if the vision model tag is among the pulled model names."""
-    return any(name.startswith(_VISION_MODEL_TAG) for name in pulled)
+    """Return True if the exact vision model tag is among the pulled model names."""
+    return _VISION_MODEL_TAG in pulled
 
 
 def test_vision_model_tag_matches_the_pulled_tag():
-    """Only the pinned tag counts; a bare alias could point at any model."""
+    """Only the exact pinned tag counts; anything else may be a different model."""
     assert _vision_model_pulled({_VISION_MODEL_TAG})
     assert not _vision_model_pulled(set())
     assert not _vision_model_pulled({"granite4.1:3b", "granite3.2-vision:latest"})
+    # A bare alias of that name could point anywhere, and a longer tag sharing
+    # the prefix is a different model -- neither counts.
     assert not _vision_model_pulled({"granite-vision-4.1:latest"})
+    assert not _vision_model_pulled({f"{_VISION_MODEL_TAG}-extra"})
 
 
 @pytest.fixture


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1187

## Description

`granite-vision-4.1` still isn't in the Ollama library, so the live vision tests added
in #1185 have been dormant since. IBM now publishes an official GGUF build — including
the `mmproj` projector Ollama needs for image input — so the model pulls straight from
Hugging Face:

```bash
ollama pull hf.co/ibm-granite/granite-vision-4.1-4b-GGUF:Q4_K_M
```

That completes the checklist on #1187:

- `IBM_GRANITE_VISION_4_1_4B` added to `model_ids`, with the `hf.co/...` tag as its
  `ollama_name` (swap in a library tag if the model is ever published there).
- `test_vision_ollama.py` uses that constant; the dormancy comments are gone.
- CI pulls the model, and the tests now genuinely run there.

### The `qualitative` marker was the real blocker

Adding the pull wasn't enough. `test/conftest.py:642` skips every `qualitative`-marked
test when `CICD=1`, so the first CI run here went green having never exercised the
round-trip — the 3.3 GB download bought nothing.

By the rule in `test/README.md`: qualitative means an assertion a model-version swap
could break, while structural, type, and functional assertions are `e2e`. These two
assert `isinstance`, `is not None`, and `len(...) > 0`, and nothing about content — so
they are `e2e`, and the marker was the only thing keeping them out of CI.

Because a silent skip had already passed for a pass once, the fixture now **fails**
rather than skips when `CICD=1`, printing what Ollama actually listed. CI owns the pull,
so a miss there is a defect. Local runs still skip, with the pull command in the reason.

One trade-off worth a second opinion: a failed pull now fails the job, which makes
Hugging Face availability a dependency of every quality run — `granite4.1:3b` from the
Ollama library has no such exposure. The step retries 5× with 20 s backoff, enough for a
blip but not an outage. I think loud beats silent here, but it is a judgement call.

### Two smaller things

- The fixture caps `CONTEXT_WINDOW` at 4096. The model's full 131072-token window
  allocates close to 9 GB for a request needing a few thousand tokens; capped it is about
  2.5 GB. That matters on a 16 GB runner already holding `granite4.1:3b`, and may be what
  @AngeloDanducci ran into (comment on #1187).
- The pull step now runs `ollama list`, so a tag mismatch is diagnosable from the log
  alone rather than by bisecting a skip.

### Cost in CI

About 30 s on a ~25 minute job, measured from the log timestamps: **15.7 s** to pull the
3.3 GB model (runners fetch at ~850 MB/s) and **16 s** to run both tests — 15.2 s for the
first, including model load, then 0.75 s for the second with the model resident.

Job totals were 24m42s (3.11), 25m03s (3.12), 24m44s (3.13) against a 19m46s–26m24s
baseline on the base commit, so the change sits well inside run-to-run variance. No need
to mark these `slow`.

### Docs

The vision docs recommended `granite3.2-vision` and never mentioned 4.1 or the `hf.co`
route, so the current-generation model looked unavailable on Ollama:

- `how-to/use-images-and-vision.md` — a Granite Vision 4.1 section with the pull command,
  an `IBM_GRANITE_VISION_4_1_4B` example, and why capping `CONTEXT_WINDOW` is worth the
  line.
- `integrations/ollama.md` — the constant in the model table, vision section pointing at
  the how-to.
- `examples/image_text_models/README.md` — the model and its pull command.

The how-to example was run against the live model before committing. Existing
`granite3.2-vision` references are untouched; that model still works.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

From the CI job logs rather than the check status, since a skip and a pass look identical
from outside (run `31476048618`):

```
test_vision_instruct_live_e2e PASSED
test_vision_chat_live_e2e     PASSED
```

on 3.11, 3.12 and 3.13. That was the first run in which they executed.

Locally, all four combinations of the fixture's guard:

| Model pulled | `CICD` | Result |
| ------------ | ------ | ------ |
| yes | `1` | both tests run and pass |
| no  | `1` | fails, listing the models Ollama reported |
| yes | unset | both tests run and pass |
| no  | unset | skips, with the pull command in the reason |

Plus `test/backends/test_vision_ollama.py` 12 passed; `uv run pytest test/ -m "not
qualitative"` 3875 passed, 21 skipped, 2 xfailed, 2 xpassed, 0 failures; `ruff format`,
`ruff check`, `mypy` clean; pre-commit on every commit.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
