### PR TITLE
feat(backends): add default_extra_body to OpenAIBackend

### DIFF
--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -362,8 +362,10 @@ print(result.thinking)                       # populated reasoning content, if a
 
 This affects models that default to thinking mode, most commonly Qwen3 served
 via vLLM with `--reasoning-parser qwen3`. To disable thinking and get a normal
-text response, pass the runtime-specific switch through `model_options`. For
-vLLM:
+text response, pass the runtime-specific switch through `extra_body`.
+
+To set it once for every call the session makes (recommended — see below for
+why), pass `default_extra_body` when constructing the backend. For vLLM:
 
 ```python
 from mellea import MelleaSession
@@ -374,12 +376,30 @@ m = MelleaSession(
         model_id="Qwen/Qwen3-Coder-Next-FP8",
         base_url="http://localhost:8000/v1",
         api_key="unused",
-        model_options={
-            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
-        },
+        default_extra_body={"chat_template_kwargs": {"enable_thinking": False}},
     )
 )
 ```
+
+`default_extra_body` fields are merged into every request this backend makes;
+a per-call override (passed via `model_options={"extra_body": ...}` on a
+single `instruct()`/`act()` call) takes precedence for that one call, and
+`chat_template_kwargs` is deep-merged across both, so a construction-time
+thinking setting is not silently dropped when a call also activates an
+intrinsic adapter (which writes its own `chat_template_kwargs.adapter_name`).
+
+Toggling thinking per call is also possible via `model_options={"extra_body":
+...}` on the call itself, but not via `model_options={"extra_body": ...}` at
+**construction** time — that older pattern is not deep-merged and can be
+silently overwritten by an unrelated per-call `extra_body` on some other
+call in the same session ([#1539](https://github.com/generative-computing/mellea/issues/1539)).
+Use `default_extra_body` for anything you want to persist across every call.
+
+Note also that switching `enable_thinking` mid-session changes the rendered
+chat-template prefix on servers like vLLM, which can invalidate that
+server's prefix/KV cache for the conversation from that point on — another
+reason to fix it once via `default_extra_body` rather than toggling it call
+by call.
 
 Other inference servers expose the same control under different names — check
 your runtime's documentation. If you intend to use thinking mode, read the

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -90,13 +90,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             falls back to *model_id*. Use this when the vLLM served model name
             differs from the adapter config location.
         api_key (str | None): API key; falls back to `OPENAI_API_KEY` env var.
-        default_extra_body (dict | None): Construction-time ``extra_body`` fields
+        default_extra_body (dict | None): Construction-time `extra_body` fields
             that are merged into every request this backend makes. Per-call
-            ``extra_body`` values (from ``model_options``) take precedence.
-            ``chat_template_kwargs`` is deep-merged across all layers so that,
-            for example, a construction-time ``enable_thinking`` flag is not
-            silently dropped when the request also carries an ``adapter_name``.
-            Defaults to ``{}`` (no extra fields).
+            `extra_body` values (from `model_options`) take precedence.
+            `chat_template_kwargs` is deep-merged across all layers so that,
+            for example, a construction-time `enable_thinking` flag is not
+            silently dropped when the request also carries an `adapter_name`.
+            Defaults to `{}` (no extra fields).
         kwargs: Additional keyword arguments forwarded to the OpenAI client.
 
     Attributes:
@@ -473,24 +473,24 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         """Merges default_extra_body, Mellea-assembled extra_body, and caller-supplied extra_body.
 
         Merge order (lowest → highest priority):
-          1. ``self._default_extra_body`` — set at construction time
-          2. ``base`` — assembled by Mellea for this request (documents, structured_outputs, …)
-          3. ``user`` — from the caller's per-call ``model_options``
+          1. `self._default_extra_body` — set at construction time
+          2. `base` — assembled by Mellea for this request (documents, structured_outputs, …)
+          3. `user` — from the caller's per-call `model_options`
 
-        Both must end up in a single ``extra_body`` value; passing two spreads
-        that each contain one raises ``TypeError`` at call time.
+        Both must end up in a single `extra_body` value; passing two spreads
+        that each contain one raises `TypeError` at call time.
 
-        ``chat_template_kwargs`` is the only nested dict Mellea writes into
-        ``extra_body`` and is deep-merged across all three layers so that, for
-        example, a construction-time ``{"enable_thinking": True}`` is not silently
-        dropped when a per-call ``{"adapter_name": "foo"}`` is also present.
+        `chat_template_kwargs` is the only nested dict Mellea writes into
+        `extra_body` and is deep-merged across all three layers so that, for
+        example, a construction-time `{"enable_thinking": True}` is not silently
+        dropped when a per-call `{"adapter_name": "foo"}` is also present.
 
         Args:
-            base: the ``extra_body`` Mellea assembled for this request.
-            user: ``extra_body`` taken from the caller's model_options, or None.
+            base: the `extra_body` Mellea assembled for this request.
+            user: `extra_body` taken from the caller's model_options, or None.
 
         Returns:
-            a new dict; ``base``, ``user``, and ``self._default_extra_body`` are
+            a new dict; `base`, `user`, and `self._default_extra_body` are
             left unmodified.
         """
         # Start from construction-time defaults, then overlay Mellea-built values.

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -1030,10 +1030,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             model_opts, is_chat_context=ctx.is_chat_context
         )
         user_extra_body = backend_specific.pop("extra_body", None)
-        if user_extra_body is not None:
-            extra_params["extra_body"] = self._merge_user_extra_body(
-                extra_params.get("extra_body") or {}, user_extra_body
-            )
+        extra_params["extra_body"] = self._merge_user_extra_body(
+            extra_params.get("extra_body") or {}, user_extra_body
+        )
 
         chat_response: Coroutine[
             Any, Any, ChatCompletion | openai.AsyncStream[ChatCompletionChunk]

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -90,6 +90,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             falls back to *model_id*. Use this when the vLLM served model name
             differs from the adapter config location.
         api_key (str | None): API key; falls back to `OPENAI_API_KEY` env var.
+        default_extra_body (dict | None): Construction-time ``extra_body`` fields
+            that are merged into every request this backend makes. Per-call
+            ``extra_body`` values (from ``model_options``) take precedence.
+            ``chat_template_kwargs`` is deep-merged across all layers so that,
+            for example, a construction-time ``enable_thinking`` flag is not
+            silently dropped when the request also carries an ``adapter_name``.
+            Defaults to ``{}`` (no extra fields).
         kwargs: Additional keyword arguments forwarded to the OpenAI client.
 
     Attributes:
@@ -114,6 +121,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         load_embedded_adapters: bool = False,
         adapter_source: str | None = None,
         api_key: str | None = None,
+        default_extra_body: dict | None = None,
         **kwargs,
     ):
         """Initialize an OpenAI-compatible backend with the given model ID and API credentials."""
@@ -170,6 +178,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         }
 
         self.default_to_constraint_checking_alora = default_to_constraint_checking_alora
