### PR TITLE
feat: allow components to declare their chat role via format_for_llm

### DIFF
--- a/docs/docs/advanced/custom-components.md
+++ b/docs/docs/advanced/custom-components.md
@@ -146,6 +146,8 @@ For components that need model-specific prompt formatting, return a
 | `template` | `str \| None` | Inline Jinja2 template string |
 | `template_order` | `list[str] \| None` | Template file names to look up; `"*"` means the class name |
 | `images` | `list \| None` | Image blocks to include |
+| `audio` | `list \| None` | Audio blocks to include |
+| `role` | `str \| None` | Chat role to serialize as; `None` uses the default (`user`, or `assistant` for model-generated components) |
 
 The formatter resolves template files from a `templates/prompts/` directory,
 traversing subdirectories that match the model ID before falling back to

--- a/docs/docs/advanced/custom-components.md
+++ b/docs/docs/advanced/custom-components.md
@@ -148,6 +148,9 @@ For components that need model-specific prompt formatting, return a
 | `images` | `list \| None` | Image blocks to include |
 | `audio` | `list \| None` | Audio blocks to include |
 | `role` | `str \| None` | Chat role to serialize as; `None` uses the default (`user`, or `assistant` for model-generated components) |
+| `thinking` | `str \| None` | Reasoning trace to carry onto the serialized message |
+| `tool_calls` | `list \| None` | OpenAI-compatible assistant tool calls to carry onto the message |
+| `tool_call_id` | `str \| None` | For a `role="tool"` component, the provider-supplied tool-call id |
 
 The formatter resolves template files from a `templates/prompts/` directory,
 traversing subdirectories that match the model ID before falling back to

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1735,6 +1735,10 @@ class TemplateRepresentation:
         images (list[ImageBlock | ImageUrlBlock] | None): Optional list of image blocks associated with this representation.
         audio (list[AudioBlock | AudioUrlBlock] | None): Optional list of audio blocks associated
             with this representation.
+        role (str | None): Optional chat role (`"system"`, `"user"`, `"assistant"`,
+            or `"tool"`) the component should be serialized as. When `None` (the
+            default), the formatter falls back to its positional guess: `"assistant"`
+            for model-generated components, `"user"` otherwise.
 
     """
 
@@ -1751,6 +1755,7 @@ class TemplateRepresentation:
     template_order: list[str] | None = None
     images: list[ImageBlock | ImageUrlBlock] | None = None
     audio: list[AudioBlock | AudioUrlBlock] | None = None
+    role: str | None = None
 
 
 @dataclass

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1739,6 +1739,13 @@ class TemplateRepresentation:
             or `"tool"`) the component should be serialized as. When `None` (the
             default), the formatter falls back to its positional guess: `"assistant"`
             for model-generated components, `"user"` otherwise.
+        thinking (str | None): Optional reasoning trace to carry onto the serialized
+            message, so a component's captured reasoning round-trips through the
+            formatter. Defaults to `None`.
+        tool_calls (list[dict[str, Any]] | None): Optional OpenAI-compatible assistant
+            tool calls to carry onto the serialized message. Defaults to `None`.
+        tool_call_id (str | None): For a `role="tool"` component, the provider-supplied
+            tool-call id, when available. Defaults to `None`.
 
     """
 
@@ -1756,6 +1763,9 @@ class TemplateRepresentation:
     images: list[ImageBlock | ImageUrlBlock] | None = None
     audio: list[AudioBlock | AudioUrlBlock] | None = None
     role: str | None = None
+    thinking: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+    tool_call_id: str | None = None
 
 
 @dataclass

--- a/mellea/formatters/chat_formatter.py
+++ b/mellea/formatters/chat_formatter.py
@@ -38,6 +38,11 @@ class ChatFormatter(Formatter):
         Returns:
             list[Message]: A list of `Message` objects ready for submission to
                 a chat completion endpoint.
