### PR TITLE
fix(backends): release() deregisters via a new remove_adapter() inverse verb

### DIFF
--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -441,7 +441,7 @@ class LocalFileBinding(WeightsBinding):
                     raise RuntimeError(
                         f"Backend refused to register adapter {self.qualified_name!r}; see "
                         "the backend's warning log — another adapter is already registered "
-                        "and active under this qualified name."
+                        "under this qualified name and has not been released."
                     )
             # `load_peft_adapter` mutates the backend's underlying PEFT model, the
             # same shared state `activate_peft_adapter`/`deactivate_peft_adapter`
@@ -510,7 +510,12 @@ class LocalFileBinding(WeightsBinding):
         *registration*, `add_adapter`'s inverse — see #1528). So once this
         binding releases, a **different**, freshly constructed
         `LocalFileBinding` for the same capability can register under the
-        same `qualified_name` on the same backend.
+        same `qualified_name` on the same backend — on a backend that
+        implements `remove_adapter`. A backend that supports the LocalFile/PEFT
+        reality (`load_peft_adapter`/`unload_peft_adapter`) but predates
+        `remove_adapter` and hasn't overridden it degrades gracefully instead
+        of raising: the binding still fully releases, but the `qualified_name`
+        stays claimed for that backend's lifetime (the pre-#1528 behaviour).
 
         Raises:
             RuntimeError: The binding is active; call `deactivate()` before
@@ -536,7 +541,14 @@ class LocalFileBinding(WeightsBinding):
                         "LocalFileBinding.release() requires deactivate() to be called first."
                     )
                 backend.unload_peft_adapter(self.qualified_name)
-                backend.remove_adapter(self.qualified_name)
+                try:
+                    backend.remove_adapter(self.qualified_name)
+                except NotImplementedError:
+                    MelleaLogger.get_logger().warning(
+                        f"{type(backend).__name__} does not implement remove_adapter(); "
+                        f"{self.qualified_name!r} stays registered for the backend's "
+                        "lifetime even though this binding has released."
+                    )
                 self.backend = None
                 self.path = None
                 self._staged_backend = None

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -439,11 +439,9 @@ class LocalFileBinding(WeightsBinding):
                 # instead, where the cause is still visible.
                 if self.backend is None:
                     raise RuntimeError(
-                        f"Backend refused to register adapter {self.qualified_name!r}; see the "
-                        "backend's warning log. Either another adapter is already registered "
-                        "under this qualified name, or this binding was previously released — "
-                        "`release()` is terminal and does not free the name for re-use "
-                        "(see #1528)."
+                        f"Backend refused to register adapter {self.qualified_name!r}; see "
+                        "the backend's warning log — another adapter is already registered "
+                        "and active under this qualified name."
                     )
             # `load_peft_adapter` mutates the backend's underlying PEFT model, the
             # same shared state `activate_peft_adapter`/`deactivate_peft_adapter`
@@ -498,20 +496,21 @@ class LocalFileBinding(WeightsBinding):
             self._active = False
 
     def release(self) -> None:
-        """Unloads the adapter's weights from the backend and clears local state.
+        """Unloads the adapter's weights and deregisters it from the backend.
 
-        Idempotent: a no-op if never prepared, or already released. Terminal, per
-        the `WeightsBinding` contract — enforced: `bind_backend()` and
-        `prepare()` both raise `RuntimeError` if called after `release()`,
-        rather than silently reviving the binding on a new backend.
+        Idempotent: a no-op if never prepared, or already released. Terminal
+        for *this binding*, per the `WeightsBinding` contract — enforced:
+        `bind_backend()` and `prepare()` both raise `RuntimeError` if called
+        after `release()`, rather than silently reviving the binding on a new
+        backend.
 
-        Does **not** fully deregister. `unload_peft_adapter` removes the adapter
-        from the backend's *loaded* set, but the backend's *registered* set
-        (`_added_adapters` on `LocalHFBackend`) keeps its entry, because
-        `add_adapter` has no inverse verb. So the `qualified_name` stays claimed
-        for the backend's lifetime and no later binding can register under it.
-        Tracked in #1528, which also asks whether re-registration should be
-        supported at all given the terminal contract.
+        Terminal does not mean the `qualified_name` stays claimed forever,
+        though: alongside `unload_peft_adapter` (which reverses the *load*),
+        `release()` calls the backend's `remove_adapter` (which reverses the
+        *registration*, `add_adapter`'s inverse — see #1528). So once this
+        binding releases, a **different**, freshly constructed
+        `LocalFileBinding` for the same capability can register under the
+        same `qualified_name` on the same backend.
 
         Raises:
             RuntimeError: The binding is active; call `deactivate()` before
@@ -537,6 +536,7 @@ class LocalFileBinding(WeightsBinding):
                         "LocalFileBinding.release() requires deactivate() to be called first."
                     )
                 backend.unload_peft_adapter(self.qualified_name)
+                backend.remove_adapter(self.qualified_name)
                 self.backend = None
                 self.path = None
                 self._staged_backend = None

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -429,6 +429,13 @@ class LocalFileBinding(WeightsBinding):
                         "instead."
                     )
 
+                # `add_adapter`'s duplicate-name check runs under only this
+                # binding's `_lifecycle_lock`, while `release()` pops the
+                # registry under the backend's `_generation_lock` — so a
+                # concurrent `release()` of a same-qualified-name binding can
+                # make this registration transiently refuse a name that is in
+                # fact free. Retryable; no shipped path registers two bindings
+                # of one capability concurrently (that is #1465's per-call case).
                 self._staged_backend.add_adapter(self)
                 # `add_adapter` signals success by setting `.backend`; it has early-return
                 # paths (notably: a different object already registered under this
@@ -441,7 +448,7 @@ class LocalFileBinding(WeightsBinding):
                     raise RuntimeError(
                         f"Backend refused to register adapter {self.qualified_name!r}; see "
                         "the backend's warning log — another adapter is already registered "
-                        "under this qualified name and has not been released."
+                        "under this qualified name."
                     )
             # `load_peft_adapter` mutates the backend's underlying PEFT model, the
             # same shared state `activate_peft_adapter`/`deactivate_peft_adapter`
