### PR TITLE
fix(backends): route intrinsic generation through adapter_scope, fix lock reentrancy

### DIFF
--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -735,8 +735,10 @@ class AdapterMixin(Backend, abc.ABC):
         This method fires hooks only; it does not open spans. Span production is a
         plugin's job (see #1464 for the rule and #1466 for the adapter-function
         spans), and the `ADAPTER_FUNCTION_*` family currently has no start hook for
-        a plugin to open a span on. See `docs/dev/adapter_observability.md` for the
-        metric schema.
+        a plugin to open a span on. Hook dispatch (`_run_async_in_thread`, no
+        timeout) runs synchronously on the calling thread, so a slow or
+        blocking-mode `ADAPTER_FUNCTION_*` subscriber delays whatever holds this
+        scope open.
 
         `deactivate()` is guarded on `activate()`'s own side effect having
         completed, not on the activate phase's hook dispatch also succeeding.
@@ -744,21 +746,27 @@ class AdapterMixin(Backend, abc.ABC):
         `activate()` already flipped the adapter on, `deactivate()` still runs —
         telemetry must not be able to strand the adapter active.
 
-        Not atomic across the whole scope: `_adapter_activation_lock()` is
-        held only inside each of `activate()`/`deactivate()`'s own verb calls
+        Not atomic across the whole scope **by itself**: `_adapter_activation_lock()`
+        is held only inside each of `activate()`/`deactivate()`'s own verb calls
         (see `LocalFileBinding.activate`), not for the `with` body in between.
         Two concurrent `adapter_scope()` calls on one backend can therefore
         interleave — one thread's body can run while a different adapter is
-        active, activated by another thread's call. Widening the lock to span
-        the whole scope was tried and reverted: it deadlocks the moment the
-        body does real async generation (confirmed against
-        `test_local_file_e2e.py`), because that work runs on the shared
-        event-loop thread while this thread holds the lock — a same-thread
-        `RLock` doesn't help across threads. No caller combines concurrent
-        `adapter_scope()` calls today (nothing outside tests calls it at all),
-        so this is latent, not reachable — but #1465 (wiring real generation
-        through this scope) has to solve the atomicity and the threading
-        interaction together, not layer one fix on top of the other.
+        active, activated by another thread's call — unless the caller closes
+        that gap itself. Widening *this method's own* lock to span the whole
+        scope was tried and reverted: it deadlocks the moment the body does
+        real async generation from the thread that opened the scope, because
+        that work runs on the shared event-loop thread while this thread holds
+        the lock — a same-thread `RLock` doesn't help across threads.
+
+        `LocalHFBackend._generate_intrinsic_with_adapter_scope` is the reference
+        example of a caller that *does* close the gap for its own call site: it
+        holds `_generation_lock` around the entire scope, which is safe there
+        only because each invocation is fully synchronous end to end and never
+        re-enters the event loop — concurrent invocations simply land on
+        different threads and serialise on the lock, rather than one thread
+        holding it while another does async work on the loop. A caller whose
+        body awaits work that re-enters generation on another thread must not
+        widen a lock this way — that reproduces the deadlock above.
 
         Args:
             adapter: The adapter to activate, or `None` (no-op).

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -768,6 +768,14 @@ class AdapterMixin(Backend, abc.ABC):
         body awaits work that re-enters generation on another thread must not
         widen a lock this way — that reproduces the deadlock above.
 
+        A caller composing `adapter_scope()` with `LocalHFBackend`'s *standard*
+        (non-intrinsic) generation path still silently ignores it: that path
+        (`_generate_with_adapter_lock`) always deactivates any adapter before
+        generating, so wrapping `generate_from_context()` in `adapter_scope()`
+        activates the adapter, generates against the base model anyway, then
+        deactivates. Pre-existing, not specific to the intrinsic path this
+        method now supports.
+
         Args:
             adapter: The adapter to activate, or `None` (no-op).
 

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -768,10 +768,13 @@ class AdapterMixin(Backend, abc.ABC):
         `LocalHFBackend._generate_intrinsic_with_adapter_scope` is the reference
         example of a caller that *does* close the gap for its own call site: it
         holds `_generation_lock` around the entire scope, which is safe there
-        only because each invocation is fully synchronous end to end and never
-        re-enters the event loop — concurrent invocations simply land on
-        different threads and serialise on the lock, rather than one thread
-        holding it while another does async work on the loop. A caller whose
+        only because the scope *body* is fully synchronous end to end and
+        does no async generation work on the event loop (its only loop
+        traffic during the scope is the hook dispatches described above —
+        one-way submissions, not re-entry into this backend) — concurrent
+        invocations simply land on different threads and serialise on the
+        lock, rather than one thread holding it while another does async work
+        on the loop. A caller whose
         body awaits work that re-enters generation on another thread must not
         widen a lock this way — that reproduces the deadlock above.
 

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -735,10 +735,17 @@ class AdapterMixin(Backend, abc.ABC):
         This method fires hooks only; it does not open spans. Span production is a
         plugin's job (see #1464 for the rule and #1466 for the adapter-function
         spans), and the `ADAPTER_FUNCTION_*` family currently has no start hook for
-        a plugin to open a span on. Hook dispatch (`_run_async_in_thread`, no
-        timeout) runs synchronously on the calling thread, so a slow or
-        blocking-mode `ADAPTER_FUNCTION_*` subscriber delays whatever holds this
-        scope open.
+        a plugin to open a span on. Hook dispatch goes through
+        `_run_async_in_thread` (no timeout): the dispatching call blocks the
+        calling thread, but the hook coroutine itself runs on the shared
+        `_EventLoopHandler` event-loop thread. A subscriber that blocks on
+        something the dispatching thread is holding deadlocks rather than
+        merely stalls — e.g. on `LocalHFBackend`, an intrinsic caller holds
+        `_generation_lock` across the whole scope, so a subscriber that
+        re-enters any `_generation_lock` path blocks the event-loop thread
+        while its owner waits on that same event loop, and reentrance cannot
+        bridge the gap. Even without such re-entry, a slow or blocking-mode
+        `ADAPTER_FUNCTION_*` subscriber delays whatever holds this scope open.
 
         `deactivate()` is guarded on `activate()`'s own side effect having
         completed, not on the activate phase's hook dispatch also succeeding.

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -606,10 +606,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hooks (`phase="activate"` and
         `"deactivate"` only — `"generate"`/`"parse"` are not emitted; adding
         those is out of scope here, see #1466), and deactivation is guaranteed
-        even if `generate_func` raises. Those hooks dispatch synchronously
-        (`_run_async_in_thread`, no timeout) while `_generation_lock` is held
-        below, so a blocking-mode `ADAPTER_FUNCTION_*` subscriber stalls
-        generation on this backend for its duration.
+        even if `generate_func` raises. Those hooks dispatch while
+        `_generation_lock` is held below: the dispatching call blocks this
+        thread with no timeout, and the hook coroutines run on the shared
+        `_EventLoopHandler` event-loop thread, so an `ADAPTER_FUNCTION_*`
+        subscriber that re-enters any `_generation_lock`-holding path (any
+        generation call or adapter activation on this backend) blocks the
+        event-loop thread while this one waits on it — a cross-thread deadlock
+        the `RLock` cannot prevent, since reentrance only helps the owning
+        thread. `ADAPTER_FUNCTION_*` subscribers must therefore be non-blocking
+        and must never re-enter this backend; a merely slow subscriber stalls
+        all generation on this backend for its duration.
 
         `IntrinsicAdapter` (the legacy shim `adapter` is expected to be) carries
         an inert `_ShimWeightsBinding` that raises on every verb, so it can't be
@@ -626,9 +633,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         concurrent caller's `activate()` can never interleave with this call's
         generation — the atomicity gap `adapter_scope()`'s own docstring flags
         as unresolved for a caller that doesn't do this. Safe here because each
-        invocation of this method runs entirely on one thread (this method is
-        only ever invoked via a single `asyncio.to_thread` call — see its call
-        site in `_generate_from_intrinsic`) and never re-enters generation on
+        invocation of this method runs entirely on one thread (in production it
+        is only ever invoked via a single `asyncio.to_thread` call — see its
+        call site in `_generate_from_intrinsic`; the unit tests call it
+        directly, also single-threaded) and never re-enters generation on
         another thread: the inner re-acquisition of `_generation_lock` inside
         `adapter_scope()`'s `activate()`/`deactivate()` (via
         `_adapter_activation_lock()`) is therefore same-thread and reentrant.
@@ -2236,20 +2244,24 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
            (for the standard, non-intrinsic generation path).
         2. `LocalFileBinding.activate()`/`.deactivate()` (driven by
            `AdapterMixin.adapter_scope()`), which holds no lock of its own.