+        self._default_extra_body: dict = default_extra_body or {}
 
         match model_id:
             case str():
@@ -458,31 +467,56 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
         return model_opts
 
-    @staticmethod
     def _merge_user_extra_body(
-        base: dict[str, Any], user: dict[str, Any] | None
+        self, base: dict[str, Any], user: dict[str, Any] | None
     ) -> dict[str, Any]:
-        """Merges a user-supplied `extra_body` into the one Mellea built.
+        """Merges default_extra_body, Mellea-assembled extra_body, and caller-supplied extra_body.
 
-        Both must end up in a single `extra_body` value; passing two spreads that
-        each contain one raises `TypeError` at call time.
+        Merge order (lowest → highest priority):
+          1. ``self._default_extra_body`` — set at construction time
+          2. ``base`` — assembled by Mellea for this request (documents, structured_outputs, …)
+          3. ``user`` — from the caller's per-call ``model_options``
+
+        Both must end up in a single ``extra_body`` value; passing two spreads
+        that each contain one raises ``TypeError`` at call time.
+
+        ``chat_template_kwargs`` is the only nested dict Mellea writes into
+        ``extra_body`` and is deep-merged across all three layers so that, for
+        example, a construction-time ``{"enable_thinking": True}`` is not silently
+        dropped when a per-call ``{"adapter_name": "foo"}`` is also present.
 
         Args:
-            base: the `extra_body` Mellea assembled for this request
-            user: `extra_body` taken from the caller's model_options, or None
+            base: the ``extra_body`` Mellea assembled for this request.
+            user: ``extra_body`` taken from the caller's model_options, or None.
 
         Returns:
-            a new dict; `base` and `user` are left unmodified
+            a new dict; ``base``, ``user``, and ``self._default_extra_body`` are
+            left unmodified.
         """
-        if user is None:
-            return base
+        # Start from construction-time defaults, then overlay Mellea-built values.
+        # Work on copies throughout so no caller dict is mutated.
+        merged = dict(self._default_extra_body)
+        default_ctk = merged.pop("chat_template_kwargs", None)
 
-        # shallow copy so .pop() below doesn't mutate the caller's dict
+        base = dict(base) if base else {}
+        base_ctk = base.pop("chat_template_kwargs", None)
+        merged.update(base)
+
+        # Merge chat_template_kwargs from default and base layers.
+        merged_ctk: dict = {}
+        if default_ctk is not None:
+            merged_ctk.update(default_ctk)
+        if base_ctk is not None:
+            merged_ctk.update(base_ctk)
+        if merged_ctk:
+            merged["chat_template_kwargs"] = merged_ctk
+
+        if user is None:
+            return merged
+
+        # Overlay caller-supplied values last (highest priority).
         user = dict(user)
-        merged = dict(base)
         user_ctk = user.pop("chat_template_kwargs", None)
-        # shallow merge is safe: chat_template_kwargs is the only nested dict key
-        # Mellea writes into extra_body; it is deep-merged separately below
         merged.update(user)
         if user_ctk is not None:
             merged["chat_template_kwargs"] = {

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -487,5 +487,52 @@ def test_default_extra_body_does_not_mutate_constructor_arg():
     assert defaults == {"chat_template_kwargs": {"enable_thinking": True}}
 
 
+async def test_standard_chat_path_applies_default_extra_body_without_per_call_override():
+    """Regression test for #1453: the standard chat path must not silently
+    drop `default_extra_body` when the caller passes no per-call `extra_body`.
+
+    `_generate_from_chat_context_standard` used to call `_merge_user_extra_body`
+    only when `model_options` carried a per-call `extra_body` override, so a
+    construction-time `default_extra_body` never reached the wire on an
+    ordinary call — defeating the "set once at construction" point of the
+    feature.
+    """
+    from mellea.core.base import CBlock
+    from mellea.stdlib.context import ChatContext
+
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+    )
+
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = ChatCompletion(
+            id="test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion",
+        )
+        mot, _ = await backend.generate_from_chat_context(
+            CBlock(value="hello"),
+            ChatContext(),
+            model_options={ModelOption.STREAM: False},
+        )
+        await mot.avalue()
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -487,6 +487,30 @@ def test_default_extra_body_does_not_mutate_constructor_arg():
     assert defaults == {"chat_template_kwargs": {"enable_thinking": True}}
 
 
+def test_default_extra_body_chat_template_kwargs_three_way_merge():
+    """default_extra_body, base, and per-call user all contribute simultaneously.
+
+    Each layer sets a distinct chat_template_kwargs key (mirroring a real call:
+    a construction-time thinking default, Mellea's own adapter-activation write,
+    and a per-call override for something else) — all three must survive.
+    """
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+    )
+    merged = backend._merge_user_extra_body(
+        {"chat_template_kwargs": {"adapter_name": "answerability"}},
+        {"chat_template_kwargs": {"thinking_budget": 5000}},
+    )
+    assert merged["chat_template_kwargs"] == {
+        "enable_thinking": True,
+        "adapter_name": "answerability",
+        "thinking_budget": 5000,
+    }
+
+
 async def test_standard_chat_path_applies_default_extra_body_without_per_call_override():
     """Regression test for #1453: the standard chat path must not silently
     drop `default_extra_body` when the caller passes no per-call `extra_body`.

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -353,9 +353,13 @@ async def test_processing_reasoning_content_takes_precedence_over_reasoning(back
 
 
 def test_merge_user_extra_body_none_returns_base(backend):
-    """A missing user extra_body leaves the base untouched."""
+    """A missing user extra_body returns a dict equal to base (a copy, not same object)."""
     base = {"documents": ["d"]}
-    assert backend._merge_user_extra_body(base, None) is base
+    result = backend._merge_user_extra_body(base, None)
+    assert result == {"documents": ["d"]}
+    assert (
+        result is not base
+    )  # always returns a new dict so default_extra_body can be layered
 
 
 def test_merge_user_extra_body_user_keys_win(backend):
@@ -427,6 +431,60 @@ async def test_generate_from_raw_merges_user_extra_body(backend):
     extra_body = call_kwargs["extra_body"]
     assert extra_body["caller_key"] == "caller-value"
     assert "guided_json" in extra_body or "structured_outputs" in extra_body
+
+
+def test_default_extra_body_applied_when_no_per_call_override():
+    """Construction-time default_extra_body is present in every merged result."""
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body={"enable_thinking": False},
+    )
+    merged = backend._merge_user_extra_body({}, None)
+    assert merged["enable_thinking"] is False
+
+
+def test_default_extra_body_overridden_by_per_call():
+    """Per-call model_options take priority over construction-time defaults."""
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body={"enable_thinking": False},
+    )
+    merged = backend._merge_user_extra_body({}, {"enable_thinking": True})
+    assert merged["enable_thinking"] is True
+
+
+def test_default_extra_body_chat_template_kwargs_deep_merged():
+    """chat_template_kwargs from default and per-call are merged key-by-key."""
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+    )
+    merged = backend._merge_user_extra_body(
+        {"chat_template_kwargs": {"adapter_name": "foo"}}, None
+    )
+    assert merged["chat_template_kwargs"] == {
+        "enable_thinking": True,
+        "adapter_name": "foo",
+    }
+
+
+def test_default_extra_body_does_not_mutate_constructor_arg():
+    """The dict passed as default_extra_body is not mutated by merge operations."""
+    defaults = {"chat_template_kwargs": {"enable_thinking": True}}
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        default_extra_body=defaults,
+    )
+    backend._merge_user_extra_body({"other_key": "val"}, {"another": "val2"})
+    assert defaults == {"chat_template_kwargs": {"enable_thinking": True}}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds an optional `default_extra_body: dict | None = None` parameter to `OpenAIBackend.__init__()`.