@@ -544,10 +551,14 @@ class LocalFileBinding(WeightsBinding):
                 try:
                     backend.remove_adapter(self.qualified_name)
                 except NotImplementedError:
+                    # State the observable fact, not the presumed cause: a real
+                    # implementation can raise NotImplementedError internally, and
+                    # that would be misdiagnosed as "does not implement it".
                     MelleaLogger.get_logger().warning(
-                        f"{type(backend).__name__} does not implement remove_adapter(); "
-                        f"{self.qualified_name!r} stays registered for the backend's "
-                        "lifetime even though this binding has released."
+                        f"{type(backend).__name__}.remove_adapter() raised "
+                        f"NotImplementedError; {self.qualified_name!r} stays registered "
+                        "for the backend's lifetime even though this binding has "
+                        "released."
                     )
                 self.backend = None
                 self.path = None

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -535,6 +535,27 @@ class AdapterMixin(Backend, abc.ABC):
             f"Backend type {type(self)} does not support unload_peft_adapter()."
         )
 
+    def remove_adapter(self, adapter_qualified_name: str) -> None:
+        """Deregister a previously added adapter, freeing its qualified name for reuse.
+
+        The inverse of `add_adapter()`. LocalFile/PEFT reality only today
+        (#1528) — `LocalFileBinding.release()` calls this after
+        `unload_peft_adapter()` so a released `qualified_name` becomes
+        claimable by a fresh binding rather than staying claimed for the
+        backend's lifetime.
+
+        Args:
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
+                adapter to deregister.
+
+        Raises:
+            NotImplementedError: If this backend's adapter reality does not
+                support deregistration.
+        """
+        raise NotImplementedError(
+            f"Backend type {type(self)} does not support remove_adapter()."
+        )
+
     def activate_peft_adapter(self, adapter_qualified_name: str) -> None:
         """Switch a previously loaded PEFT adapter on for subsequent generation.
 

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -447,7 +447,7 @@ class AdapterMixin(Backend, abc.ABC):
 
     Three verbs are universal across every adapter reality (LocalFile/PEFT,
     Embedded/Granite Switch, ServerMediated): `base_model_name`,
-    `add_adapter`, and `list_adapters`. The remaining four verbs are
+    `add_adapter`, and `list_adapters`. The remaining seven verbs are
     reality-specific — a concrete backend overrides only the verb(s) matching
     its own reality; the others keep raising `NotImplementedError`.
 
@@ -721,11 +721,13 @@ class AdapterMixin(Backend, abc.ABC):
         # colliding qualified name (they share `f"{name}_{type}"` with
         # `IntrinsicAdapter`), say so — the alternative is an opaque KeyError
         # that gives no hint the two registration paths collided.
-        added = getattr(self, "_added_adapters", {})
+        # list(...): same concurrent-mutation hazard as `_find_adapter` — snapshot
+        # before iterating rather than holding a live view over `_added_adapters`.
+        added = list(getattr(self, "_added_adapters", {}).items())
         blocking = next(
             (
                 v
-                for k, v in added.items()
+                for k, v in added
                 if k.startswith(f"{name}_") and not isinstance(v, _AdapterCore)
             ),
             None,
@@ -892,14 +894,19 @@ class AdapterMixin(Backend, abc.ABC):
         Returns:
             _AdapterCore | None: Matching adapter, or `None` if not found.
         """
-        adapters = getattr(self, "_added_adapters", {})
+        # Snapshot into a list: `_added_adapters` is no longer insert-only since
+        # `remove_adapter()` (#1528) can delete from it. A concurrent `release()`
+        # mutating the dict while this loop holds a live `.values()` view would
+        # raise "dictionary changed size during iteration"; iterating a list
+        # copy instead is immune to a mutation of the underlying dict.
+        adapters = list(getattr(self, "_added_adapters", {}).values())
         if adapter_types is None:
-            for a in adapters.values():
+            for a in adapters:
                 if isinstance(a, _AdapterCore) and a.identity.capability == capability:
                     return a
             return None
         for preferred_type in adapter_types:
-            for a in adapters.values():
+            for a in adapters:
                 if (
                     isinstance(a, _AdapterCore)
                     and a.identity.capability == capability

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -899,6 +899,14 @@ class AdapterMixin(Backend, abc.ABC):
         # mutating the dict while this loop holds a live `.values()` view would
         # raise "dictionary changed size during iteration"; iterating a list
         # copy instead is immune to a mutation of the underlying dict.
+        #
+        # The snapshot also means this lookup can still see an entry that
+        # `remove_adapter()` just popped — harmless today because a qualified
+        # name is held by either a `LocalFileBinding` or an `IntrinsicAdapter`
+        # shim (never both) and the generation path consumes only shims.
+        # `remove_adapter()` is public, though, so any registered entry — shim
+        # or binding — can be popped: re-check that invariant when #1465 moves
+        # generation inside `adapter_scope`.
         adapters = list(getattr(self, "_added_adapters", {}).values())
         if adapter_types is None:
             for a in adapters:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2113,6 +2113,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         already-added no-op). If the adapter is not currently registered, a
         log message is emitted and the method returns without error.
 
+        For a `LocalFileBinding`, call `binding.release()` instead: it runs
+        this verb and also marks the binding released, so a later
+        `activate()`/`deactivate()` keeps working. Calling this method
+        directly on a registered binding clears only `.backend`/`.path` — the
+        binding's `_loaded`/`_released` state is untouched, so
+        `activate()`/`deactivate()` then raise the `prepare()`-required error
+        until `prepare()` is called again.
+
         Args:
             adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to deregister.

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2114,12 +2114,16 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         log message is emitted and the method returns without error.
 
         For a `LocalFileBinding`, call `binding.release()` instead: it runs