+
+        Raises:
+            ValueError: If a component declares a `role` (via its
+                `TemplateRepresentation`) outside `Message.Role`; role
+                validation is deferred to `Message`/`ToolMessage`.
         """
 
         def _to_msg(c: Span) -> Message:

--- a/mellea/formatters/chat_formatter.py
+++ b/mellea/formatters/chat_formatter.py
@@ -11,6 +11,8 @@ outputs. Concrete backends call this formatter when preparing input for a chat
 completion endpoint.
 """
 
+from typing import cast
+
 from ..core import Component, Formatter, ModelOutputThunk, Span, TemplateRepresentation
 from ..stdlib.components.chat import Message
 
@@ -24,8 +26,10 @@ class ChatFormatter(Formatter):
         Iterates over each element in the context history and converts it to a
         `Message` with an appropriate role. `ModelOutputThunk` instances are
         treated as assistant responses, while all other `Component` and
-        `CBlock` objects default to the `user` role. Image attachments and
-        parsed structured outputs are handled transparently.
+        `CBlock` objects default to the `user` role. A `Component` may override
+        this positional guess by setting `role` on the `TemplateRepresentation`
+        returned from its `format_for_llm`. Image attachments and parsed
+        structured outputs are handled transparently.
 
         Args:
             cs (list[Span]): The linearized sequence of context
@@ -69,6 +73,11 @@ class ChatFormatter(Formatter):
                     if isinstance(tr, TemplateRepresentation):
                         images = tr.images
                         audio = tr.audio