-        3. `_generate_intrinsic_with_adapter_scope`, which also holds
-           `_generation_lock` itself, for the whole activate -> generate ->
-           deactivate section — and calls into caller 2's path via
-           `adapter_scope()` from inside that section (#1465).
+        3. `_IntrinsicPeftBinding.activate()`/`.deactivate()` (driven by
+           `_generate_intrinsic_with_adapter_scope` via
+           `AdapterMixin.adapter_scope()`), the intrinsic-path counterpart of
+           caller 2's `LocalFileBinding` — whose driver also holds
+           `_generation_lock` itself for the whole activate -> generate ->
+           deactivate section (#1465), so those verb acquisitions nest
+           same-thread inside that outer hold.
 
-        This method exists for caller 2 — so it is not a duplicate of the lock
-        callers 1 and 3 take, it is the only thing satisfying the precondition
-        on that path.
+        This method exists for callers 2 and 3 — so it is not a duplicate of
+        the lock caller 1 (and, on the outer level, caller 3's driver) takes,
+        it is the only thing satisfying the precondition on those paths.
 
-        Caller 3 nests inside caller 2's lock acquisition on the same thread
-        (see `_generate_intrinsic_with_adapter_scope`'s docstring), which is
-        exactly why `_generation_lock` is a `threading.RLock`: a plain
-        `threading.Lock` would deadlock on that same-thread re-acquisition
-        (this was #1465's known lock-reentrancy issue).
+        Caller 3's verb acquisitions nest inside its driver's `_generation_lock`
+        hold on the same thread (see `_generate_intrinsic_with_adapter_scope`'s
+        docstring), which is exactly why `_generation_lock` is a
+        `threading.RLock`: a plain `threading.Lock` would deadlock on that
+        same-thread re-acquisition (this was #1465's known lock-reentrancy
+        issue).
         """
         return self._generation_lock
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -583,10 +583,19 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         adapter is deactivated before the model call, and the model's active
         state is asserted before and after. Adapter-active generation goes
         elsewhere — `_generate_intrinsic_with_adapter_scope` for intrinsics
-        (routed through `adapter_scope`, with its lifecycle hooks), and
-        Granite Switch's embedded activation via the binding's
-        `apply_activation` (#1018). Neither path activates through this
-        method — which is why it takes no adapter name.
+        (routed through `adapter_scope`, with its lifecycle hooks), and, once
+        #1018 lands, Granite Switch's embedded activation through a binding
+        `apply_activation` verb (not yet implemented — that is #1142's work) —
+        so no current path activates through this method, which is why it
+        takes no adapter name.
+
+        Args:
+            generate_func: The synchronous generation callable to invoke.
+            *args: Positional arguments forwarded to `generate_func`.
+            **kwargs: Keyword arguments forwarded to `generate_func`.
+
+        Returns:
+            Whatever `generate_func` returns.
         """
         with self._generation_lock:
             self.deactivate_peft_adapter("")

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -16,7 +16,7 @@ import functools
 import json
 import threading
 from collections.abc import Callable, Coroutine, Sequence
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import jinja2
 import jinja2.meta
@@ -77,7 +77,13 @@ from ..stdlib.requirements import ALoraRequirement, LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
 from ._options import resolve_model_options
 from .adapters import AdapterMixin, IntrinsicAdapter, LocalHFAdapter
-from .adapters._core import LocalFileBinding
+from .adapters._core import (
+    Adapter as _AdapterCore,
+    Identity,
+    IOContract,
+    LocalFileBinding,
+    WeightsBinding,
+)
 from .adapters.adapter import AdapterInput
 from .backend import FormatterBackend
 from .cache import Cache, SimpleLRUCache
@@ -450,8 +456,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         self._added_adapters: dict[str, LocalHFAdapter | LocalFileBinding] = {}
         self._loaded_adapters: dict[str, LocalHFAdapter | LocalFileBinding] = {}
 
-        self._generation_lock = threading.Lock()
-        """Used to force generation requests to be non-concurrent. Necessary for preventing issues with adapters."""
+        self._generation_lock = threading.RLock()
+        """Forces generation requests to be non-concurrent, and guards adapter
+        activation (`_adapter_activation_lock()` returns this same lock).
+
+        Reentrant (`threading.RLock`, not `threading.Lock`) because
+        `_generate_intrinsic_with_adapter_scope` holds it for a whole
+        activate -> generate -> deactivate critical section, and
+        `adapter_scope()`'s `activate()`/`deactivate()` re-acquire it from
+        inside that section, on the same thread, via `_adapter_activation_lock()`.
+        A plain `Lock` deadlocks on that same-thread re-acquisition (#1465).
+        """
 
     def _make_dc_cache(self, toks, **model_options):
         dc = DynamicCache()
@@ -575,6 +590,63 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             out = generate_func(*args, **kwargs)
             _assert_correct_adapters(adapter_name, self._model)
             return out
+
+    def _generate_intrinsic_with_adapter_scope(
+        self, adapter: IntrinsicAdapter, generate_func: Callable, *args, **kwargs
+    ):
+        """Runs `generate_func` with `adapter` active, inside `AdapterMixin.adapter_scope`.
+
+        Replaces the old direct load-then-activate-then-generate sequence
+        `_generate_from_intrinsic` used to run through `_generate_with_adapter_lock`
+        (#1465): the model call now runs inside `adapter_scope`, so activation and
+        deactivation fire the `ADAPTER_FUNCTION_PHASE_COMPLETE`/
+        `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hooks, and deactivation is
+        guaranteed even if `generate_func` raises.
+
+        `IntrinsicAdapter` (the legacy shim `adapter` is expected to be) carries
+        an inert `_ShimWeightsBinding` that raises on every verb, so it can't be
+        handed to `adapter_scope()` directly. This method builds a fresh
+        `_AdapterCore` wrapping a `_IntrinsicPeftBinding` instead, which drives
+        this backend's own `load_peft_adapter`/`activate_peft_adapter`/
+        `deactivate_peft_adapter` verbs — the same verbs
+        `_generate_with_adapter_lock` used to call directly.
+
+        Holds `_generation_lock` for the *entire* activate -> generate ->
+        deactivate section, not just around activation, so a concurrent
+        caller's `activate()` can never interleave with this call's generation
+        — the atomicity gap `adapter_scope()`'s own docstring flags as
+        unresolved for real concurrent callers. This is safe specifically
+        because this method only ever runs inside a single `asyncio.to_thread`
+        worker thread (see its call site in `_generate_from_intrinsic`): the
+        inner re-acquisition of `_generation_lock` inside `adapter_scope()`'s
+        `activate()`/`deactivate()` (via `_adapter_activation_lock()`) is
+        same-thread, so it's reentrant rather than a cross-thread deadlock.
+
+        Args:
+            adapter: The (legacy) `IntrinsicAdapter` to activate for this call.
+            generate_func: The synchronous generation callable to invoke while
+                `adapter` is active.
+            *args: Positional arguments forwarded to `generate_func`.
+            **kwargs: Keyword arguments forwarded to `generate_func`.
+
+        Returns:
+            Whatever `generate_func` returns.
+        """
+        scope_adapter = _AdapterCore(
+            identity=Identity(
+                name=adapter.name,
+                adapter_type=adapter.adapter_type.value,
+                capability=adapter.name,
+            ),
+            io_contract=_NoIntrinsicIOContract(),
+            weights=_IntrinsicPeftBinding(self, adapter.qualified_name),
+        )
+        with self._generation_lock:
+            with self.adapter_scope(scope_adapter):
+                _assert_correct_adapters(adapter.qualified_name, self._model)
+                out = generate_func(*args, **kwargs)
+                _assert_correct_adapters(adapter.qualified_name, self._model)
+                return out
 
     async def _generate_from_intrinsic(
         self,
@@ -770,8 +842,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             model_arg = _CapturingModelProxy()  # type: ignore[assignment]
 
         chat_response = asyncio.to_thread(
-            self._generate_with_adapter_lock,
-            adapter.qualified_name,
+            self._generate_intrinsic_with_adapter_scope,
+            adapter,
             granite_formatters.base.util.generate_with_transformers,  # type: ignore
             # Passed as args/kwargs to generate.
             self._tokenizer,
@@ -2145,23 +2217,27 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         """Reuse `_generation_lock` for exclusivity around adapter activation.
 
         `activate_peft_adapter`/`deactivate_peft_adapter` document "must be called
-        while holding `_generation_lock`" as a precondition, and they have two
+        while holding `_generation_lock`" as a precondition, and they have three
         callers:
 
-        1. `_generate_with_adapter_lock`, which takes `_generation_lock` itself.
+        1. `_generate_with_adapter_lock`, which takes `_generation_lock` itself
+           (for the standard, non-intrinsic generation path).
         2. `LocalFileBinding.activate()`/`.deactivate()` (driven by
            `AdapterMixin.adapter_scope()`), which holds no lock of its own.
+        3. `_generate_intrinsic_with_adapter_scope`, which also holds
+           `_generation_lock` itself, for the whole activate -> generate ->
+           deactivate section — and calls into caller 2's path via
+           `adapter_scope()` from inside that section (#1465).
 
-        This exists for caller 2 — so it is not a duplicate of the lock caller 1
-        takes, it is the only thing satisfying the precondition on that path.
+        This method exists for caller 2 — so it is not a duplicate of the lock
+        callers 1 and 3 take, it is the only thing satisfying the precondition
+        on that path.
 
-        TODO(#1465): `_generation_lock` is a plain non-reentrant `threading.Lock`.
-        Nothing nests these two callers today, because generation still runs
-        outside `adapter_scope`. When #1465 moves the model call inside the scope,
-        `activate()` will re-acquire this lock while `_generate_with_adapter_lock`
-        already holds it and deadlock. #1465 owns the fix (make it reentrant, or
-        restructure so the scope takes the lock once); it must not be resolved by
-        dropping the lock here, which would leave caller 2's precondition unmet.
+        Caller 3 nests inside caller 2's lock acquisition on the same thread
+        (see `_generate_intrinsic_with_adapter_scope`'s docstring), which is
+        exactly why `_generation_lock` is a `threading.RLock`: a plain
+        `threading.Lock` would deadlock on that same-thread re-acquisition
+        (this was #1465's known lock-reentrancy issue).
         """
         return self._generation_lock
 
@@ -2206,3 +2282,66 @@ def _assert_correct_adapters(expected_state: str, model: PreTrainedModel):
             )
         else:
             raise e
+
+
+class _NoIntrinsicIOContract(IOContract):
+    """Placeholder `IOContract` for `_generate_intrinsic_with_adapter_scope`'s `_AdapterCore`.
+
+    `_generate_from_intrinsic` builds its own I/O handling directly (the
+    rewriter/result-processor pipeline driven by `adapter.config`) and only
+    needs `adapter_scope()` for its activate/deactivate lifecycle hooks —
+    `adapter_scope()` never reads `Adapter.io_contract`, so this slot is filled
+    only to satisfy the dataclass's required field.
+    """
+
+    def build_prompt(self, **kwargs: object) -> Component:
+        raise NotImplementedError(
+            "not used on the intrinsic generation path (#1465): "
+            "_generate_from_intrinsic builds prompts via IntrinsicsRewriter."
+        )
+
+    def parse(self, raw: str) -> dict[str, object]:
+        raise NotImplementedError(
+            "not used on the intrinsic generation path (#1465): "
+            "_generate_from_intrinsic parses output via IntrinsicsResultProcessor."
+        )
+
+
+class _IntrinsicPeftBinding(WeightsBinding):
+    """Drives already-registered PEFT verbs for one intrinsic-generation call.
+
+    `IntrinsicAdapter` (the legacy shim, see `mellea.backends.adapters.adapter`)
+    carries an inert `_ShimWeightsBinding` that raises on every verb, so it
+    can't be handed to `adapter_scope()` directly.
+    `_generate_intrinsic_with_adapter_scope` builds one of these fresh per call
+    instead, and it drives the backend's own `load_peft_adapter`/
+    `activate_peft_adapter`/`deactivate_peft_adapter` verbs — the same verbs
+    `_generate_with_adapter_lock` used to call directly, before generation was
+    routed through `adapter_scope` (#1465).
+
+    `prepare()`/`release()` are no-ops: registration and the weights download
+    already happened in `add_adapter()` when the intrinsic adapter was
+    resolved (see `AdapterMixin.resolve_adapter`), and this binding doesn't own
+    that lifecycle — it only exists for the duration of one generate call.
+    """
+
+    binding_type: ClassVar[str] = "intrinsic_legacy"
+
+    def __init__(self, backend: LocalHFBackend, qualified_name: str) -> None:
+        self._backend = backend
+        self._qualified_name = qualified_name
+
+    def prepare(self) -> None:
+        return
+
+    def activate(self) -> None:
+        with self._backend._adapter_activation_lock():
+            self._backend.load_peft_adapter(self._qualified_name)
+            self._backend.activate_peft_adapter(self._qualified_name)
+
+    def deactivate(self) -> None:
+        with self._backend._adapter_activation_lock():
+            self._backend.deactivate_peft_adapter(self._qualified_name)
+
+    def release(self) -> None:
+        return

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -576,20 +576,24 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             return mot, ctx.add(action).add(mot)
 
-    def _generate_with_adapter_lock(
-        self, adapter_name: str, generate_func: Callable, *args, **kwargs
-    ):
-        """Helper function for ensuring exclusive generation when adapters are present. Necessary to prevent generating with incorrect weights."""
-        with self._generation_lock:
-            if adapter_name != "":
-                self.load_peft_adapter(adapter_name)
-                self.activate_peft_adapter(adapter_name)
-            else:
-                self.deactivate_peft_adapter(adapter_name)
+    def _generate_with_adapter_lock(self, generate_func: Callable, *args, **kwargs):
+        """Exclusive generation against the base model for the standard path.
 
-            _assert_correct_adapters(adapter_name, self._model)
+        Standard (non-intrinsic) generation runs without adapters: any active
+        adapter is deactivated before the model call, and the model's active
+        state is asserted before and after. Adapter-active generation goes
+        elsewhere — `_generate_intrinsic_with_adapter_scope` for intrinsics
+        (routed through `adapter_scope`, with its lifecycle hooks), and
+        Granite Switch's embedded activation via the binding's
+        `apply_activation` (#1018). Neither path activates through this
+        method — which is why it takes no adapter name.
+        """
+        with self._generation_lock:
+            self.deactivate_peft_adapter("")
+
+            _assert_correct_adapters("", self._model)
             out = generate_func(*args, **kwargs)
-            _assert_correct_adapters(adapter_name, self._model)
+            _assert_correct_adapters("", self._model)
             return out
 
     def _generate_intrinsic_with_adapter_scope(
@@ -1187,7 +1191,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             chat_response = asyncio.to_thread(
                 self._generate_with_adapter_lock,
-                "",  # Empty for no adapters.
                 self._model.generate,  # type: ignore
                 # Passed as args/kwargs to generate.
                 input_ids.to(self._device),
@@ -1381,7 +1384,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             chat_response = asyncio.to_thread(
                 self._generate_with_adapter_lock,
-                "",  # Empty for no adapters.
                 self._model.generate,  # type: ignore
                 # Passed as args/kwargs to generate.
                 inputs=input_ids["input_ids"],
@@ -1809,7 +1811,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         outputs = await asyncio.to_thread(
             self._generate_with_adapter_lock,
-            "",  # Empty for no adapter.
             self._model.generate,  # type: ignore
             # Passed as args/kwargs to generate.
             input_ids=inputs["input_ids"],
@@ -2238,8 +2239,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         while holding `_generation_lock`" as a precondition, and they have three
         callers:
 
-        1. `_generate_with_adapter_lock`, which takes `_generation_lock` itself
-           (for the standard, non-intrinsic generation path).
+        1. `_generate_with_adapter_lock` (the standard, non-intrinsic
+           generation path), which takes `_generation_lock` itself and calls
+           only `deactivate_peft_adapter` — never the activation verbs,
+           because standard generation always runs against the base model.
         2. `LocalFileBinding.activate()`/`.deactivate()` (driven by
            `AdapterMixin.adapter_scope()`), which holds no lock of its own.
         3. `_IntrinsicPeftBinding.activate()`/`.deactivate()` (driven by

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -16,7 +16,7 @@ import functools
 import json
 import threading
 from collections.abc import Callable, Coroutine, Sequence
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, TypeVar, cast
 
 import jinja2
 import jinja2.meta
@@ -79,7 +79,6 @@ from ._options import resolve_model_options
 from .adapters import AdapterMixin, IntrinsicAdapter, LocalHFAdapter
 from .adapters._core import (
     Adapter as _AdapterCore,
-    Identity,
     IOContract,
     LocalFileBinding,
     WeightsBinding,
@@ -142,6 +141,8 @@ Hugging Face backends can initialize themselves from a model string if the trans
 TransformersTorchConfig = tuple[PreTrainedTokenizerBase, PreTrainedModel, torch.device]
 
 format: None = None  # typing this variable in order to shadow the global format function and ensure mypy checks for errors
+
+_T = TypeVar("_T")
 
 
 @dataclasses.dataclass
@@ -592,35 +593,47 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             return out
 
     def _generate_intrinsic_with_adapter_scope(
-        self, adapter: IntrinsicAdapter, generate_func: Callable, *args, **kwargs
-    ):
+        self,
+        adapter: IntrinsicAdapter,
+        generate_func: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
         """Runs `generate_func` with `adapter` active, inside `AdapterMixin.adapter_scope`.
 
-        Replaces the old direct load-then-activate-then-generate sequence
-        `_generate_from_intrinsic` used to run through `_generate_with_adapter_lock`
-        (#1465): the model call now runs inside `adapter_scope`, so activation and
+        The model call now runs inside `adapter_scope`, so activation and
         deactivation fire the `ADAPTER_FUNCTION_PHASE_COMPLETE`/
-        `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hooks, and deactivation is
-        guaranteed even if `generate_func` raises.
+        `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hooks (`phase="activate"` and
+        `"deactivate"` only — `"generate"`/`"parse"` are not emitted; adding
+        those is out of scope here, see #1466), and deactivation is guaranteed
+        even if `generate_func` raises. Those hooks dispatch synchronously
+        (`_run_async_in_thread`, no timeout) while `_generation_lock` is held
+        below, so a blocking-mode `ADAPTER_FUNCTION_*` subscriber stalls
+        generation on this backend for its duration.
 
         `IntrinsicAdapter` (the legacy shim `adapter` is expected to be) carries
         an inert `_ShimWeightsBinding` that raises on every verb, so it can't be
         handed to `adapter_scope()` directly. This method builds a fresh
-        `_AdapterCore` wrapping a `_IntrinsicPeftBinding` instead, which drives
+        `_AdapterCore` around `adapter`'s own `identity` (not a rebuilt one —
+        rebuilding it would re-run `Identity.__post_init__`'s capability-registry
+        check on every call) wrapping a `_IntrinsicPeftBinding`, which drives
         this backend's own `load_peft_adapter`/`activate_peft_adapter`/
         `deactivate_peft_adapter` verbs — the same verbs
         `_generate_with_adapter_lock` used to call directly.
 
-        Holds `_generation_lock` for the *entire* activate -> generate ->
-        deactivate section, not just around activation, so a concurrent
-        caller's `activate()` can never interleave with this call's generation
-        — the atomicity gap `adapter_scope()`'s own docstring flags as
-        unresolved for real concurrent callers. This is safe specifically
-        because this method only ever runs inside a single `asyncio.to_thread`
-        worker thread (see its call site in `_generate_from_intrinsic`): the
-        inner re-acquisition of `_generation_lock` inside `adapter_scope()`'s
-        `activate()`/`deactivate()` (via `_adapter_activation_lock()`) is
-        same-thread, so it's reentrant rather than a cross-thread deadlock.
+        Holds `_generation_lock` for the *entire* prepare -> activate ->
+        generate -> deactivate section, not just around activation, so a
+        concurrent caller's `activate()` can never interleave with this call's
+        generation — the atomicity gap `adapter_scope()`'s own docstring flags
+        as unresolved for a caller that doesn't do this. Safe here because each
+        invocation of this method runs entirely on one thread (this method is
+        only ever invoked via a single `asyncio.to_thread` call — see its call
+        site in `_generate_from_intrinsic`) and never re-enters generation on
+        another thread: the inner re-acquisition of `_generation_lock` inside
+        `adapter_scope()`'s `activate()`/`deactivate()` (via
+        `_adapter_activation_lock()`) is therefore same-thread and reentrant.
+        Concurrent invocations land on different `asyncio.to_thread` pool
+        threads and simply serialise on the lock.
 
         Args:
             adapter: The (legacy) `IntrinsicAdapter` to activate for this call.
@@ -633,15 +646,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             Whatever `generate_func` returns.
         """
         scope_adapter = _AdapterCore(
-            identity=Identity(
-                name=adapter.name,
-                adapter_type=adapter.adapter_type.value,
-                capability=adapter.name,
+            identity=adapter.identity,
+            io_contract=_UnusedIOContract(),
+            weights=_IntrinsicPeftBinding(
+                self, adapter.qualified_name, adapter.intrinsic_metadata.revision
             ),
-            io_contract=_NoIntrinsicIOContract(),
-            weights=_IntrinsicPeftBinding(self, adapter.qualified_name),
         )
         with self._generation_lock:
+            scope_adapter.weights.prepare()
             with self.adapter_scope(scope_adapter):
                 _assert_correct_adapters(adapter.qualified_name, self._model)
                 out = generate_func(*args, **kwargs)
@@ -2284,7 +2296,7 @@ def _assert_correct_adapters(expected_state: str, model: PreTrainedModel):
             raise e
 
 
-class _NoIntrinsicIOContract(IOContract):
+class _UnusedIOContract(IOContract):
     """Placeholder `IOContract` for `_generate_intrinsic_with_adapter_scope`'s `_AdapterCore`.
 
     `_generate_from_intrinsic` builds its own I/O handling directly (the
@@ -2296,13 +2308,13 @@ class _NoIntrinsicIOContract(IOContract):
 
     def build_prompt(self, **kwargs: object) -> Component:
         raise NotImplementedError(
-            "not used on the intrinsic generation path (#1465): "
+            "not used on the intrinsic generation path: "
             "_generate_from_intrinsic builds prompts via IntrinsicsRewriter."
         )
 
     def parse(self, raw: str) -> dict[str, object]:
         raise NotImplementedError(
-            "not used on the intrinsic generation path (#1465): "
+            "not used on the intrinsic generation path: "
             "_generate_from_intrinsic parses output via IntrinsicsResultProcessor."
         )
 
@@ -2316,27 +2328,49 @@ class _IntrinsicPeftBinding(WeightsBinding):
     `_generate_intrinsic_with_adapter_scope` builds one of these fresh per call
     instead, and it drives the backend's own `load_peft_adapter`/
     `activate_peft_adapter`/`deactivate_peft_adapter` verbs — the same verbs
-    `_generate_with_adapter_lock` used to call directly, before generation was
-    routed through `adapter_scope` (#1465).
+    `_generate_with_adapter_lock` used to call directly before generation was
+    routed through `adapter_scope`.
 
-    `prepare()`/`release()` are no-ops: registration and the weights download
-    already happened in `add_adapter()` when the intrinsic adapter was
-    resolved (see `AdapterMixin.resolve_adapter`), and this binding doesn't own
-    that lifecycle — it only exists for the duration of one generate call.
+    `binding_type` is `"local_file"`, not a distinct value: this binding loads
+    LoRA/aLoRA weights downloaded to local disk via PEFT — the same reality
+    `LocalFileBinding` reports — so it must share that value rather than
+    fragment the weights-reality metric dimension. A distinct class exists
+    rather than reusing `LocalFileBinding` directly because `LocalFileBinding.prepare()`
+    calls `add_adapter()`, which would collide with the `IntrinsicAdapter`
+    already registered under this `qualified_name`.
+
+    `prepare()` loads the weights (mirrors `LocalFileBinding.prepare()`'s
+    phase boundary: the load belongs to `"prepare"`, not `"activate"`, so
+    `phase="activate"` duration stays comparable across bindings).
+    `release()` is a no-op: registration happened in `add_adapter()` when the
+    intrinsic adapter was resolved (see `AdapterMixin.resolve_adapter`), and
+    this binding doesn't own that lifecycle — it only exists for the duration
+    of one generate call.
+
+    Attributes:
+        revision (str | None): The catalogue revision `adapter_scope()` reports
+            to the `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hook. Set explicitly
+            (rather than left for `adapter_scope()`'s `getattr(..., None)`
+            fallback) because `IntrinsicAdapter`s are always pinned to a
+            catalogue SHA; reporting `None` would mislabel every intrinsic
+            invocation as unpinned.
     """
 
-    binding_type: ClassVar[str] = "intrinsic_legacy"
+    binding_type: ClassVar[str] = "local_file"
 
-    def __init__(self, backend: LocalHFBackend, qualified_name: str) -> None:
+    def __init__(
+        self, backend: LocalHFBackend, qualified_name: str, revision: str | None
+    ) -> None:
         self._backend = backend
         self._qualified_name = qualified_name
+        self.revision = revision
 
     def prepare(self) -> None:
-        return
+        with self._backend._adapter_activation_lock():
+            self._backend.load_peft_adapter(self._qualified_name)
 
     def activate(self) -> None:
         with self._backend._adapter_activation_lock():
-            self._backend.load_peft_adapter(self._qualified_name)
             self._backend.activate_peft_adapter(self._qualified_name)
 
     def deactivate(self) -> None:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -463,7 +463,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         Reentrant (`threading.RLock`, not `threading.Lock`) because
         `_generate_intrinsic_with_adapter_scope` holds it for a whole
-        activate -> generate -> deactivate critical section, and
+        prepare -> activate -> generate -> deactivate critical section, and
         `adapter_scope()`'s `activate()`/`deactivate()` re-acquire it from
         inside that section, on the same thread, via `_adapter_activation_lock()`.
         A plain `Lock` deadlocks on that same-thread re-acquisition (#1465).
@@ -607,16 +607,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         `"deactivate"` only — `"generate"`/`"parse"` are not emitted; adding
         those is out of scope here, see #1466), and deactivation is guaranteed
         even if `generate_func` raises. Those hooks dispatch while
-        `_generation_lock` is held below: the dispatching call blocks this
-        thread with no timeout, and the hook coroutines run on the shared
-        `_EventLoopHandler` event-loop thread, so an `ADAPTER_FUNCTION_*`
-        subscriber that re-enters any `_generation_lock`-holding path (any
-        generation call or adapter activation on this backend) blocks the
-        event-loop thread while this one waits on it — a cross-thread deadlock
-        the `RLock` cannot prevent, since reentrance only helps the owning
-        thread. `ADAPTER_FUNCTION_*` subscribers must therefore be non-blocking
-        and must never re-enter this backend; a merely slow subscriber stalls
-        all generation on this backend for its duration.
+        `_generation_lock` is held below — see `adapter_scope()`'s
+        hook-dispatch paragraph for the mechanism (blocked call, no timeout,
+        hook coroutines on the shared event-loop thread) — so an
+        `ADAPTER_FUNCTION_*` subscriber that re-enters any
+        `_generation_lock`-holding path (any generation call or adapter
+        activation on this backend) deadlocks this backend rather than merely
+        stalling it (the `RLock` cannot bridge the gap: reentrance only helps
+        the owning thread), and a merely slow subscriber stalls all generation
+        on this backend for that dispatch's duration. `ADAPTER_FUNCTION_*`
+        subscribers must therefore be non-blocking and must never re-enter
+        this backend.
 
         `IntrinsicAdapter` (the legacy shim `adapter` is expected to be) carries
         an inert `_ShimWeightsBinding` that raises on every verb, so it can't be
@@ -2248,20 +2249,19 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
            `_generate_intrinsic_with_adapter_scope` via
            `AdapterMixin.adapter_scope()`), the intrinsic-path counterpart of
            caller 2's `LocalFileBinding` — whose driver also holds
-           `_generation_lock` itself for the whole activate -> generate ->
-           deactivate section (#1465), so those verb acquisitions nest
-           same-thread inside that outer hold.
+           `_generation_lock` itself for the whole prepare -> activate ->
+           generate -> deactivate section (#1465).
 
         This method exists for callers 2 and 3 — so it is not a duplicate of
         the lock caller 1 (and, on the outer level, caller 3's driver) takes,
         it is the only thing satisfying the precondition on those paths.
 
-        Caller 3's verb acquisitions nest inside its driver's `_generation_lock`
-        hold on the same thread (see `_generate_intrinsic_with_adapter_scope`'s
-        docstring), which is exactly why `_generation_lock` is a
-        `threading.RLock`: a plain `threading.Lock` would deadlock on that
-        same-thread re-acquisition (this was #1465's known lock-reentrancy
-        issue).
+        Caller 3's verb acquisitions therefore nest inside its driver's
+        `_generation_lock` hold on the same thread (see
+        `_generate_intrinsic_with_adapter_scope`'s docstring), which is
+        exactly why `_generation_lock` is a `threading.RLock`: a plain
+        `threading.Lock` would deadlock on that same-thread re-acquisition
+        (this was #1465's known lock-reentrancy issue).
         """
         return self._generation_lock
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -607,17 +607,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         `"deactivate"` only — `"generate"`/`"parse"` are not emitted; adding
         those is out of scope here, see #1466), and deactivation is guaranteed
         even if `generate_func` raises. Those hooks dispatch while
-        `_generation_lock` is held below — see `adapter_scope()`'s
-        hook-dispatch paragraph for the mechanism (blocked call, no timeout,
-        hook coroutines on the shared event-loop thread) — so an
-        `ADAPTER_FUNCTION_*` subscriber that re-enters any
-        `_generation_lock`-holding path (any generation call or adapter
-        activation on this backend) deadlocks this backend rather than merely
-        stalling it (the `RLock` cannot bridge the gap: reentrance only helps
-        the owning thread), and a merely slow subscriber stalls all generation
-        on this backend for that dispatch's duration. `ADAPTER_FUNCTION_*`
-        subscribers must therefore be non-blocking and must never re-enter
-        this backend.
+        `_generation_lock` is held below: the deadlock and stall consequences
+        in `adapter_scope()`'s hook-dispatch paragraph apply here in full,
+        since this backend's `_generation_lock` is what the dispatching thread
+        holds, and the `RLock` cannot rescue a subscriber that re-enters from
+        the event-loop thread — reentrance only helps the owning thread.
+        `ADAPTER_FUNCTION_*` subscribers must therefore be non-blocking and
+        must never re-enter this backend; a merely slow one stalls all
+        generation on this backend for that dispatch's duration.
 
         `IntrinsicAdapter` (the legacy shim `adapter` is expected to be) carries
         an inert `_ShimWeightsBinding` that raises on every verb, so it can't be
@@ -636,8 +633,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         as unresolved for a caller that doesn't do this. Safe here because each
         invocation of this method runs entirely on one thread (in production it
         is only ever invoked via a single `asyncio.to_thread` call — see its
-        call site in `_generate_from_intrinsic`; the unit tests call it
-        directly, also single-threaded) and never re-enters generation on
+        call site in `_generate_from_intrinsic`; the tests call it directly,
+        one invocation per thread) and never re-enters generation on
         another thread: the inner re-acquisition of `_generation_lock` inside
         `adapter_scope()`'s `activate()`/`deactivate()` (via
         `_adapter_activation_lock()`) is therefore same-thread and reentrant.
@@ -2357,15 +2354,11 @@ class _IntrinsicPeftBinding(WeightsBinding):
     `release()` is a no-op: registration happened in `add_adapter()` when the
     intrinsic adapter was resolved (see `AdapterMixin.resolve_adapter`), and
     this binding doesn't own that lifecycle — it only exists for the duration
-    of one generate call.
-
-    Attributes:
-        revision (str | None): The catalogue revision `adapter_scope()` reports
-            to the `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hook. Set explicitly
-            (rather than left for `adapter_scope()`'s `getattr(..., None)`
-            fallback) because `IntrinsicAdapter`s are always pinned to a
-            catalogue SHA; reporting `None` would mislabel every intrinsic
-            invocation as unpinned.
+    of one generate call. `revision` — the value `adapter_scope()` reports to
+    the `ADAPTER_FUNCTION_INVOCATION_COMPLETE` hook — is set explicitly rather
+    than left for `adapter_scope()`'s `getattr(..., None)` fallback, because
+    `IntrinsicAdapter`s are always pinned to a catalogue SHA; reporting
+    `None` would mislabel every intrinsic invocation as unpinned.
     """
 
     binding_type: ClassVar[str] = "local_file"

--- a/mellea/stdlib/components/intrinsic/_util.py
+++ b/mellea/stdlib/components/intrinsic/_util.py
@@ -218,9 +218,9 @@ def call_intrinsic(
     backend.resolve_adapter(intrinsic_name)
 
     # Adapter activation is the backend's responsibility — the HF backend acquires
-    # its generation lock and sets the active adapter inside _generate_with_adapter_lock,
-    # immediately before generation.  Activating here (outside that lock) would race
-    # with concurrent async requests.
+    # its generation lock and activates the adapter inside adapter_scope(), driven
+    # from _generate_intrinsic_with_adapter_scope immediately before generation.
+    # Activating here (outside that lock) would race with concurrent async requests.
     intrinsic = Intrinsic(
         intrinsic_name,
         intrinsic_kwargs=kwargs,

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -14,7 +14,11 @@ called directly (bypassing `generate_from_context()`'s standard path, which
 always deactivates adapters first via `_generate_with_adapter_lock("", ...)`)
 so the active-adapter assertion straddling the generate call is a genuine
 proof that generation ran with the adapter active, not a smoke test that
-generation merely succeeded afterwards.
+generation merely succeeded afterwards. A separate `generate_from_context()`
+call after the scope exits is the composition smoke test: mellea's own
+generation path must still work cleanly against a backend that has a
+scoped-and-released adapter registered — it does not exercise the adapter
+itself, since the standard path always deactivates first.
 
 Assertions are structural/functional only (adapter registered, real model
 reports it active during and after generation, adapter cleanly released), per
@@ -48,7 +52,8 @@ from mellea.backends.adapters._core import (
     LocalFileBinding,
 )
 from mellea.backends.huggingface import LocalHFBackend
-from mellea.core import Component
+from mellea.core import CBlock, Component
+from mellea.stdlib.context import SimpleContext
 from test.conftest import cleanup_gpu_backend, hf_skip
 
 
@@ -109,8 +114,18 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
         value = backend._tokenizer.decode(out_ids[0], skip_special_tokens=True)  # type: ignore[union-attr]
 
     assert binding.qualified_name not in backend._model.active_adapters()  # type: ignore[union-attr]
-    assert isinstance(value, str)
-    assert len(value) > 0
+    assert value.strip()
+
+    # Composition smoke test: generate_from_context() must still work once the
+    # scope has exited (see module docstring — it does not exercise the
+    # adapter itself, since the standard path always deactivates first).
+    ctx = SimpleContext().add(CBlock("Is the sky blue?"))
+    mot, _ = await backend.generate_from_context(
+        CBlock("Is the sky blue?"), ctx, model_options={}
+    )
+    composed_value = await mot.avalue()
+    assert isinstance(composed_value, str)
+    assert len(composed_value) > 0
 
     binding.release()
     assert binding.backend is None

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -9,14 +9,15 @@ PEFT machinery, or model. Requires GPU and network/Hub access; not expected to
 run in CI or in sandboxes without hardware access (see test/README.md).
 
 `adapter_scope()` is asserted to really flip the real PEFT model's active
-adapter set. `generate_from_context()` on a plain `CBlock` is only a
-smoke-test that generation still succeeds afterwards — it does not run
-through the activated adapter, since the standard generation path always
-deactivates adapters first (`_generate_with_adapter_lock("", ...)`); wiring
-that path onto `adapter_scope` is deferred to #1465.
+adapter set, and to keep it active across a real generate call: the model is
+called directly (bypassing `generate_from_context()`'s standard path, which
+always deactivates adapters first via `_generate_with_adapter_lock("", ...)`)
+so the active-adapter assertion straddling the generate call is a genuine
+proof that generation ran with the adapter active, not a smoke test that
+generation merely succeeded afterwards.
 
 Assertions are structural/functional only (adapter registered, real model
-reports it active, generation succeeds, adapter cleanly released), per
+reports it active during and after generation, adapter cleanly released), per
 test/README.md's e2e rules — no assertions on generated text content.
 """
 
@@ -47,8 +48,7 @@ from mellea.backends.adapters._core import (
     LocalFileBinding,
 )
 from mellea.backends.huggingface import LocalHFBackend
-from mellea.core import CBlock, Component
-from mellea.stdlib.context import SimpleContext
+from mellea.core import Component
 from test.conftest import cleanup_gpu_backend, hf_skip
 
 
@@ -88,17 +88,25 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
     assert binding.backend is backend
     assert binding.qualified_name in backend.list_adapters()
 
-    ctx = SimpleContext().add(CBlock("Is the sky blue?"))
     with backend.adapter_scope(adapter):
-        # Confirms activate() really flipped the real PEFT model's active
-        # adapter — the generate call below does not run through it (see
-        # module docstring), so this is the only in-scope proof of activation.
+        # Confirms activate() really flipped the real PEFT model's active adapter.
         assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
 
-        mot, _ = await backend.generate_from_context(
-            CBlock("Is the sky blue?"), ctx, model_options={}
+        # Generate directly against the real model rather than through
+        # generate_from_context() — that standard path always deactivates
+        # adapters first (_generate_with_adapter_lock("", ...)), which would
+        # make this a smoke test that generation merely succeeds afterwards,
+        # not a demonstration that generation ran with the adapter active.
+        toks = backend._tokenizer("Is the sky blue?", return_tensors="pt").to(  # type: ignore[union-attr]
+            backend._device  # type: ignore[union-attr]
         )
-        value = await mot.avalue()
+        with torch.no_grad():
+            out_ids = backend._model.generate(**toks, max_new_tokens=8)  # type: ignore[union-attr]
+
+        # Still inside the scope: the adapter must still be the one active
+        # during generation, not just at scope-entry.
+        assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
+        value = backend._tokenizer.decode(out_ids[0], skip_special_tokens=True)  # type: ignore[union-attr]
 
     assert binding.qualified_name not in backend._model.active_adapters()  # type: ignore[union-attr]
     assert isinstance(value, str)

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -11,7 +11,7 @@ run in CI or in sandboxes without hardware access (see test/README.md).
 `adapter_scope()` is asserted to really flip the real PEFT model's active
 adapter set, and to keep it active across a real generate call: the model is
 called directly (bypassing `generate_from_context()`'s standard path, which
-always deactivates adapters first via `_generate_with_adapter_lock("", ...)`)
+always deactivates adapters first via `_generate_with_adapter_lock`)
 so the active-adapter assertion straddling the generate call is a genuine
 proof that generation ran with the adapter active, not a smoke test that
 generation merely succeeded afterwards. A separate `generate_from_context()`
@@ -99,7 +99,7 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
 
         # Generate directly against the real model rather than through
         # generate_from_context() — that standard path always deactivates
-        # adapters first (_generate_with_adapter_lock("", ...)), which would
+        # adapters first (_generate_with_adapter_lock), which would
         # make this a smoke test that generation merely succeeds afterwards,
         # not a demonstration that generation ran with the adapter active.
         toks = backend._tokenizer("Is the sky blue?", return_tensors="pt").to(  # type: ignore[union-attr]

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -105,16 +105,17 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
         toks = backend._tokenizer("Is the sky blue?", return_tensors="pt").to(  # type: ignore[union-attr]
             backend._device  # type: ignore[union-attr]
         )
+        # No assertion on the raw output: `model.generate` returns the prompt
+        # plus completion, so any decode would be non-empty regardless, and
+        # generated content is out of scope per the module docstring.
         with torch.no_grad():
-            out_ids = backend._model.generate(**toks, max_new_tokens=8)  # type: ignore[union-attr]
+            backend._model.generate(**toks, max_new_tokens=8)  # type: ignore[union-attr]
 
         # Still inside the scope: the adapter must still be the one active
         # during generation, not just at scope-entry.
         assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
-        value = backend._tokenizer.decode(out_ids[0], skip_special_tokens=True)  # type: ignore[union-attr]
 
     assert binding.qualified_name not in backend._model.active_adapters()  # type: ignore[union-attr]
-    assert value.strip()
 
     # Composition smoke test: generate_from_context() must still work once the
     # scope has exited (see module docstring — it does not exercise the

--- a/test/backends/test_adapters/test_local_file_e2e.py
+++ b/test/backends/test_adapters/test_local_file_e2e.py
@@ -9,16 +9,17 @@ PEFT machinery, or model. Requires GPU and network/Hub access; not expected to
 run in CI or in sandboxes without hardware access (see test/README.md).
 
 `adapter_scope()` is asserted to really flip the real PEFT model's active
-adapter set, and to keep it active across a real generate call: the model is
-called directly (bypassing `generate_from_context()`'s standard path, which
-always deactivates adapters first via `_generate_with_adapter_lock`)
-so the active-adapter assertion straddling the generate call is a genuine
-proof that generation ran with the adapter active, not a smoke test that
-generation merely succeeded afterwards. A separate `generate_from_context()`
-call after the scope exits is the composition smoke test: mellea's own
-generation path must still work cleanly against a backend that has a
-scoped-and-released adapter registered — it does not exercise the adapter
-itself, since the standard path always deactivates first.
+adapter set, and to keep it active across a real generate call. The test holds
+`_generation_lock` across the scope and direct model call, matching the
+intrinsic generation path's reentrant lock shape. It bypasses
+`generate_from_context()` because that standard path always deactivates
+adapters first; the active-adapter assertion straddling the generate call is
+therefore proof that generation ran with the adapter active, not a smoke test
+that generation merely succeeded afterwards. A separate
+`generate_from_context()` call after the scope exits is the composition smoke
+test: mellea's own generation path must still work cleanly against a backend
+that has a scoped-and-released adapter registered — it does not exercise the
+adapter itself, since the standard path always deactivates first.
 
 Assertions are structural/functional only (adapter registered, real model
 reports it active during and after generation, adapter cleanly released), per
@@ -93,27 +94,29 @@ async def test_local_file_binding_full_lifecycle_against_real_model(backend):
     assert binding.backend is backend
     assert binding.qualified_name in backend.list_adapters()
 
-    with backend.adapter_scope(adapter):
-        # Confirms activate() really flipped the real PEFT model's active adapter.
-        assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
+    # `_generate_intrinsic_with_adapter_scope()` holds this lock for its whole
+    # prepare -> activate -> generate -> deactivate critical section.
+    # `adapter_scope()` reacquires it during activation/deactivation, so this
+    # real-model test also proves that same-thread reentrancy works in practice.
+    with backend._generation_lock:
+        with backend.adapter_scope(adapter):
+            # Confirms activate() really flipped the real PEFT model's active adapter.
+            assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
 
-        # Generate directly against the real model rather than through
-        # generate_from_context() — that standard path always deactivates
-        # adapters first (_generate_with_adapter_lock), which would
-        # make this a smoke test that generation merely succeeds afterwards,
-        # not a demonstration that generation ran with the adapter active.
-        toks = backend._tokenizer("Is the sky blue?", return_tensors="pt").to(  # type: ignore[union-attr]
-            backend._device  # type: ignore[union-attr]
-        )
-        # No assertion on the raw output: `model.generate` returns the prompt
-        # plus completion, so any decode would be non-empty regardless, and
-        # generated content is out of scope per the module docstring.
-        with torch.no_grad():
-            backend._model.generate(**toks, max_new_tokens=8)  # type: ignore[union-attr]
+            # Generate directly against the real model rather than through
+            # generate_from_context() — that standard path always deactivates
+            # adapters first, which would make this a smoke test that generation
+            # merely succeeds afterwards, not a demonstration that generation ran
+            # with the adapter active.
+            toks = backend._tokenizer("Is the sky blue?", return_tensors="pt").to(
+                backend._device
+            )  # type: ignore[union-attr]
+            with torch.no_grad():
+                backend._model.generate(**toks, max_new_tokens=8)  # type: ignore[union-attr]
 
-        # Still inside the scope: the adapter must still be the one active
-        # during generation, not just at scope-entry.
-        assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
+            # Still inside the scope: the adapter must still be the one active
+            # during generation, not just at scope-entry.
+            assert binding.qualified_name in backend._model.active_adapters()  # type: ignore[union-attr]
 
     assert binding.qualified_name not in backend._model.active_adapters()  # type: ignore[union-attr]
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -529,6 +529,74 @@ def test_generate_intrinsic_with_adapter_scope_deactivates_on_error():
     backend._model.set_adapter.assert_any_call([])  # type: ignore[attr-defined]
 
 
+def test_generate_intrinsic_with_adapter_scope_error_hook_payload():
+    """A failed intrinsic generation reports `outcome="error"` with both phase events.
+
+    The `AdapterMixin.adapter_scope` contract for a failing body is pinned
+    generically (against a `LocalFileBinding`) in `test_adapter_scope.py`; this
+    pins it with the intrinsic payload — `name`, `adapter_type`, `binding_type`
+    and the pinned `revision` — so a regression can't silently mislabel
+    intrinsic failures while the generic coverage keeps passing.
+    """
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    adapter = _make_fake_intrinsic_adapter(
+        "answerability_alora", revision="deadbeef00000000000000000000000000000000"
+    )
+    _register_fake_adapter(backend, adapter.qualified_name, "/fake/path")
+
+    def failing_generate():
+        raise RuntimeError("boom")
+
+    with capture_adapter_hooks() as mock_invoke:
+        with pytest.raises(RuntimeError, match="boom"):
+            backend._generate_intrinsic_with_adapter_scope(adapter, failing_generate)
+
+    payloads = hook_payloads(mock_invoke)
+    phases = [p.phase for p in payloads if hasattr(p, "phase")]
+    assert phases == ["activate", "deactivate"]
+
+    invocations = [p for p in payloads if hasattr(p, "outcome")]
+    assert len(invocations) == 1
+    invocation = invocations[0]
+    assert invocation.outcome == "error"
+    assert isinstance(invocation.error, RuntimeError)
+    assert invocation.name == "answerability"
+    assert invocation.adapter_type == "alora"
+    assert invocation.binding_type == "local_file"
+    assert invocation.revision == "deadbeef00000000000000000000000000000000"
+
+    assert backend._model.active_adapters() == []
+
+
+def test_generate_intrinsic_with_adapter_scope_prepare_failure_no_hooks():
+    """A `load_peft_adapter` failure happens before `adapter_scope()` is entered.
+
+    So no adapter hooks fire at all, activation state is unchanged, and the
+    next call still succeeds — a failed load must not poison later calls.
+    """
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    adapter = _make_fake_intrinsic_adapter("answerability_alora")
+    _register_fake_adapter(backend, adapter.qualified_name, "/fake/path")
+
+    with (
+        capture_adapter_hooks() as mock_invoke,
+        patch.object(
+            backend, "load_peft_adapter", side_effect=RuntimeError("load failed")
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="load failed"):
+            backend._generate_intrinsic_with_adapter_scope(adapter, lambda: "output")
+
+    assert hook_payloads(mock_invoke) == []
+    assert backend._model.active_adapters() == []
+
+    out = backend._generate_intrinsic_with_adapter_scope(adapter, lambda: "output")
+    assert out == "output"
+    assert backend._model.active_adapters() == []
+
+
 def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
     """Two concurrent intrinsic generate calls must never see each other's adapter active.
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -529,7 +529,7 @@ def test_generate_intrinsic_with_adapter_scope_deactivates_on_error():
     backend._model.set_adapter.assert_any_call([])  # type: ignore[attr-defined]
 
 
-def test_generate_intrinsic_with_adapter_scope_error_hook_payload():
+def test_generate_intrinsic_with_adapter_scope_reports_error_outcome_in_hook_payload():
     """A failed intrinsic generation reports `outcome="error"` with both phase events.
 
     The `AdapterMixin.adapter_scope` contract for a failing body is pinned
@@ -569,7 +569,7 @@ def test_generate_intrinsic_with_adapter_scope_error_hook_payload():
     assert backend._model.active_adapters() == []
 
 
-def test_generate_intrinsic_with_adapter_scope_prepare_failure_no_hooks():
+def test_generate_intrinsic_with_adapter_scope_fires_no_hooks_on_prepare_failure():
     """A `load_peft_adapter` failure happens before `adapter_scope()` is entered.
 
     So no adapter hooks fire at all, activation state is unchanged, and the

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -340,11 +340,11 @@ def test_generation_lock_is_reentrant():
     """`_generation_lock` must be a `threading.RLock`, not a plain `threading.Lock`.
 
     `_generate_intrinsic_with_adapter_scope` (issue #1465) holds `_generation_lock`
-    for the whole activate -> generate -> deactivate critical section on one
-    thread, and `adapter_scope()`'s activate()/deactivate() re-acquire the same
-    lock (via `_adapter_activation_lock()`) from inside that section. A plain
-    `Lock` can't tell that the second acquisition is same-thread and refuses it;
-    only an `RLock` allows it.
+    for the whole prepare -> activate -> generate -> deactivate critical section
+    on one thread, and the binding's verb calls (prepare/activate/deactivate)
+    re-acquire the same lock (via `_adapter_activation_lock()`) from inside that
+    section. A plain `Lock` can't tell that the second acquisition is
+    same-thread and refuses it; only an `RLock` allows it.
     """
     backend = _make_backend()
     lock = backend._generation_lock
@@ -391,14 +391,15 @@ def _make_fake_intrinsic_adapter(
     qualified_name: str, revision: str = "fake0000000000000000000000000000000000000"
 ) -> IntrinsicAdapter:
     """Builds a minimal `IntrinsicAdapter` stand-in, bypassing `__init__` (which
-    downloads the adapter's `io.yaml`), exposing only the attributes
-    `_generate_intrinsic_with_adapter_scope` reads: `.name`, `.qualified_name`,
-    `.adapter_type`, `.identity` (reused directly, not rebuilt, so this must
-    already be the real `Identity` `IntrinsicAdapter.__init__` would have
-    built), and `.intrinsic_metadata.revision` (the catalogue-pinned SHA
-    `_IntrinsicPeftBinding` reports to telemetry — real `IntrinsicsCatalogEntry.revision`
-    is a required, non-optional `str`, so this stand-in mirrors that rather
-    than allowing `None`).
+    downloads the adapter's `io.yaml`), exposing the attribute set
+    `_generate_intrinsic_with_adapter_scope` reads — `.identity` (reused
+    directly, not rebuilt, so this must already be the real `Identity`
+    `IntrinsicAdapter.__init__` would have built), `.qualified_name`, and
+    `.intrinsic_metadata.revision` — plus `.name`/`.adapter_type` for realism
+    (the method reaches those via `identity`, not the stand-in's own fields).
+    The stand-in pins `revision` to a catalogue SHA, mirroring the real
+    `IntrinsicsCatalogEntry.revision` (a required, non-optional `str`) rather
+    than allowing `None`.
     """
     name, _, adapter_type_str = qualified_name.rpartition("_")
     adapter_type = (
@@ -600,12 +601,12 @@ def test_generate_intrinsic_with_adapter_scope_fires_no_hooks_on_prepare_failure
 def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
     """Two concurrent intrinsic generate calls must never see each other's adapter active.
 
-    Regression coverage for the atomicity gap `adapter_scope()`'s own docstring
-    flags as latent until #1465 wires real concurrent generation through it: if
-    `_generation_lock` only guarded `activate()`/`deactivate()` themselves
-    (rather than the whole activate -> generate -> deactivate section), one
-    thread's `activate()` could interleave during another thread's generate call.
-    The `time.sleep` below widens that window so a regression would be caught
+    Regression coverage for the intra-scope atomicity gap `adapter_scope()`'s
+    docstring describes: if `_generation_lock` only guarded the verb calls
+    themselves (rather than the whole prepare -> activate -> generate ->
+    deactivate section its driver now holds, per #1465), one thread's
+    `activate()` could interleave during another thread's generate call. The
+    `time.sleep` below widens that window so a regression would be caught
     reliably rather than by luck.
     """
     backend = _make_backend()

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -4,6 +4,8 @@
 """Unit tests for HuggingFace backend pure-logic helpers — no model load required."""
 
 import asyncio
+import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +25,7 @@ import struct
 from transformers.generation.utils import GenerateDecoderOnlyOutput
 
 from mellea.backends import ModelOption
-from mellea.backends.adapters import AdapterMixin, IntrinsicAdapter
+from mellea.backends.adapters import AdapterMixin, AdapterType, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
@@ -218,8 +220,11 @@ def _make_intrinsic_backend_stub(stub_backend):
         LocalHFBackend._make_backend_specific_and_remove(stub_backend, opts)
     )
     stub_backend.post_processing = lambda *args, **kwargs: None
-    stub_backend._generate_with_adapter_lock = (
-        lambda adapter_name, generate_func, *args: generate_func(*args)
+    # Bypasses locking/adapter_scope entirely — these tests exercise option-merging
+    # and logits capture, not activation semantics (see
+    # test_generate_intrinsic_with_adapter_scope_* below for that).
+    stub_backend._generate_intrinsic_with_adapter_scope = (
+        lambda adapter, generate_func, *args, **kwargs: generate_func(*args, **kwargs)
     )
     stub_backend._find_adapter = lambda cap, types=None: AdapterMixin._find_adapter(
         stub_backend, cap, types
@@ -324,6 +329,185 @@ def test_adapter_activation_lock_is_the_generation_lock():
     backend = _make_backend()
 
     assert backend._adapter_activation_lock() is backend._generation_lock
+
+
+def test_generation_lock_is_reentrant():
+    """`_generation_lock` must be a `threading.RLock`, not a plain `threading.Lock`.
+
+    `_generate_intrinsic_with_adapter_scope` (issue #1465) holds `_generation_lock`
+    for the whole activate -> generate -> deactivate critical section on one
+    thread, and `adapter_scope()`'s activate()/deactivate() re-acquire the same
+    lock (via `_adapter_activation_lock()`) from inside that section. A plain
+    `Lock` can't tell that the second acquisition is same-thread and refuses it;
+    only an `RLock` allows it.
+    """
+    backend = _make_backend()
+    lock = backend._generation_lock
+
+    assert lock.acquire(blocking=False)
+    reentrant = lock.acquire(blocking=False)
+    if reentrant:
+        lock.release()
+    lock.release()
+
+    assert reentrant, "expected _generation_lock to be reentrant (threading.RLock)"
+
+
+def test_generation_lock_reentrant_activation_does_not_deadlock():
+    """Regression test for #1465's known lock-reentrancy deadlock.
+
+    `activate()`/`deactivate()` (driven by `adapter_scope()`) acquire
+    `_adapter_activation_lock()`, which is `_generation_lock`. Intrinsic
+    generation holds `_generation_lock` for its whole critical section (see
+    `_generate_intrinsic_with_adapter_scope`), so that inner acquisition happens
+    on the same thread while the outer one is still held. Runs on a background
+    thread with a bounded join so a regression to a non-reentrant lock fails
+    fast instead of hanging the suite.
+    """
+    backend = _make_backend()
+    completed = threading.Event()
+
+    def nested_acquire():
+        with backend._generation_lock:
+            with backend._adapter_activation_lock():
+                completed.set()
+
+    t = threading.Thread(target=nested_acquire, daemon=True)
+    t.start()
+    t.join(timeout=5)
+
+    assert completed.is_set(), (
+        "re-acquiring _adapter_activation_lock() while already holding "
+        "_generation_lock deadlocked; _generation_lock must be reentrant"
+    )
+
+
+def _make_fake_intrinsic_adapter(qualified_name: str) -> IntrinsicAdapter:
+    """Builds a minimal `IntrinsicAdapter` stand-in, bypassing `__init__` (which
+    downloads the adapter's `io.yaml`), exposing only the attributes
+    `_generate_intrinsic_with_adapter_scope` reads.
+    """
+    name, _, adapter_type = qualified_name.rpartition("_")
+    adapter = IntrinsicAdapter.__new__(IntrinsicAdapter)
+    adapter.name = name
+    adapter.qualified_name = qualified_name
+    adapter.adapter_type = (
+        AdapterType.ALORA if adapter_type == "alora" else AdapterType.LORA
+    )
+    return adapter
+
+
+def _register_fake_adapter(
+    backend: LocalHFBackend, qualified_name: str, path: str
+) -> None:
+    """Registers a minimal `IntrinsicAdapter` stand-in under `_added_adapters`,
+    satisfying what `load_peft_adapter` reads (`.path`, `.qualified_name`).
+    """
+    fake = IntrinsicAdapter.__new__(IntrinsicAdapter)
+    fake.path = path
+    fake.qualified_name = qualified_name
+    backend._added_adapters[qualified_name] = fake
+
+
+def _wire_fake_peft_model(backend: LocalHFBackend) -> None:
+    """Makes `backend._model.set_adapter`/`.active_adapters` track real state.
+
+    Without this, both are unconfigured `MagicMock`s: `set_adapter` records
+    calls but doesn't affect what `active_adapters()` returns, so activation
+    couldn't be observed from the generate callback.
+    """
+    active: list[str] = []
+
+    def fake_set_adapter(name_or_names):
+        if isinstance(name_or_names, list):
+            active.clear()
+        else:
+            active[:] = [name_or_names]
+
+    backend._model.set_adapter.side_effect = fake_set_adapter  # type: ignore[attr-defined]
+    backend._model.active_adapters.side_effect = lambda: list(active)  # type: ignore[attr-defined]
+
+
+def test_generate_intrinsic_with_adapter_scope_activates_during_generation():
+    """Generation demonstrably runs with the adapter active — asserted from
+    inside the generate callback via the real (mocked) PEFT model state, not
+    smoke-tested by checking generation merely succeeds.
+    """
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    adapter = _make_fake_intrinsic_adapter("answerability_alora")
+    _register_fake_adapter(backend, adapter.qualified_name, "/fake/path")
+
+    seen_during_generation = []
+
+    def fake_generate():
+        seen_during_generation.append(backend._model.active_adapters())
+        return "output"
+
+    out = backend._generate_intrinsic_with_adapter_scope(adapter, fake_generate)
+
+    assert out == "output"
+    assert seen_during_generation == [[adapter.qualified_name]]
+    assert backend._model.active_adapters() == []
+
+
+def test_generate_intrinsic_with_adapter_scope_deactivates_on_error():
+    """`adapter_scope()`'s deactivate-in-finally guarantee holds on the intrinsic path."""
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    adapter = _make_fake_intrinsic_adapter("answerability_alora")
+    _register_fake_adapter(backend, adapter.qualified_name, "/fake/path")
+
+    def failing_generate():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        backend._generate_intrinsic_with_adapter_scope(adapter, failing_generate)
+
+    assert backend._model.active_adapters() == []
+
+
+def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
+    """Two concurrent intrinsic generate calls must never see each other's adapter active.
+
+    Regression coverage for the atomicity gap `adapter_scope()`'s own docstring
+    flags as latent until #1465 wires real concurrent generation through it: if
+    `_generation_lock` only guarded `activate()`/`deactivate()` themselves
+    (rather than the whole activate -> generate -> deactivate section), one
+    thread's `activate()` could interleave during another thread's generate call.
+    The `time.sleep` below widens that window so a regression would be caught
+    reliably rather than by luck.
+    """
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    _register_fake_adapter(backend, "answerability_lora", "/fake/a")
+    _register_fake_adapter(backend, "uncertainty_lora", "/fake/b")
+
+    mismatches: list[tuple[str, list[str]]] = []
+
+    def run(qualified_name: str):
+        adapter = _make_fake_intrinsic_adapter(qualified_name)
+
+        def fake_generate():
+            time.sleep(0.05)
+            current = backend._model.active_adapters()
+            if current != [qualified_name]:
+                mismatches.append((qualified_name, current))
+            return "ok"
+
+        backend._generate_intrinsic_with_adapter_scope(adapter, fake_generate)
+
+    threads = [
+        threading.Thread(target=run, args=("answerability_lora",)),
+        threading.Thread(target=run, args=("uncertainty_lora",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not any(t.is_alive() for t in threads)
+    assert mismatches == []
 
 
 def test_list_adapters_reflects_registration_not_just_loading():

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -237,16 +237,18 @@ def _make_intrinsic_backend_stub(stub_backend):
     return stub_backend
 
 
-def test_generate_with_adapter_lock_deactivates_before_generating():
-    """_generate_with_adapter_lock generates against the base model.
+def test_generate_with_adapter_lock_deactivates_and_calls_generate_func():
+    """_generate_with_adapter_lock delegates deactivation and runs the model call.
 
     Standard (non-intrinsic) generation runs without adapters: the method
     delegates to `deactivate_peft_adapter("")` (rather than calling
-    `_model.set_adapter` directly, Epic #929 Phase 2 / issue #1141) and never
-    touches the activation verbs or `load_peft_adapter`. Since #1465 routed
+    `_model.set_adapter` directly, Epic #929 Phase 2 / issue #1141), never
+    touches the activation verbs or `load_peft_adapter`, and forwards to
+    `generate_func` (its return value is the method's). Since #1465 routed
     intrinsic generation through `_generate_intrinsic_with_adapter_scope`, no
     production caller passes it an adapter to activate — which is why the
-    method takes no adapter name at all.
+    method takes no adapter name at all. The method's deactivate-then-generate
+    ordering is fixed by its body, not observable from these patched verbs.
     """
     backend = _make_backend()
     backend._model.active_adapters.return_value = []  # type: ignore[union-attr]
@@ -256,8 +258,9 @@ def test_generate_with_adapter_lock_deactivates_before_generating():
         patch.object(backend, "activate_peft_adapter") as mock_activate,
         patch.object(backend, "deactivate_peft_adapter") as mock_deactivate,
     ):
-        backend._generate_with_adapter_lock(lambda: "output")
+        out = backend._generate_with_adapter_lock(lambda: "output")
 
+    assert out == "output"
     mock_deactivate.assert_called_once_with("")
     mock_activate.assert_not_called()
     mock_load.assert_not_called()

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -484,6 +484,7 @@ def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
     _register_fake_adapter(backend, "uncertainty_lora", "/fake/b")
 
     mismatches: list[tuple[str, list[str]]] = []
+    errors: list[BaseException] = []
 
     def run(qualified_name: str):
         adapter = _make_fake_intrinsic_adapter(qualified_name)
@@ -495,7 +496,10 @@ def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
                 mismatches.append((qualified_name, current))
             return "ok"
 
-        backend._generate_intrinsic_with_adapter_scope(adapter, fake_generate)
+        try:
+            backend._generate_intrinsic_with_adapter_scope(adapter, fake_generate)
+        except BaseException as exc:  # surfaced via `errors`, not swallowed
+            errors.append(exc)
 
     threads = [
         threading.Thread(target=run, args=("answerability_lora",)),
@@ -507,6 +511,11 @@ def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
         t.join(timeout=5)
 
     assert not any(t.is_alive() for t in threads)
+    # A `Thread` swallows exceptions from its target by default, so without this
+    # check a totally broken `_generate_intrinsic_with_adapter_scope` (e.g. an
+    # AttributeError before `fake_generate` ever runs) would leave `mismatches`
+    # empty and this test would pass vacuously.
+    assert errors == []
     assert mismatches == []
 
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -27,6 +27,7 @@ from transformers.generation.utils import GenerateDecoderOnlyOutput
 from mellea.backends import ModelOption
 from mellea.backends.adapters import AdapterMixin, AdapterType, IntrinsicAdapter
 from mellea.backends.adapters._core import Identity
+from mellea.backends.adapters.catalog import IntrinsicsCatalogEntry
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
 from mellea.formatters.granite.base.util import (
@@ -42,6 +43,10 @@ from mellea.stdlib.components import (
     Message,
 )
 from mellea.stdlib.context import ChatContext
+from test.backends.test_adapters._hook_capture import (
+    capture_adapter_hooks,
+    hook_payloads,
+)
 
 # Minimal 1x1 PNG for testing
 _MINIMAL_PNG = (
@@ -382,17 +387,34 @@ def test_generation_lock_reentrant_activation_does_not_deadlock():
     )
 
 
-def _make_fake_intrinsic_adapter(qualified_name: str) -> IntrinsicAdapter:
+def _make_fake_intrinsic_adapter(
+    qualified_name: str, revision: str = "fake0000000000000000000000000000000000000"
+) -> IntrinsicAdapter:
     """Builds a minimal `IntrinsicAdapter` stand-in, bypassing `__init__` (which
     downloads the adapter's `io.yaml`), exposing only the attributes
-    `_generate_intrinsic_with_adapter_scope` reads.
+    `_generate_intrinsic_with_adapter_scope` reads: `.name`, `.qualified_name`,
+    `.adapter_type`, `.identity` (reused directly, not rebuilt, so this must
+    already be the real `Identity` `IntrinsicAdapter.__init__` would have
+    built), and `.intrinsic_metadata.revision` (the catalogue-pinned SHA
+    `_IntrinsicPeftBinding` reports to telemetry — real `IntrinsicsCatalogEntry.revision`
+    is a required, non-optional `str`, so this stand-in mirrors that rather
+    than allowing `None`).
     """
-    name, _, adapter_type = qualified_name.rpartition("_")
+    name, _, adapter_type_str = qualified_name.rpartition("_")
+    adapter_type = (
+        AdapterType.ALORA if adapter_type_str == "alora" else AdapterType.LORA
+    )
     adapter = IntrinsicAdapter.__new__(IntrinsicAdapter)
     adapter.name = name
     adapter.qualified_name = qualified_name
-    adapter.adapter_type = (
-        AdapterType.ALORA if adapter_type == "alora" else AdapterType.LORA
+    adapter.adapter_type = adapter_type
+    adapter.intrinsic_metadata = IntrinsicsCatalogEntry(
+        name=name, repo_id="fake/repo", revision=revision
+    )
+    object.__setattr__(
+        adapter,
+        "identity",
+        Identity(name=name, adapter_type=adapter_type.value, capability=name),
     )
     return adapter
 
@@ -449,6 +471,42 @@ def test_generate_intrinsic_with_adapter_scope_activates_during_generation():
     assert out == "output"
     assert seen_during_generation == [[adapter.qualified_name]]
     assert backend._model.active_adapters() == []
+
+
+def test_generate_intrinsic_with_adapter_scope_fires_hooks_with_correct_payload():
+    """The hooks `_generate_intrinsic_with_adapter_scope`'s docstring claims to
+    enable must actually fire, with a payload that matches reality — not just
+    smoke-tested by checking that *some* hooks fire.
+
+    Regression coverage for two bugs caught in review: `revision` reported as
+    `None` (mislabelled "unpinned") despite the adapter being pinned, and
+    `binding_type` set to an invented `"intrinsic_legacy"` value instead of the
+    `"local_file"` reality this binding actually is.
+    """
+    backend = _make_backend()
+    _wire_fake_peft_model(backend)
+    adapter = _make_fake_intrinsic_adapter(
+        "answerability_alora", revision="deadbeef00000000000000000000000000000000"
+    )
+    _register_fake_adapter(backend, adapter.qualified_name, "/fake/path")
+
+    with capture_adapter_hooks() as mock_invoke:
+        out = backend._generate_intrinsic_with_adapter_scope(adapter, lambda: "output")
+
+    assert out == "output"
+    payloads = hook_payloads(mock_invoke)
+
+    phases = [p.phase for p in payloads if hasattr(p, "phase")]
+    assert phases == ["activate", "deactivate"]
+
+    invocations = [p for p in payloads if hasattr(p, "outcome")]
+    assert len(invocations) == 1
+    invocation = invocations[0]
+    assert invocation.outcome == "success"
+    assert invocation.name == "answerability"
+    assert invocation.adapter_type == "alora"
+    assert invocation.binding_type == "local_file"
+    assert invocation.revision == "deadbeef00000000000000000000000000000000"
 
 
 def test_generate_intrinsic_with_adapter_scope_deactivates_on_error():

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -471,6 +471,9 @@ def test_generate_intrinsic_with_adapter_scope_activates_during_generation():
     assert out == "output"
     assert seen_during_generation == [[adapter.qualified_name]]
     assert backend._model.active_adapters() == []
+    # Asserts the real verb ran deactivation, not just that _wire_fake_peft_model's
+    # `active_adapters()` mock still happens to read back empty.
+    backend._model.set_adapter.assert_any_call([])  # type: ignore[attr-defined]
 
 
 def test_generate_intrinsic_with_adapter_scope_fires_hooks_with_correct_payload():
@@ -523,6 +526,7 @@ def test_generate_intrinsic_with_adapter_scope_deactivates_on_error():
         backend._generate_intrinsic_with_adapter_scope(adapter, failing_generate)
 
     assert backend._model.active_adapters() == []
+    backend._model.set_adapter.assert_any_call([])  # type: ignore[attr-defined]
 
 
 def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
@@ -556,7 +560,7 @@ def test_concurrent_intrinsic_calls_cannot_observe_each_others_adapter():
 
         try:
             backend._generate_intrinsic_with_adapter_scope(adapter, fake_generate)
-        except BaseException as exc:  # surfaced via `errors`, not swallowed
+        except Exception as exc:  # surfaced via `errors`, not swallowed
             errors.append(exc)
 
     threads = [

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -237,52 +237,30 @@ def _make_intrinsic_backend_stub(stub_backend):
     return stub_backend
 
 
-def test_generate_with_adapter_lock_calls_load_peft_adapter():
-    """Regression guard: the internal adapter-lock call site (Epic #929 Phase 2,
-    issue #1140) must use the renamed `load_peft_adapter` verb, not the old
-    `load_adapter` name.
+def test_generate_with_adapter_lock_deactivates_before_generating():
+    """_generate_with_adapter_lock generates against the base model.
+
+    Standard (non-intrinsic) generation runs without adapters: the method
+    delegates to `deactivate_peft_adapter("")` (rather than calling
+    `_model.set_adapter` directly, Epic #929 Phase 2 / issue #1141) and never
+    touches the activation verbs or `load_peft_adapter`. Since #1465 routed
+    intrinsic generation through `_generate_intrinsic_with_adapter_scope`, no
+    production caller passes it an adapter to activate — which is why the
+    method takes no adapter name at all.
     """
     backend = _make_backend()
-    backend._model.active_adapters.return_value = ["my_adapter"]  # type: ignore[union-attr]
-
-    with patch.object(backend, "load_peft_adapter") as mock_load:
-        backend._generate_with_adapter_lock("my_adapter", lambda: "output")
-
-    mock_load.assert_called_once_with("my_adapter")
-    # Deliberately no `_model.set_adapter` assertion. Since #1141 that call is
-    # reached via `activate_peft_adapter` rather than inlined here, so asserting
-    # it would make this test an unannounced guard for the delegation chain --
-    # failing on a change to `activate_peft_adapter` without naming it. The chain
-    # is covered by `test_generate_with_adapter_lock_uses_activate_deactivate_verbs`
-    # and the verb itself by `test_activate_peft_adapter_calls_set_adapter`.
-
-
-def test_generate_with_adapter_lock_uses_activate_deactivate_verbs():
-    """_generate_with_adapter_lock delegates to the new activate/deactivate verbs
-    rather than calling `_model.set_adapter` directly (Epic #929 Phase 2, issue #1141).
-    """
-    backend = _make_backend()
-    backend._model.active_adapters.return_value = ["my_adapter"]  # type: ignore[union-attr]
-
-    with (
-        patch.object(backend, "load_peft_adapter"),
-        patch.object(backend, "activate_peft_adapter") as mock_activate,
-        patch.object(backend, "deactivate_peft_adapter") as mock_deactivate,
-    ):
-        backend._generate_with_adapter_lock("my_adapter", lambda: "output")
-
-    mock_activate.assert_called_once_with("my_adapter")
-    mock_deactivate.assert_not_called()
-
     backend._model.active_adapters.return_value = []  # type: ignore[union-attr]
+
     with (
+        patch.object(backend, "load_peft_adapter") as mock_load,
         patch.object(backend, "activate_peft_adapter") as mock_activate,
         patch.object(backend, "deactivate_peft_adapter") as mock_deactivate,
     ):
-        backend._generate_with_adapter_lock("", lambda: "output")
+        backend._generate_with_adapter_lock(lambda: "output")
 
-    mock_activate.assert_not_called()
     mock_deactivate.assert_called_once_with("")
+    mock_activate.assert_not_called()
+    mock_load.assert_not_called()
 
 
 def test_activate_peft_adapter_calls_set_adapter():


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1465.

## Description

Intrinsic generation previously occurred outside `adapter_scope()`, so the adapter lifecycle was disconnected from the model call it was meant to control. Moving generation into that scope exposed a lock re-entrancy deadlock and an atomicity gap between activation and generation.

This PR routes intrinsic generation through `adapter_scope()`, uses a re-entrant generation lock for the full lifecycle, and records the correct lifecycle-hook metadata. The active adapter is now demonstrably the one used for generation, and cleanup occurs when generation fails.

## Where this fits

This is Phase 2 work for Epic #929 and follows #1141 / PR #1454. It enables the `generate` and `parse` span work in #1466. Embedded adapters (#1142 / #1018), output-contract resolution (#1516), and shim removal (#1144) remain separate.

## What changed

- Route `LocalHFBackend` intrinsic calls through an adapter-scoped binding.
- Make the generation lock re-entrant and hold it across prepare, activate, generate, and deactivate.
- Preserve adapter identity, revision, binding type, phase boundaries, and error outcomes in lifecycle hooks.
- Remove the now-orphaned adapter activation branch from the ordinary generation helper.
- Add regression tests for deadlock avoidance, active-adapter use, failure cleanup, hook payloads, and concurrent calls.

## Caveat

The hardware-backed end-to-end test is updated but was not run locally. `generate` and `parse` spans are intentionally deferred to #1466.

## Testing

Focused backend tests, the non-qualitative suite, Ruff, mypy, and the documentation quality gate pass. Required GitHub checks pass.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