-        this verb and also marks the binding released, so a later
-        `activate()`/`deactivate()` keeps working. Calling this method
-        directly on a registered binding clears only `.backend`/`.path` — the
-        binding's `_loaded`/`_released` state is untouched, so
-        `activate()`/`deactivate()` then raise the `prepare()`-required error
-        until `prepare()` is called again.
+        this verb and also marks the binding released, so the binding's
+        lifecycle state stays coherent with the registry. Calling this
+        method directly on a registered binding clears only `.backend`/
+        `.path` — the binding's `_loaded`/`_released` state is untouched, so
+        a later `activate()`/`deactivate()` raises the `prepare()`-required
+        error even though the binding was never released, and the real
+        cause (an external `remove_adapter()`) is nowhere in the message.
+        `prepare()` self-heals that state (re-registers via the staged
+        backend and reloads), but `release()` is the intended way to free
+        the name.
 
         Args:
             adapter_qualified_name (str): The `adapter.qualified_name` of the

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2102,6 +2102,26 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         # Remove the adapter from the list of loaded adapters.
         del self._loaded_adapters[adapter.qualified_name]
 
+    def remove_adapter(self, adapter_qualified_name: str) -> None:
+        """Deregister a previously added adapter, freeing its qualified name for reuse.
+
+        The inverse of `add_adapter()`. If the adapter is not currently
+        registered, a log message is emitted and the method returns without
+        error.
+
+        Args:
+            adapter_qualified_name (str): The `adapter.qualified_name` of the
+                adapter to deregister.
+        """
+        if adapter_qualified_name not in self._added_adapters:
+            MelleaLogger.get_logger().info(
+                f"could not remove adapter {adapter_qualified_name} for backend {self}: "
+                "adapter was not registered"
+            )
+            return
+
+        del self._added_adapters[adapter_qualified_name]
+
     def activate_peft_adapter(self, adapter_qualified_name: str) -> None:
         """Switch a previously loaded PEFT adapter on for subsequent generation.
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2105,22 +2105,44 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
     def remove_adapter(self, adapter_qualified_name: str) -> None:
         """Deregister a previously added adapter, freeing its qualified name for reuse.
 
-        The inverse of `add_adapter()`. If the adapter is not currently
-        registered, a log message is emitted and the method returns without
-        error.
+        The inverse of `add_adapter()`: reverses all three of its mutations
+        (registry entry, `.path`, `.backend`), not just the registry entry —
+        otherwise the removed object would be left with `.backend` still
+        naming this backend, silently blocking it from being re-added anywhere
+        (`add_adapter()`'s `adapter.backend is self` guard treats that as an
+        already-added no-op). If the adapter is not currently registered, a
+        log message is emitted and the method returns without error.
 
         Args:
             adapter_qualified_name (str): The `adapter.qualified_name` of the
                 adapter to deregister.
+
+        Raises:
+            ValueError: The adapter is still loaded (`load_peft_adapter()` was
+                called and `unload_peft_adapter()` was not). Freeing the name
+                while it is still loaded would let a later `load_peft_adapter()`
+                call for a *different* adapter hit PEFT's "already exists"
+                error — silently swallowed by `load_peft_adapter()` — and keep
+                running on this adapter's stale weights under the new one's
+                identity. Call `unload_peft_adapter()` first.
         """
-        if adapter_qualified_name not in self._added_adapters:
+        if adapter_qualified_name in self._loaded_adapters:
+            raise ValueError(
+                f"cannot remove adapter {adapter_qualified_name} for backend {self}: "
+                "it is still loaded; call unload_peft_adapter() first (release() "
+                "does this for you)."
+            )
+
+        adapter = self._added_adapters.pop(adapter_qualified_name, None)
+        if adapter is None:
             MelleaLogger.get_logger().info(
                 f"could not remove adapter {adapter_qualified_name} for backend {self}: "
                 "adapter was not registered"
             )
             return
 
-        del self._added_adapters[adapter_qualified_name]
+        adapter.backend = None
+        adapter.path = None
 
     def activate_peft_adapter(self, adapter_qualified_name: str) -> None:
         """Switch a previously loaded PEFT adapter on for subsequent generation.

--- a/test/backends/test_adapters/test_adapter_mixin.py
+++ b/test/backends/test_adapters/test_adapter_mixin.py
@@ -5,8 +5,9 @@
 
 Verifies that:
   - the reality-specific verbs (`load_peft_adapter`, `unload_peft_adapter`,
-    `activate_peft_adapter`, `deactivate_peft_adapter`, `render_controls`,
-    `set_request_adapter`) raise `NotImplementedError` by default on the mixin
+    `remove_adapter`, `activate_peft_adapter`, `deactivate_peft_adapter`,
+    `render_controls`, `set_request_adapter`) raise `NotImplementedError` by
+    default on the mixin
   - each concrete backend overrides only the verb(s) matching its own adapter
     reality, leaving the others on the default (raising) implementation
 """
@@ -22,6 +23,7 @@ from mellea.backends.openai import OpenAIBackend
 _REALITY_SPECIFIC_VERBS = (
     "load_peft_adapter",
     "unload_peft_adapter",
+    "remove_adapter",
     "activate_peft_adapter",
     "deactivate_peft_adapter",
     "render_controls",
@@ -44,6 +46,7 @@ def test_hf_backend_overrides_only_peft_verbs():
     """LocalHFBackend (LocalFile/PEFT reality) overrides the PEFT verbs only."""
     assert "load_peft_adapter" in vars(LocalHFBackend)
     assert "unload_peft_adapter" in vars(LocalHFBackend)
+    assert "remove_adapter" in vars(LocalHFBackend)
     assert "activate_peft_adapter" in vars(LocalHFBackend)
     assert "deactivate_peft_adapter" in vars(LocalHFBackend)
     assert "render_controls" not in vars(LocalHFBackend)
@@ -55,6 +58,7 @@ def test_openai_backend_overrides_only_render_controls():
     assert "render_controls" in vars(OpenAIBackend)
     assert "load_peft_adapter" not in vars(OpenAIBackend)
     assert "unload_peft_adapter" not in vars(OpenAIBackend)
+    assert "remove_adapter" not in vars(OpenAIBackend)
     assert "set_request_adapter" not in vars(OpenAIBackend)
 
 

--- a/test/backends/test_adapters/test_local_file_binding.py
+++ b/test/backends/test_adapters/test_local_file_binding.py
@@ -31,18 +31,29 @@ def _fake_backend_with_registry():
     """An AdapterMixin-conforming double with real `LocalHFBackend.add_adapter`/
     `remove_adapter` registration semantics, so tests can exercise the #1528
     re-registration contract without a real model.