+                        # A component may declare its own role; honor it over the
+                        # positional guess. `Message` validates the role value and
+                        # raises ValueError for anything outside `Message.Role`.
+                        if tr.role is not None:
+                            role = cast(Message.Role, tr.role)
 
                     return Message(
                         role=role, content=self.print(c), images=images, audio=audio

--- a/mellea/formatters/chat_formatter.py
+++ b/mellea/formatters/chat_formatter.py
@@ -11,10 +11,8 @@ outputs. Concrete backends call this formatter when preparing input for a chat
 completion endpoint.
 """
 
-from typing import cast
-
 from ..core import Component, Formatter, ModelOutputThunk, Span, TemplateRepresentation
-from ..stdlib.components.chat import Message
+from ..stdlib.components.chat import Message, message_from_template_representation
 
 
 class ChatFormatter(Formatter):
@@ -28,8 +26,10 @@ class ChatFormatter(Formatter):
         treated as assistant responses, while all other `Component` and
         `CBlock` objects default to the `user` role. A `Component` may override
         this positional guess by setting `role` on the `TemplateRepresentation`
-        returned from its `format_for_llm`. Image attachments and parsed
-        structured outputs are handled transparently.
+        returned from its `format_for_llm`, and a component with `role="tool"`
+        may additionally declare `tool_name`/`tool_args`/`tool_call_id` to be
+        rendered as a `ToolMessage`. Image attachments and parsed structured
+        outputs are handled transparently.
 
         Args:
             cs (list[Span]): The linearized sequence of context
@@ -65,23 +65,21 @@ class ChatFormatter(Formatter):
 
             match c:
                 case Message():
+                    # A Message (or ToolMessage) is already a fully-formed chat
+                    # message; return it verbatim so subtype-specific state such as
+                    # `ToolMessage._tool.tool_call_id` survives to the backend payload.
                     return c
                 case Component():
-                    images = None
-                    audio = None
                     tr = c.format_for_llm()
                     if isinstance(tr, TemplateRepresentation):
-                        images = tr.images
-                        audio = tr.audio
-                        # A component may declare its own role; honor it over the
-                        # positional guess. `Message` validates the role value and
-                        # raises ValueError for anything outside `Message.Role`.
-                        if tr.role is not None:
-                            role = cast(Message.Role, tr.role)
-
-                    return Message(
-                        role=role, content=self.print(c), images=images, audio=audio
-                    )
+                        # A component may declare its own role and tool metadata via
+                        # its template representation; honor them over the positional
+                        # guess. Role validation is deferred to `Message`/`ToolMessage`,
+                        # which raise ValueError for anything outside `Message.Role`.
+                        return message_from_template_representation(
+                            tr, default_role=role, content=self.print(c)
+                        )
+                    return Message(role=role, content=self.print(c))
                 case _:
                     return Message(role=role, content=self.print(c))
 

--- a/mellea/helpers/openai_compatible_helpers.py
+++ b/mellea/helpers/openai_compatible_helpers.py
@@ -264,12 +264,14 @@ def message_to_openai_message(
         images or audio, `"content"` is a list of content-part dicts; otherwise
         is a plain string. For tool-only assistant turns, `"content"` is `None`
         and `"tool_calls"` carries the structured call list. When content is
-        present alongside tool calls, both keys are included. For a `ToolMessage`
-        (a tool-result turn) whose originating `ModelToolCall` carries a
-        provider-supplied id, the dict also carries `"tool_call_id"` (matching the
-        assistant tool call), as spec-strict OpenAI-compatible providers require
-        on `role: "tool"` messages. When `replay_reasoning` is `True` and
-        reasoning is present, the dict also carries a `"reasoning_content"` field.
+        present alongside tool calls, both keys are included. For a tool-result
+        turn whose message carries a provider-supplied `tool_call_id` (a
+        `ToolMessage`, which forwards it from its `ModelToolCall`, or a plain
+        `Message` that declared it directly), the dict also carries
+        `"tool_call_id"` (matching the assistant tool call), as spec-strict
+        OpenAI-compatible providers require on `role: "tool"` messages. When
+        `replay_reasoning` is `True` and reasoning is present, the dict also
+        carries a `"reasoning_content"` field.
 
     Raises:
         ValueError: If the message contains an `AudioUrlBlock`. The OpenAI Chat
@@ -330,19 +332,17 @@ def message_to_openai_message(
 
     # Tool-result turns: spec-strict OpenAI-compatible providers require a
     # `role: "tool"` message to reference the assistant's originating tool call
-    # via `tool_call_id` (issue #1389). Emit it when the ToolMessage carries a
-    # provider-supplied id. The import is deferred (like `extract_model_tool_requests`
-    # above) purely to keep it out of module load; narrowing on `ToolMessage`
-    # leaves plain `role="tool"` Messages, and id-less parses (e.g. Hugging Face
-    # raw-string tool calls), untouched. The optional `name` field is deliberately
-    # omitted: it is a legacy carryover from `role: "function"`, not part of the
-    # OpenAI tool-message schema, and is not required to satisfy the result-turn
-    # contract. Gate on truthiness (matching `build_tool_calls` below) so an empty
-    # id is treated as absent.
-    from ..stdlib.components import ToolMessage
-
-    if isinstance(msg, ToolMessage) and msg._tool.tool_call_id:
-        result["tool_call_id"] = msg._tool.tool_call_id
+    # via `tool_call_id` (issue #1389). Emit it when the message carries a
+    # provider-supplied id. Both a `ToolMessage` (which forwards its
+    # `ModelToolCall.tool_call_id` to the base `Message` at construction) and a
+    # plain `Message` built from a component that declared `role="tool"` +
+    # `tool_call_id` in its template representation expose it via `msg.tool_call_id`.
+    # The optional `name` field is deliberately omitted: it is a legacy carryover
+    # from `role: "function"`, not part of the OpenAI tool-message schema, and is
+    # not required to satisfy the result-turn contract. Gate on truthiness
+    # (matching `build_tool_calls` below) so an empty id is treated as absent.
+    if msg.tool_call_id:
+        result["tool_call_id"] = msg.tool_call_id
 
     if replay_reasoning and msg.thinking:
         result["reasoning_content"] = msg.thinking

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -53,6 +53,11 @@ class Message(Component["Message"]):
             the message.
         tool_calls (list[dict[str, Any]] | None): Optional OpenAI-compatible
             assistant tool calls associated with the message.
+        tool_call_id (str | None): Optional provider-supplied tool-call id that a
+            `role="tool"` message references, so a tool-result turn can be linked
+            back to the assistant tool call that produced it (issue #1389).
+            `ToolMessage` sources this from its `ModelToolCall` instead; set it
+            directly only when constructing a bare `role="tool"` `Message`.
         thinking (str | None): Optional reasoning trace produced by a thinking
             model on the turn that generated this message. Populated by `_parse`
             from `ModelOutputThunk.thinking`; carried through `as_chat_history`
@@ -77,9 +82,10 @@ class Message(Component["Message"]):
         audio: None | list[AudioBlock | AudioUrlBlock] = None,
         documents: None | Iterable[str | Document] = None,
         tool_calls: list[dict[str, Any]] | None = None,
+        tool_call_id: str | None = None,
         thinking: str | None = None,
     ):
-        """Initialize a Message with a role, text content, optional images, audio, documents, tool calls, and an optional reasoning trace."""
+        """Initialize a Message with a role, text content, optional images, audio, documents, tool calls, an optional tool-call id, and an optional reasoning trace."""
         if role not in get_args(Message.Role):
             raise ValueError(
                 f"Invalid role {role!r}. Must be one of: {list(get_args(Message.Role))}"
@@ -92,6 +98,7 @@ class Message(Component["Message"]):
         self._audio = audio
         self._docs = _coerce_to_documents(documents)
         self._tool_calls = tool_calls
+        self._tool_call_id = tool_call_id
 
     @property
     def images(self) -> None | list[ImageBlock | ImageUrlBlock]:
@@ -107,6 +114,11 @@ class Message(Component["Message"]):
     def tool_calls(self) -> list[dict[str, Any]] | None:
         """Returns the OpenAI-compatible tool calls associated with this message."""
         return self._tool_calls
+
+    @property
+    def tool_call_id(self) -> str | None:
+        """Returns the tool-call id this `role="tool"` message references, if any."""
+        return self._tool_call_id
 
     def parts(self) -> list[Span]:
         """Return the constituent parts of this message, including content, documents, images, and audio.
@@ -127,6 +139,10 @@ class Message(Component["Message"]):
     def format_for_llm(self) -> TemplateRepresentation:
         """Formats the content for a Language Model.
 
+        Declares this message's `role` and carries its `thinking`, `tool_calls`,
+        and `tool_call_id` so the representation is a faithful, self-describing
+        view of the message (see `message_from_template_representation`).
+
         Returns:
             The formatted output suitable for language models.
         """
@@ -136,6 +152,10 @@ class Message(Component["Message"]):
             template_order=["*", "Message"],
             images=self._images,
             audio=self._audio,
+            role=self.role,
+            thinking=self.thinking,
+            tool_calls=self._tool_calls,
+            tool_call_id=self._tool_call_id,
         )
 
     def __repr__(self) -> str:
@@ -265,7 +285,7 @@ class ToolMessage(Message):
         tool: ModelToolCall,
     ):
         """Initialize a ToolMessage with role, content, tool output, name, args, and tool call."""
-        super().__init__(role, content)
+        super().__init__(role, content, tool_call_id=tool.tool_call_id)
         self.name = name
         self.arguments = args
         self._tool_output = tool_output
@@ -274,6 +294,38 @@ class ToolMessage(Message):
     def __repr__(self) -> str:
         """Pretty representation of messages, because they are a special case."""
         return f'mellea.ToolMessage(role="{self.role}", content="{self.content}", name="{self.name}")'
+
+
+def message_from_template_representation(
+    tr: TemplateRepresentation, *, default_role: "Message.Role", content: str
+) -> Message:
+    """Build a `Message` from a component's `TemplateRepresentation`.
+
+    Shared by `ChatFormatter.to_chat_messages` and `as_generic_chat_history` so a
+    component's declared role and tool metadata are honored consistently across both
+    conversion paths. The representation's `role` overrides `default_role` when set;
+    role validation is deferred to `Message`, which raises `ValueError` for anything
+    outside `Message.Role`. `thinking`, `tool_calls`, and (for `role="tool"`)
+    `tool_call_id` are carried onto the resulting message.
+
+    Args:
+        tr: The template representation returned by the component's `format_for_llm`.
+        default_role: The positional role guess to use when `tr.role` is `None`.
+        content: The already-rendered text content for the message.
+
+    Returns:
+        A `Message` with the resolved role, content, attachments, and tool metadata.
+    """
+    role = tr.role if tr.role is not None else default_role
+    return Message(
+        role=role,  # type: ignore[arg-type]  # validated by Message.__init__
+        content=content,
+        images=tr.images,
+        audio=tr.audio,
+        tool_calls=tr.tool_calls,
+        tool_call_id=tr.tool_call_id,
+        thinking=tr.thinking,
+    )
 
 
 def as_chat_history(ctx: Context) -> list[Message]:
@@ -389,6 +441,24 @@ def as_generic_chat_history(
                     content = formatter(c)
                 else:
                     content = str(c)
+                return Message(role="user", content=content)
+            case Component():
+                # A component may declare its own role (and tool metadata) via its
+                # template representation; honor it over the `user` default, keeping
+                # this path consistent with `ChatFormatter.to_chat_messages`. Stay
+                # permissive: some components (e.g. `Intrinsic`) intentionally raise
+                # from `format_for_llm` because they are only ever the action, never
+                # part of the rendered context. Fall back to stringifying them via
+                # the formatter — the pre-existing behavior for arbitrary components.
+                content = formatter(c)
+                try:
+                    tr = c.format_for_llm()
+                except NotImplementedError:
+                    tr = None
+                if isinstance(tr, TemplateRepresentation):
+                    return message_from_template_representation(
+                        tr, default_role="user", content=content
+                    )
                 return Message(role="user", content=content)
             case _:
                 content = formatter(c)

--- a/test/formatters/test_template_formatter.py
+++ b/test/formatters/test_template_formatter.py
@@ -104,17 +104,30 @@ def test_to_chat_messages_preserves_audio(tf: TemplateFormatter):
 
 
 class _RoleComponent(Component[str]):
-    """Component whose serialized role is configurable via `format_for_llm`."""
+    """Component whose serialized role and tool metadata are configurable via `format_for_llm`."""
 
-    def __init__(self, role: str | None = None):
+    def __init__(
+        self,
+        role: str | None = None,
+        *,
+        tool_calls: list[dict] | None = None,
+        tool_call_id: str | None = None,
+    ):
         self._role = role
+        self._tool_calls = tool_calls
+        self._tool_call_id = tool_call_id
 
     def parts(self) -> list[Span]:
         return []
 
     def format_for_llm(self) -> TemplateRepresentation:
         return TemplateRepresentation(
-            obj=self, args={}, template="role component", role=self._role
+            obj=self,
+            args={},
+            template="role component",
+            role=self._role,
+            tool_calls=self._tool_calls,
+            tool_call_id=self._tool_call_id,
         )
 
     def _parse(self, computed: ModelOutputThunk) -> str:
@@ -158,6 +171,27 @@ def test_to_chat_messages_invalid_role_raises(tf: TemplateFormatter):
     """An unrecognized declared role is rejected with a ValueError."""
     with pytest.raises(ValueError):
         tf.to_chat_messages([_RoleComponent(role="banana")])
+
+
+def test_to_chat_messages_carries_tool_calls(tf: TemplateFormatter):
+    """A component may declare `tool_calls`, which flow onto the resulting message."""
+    tool_calls = [{"id": "call_1", "function": {"name": "f", "arguments": "{}"}}]
+    msgs = tf.to_chat_messages(
+        [_RoleComponent(role="assistant", tool_calls=tool_calls)]
+    )
+
+    assert len(msgs) == 1
+    assert msgs[0].role == "assistant"
+    assert msgs[0].tool_calls == tool_calls
+
+
+def test_to_chat_messages_tool_role_carries_tool_call_id(tf: TemplateFormatter):
+    """A `role="tool"` component may declare a `tool_call_id`, which round-trips onto the message."""
+    msgs = tf.to_chat_messages([_RoleComponent(role="tool", tool_call_id="call_42")])
+
+    assert len(msgs) == 1
+    assert msgs[0].role == "tool"
+    assert msgs[0].tool_call_id == "call_42"
 
 
 def test_custom_template_string(tf: TemplateFormatter):

--- a/test/formatters/test_template_formatter.py
+++ b/test/formatters/test_template_formatter.py
@@ -103,6 +103,63 @@ def test_to_chat_messages_preserves_audio(tf: TemplateFormatter):
     assert msgs[0].audio == audio
 
 
+class _RoleComponent(Component[str]):
+    """Component whose serialized role is configurable via `format_for_llm`."""
+
+    def __init__(self, role: str | None = None):
+        self._role = role
+
+    def parts(self) -> list[Span]:
+        return []
+
+    def format_for_llm(self) -> TemplateRepresentation:
+        return TemplateRepresentation(
+            obj=self, args={}, template="role component", role=self._role
+        )
+
+    def _parse(self, computed: ModelOutputThunk) -> str:
+        return ""
+
+
+def test_template_representation_role_defaults_to_none():
+    """`TemplateRepresentation.role` defaults to `None` so behavior is opt-in."""
+    repr = TemplateRepresentation(obj=object(), args={})
+    assert repr.role is None
+
+
+def test_to_chat_messages_honors_component_role(tf: TemplateFormatter):
+    """A component declaring `role` in its representation controls its message role."""
+    msgs = tf.to_chat_messages([_RoleComponent(role="system")])
+
+    assert len(msgs) == 1
+    assert msgs[0].role == "system"
+
+
+def test_to_chat_messages_defaults_role_when_unset(tf: TemplateFormatter):
+    """A component that declares no role still defaults to `user`."""
+    msgs = tf.to_chat_messages([_RoleComponent()])
+
+    assert len(msgs) == 1
+    assert msgs[0].role == "user"
+
+
+def test_to_chat_messages_role_on_modeloutputthunk_parsed_repr(tf: TemplateFormatter):
+    """A role declared by a MOT's component `parsed_repr` overrides the assistant default."""
+    action = ModelOutputThunk(value="ignored")
+    action.parsed_repr = _RoleComponent(role="system")
+
+    msgs = tf.to_chat_messages([action])
+
+    assert len(msgs) == 1
+    assert msgs[0].role == "system"
+
+
+def test_to_chat_messages_invalid_role_raises(tf: TemplateFormatter):
+    """An unrecognized declared role is rejected with a ValueError."""
+    with pytest.raises(ValueError):
+        tf.to_chat_messages([_RoleComponent(role="banana")])
+
+
 def test_custom_template_string(tf: TemplateFormatter):
     class _TemplInstruction(Instruction):
         def format_for_llm(self) -> TemplateRepresentation:

--- a/test/stdlib/components/test_chat.py
+++ b/test/stdlib/components/test_chat.py
@@ -11,9 +11,11 @@ from mellea.core import (
     AudioBlock,
     AudioUrlBlock,
     CBlock,
+    Component,
     ModelOutputThunk,
     ModelToolCall,
     RawProviderResponse,
+    Span,
     TemplateRepresentation,
 )
 from mellea.formatters.chat_formatter import ChatFormatter
@@ -1018,6 +1020,153 @@ def test_parse_tool_calls_openai_streaming_normalized_shape():
     assert result.role == "assistant"
     assert result.content == ""
     assert result.tool_calls == tool_calls
+
+
+# --- Message/ToolMessage format_for_llm role & tool metadata ---
+
+
+def test_message_format_for_llm_declares_role_and_metadata():
+    """`Message.format_for_llm` carries role, thinking, tool_calls, and tool_call_id."""
+    tool_calls = [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}]
+    msg = Message(
+        "assistant", "hi", tool_calls=tool_calls, tool_call_id="c1", thinking="because"
+    )
+
+    tr = msg.format_for_llm()
+
+    assert tr.role == "assistant"
+    assert tr.thinking == "because"
+    assert tr.tool_calls == tool_calls
+    assert tr.tool_call_id == "c1"
+
+
+def test_tool_message_sets_tool_call_id_from_tool():
+    """A `ToolMessage` derives its `tool_call_id` from its `ModelToolCall`."""
+    tool = ModelToolCall(
+        name="f", func=_make_tool_call("f").func, args={}, tool_call_id="call_9"
+    )
+    tm = ToolMessage(
+        role="tool", content="out", tool_output="out", name="f", args={}, tool=tool
+    )
+
+    assert tm.tool_call_id == "call_9"
+
+
+def test_tool_message_format_for_llm_declares_role_and_call_id():
+    """`ToolMessage.format_for_llm` carries the tool role and call id from its tool."""
+    tool = ModelToolCall(
+        name="f",
+        func=_make_tool_call("f").func,
+        args={"location": "LA"},
+        tool_call_id="call_9",
+    )
+    tm = ToolMessage(
+        role="tool",
+        content="out",
+        tool_output="out",
+        name="f",
+        args={"location": "LA"},
+        tool=tool,
+    )
+
+    tr = tm.format_for_llm()
+
+    assert tr.role == "tool"
+    assert tr.tool_call_id == "call_9"
+
+
+# --- as_generic_chat_history honors declared component role ---
+
+
+class _RoleComponent(Component[str]):
+    """Component whose serialized role and tool metadata are configurable."""
+
+    def __init__(self, role=None, *, tool_call_id=None):
+        self._role = role
+        self._tool_call_id = tool_call_id
+
+    def parts(self) -> list[Span]:
+        return []
+
+    def format_for_llm(self) -> TemplateRepresentation:
+        return TemplateRepresentation(
+            obj=self,
+            args={},
+            template="x",
+            role=self._role,
+            tool_call_id=self._tool_call_id,
+        )
+
+    def _parse(self, computed: ModelOutputThunk) -> str:
+        return ""
+
+
+def test_as_generic_chat_history_honors_component_role():
+    """A component declaring a role controls its message role, over the `user` default."""
+    ctx = ChatContext().add(_RoleComponent(role="system"))
+
+    history = as_generic_chat_history(ctx)
+
+    assert len(history) == 1
+    assert history[0].role == "system"
+
+
+def test_as_generic_chat_history_defaults_role_when_unset():
+    """A component declaring no role still defaults to `user`."""
+    ctx = ChatContext().add(_RoleComponent())
+
+    history = as_generic_chat_history(ctx)
+
+    assert len(history) == 1
+    assert history[0].role == "user"
+
+
+def test_as_generic_chat_history_carries_tool_call_id():
+    """A `role="tool"` component's `tool_call_id` round-trips onto the message."""
+    ctx = ChatContext().add(_RoleComponent(role="tool", tool_call_id="call_7"))
+
+    history = as_generic_chat_history(ctx)
+
+    assert len(history) == 1
+    assert history[0].role == "tool"
+    assert history[0].tool_call_id == "call_7"
+
+
+def test_as_generic_chat_history_component_format_for_llm_raises():
+    """A component whose `format_for_llm` raises (e.g. `Intrinsic`) degrades to a `user` message rather than crashing."""
+
+    class _UnrenderableComponent(Component[str]):
+        def parts(self) -> list[Span]:
+            return []
+
+        def format_for_llm(self) -> TemplateRepresentation:
+            raise NotImplementedError("only usable as the action, not in context")
+
+        def __str__(self) -> str:
+            return "unrenderable"
+
+        def _parse(self, computed: ModelOutputThunk) -> str:
+            return ""
+
+    ctx = ChatContext().add(_UnrenderableComponent())
+
+    history = as_generic_chat_history(ctx)
+
+    assert len(history) == 1
+    assert history[0].role == "user"
+    assert history[0].content == "unrenderable"
+
+
+# --- Serializer reads tool_call_id off a plain Message ---
+
+
+def test_openai_message_reads_tool_call_id_from_plain_message():
+    """A plain `role="tool"` Message with a `tool_call_id` serializes it into the payload."""
+    msg = Message("tool", "result", tool_call_id="call_5")
+
+    result = message_to_openai_message(msg)
+
+    assert result["tool_call_id"] == "call_5"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #377 

## Description
<!-- What does this PR do and why? -->
allow components to declare their chat role via format_for_llm

Needed as a precursor to #1030 

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