Fields set at construction time are merged into `extra_body` on every request the backend makes, at lower priority than Mellea-assembled values and lower priority than per-call `model_options`.

Closes #1453.

**Scope note (read before reviewing):** this fixes the *session-wide default* case — `default_extra_body` now reliably reaches every request this backend makes, including calls that don't pass any per-call `extra_body` at all. It does **not** fix the older, already-documented `OpenAIBackend(model_options={"extra_body": ...})` construction-time pattern, which goes through a different, shared merge path (`resolve_model_options` / `merge_model_options` in `mellea/backends/_options.py`) that does a flat replace rather than a deep merge — that pattern can still be silently clobbered by an unrelated per-call `extra_body` on some other call in the same session. That's a distinct bug with a wider blast radius (it's shared merge code also used by `LocalHFBackend`), tracked separately as #1539 rather than folded in here.

## Motivation

Callers that need a vendor-specific `extra_body` field on every request (for example, `chat_template_kwargs` for thinking-tier control on vLLM-compatible servers) currently have no way to set it once. The only option is to pass it in `model_options` at every `instruct()` / `act()` call site, which is verbose and error-prone in any wrapper code.

There's a second, stronger reason to set this once rather than per call: on servers like vLLM, `chat_template_kwargs.enable_thinking` changes the *rendered chat-template prefix*, not just a sampling parameter. Toggling it call-to-call can invalidate that server's prefix/KV cache for the conversation from that point on. Setting it once at construction keeps the template shape — and the cache — stable for the whole session.

## Example use case

The scenario this deep-merge exists for: a session that sets a thinking
default once at construction, *and* also makes calls that activate an
intrinsic/aLoRA adapter (which independently writes into the same
`chat_template_kwargs` key to activate itself). Without the deep merge,
whichever of the two got assembled last would silently overwrite the
other's entry.

Verified directly against `_merge_user_extra_body` (this is the actual
three-way test added in this PR, not a hypothetical):

```python
backend = OpenAIBackend(
    model_id="gpt-4o", base_url="http://localhost:9999/v1", api_key="test-key",
    default_extra_body={"chat_template_kwargs": {"enable_thinking": True}},
)

merged = backend._merge_user_extra_body(
    {"chat_template_kwargs": {"adapter_name": "answerability"}},  # Mellea's own adapter-activation write
    {"chat_template_kwargs": {"thinking_budget": 5000}},           # a per-call override
)
assert merged["chat_template_kwargs"] == {
    "enable_thinking": True,       # from default_extra_body — survives
    "adapter_name": "answerability",  # from Mellea's adapter activation — survives
    "thinking_budget": 5000,       # from the per-call override — wins on conflicts
}
```

At the session level, this is what lets a caller set `enable_thinking`
once when constructing the backend and then freely mix ordinary
`instruct()`/`act()` calls with calls that use an intrinsic adapter
(`mellea.stdlib.components.intrinsic`) in the same session, without either
one silently clobbering the other's `chat_template_kwargs` entry.

## Merge order (lowest → highest priority)

1. `default_extra_body` — set at construction time
2. `base` — assembled by Mellea per request (documents, structured_outputs, adapter activation, …)
3. `user` — from the caller's per-call `model_options`

`chat_template_kwargs` is deep-merged across all three layers so that, for example, a construction-time `enable_thinking` flag is not silently dropped when the request also carries an `adapter_name` injected by Mellea (intrinsic/adapter calls write their own `chat_template_kwargs.adapter_name` to activate the correct adapter).

## Changes

- `OpenAIBackend.__init__`: new keyword-only `default_extra_body` param (default `None` / `{}`)
- `_merge_user_extra_body`: promoted from `@staticmethod` to instance method; now layers `self._default_extra_body` as the base; all existing call sites are unchanged
- **Fix**: `_generate_from_chat_context_standard` (the primary chat-completion path) only invoked `_merge_user_extra_body` when a per-call `extra_body` override was present, so `default_extra_body` was silently dropped on any ordinary call that didn't also pass one — defeating the "set once at construction" point of this feature. The merge is now unconditional at that call site.
- Updated docstrings
- `docs/docs/integrations/openai.md`: the thinking-mode troubleshooting section now recommends `default_extra_body` for anything meant to persist across a session's calls, and flags the caveat on the older `model_options={"extra_body": ...}`-at-construction pattern (see #1539)

## Tests

- Updated `test_merge_user_extra_body_none_returns_base`: the method now always returns a new dict (can no longer return the original `base` by identity since `default_extra_body` must be layered in). Test updated to check equality rather than identity.
- Added:
  - `test_default_extra_body_applied_when_no_per_call_override`
  - `test_default_extra_body_overridden_by_per_call`
  - `test_default_extra_body_chat_template_kwargs_deep_merged`
  - `test_default_extra_body_does_not_mutate_constructor_arg`
  - `test_default_extra_body_chat_template_kwargs_three_way_merge` — all three layers (`default_extra_body`, `base`, per-call `user`) contributing to `chat_template_kwargs` simultaneously; the other tests each only covered two of the three layers at once.
  - `test_standard_chat_path_applies_default_extra_body_without_per_call_override` — regression test for the call-site bug above, exercising the real `generate_from_chat_context` path with a mocked client. Verified it fails against the pre-fix code (`KeyError: 'extra_body'`) and passes with the fix.

## Backward compatibility

Fully additive — `default_extra_body` defaults to `{}` and the merge is a no-op when it is empty. No existing callers are affected.

## Follow-up

#1539 tracks fixing the shared `resolve_model_options`/`merge_model_options` merge so the older `model_options={"extra_body": ...}` construction-time pattern gets the same deep-merge safety as `default_extra_body`, across all backends that use it (not just `OpenAIBackend`).