+
+    Mirrors both of `LocalHFBackend.add_adapter`'s guards — the
+    `binding.backend is not None` early-return (huggingface.py:2012-2017), not
+    just the duplicate-qualified-name refusal — so a `remove_adapter()` that
+    forgot to clear `.backend`/`.path` would show up here as a re-registration
+    failure, not just at the real-backend level (#1554 review finding 1).
     """
     backend = MagicMock()
     registry: dict[str, LocalFileBinding] = {}
 
     def add_adapter(binding: LocalFileBinding) -> None:
+        if binding.backend is not None:
+            return  # mirrors LocalHFBackend's "already added" early-return
         if binding.qualified_name in registry:
             return  # mirrors LocalHFBackend's refusal-with-warning path
         binding.backend = backend
         registry[binding.qualified_name] = binding
 
     def remove_adapter(qualified_name: str) -> None:
-        registry.pop(qualified_name, None)
+        removed = registry.pop(qualified_name, None)
+        if removed is not None:
+            removed.backend = None
+            removed.path = None
 
     backend.add_adapter.side_effect = add_adapter
     backend.remove_adapter.side_effect = remove_adapter
@@ -386,6 +397,7 @@ def test_release_after_bind_before_prepare_clears_staged_backend():
     assert binding._staged_backend is None
     assert binding._released
     backend.unload_peft_adapter.assert_not_called()
+    backend.remove_adapter.assert_not_called()
 
 
 def test_release_unloads_and_clears_state():
@@ -427,6 +439,34 @@ def test_release_frees_the_qualified_name_for_a_fresh_binding():
 
     assert second.backend is backend
     assert second.qualified_name in backend.list_adapters()
+
+
+def test_release_degrades_gracefully_when_backend_lacks_remove_adapter():
+    """release() must fully complete even if the backend predates remove_adapter().
+
+    Regression guard for #1554 review finding 4: `AdapterMixin.remove_adapter`
+    defaults to `raise NotImplementedError` (mellea/backends/adapters/adapter.py).
+    A backend supporting the LocalFile/PEFT reality (`unload_peft_adapter`, etc.)
+    but not overriding `remove_adapter` used to have `release()` propagate that
+    exception mid-teardown, leaving `_released` False forever — every retry just
+    re-raised. `release()` must catch it, log, and finish releasing anyway (the
+    qualified_name simply stays claimed for that backend's lifetime, same as
+    before #1528).
+    """
+    backend = _fake_backend()
+    backend.remove_adapter.side_effect = NotImplementedError(
+        "Backend type <fake> does not support remove_adapter()."
+    )
+    binding = LocalFileBinding(name="answerability")
+    binding.bind_backend(backend)
+    binding.prepare()
+
+    binding.release()  # must not raise
+
+    backend.unload_peft_adapter.assert_called_once_with(binding.qualified_name)
+    assert binding._released
+    assert binding.backend is None
+    assert binding.path is None
 
 
 def test_release_requires_deactivation_after_activation():
@@ -540,6 +580,7 @@ def test_release_is_idempotent():
     binding.release()
 
     backend.unload_peft_adapter.assert_called_once()
+    backend.remove_adapter.assert_called_once()
 
 
 def test_prepare_fires_phase_complete_metric_when_plugins_present():

--- a/test/backends/test_adapters/test_local_file_binding.py
+++ b/test/backends/test_adapters/test_local_file_binding.py
@@ -27,6 +27,29 @@ def _fake_backend():
     return backend
 
 
+def _fake_backend_with_registry():
+    """An AdapterMixin-conforming double with real `LocalHFBackend.add_adapter`/
+    `remove_adapter` registration semantics, so tests can exercise the #1528
+    re-registration contract without a real model.
+    """
+    backend = MagicMock()
+    registry: dict[str, LocalFileBinding] = {}
+
+    def add_adapter(binding: LocalFileBinding) -> None:
+        if binding.qualified_name in registry:
+            return  # mirrors LocalHFBackend's refusal-with-warning path
+        binding.backend = backend
+        registry[binding.qualified_name] = binding
+
+    def remove_adapter(qualified_name: str) -> None:
+        registry.pop(qualified_name, None)
+
+    backend.add_adapter.side_effect = add_adapter
+    backend.remove_adapter.side_effect = remove_adapter
+    backend.list_adapters.side_effect = lambda: list(registry.keys())
+    return backend
+
+
 def test_construction_defaults():
     binding = LocalFileBinding()
     assert binding.name == ""
@@ -374,9 +397,36 @@ def test_release_unloads_and_clears_state():
     binding.release()
 
     backend.unload_peft_adapter.assert_called_once_with(binding.qualified_name)
+    backend.remove_adapter.assert_called_once_with(binding.qualified_name)
     assert binding.backend is None
     assert binding.path is None
     assert binding._staged_backend is None
+
+
+def test_release_frees_the_qualified_name_for_a_fresh_binding():
+    """A different LocalFileBinding can claim a released qualified_name.
+
+    Regression guard for #1528: `release()` now calls the backend's
+    `remove_adapter()` inverse verb, so the `qualified_name` no longer stays
+    claimed for the backend's lifetime once the original binding tears down.
+    The original binding itself stays terminal — only the *name* is freed.
+    """
+    backend = _fake_backend_with_registry()
+    first = LocalFileBinding(name="answerability")
+    first.bind_backend(backend)
+    first.prepare()
+    first.release()
+
+    assert first.qualified_name not in backend.list_adapters()
+    with pytest.raises(RuntimeError, match="release"):
+        first.prepare()
+
+    second = LocalFileBinding(name="answerability")
+    second.bind_backend(backend)
+    second.prepare()  # must not raise "Backend refused to register"
+
+    assert second.backend is backend
+    assert second.qualified_name in backend.list_adapters()
 
 
 def test_release_requires_deactivation_after_activation():
@@ -472,6 +522,7 @@ def test_release_retries_after_unload_failure():
     binding.release()
 
     assert backend.unload_peft_adapter.call_count == 2
+    backend.remove_adapter.assert_called_once_with(binding.qualified_name)
     assert binding._released
     assert binding.backend is None
     assert binding.path is None

--- a/test/backends/test_adapters/test_local_file_binding.py
+++ b/test/backends/test_adapters/test_local_file_binding.py
@@ -32,11 +32,12 @@ def _fake_backend_with_registry():
     `remove_adapter` registration semantics, so tests can exercise the #1528
     re-registration contract without a real model.
 
-    Mirrors both of `LocalHFBackend.add_adapter`'s guards — the
-    `binding.backend is not None` early-return (huggingface.py:2012-2017), not
-    just the duplicate-qualified-name refusal — so a `remove_adapter()` that
-    forgot to clear `.backend`/`.path` would show up here as a re-registration
-    failure too, not just at the real-backend level.
+    Mirrors `LocalHFBackend.add_adapter`'s `binding.backend is not None`
+    early-return and its duplicate-qualified-name refusal — the real method's
+    cross-backend `raise Exception` outcome is folded into the early-return
+    no-op here — so a `remove_adapter()` that forgot to clear `.backend`/
+    `.path` would show up here as a re-registration failure too, not just at
+    the real-backend level.
     """
     backend = MagicMock()
     registry: dict[str, LocalFileBinding] = {}
@@ -447,7 +448,7 @@ def test_release_degrades_gracefully_when_backend_lacks_remove_adapter():
     `AdapterMixin.remove_adapter` defaults to `raise NotImplementedError`
     (mellea/backends/adapters/adapter.py). A backend supporting the
     LocalFile/PEFT reality (`unload_peft_adapter`, etc.) but not overriding
-    `remove_adapter` used to have `release()` propagate that exception
+    `remove_adapter` would have `release()` propagate that exception
     mid-teardown, leaving `_released` False forever — every retry just
     re-raised. `release()` must catch it, log, and finish releasing anyway
     (the qualified_name simply stays claimed for that backend's lifetime,

--- a/test/backends/test_adapters/test_local_file_binding.py
+++ b/test/backends/test_adapters/test_local_file_binding.py
@@ -36,7 +36,7 @@ def _fake_backend_with_registry():
     `binding.backend is not None` early-return (huggingface.py:2012-2017), not
     just the duplicate-qualified-name refusal — so a `remove_adapter()` that
     forgot to clear `.backend`/`.path` would show up here as a re-registration
-    failure, not just at the real-backend level (#1554 review finding 1).
+    failure too, not just at the real-backend level.
     """
     backend = MagicMock()
     registry: dict[str, LocalFileBinding] = {}
@@ -444,14 +444,14 @@ def test_release_frees_the_qualified_name_for_a_fresh_binding():
 def test_release_degrades_gracefully_when_backend_lacks_remove_adapter():
     """release() must fully complete even if the backend predates remove_adapter().
 
-    Regression guard for #1554 review finding 4: `AdapterMixin.remove_adapter`
-    defaults to `raise NotImplementedError` (mellea/backends/adapters/adapter.py).
-    A backend supporting the LocalFile/PEFT reality (`unload_peft_adapter`, etc.)
-    but not overriding `remove_adapter` used to have `release()` propagate that
-    exception mid-teardown, leaving `_released` False forever — every retry just
-    re-raised. `release()` must catch it, log, and finish releasing anyway (the
-    qualified_name simply stays claimed for that backend's lifetime, same as
-    before #1528).
+    `AdapterMixin.remove_adapter` defaults to `raise NotImplementedError`
+    (mellea/backends/adapters/adapter.py). A backend supporting the
+    LocalFile/PEFT reality (`unload_peft_adapter`, etc.) but not overriding
+    `remove_adapter` used to have `release()` propagate that exception
+    mid-teardown, leaving `_released` False forever — every retry just
+    re-raised. `release()` must catch it, log, and finish releasing anyway
+    (the qualified_name simply stays claimed for that backend's lifetime,
+    same as before #1528).
     """
     backend = _fake_backend()
     backend.remove_adapter.side_effect = NotImplementedError(

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -106,9 +106,10 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
 
     binding.release()
     assert binding.backend is None
-    # list_adapters() reports everything ever registered via add_adapter,
-    # regardless of load state — release() only reverses the load, so check
-    # the loaded-adapters bookkeeping directly instead.
+    # #1528: release() now deregisters via the backend's remove_adapter()
+    # inverse verb, so a released adapter no longer appears in
+    # list_adapters() either.
+    assert binding.qualified_name not in backend.list_adapters()
     assert binding.qualified_name not in backend._loaded_adapters
 
 

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -289,7 +289,7 @@ def test_find_adapter_honours_type_preference_order():
 class _MutatingCapability:
     """Capability sentinel whose `__eq__` deletes an entry from the registry
     it is compared against, simulating a concurrent `release()` mutating
-    `_added_adapters` mid-iteration (#1554 review finding 3).
+    `_added_adapters` mid-iteration.
 
     `_find_adapter` compares `a.identity.capability == capability` for each
     registered adapter in turn; a real `str.__eq__` against this sentinel
@@ -316,12 +316,11 @@ class _MutatingCapability:
 def test_find_adapter_survives_concurrent_removal_during_iteration():
     """`_find_adapter` must not iterate a live view over `_added_adapters`.
 
-    Regression guard for #1554 review finding 3: before this PR,
-    `_added_adapters` was insert-only, so iterating it was always safe.
-    `remove_adapter()` (#1528) made it the first-ever runtime deletion site,
-    and a concurrent `release()` mutating the dict while `_find_adapter`
-    holds a live `.values()` view raises `RuntimeError: dictionary changed
-    size during iteration`. `_find_adapter` must snapshot into a list first.
+    `_added_adapters` was insert-only until `remove_adapter()` (#1528) added
+    the first runtime deletion from it. A concurrent `release()` mutating the
+    dict while `_find_adapter` holds a live `.values()` view raises
+    `RuntimeError: dictionary changed size during iteration`. `_find_adapter`
+    must snapshot into a list first.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -313,6 +313,40 @@ class _MutatingCapability:
         return hash("mutating-capability-sentinel")
 
 
+class _MutatingName:
+    """Capability-name sentinel whose `__str__` pops an entry from the
+    registry, simulating a concurrent `release()` mutating
+    `_added_adapters` while `resolve_adapter`'s collision scan builds
+    `f"{name}_"` on every iteration.
+
+    Companion to `_MutatingCapability` (which fires from a reflected
+    `str.__eq__` inside `_find_adapter`): the collision scan never compares
+    `name` with `==`, so the side effect hooks `__str__` instead — the
+    f-string build fires it from inside the scan, deterministically, with no
+    threading. `__add__` answers without firing: `Adapter.__init__` builds
+    `qualified_name` as `name + "_" + ...` during the lazy-registration
+    step, and the mutation must land in the scan, not in registration.
+    """
+
+    def __init__(self, registry: dict, key_to_remove: str, prefix: str) -> None:
+        self._registry = registry
+        self._key_to_remove = key_to_remove
+        self._prefix = prefix
+        self.fired = False
+
+    def __add__(self, other: str) -> str:
+        return self._prefix + other
+
+    def __str__(self) -> str:
+        if not self.fired:
+            self.fired = True
+            self._registry.pop(self._key_to_remove, None)
+        return self._prefix
+
+    def __repr__(self) -> str:
+        return f"_MutatingName({self._prefix!r})"
+
+
 def test_find_adapter_survives_concurrent_removal_during_iteration():
     """`_find_adapter` must not iterate a live view over `_added_adapters`.
 
@@ -337,6 +371,56 @@ def test_find_adapter_survives_concurrent_removal_during_iteration():
     assert capability.fired, "the mutation must have fired during iteration"
     assert result is None
     assert second.qualified_name not in registry
+
+
+def test_resolve_adapter_survives_concurrent_removal_during_iteration():
+    """`resolve_adapter`'s collision scan must not iterate a live view of `_added_adapters`.
+
+    Guards the `list(...)` snapshot with the same deterministic sentinel
+    pattern as
+    `test_find_adapter_survives_concurrent_removal_during_iteration`: the
+    pop fires from the scan's `f"{name}_"` build on the first (non-matching)
+    entry, so a live `.items()` view raises
+    `RuntimeError: dictionary changed size during iteration` when the scan
+    then advances, while the snapshot iterates on.
+    """
+    binding = LocalFileBinding(name="answerability", adapter_type=AdapterType.LORA)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        distractor = EmbeddedIntrinsicAdapter(
+            "uncertainty", config={}, technology="lora"
+        )
+
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+    registry = {distractor.qualified_name: distractor, binding.qualified_name: binding}
+    mock_backend._added_adapters = registry
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+    # Nothing new lands in the registry: the binding keeps the name, exactly
+    # as the real duplicate-key guard would.
+    mock_backend.add_adapter.side_effect = lambda a: None
+
+    name = _MutatingName(registry, distractor.qualified_name, "answerability")
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=_MOCK_CATALOG_ENTRY,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
+    ):
+        with pytest.raises(KeyError, match=r"LocalFileBinding.*answerability_lora"):
+            AdapterMixin.resolve_adapter(mock_backend, name)
+
+    assert name.fired, "the mutation must have fired during the collision scan"
+    assert distractor.qualified_name not in registry
+    assert binding.qualified_name in registry
 
 
 def test_resolve_adapter_names_the_conflict_when_a_binding_blocks_registration():

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -286,6 +286,60 @@ def test_find_adapter_honours_type_preference_order():
     assert result is alora, "alora must win over lora regardless of insertion order"
 
 
+class _MutatingCapability:
+    """Capability sentinel whose `__eq__` deletes an entry from the registry
+    it is compared against, simulating a concurrent `release()` mutating
+    `_added_adapters` mid-iteration (#1554 review finding 3).
+
+    `_find_adapter` compares `a.identity.capability == capability` for each
+    registered adapter in turn; a real `str.__eq__` against this sentinel
+    returns `NotImplemented`, so Python falls back to this class's reflected
+    `__eq__` — firing the side effect from inside the loop, deterministically,
+    with no actual threading required.
+    """
+
+    def __init__(self, registry: dict, key_to_remove: str) -> None:
+        self._registry = registry
+        self._key_to_remove = key_to_remove
+        self.fired = False
+
+    def __eq__(self, other: object) -> bool:
+        if not self.fired:
+            self.fired = True
+            self._registry.pop(self._key_to_remove, None)
+        return False
+
+    def __hash__(self) -> int:
+        return hash("mutating-capability-sentinel")
+
+
+def test_find_adapter_survives_concurrent_removal_during_iteration():
+    """`_find_adapter` must not iterate a live view over `_added_adapters`.
+
+    Regression guard for #1554 review finding 3: before this PR,
+    `_added_adapters` was insert-only, so iterating it was always safe.
+    `remove_adapter()` (#1528) made it the first-ever runtime deletion site,
+    and a concurrent `release()` mutating the dict while `_find_adapter`
+    holds a live `.values()` view raises `RuntimeError: dictionary changed
+    size during iteration`. `_find_adapter` must snapshot into a list first.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        first = EmbeddedIntrinsicAdapter("answerability", config={}, technology="lora")
+        second = EmbeddedIntrinsicAdapter("uncertainty", config={}, technology="lora")
+
+    mock_backend = MagicMock(spec=AdapterMixin)
+    registry = {first.qualified_name: first, second.qualified_name: second}
+    mock_backend._added_adapters = registry
+
+    capability = _MutatingCapability(registry, second.qualified_name)
+    result = AdapterMixin._find_adapter(mock_backend, capability)  # must not raise
+
+    assert capability.fired, "the mutation must have fired during iteration"
+    assert result is None
+    assert second.qualified_name not in registry
+
+
 def test_resolve_adapter_names_the_conflict_when_a_binding_blocks_registration():
     """resolve_adapter's KeyError should name the collision, not just say "not found".
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -350,6 +350,48 @@ def test_add_non_local_hf_adapter_raises():
         backend.add_adapter(mock_adapter)
 
 
+def test_remove_adapter_removes_from_added_adapters():
+    """remove_adapter() is the inverse of add_adapter() (#1528)."""
+    backend = _make_backend()
+    adapter = _make_intrinsic_adapter_stub()
+    adapter.backend = None
+    adapter.get_local_hf_path = lambda base_model_name: "/fake/path"
+    backend.add_adapter(adapter)
+    assert adapter.qualified_name in backend.list_adapters()
+
+    backend.remove_adapter(adapter.qualified_name)
+
+    assert adapter.qualified_name not in backend.list_adapters()
+    assert adapter.qualified_name not in backend._added_adapters
+
+
+def test_remove_adapter_unregistered_name_is_noop():
+    """remove_adapter() on a name that was never added must not raise."""
+    backend = _make_backend()
+    backend.remove_adapter("never_registered_lora")  # must not raise
+
+
+def test_add_adapter_after_remove_adapter_allows_a_fresh_registration():
+    """#1528: removing an adapter frees its qualified_name for a different
+    adapter object to register under — the name is no longer burned for the
+    backend's lifetime.
+    """
+    backend = _make_backend()
+    first = _make_intrinsic_adapter_stub()
+    first.backend = None
+    first.get_local_hf_path = lambda base_model_name: "/fake/path"
+    backend.add_adapter(first)
+    backend.remove_adapter(first.qualified_name)
+
+    second = _make_intrinsic_adapter_stub()
+    second.backend = None
+    second.get_local_hf_path = lambda base_model_name: "/fake/path-2"
+    backend.add_adapter(second)
+
+    assert second.backend is backend
+    assert backend._added_adapters[second.qualified_name] is second
+
+
 def test_seed_forces_do_sample_true(stub_backend):
     """Issue #40: a seed alone must flip do_sample=True so it isn't ignored."""
     out = _call(stub_backend, {ModelOption.SEED: 42})

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -397,9 +397,8 @@ def test_remove_adapter_clears_backend_and_path_references():
     the registry entry.
 
     Regression guard: `add_adapter()` sets `.path` and `.backend = self` in
-    addition to inserting into `_added_adapters`
-    (mellea/backends/huggingface.py:2035-2037). A `remove_adapter()` that only
-    pops the dict entry leaves the removed object's `.backend` pointing at a
+    addition to inserting into `_added_adapters`. A `remove_adapter()` that
+    only pops the dict entry leaves the removed object's `.backend` pointing at a
     backend that no longer knows about it — bricking the object for
     re-registration anywhere (see the next test).
     """
@@ -421,9 +420,8 @@ def test_add_adapter_after_remove_adapter_allows_reregistering_the_same_object()
     """A removed adapter object, not just a fresh one, must be re-addable.
 
     Before `remove_adapter()` cleared `.backend`, re-adding the *same* object
-    hit the `adapter.backend is self` early-return in `add_adapter()`
-    (mellea/backends/huggingface.py:2012-2017) — a silent no-op, never
-    re-registered, with no exception raised.
+    hit the `adapter.backend is self` early-return in `add_adapter()` — a
+    silent no-op, never re-registered, with no exception raised.
     """
     backend = _make_backend()
     adapter = _make_intrinsic_adapter_stub()
@@ -442,8 +440,8 @@ def test_remove_adapter_raises_if_still_loaded():
     """remove_adapter() must refuse to free a name that is still loaded.
 
     `load_peft_adapter()` deliberately swallows PEFT's "Adapter with name X
-    already exists." (mellea/backends/huggingface.py:2068-2073) — safe only
-    because a qualified_name, once claimed, could never be reclaimed. Freeing
+    already exists." — safe only because a qualified_name, once claimed,
+    could never be reclaimed. Freeing
     the name while it is still loaded lets a later `load_peft_adapter()` call
     for a *different* adapter object hit that swallow and silently keep
     running on the old weights. `unload_peft_adapter()` (which `release()`

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -392,6 +392,85 @@ def test_add_adapter_after_remove_adapter_allows_a_fresh_registration():
     assert backend._added_adapters[second.qualified_name] is second
 
 
+def test_remove_adapter_clears_backend_and_path_references():
+    """remove_adapter() must reverse ALL of add_adapter()'s mutations, not just
+    the registry entry.
+
+    Regression guard: `add_adapter()` sets `.path` and `.backend = self` in
+    addition to inserting into `_added_adapters`
+    (mellea/backends/huggingface.py:2035-2037). A `remove_adapter()` that only
+    pops the dict entry leaves the removed object's `.backend` pointing at a
+    backend that no longer knows about it — bricking the object for
+    re-registration anywhere (see the next test).
+    """
+    backend = _make_backend()
+    adapter = _make_intrinsic_adapter_stub()
+    adapter.backend = None
+    adapter.get_local_hf_path = lambda base_model_name: "/fake/path"
+    backend.add_adapter(adapter)
+    assert adapter.backend is backend
+    assert adapter.path == "/fake/path"
+
+    backend.remove_adapter(adapter.qualified_name)
+
+    assert adapter.backend is None
+    assert adapter.path is None
+
+
+def test_add_adapter_after_remove_adapter_allows_reregistering_the_same_object():
+    """A removed adapter object, not just a fresh one, must be re-addable.
+
+    Regression guard for #1554 review finding 1: before `remove_adapter()`
+    cleared `.backend`, re-adding the *same* object hit the `adapter.backend
+    is self` early-return in `add_adapter()`
+    (mellea/backends/huggingface.py:2012-2017) — a silent no-op, never
+    re-registered, with no exception raised.
+    """
+    backend = _make_backend()
+    adapter = _make_intrinsic_adapter_stub()
+    adapter.backend = None
+    adapter.get_local_hf_path = lambda base_model_name: "/fake/path"
+    backend.add_adapter(adapter)
+    backend.remove_adapter(adapter.qualified_name)
+
+    backend.add_adapter(adapter)
+
+    assert adapter.backend is backend
+    assert backend._added_adapters[adapter.qualified_name] is adapter
+
+
+def test_remove_adapter_raises_if_still_loaded():
+    """remove_adapter() must refuse to free a name that is still loaded.
+
+    Regression guard for #1554 review finding 2: `load_peft_adapter()`
+    deliberately swallows PEFT's "Adapter with name X already exists."
+    (mellea/backends/huggingface.py:2068-2073) — safe only because a
+    qualified_name, once claimed, could never be reclaimed. Freeing the name
+    while it is still loaded lets a later `load_peft_adapter()` call for a
+    *different* adapter object hit that swallow and silently keep running on
+    the old weights. `unload_peft_adapter()` (which `release()` always calls
+    first) must clear `_loaded_adapters` before `remove_adapter()` can
+    succeed.
+    """
+    backend = _make_backend()
+    adapter = _make_intrinsic_adapter_stub()
+    adapter.backend = None
+    adapter.get_local_hf_path = lambda base_model_name: "/fake/path"
+    backend.add_adapter(adapter)
+    backend.load_peft_adapter(adapter.qualified_name)
+    assert adapter.qualified_name in backend._loaded_adapters
+
+    with pytest.raises(ValueError, match="still loaded"):
+        backend.remove_adapter(adapter.qualified_name)
+
+    assert adapter.qualified_name in backend._added_adapters
+
+    backend.unload_peft_adapter(adapter.qualified_name)
+    backend.remove_adapter(adapter.qualified_name)  # now succeeds
+
+    assert adapter.qualified_name not in backend._added_adapters
+
+
 def test_seed_forces_do_sample_true(stub_backend):
     """Issue #40: a seed alone must flip do_sample=True so it isn't ignored."""
     out = _call(stub_backend, {ModelOption.SEED: 42})

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -420,9 +420,8 @@ def test_remove_adapter_clears_backend_and_path_references():
 def test_add_adapter_after_remove_adapter_allows_reregistering_the_same_object():
     """A removed adapter object, not just a fresh one, must be re-addable.
 
-    Regression guard for #1554 review finding 1: before `remove_adapter()`
-    cleared `.backend`, re-adding the *same* object hit the `adapter.backend
-    is self` early-return in `add_adapter()`
+    Before `remove_adapter()` cleared `.backend`, re-adding the *same* object
+    hit the `adapter.backend is self` early-return in `add_adapter()`
     (mellea/backends/huggingface.py:2012-2017) — a silent no-op, never
     re-registered, with no exception raised.
     """
@@ -442,15 +441,14 @@ def test_add_adapter_after_remove_adapter_allows_reregistering_the_same_object()
 def test_remove_adapter_raises_if_still_loaded():
     """remove_adapter() must refuse to free a name that is still loaded.
 
-    Regression guard for #1554 review finding 2: `load_peft_adapter()`
-    deliberately swallows PEFT's "Adapter with name X already exists."
-    (mellea/backends/huggingface.py:2068-2073) — safe only because a
-    qualified_name, once claimed, could never be reclaimed. Freeing the name
-    while it is still loaded lets a later `load_peft_adapter()` call for a
-    *different* adapter object hit that swallow and silently keep running on
-    the old weights. `unload_peft_adapter()` (which `release()` always calls
-    first) must clear `_loaded_adapters` before `remove_adapter()` can
-    succeed.
+    `load_peft_adapter()` deliberately swallows PEFT's "Adapter with name X
+    already exists." (mellea/backends/huggingface.py:2068-2073) — safe only
+    because a qualified_name, once claimed, could never be reclaimed. Freeing
+    the name while it is still loaded lets a later `load_peft_adapter()` call
+    for a *different* adapter object hit that swallow and silently keep
+    running on the old weights. `unload_peft_adapter()` (which `release()`
+    always calls first) must clear `_loaded_adapters` before `remove_adapter()`
+    can succeed.
     """
     backend = _make_backend()
     adapter = _make_intrinsic_adapter_stub()


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1528.

## Description

`LocalFileBinding.release()` unloaded adapter weights but left the adapter registered with the backend. That permanently reserved its qualified name, so a fresh binding for the same capability could not be prepared later in the same process.

This PR adds `remove_adapter()` as the inverse of registration and calls it during `LocalFileBinding.release()`. A released binding remains terminal; a newly created binding can now register the released name safely.

## Where this fits

This is Phase 2 work for Epic #929. It resolves the lifecycle decision needed by #1465 and is independent of the embedded-adapter work in #1142 and telemetry work in #1466. Shim removal remains with #1144.

## What changed

- Add the `AdapterMixin.remove_adapter()` backend verb and the `LocalHFBackend` implementation.
- Deregister local-file adapters during release, while rejecting removal of still-loaded adapters.
- Clear removed registration state and snapshot adapter-registry iteration to keep concurrent reads safe.
- Add regression coverage for re-registration, terminal bindings, and registry safety.

## Caveat

Backends that do not implement `remove_adapter()` retain the previous release behaviour and emit a warning rather than failing teardown.

## Testing

Focused adapter and Hugging Face tests, the non-qualitative suite, Ruff, mypy, and the documentation quality gate pass. Required GitHub checks pass.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
