### PR TITLE
fix: rewrite broken aLora 101 example for the intrinsics API

### DIFF
--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -1,45 +1,53 @@
-# pytest: skip, huggingface, e2e
-# SKIP REASON: broken stembolts adapter/example, pending rewrite to new intrinsics API (#385).
+# pytest: huggingface, e2e, qualitative, slow
+"""How `ALoraRequirement` routes validation through a fast adapter.
+
+Uses the catalog-native `requirement-check` adapter (registered here via
+`IntrinsicAdapter`, still the only working way to drive `_generate_from_intrinsic` —
+see #1144) to compare aLoRA-backed validation against full LLM-as-judge generation
+for the same requirement. `LLMaJRequirement` is used for the comparison because
+`ALoraRequirement` always routes through the registered adapter regardless of
+`backend.default_to_constraint_checking_alora`.
+
+For loading a fully custom, non-catalog adapter with your own output schema
+(not the generic `{"requirement_check": {"score": ...}}` shape), see
+`stembolts_intrinsic.py` and `102_example.py` in this directory.
+"""
 
 import time
 
 from mellea import MelleaSession
-from mellea.backends.adapters.adapter import CustomIntrinsicAdapter
+from mellea.backends.adapters import AdapterType
+from mellea.backends.adapters.adapter import IntrinsicAdapter
 from mellea.backends.cache import SimpleLRUCache
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import GenerateLog
 from mellea.stdlib.context import ChatContext
-from mellea.stdlib.requirements import ALoraRequirement, Requirement
+from mellea.stdlib.requirements import ALoraRequirement, LLMaJRequirement, Requirement
 
-backend = LocalHFBackend(
-    model_id="ibm-granite/granite-3.3-2b-instruct", cache=SimpleLRUCache(5)
-)
+backend = LocalHFBackend(model_id="ibm-granite/granite-4.1-3b", cache=SimpleLRUCache(5))
 
 m = MelleaSession(backend=backend, ctx=ChatContext())
 
+# Register the aLoRA variant of the catalog's requirement-check adapter. Without
+# this, ALoraRequirement finds no matching adapter and silently falls back to
+# regular generation (a warning is logged, but validation still "succeeds").
+backend.add_adapter(
+    IntrinsicAdapter(
+        "requirement-check",
+        adapter_type=AdapterType.ALORA,
+        base_model_name=backend.base_model_name,
+    )
+)
 
-class StemboltAdapter(CustomIntrinsicAdapter):
-    def __init__(self):
-        super().__init__(
-            model_id="nfulton/stembolts",
-            intrinsic_name="stembolts",
-            base_model_name="granite-3.3-2b-instruct",
-        )
-
-
-granite_33_2b_stembolt_adapter = StemboltAdapter()
-
-backend.add_adapter(granite_33_2b_stembolt_adapter)
+description = "The summary must mention the suspected cause of failure."
 
 # define a requirement
-failure_check = ALoraRequirement(
-    "The diagnostic confidence should be in the unit interval and greater than 0.9.",
-    intrinsic_name=granite_33_2b_stembolt_adapter.intrinsic_name,
-)
+failure_check = ALoraRequirement(description)
 failure_check.check_only = True
 
 res = m.instruct(
-    "Oil seepage around piston rings suggests seal degradation",
+    "Write a triage summary based on this technician note: Oil seepage around "
+    "piston rings suggests seal degradation.",
     requirements=[failure_check],
     strategy=None,
 )
@@ -51,17 +59,12 @@ print(
 )  # retrieve prompt information from session context
 
 
-def validate_reqs(reqs: list[Requirement]):
+def validate_reqs(reqs: list[Requirement], label: str):
     """Validate the requirements against the last output in the session."""
-    print("==== Validation =====")
-    print(
-        "using aLora"
-        if backend.default_to_constraint_checking_alora
-        else "using NO alora"
-    )
+    print(f"==== Validation ({label}) =====")
 
     # helper to collect validation prompts (because validation calls never get added to session contexts).
-    logs: list[GenerateLog] = []  # type: ignore
+    logs: list[GenerateLog] = []
 
     # Run the validation. No output needed, because the last output in "m" will be used. Timing added.
     start_time = time.time()
@@ -82,19 +85,32 @@ def validate_reqs(reqs: list[Requirement]):
         if isinstance(log, GenerateLog):
             print(f" - {{prompt: {log.prompt}\n   raw result: {log.result.value} }}")  # type: ignore
 
-    return end_time - start_time, val_res
+    return delta_t, val_res
 
 
-# NOTE: This is not meant for use in regular programming using mellea, but just as an illustration for the speedup you can get with aloras.
-# force to run without alora
-backend.default_to_constraint_checking_alora = False
-computetime_no_alora, no_alora_result = validate_reqs([failure_check])
+llmaj_check = LLMaJRequirement(description)
 
-# run with aLora -- which is the default if the constraint alora is added to a model
-backend.default_to_constraint_checking_alora = True
-computetime_alora, alora_result = validate_reqs([failure_check])
+# Warm up both paths first: the *first* call against a freshly-registered aLoRA
+# adapter also pays a one-time PEFT weight-load cost that has nothing to do with
+# per-call latency, so timing a cold call would overstate the difference below.
+m.validate([failure_check])
+m.validate([llmaj_check])
 
+# ALoraRequirement always routes through the registered aLoRA adapter.
+computetime_alora, alora_result = validate_reqs([failure_check], "aLoRA")
 
+# LLMaJRequirement always bypasses adapters, regardless of what's registered --
+# the only way to get a genuine no-adapter timing comparison for the same check.
+computetime_llmaj, llmaj_result = validate_reqs([llmaj_check], "LLM-as-judge")
+
+print(f"aLoRA validation:        {computetime_alora:.3f}s")
+print(f"LLM-as-judge validation: {computetime_llmaj:.3f}s")
 print(
-    f"Speed up time with using aloras is {((computetime_alora - computetime_no_alora) / computetime_no_alora * 100):.2f}% ({computetime_alora - computetime_no_alora} seconds). This speedup is absolute -- not normalized for token count."
+    "NOTE: these numbers do not demonstrate a speedup either way, and that's "
+    "expected. aLoRA's architectural advantage is reusing an already-computed "
+    "KV cache instead of recomputing the context under adapter-modified weights -- "
+    "mellea's adapter-activation path doesn't exercise that yet (KV-cache reuse is "
+    "experimental and gated behind `cache=True` context blocks, not wired into "
+    "intrinsics). Over one short call, the token-count difference between a "
+    "JSON+score output and a one-word yes/no answer dominates instead."
 )

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -17,7 +17,7 @@ runnable as an automated example).
 
 import time
 
-from mellea import MelleaSession
+from mellea import MelleaSession, model_ids
 from mellea.backends.adapters import AdapterType
 from mellea.backends.adapters.adapter import IntrinsicAdapter
 from mellea.backends.cache import SimpleLRUCache
@@ -26,7 +26,7 @@ from mellea.core import GenerateLog, ValidationResult
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import ALoraRequirement, LLMaJRequirement, Requirement
 
-backend = LocalHFBackend(model_id="ibm-granite/granite-4.1-3b", cache=SimpleLRUCache(5))
+backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5))
 
 m = MelleaSession(backend=backend, ctx=ChatContext())
 
@@ -38,7 +38,7 @@ m = MelleaSession(backend=backend, ctx=ChatContext())
 # also load-bearing here: routing only looks up ("alora",), so registering the
 # LORA variant instead would hit the same failure.
 backend.add_adapter(
-    IntrinsicAdapter(
+    IntrinsicAdapter(  # emits a DeprecationWarning -- see module docstring, #1144
         "requirement-check",
         adapter_type=AdapterType.ALORA,
         base_model_name=backend.base_model_name,

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -31,14 +31,15 @@ backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUC
 m = MelleaSession(backend=backend, ctx=ChatContext())
 
 # Register the aLoRA variant of the catalog's requirement-check adapter. Without
-# this, ALoraRequirement logs a warning, falls back to regular generation, and
-# then fails: the fallback prompt asks for a plain "yes"/"no", but
-# ALoraRequirement always parses results as JSON via requirement_check_to_bool,
-# so it raises json.JSONDecodeError on that fallback output. The ALORA type is
-# also load-bearing here: routing only looks up ("alora",), so registering the
-# LORA variant instead would hit the same failure.
+# this, ALoraRequirement logs a warning and falls back to regular generation,
+# whose prompt asks for a plain "yes"/"no" answer — but the result is still
+# parsed as JSON by requirement_check_to_bool, so a plain yes/no reply fails
+# validation in practice (a JSON reply that doesn't match the schema instead
+# raises AdapterSchemaMismatchError). The ALORA type is also load-bearing here:
+# routing only looks up ("alora",), so registering the LORA variant instead
+# would hit the same failure.
 backend.add_adapter(
-    IntrinsicAdapter(  # emits a DeprecationWarning -- see module docstring, #1144
+    IntrinsicAdapter(  # emits a DeprecationWarning — see module docstring, #1144
         "requirement-check",
         adapter_type=AdapterType.ALORA,
         base_model_name=backend.base_model_name,
@@ -48,7 +49,7 @@ backend.add_adapter(
 description = "The summary must mention the suspected cause of failure."
 
 # define a requirement
-failure_check = ALoraRequirement(description)
+alora_check = ALoraRequirement(description)
 
 res = m.instruct(
     "Write a triage summary based on this technician note: Oil seepage around "
@@ -100,13 +101,13 @@ llmaj_check = LLMaJRequirement(description)
 # aLoRA adapter pays a one-time PEFT weight-load cost that has nothing to do with
 # per-call latency; the LLM-as-judge call has no such cost, but gets a warm-up too
 # so both measurements below are on equal footing.
-m.validate([failure_check])
+m.validate([alora_check])
 m.validate([llmaj_check])
 
 # ALoraRequirement always routes through the registered aLoRA adapter.
-computetime_alora, _ = validate_reqs([failure_check], "aLoRA")
+computetime_alora, _ = validate_reqs([alora_check], "aLoRA")
 
-# LLMaJRequirement always bypasses adapters, regardless of what's registered --
+# LLMaJRequirement always bypasses adapters, regardless of what's registered —
 # the only way to get a genuine no-adapter timing comparison for the same check.
 computetime_llmaj, _ = validate_reqs([llmaj_check], "LLM-as-judge")
 
@@ -114,7 +115,7 @@ print(f"aLoRA validation:        {computetime_alora:.3f}s")
 print(f"LLM-as-judge validation: {computetime_llmaj:.3f}s")
 print(
     "NOTE: whichever way these numbers land, they are not measuring aLoRA's "
-    "architectural advantage -- reusing an already-computed KV cache instead of "
+    "architectural advantage — reusing an already-computed KV cache instead of "
     "recomputing the context under adapter-modified weights. `generate_from_context` "
     "never routes through that KV-cache-reuse path (`_generate_from_context_with_kv_cache`; "
     "reachable today only by calling it directly, see `docs/kv_smash/hf_example.py`), so "

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -20,13 +20,13 @@ import time
 from mellea import MelleaSession, model_ids
 from mellea.backends.adapters import AdapterType
 from mellea.backends.adapters.adapter import IntrinsicAdapter
-from mellea.backends.cache import SimpleLRUCache
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import GenerateLog, ValidationResult
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import ALoraRequirement, LLMaJRequirement, Requirement
 
-backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B, cache=SimpleLRUCache(5))
+# The example does not reuse generated KV caches, so avoid creating and retaining them.
+backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B, use_caches=False)
 
 m = MelleaSession(backend=backend, ctx=ChatContext())
 

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -1,4 +1,4 @@
-# pytest: huggingface, e2e, qualitative, slow
+# pytest: huggingface, e2e, slow
 """How `ALoraRequirement` routes validation through a fast adapter.
 
 Uses the catalog-native `requirement-check` adapter (registered here via
@@ -10,7 +10,9 @@ for the same requirement. `LLMaJRequirement` is used for the comparison because
 
 For loading a fully custom, non-catalog adapter with your own output schema
 (not the generic `{"requirement_check": {"score": ...}}` shape), see
-`stembolts_intrinsic.py` and `102_example.py` in this directory.
+`stembolts_intrinsic.py` in this directory — it has no standalone entry point of
+its own; `102_example.py` drives it interactively (reads from stdin, so it isn't
+runnable as an automated example).
 """
 
 import time
@@ -20,7 +22,7 @@ from mellea.backends.adapters import AdapterType
 from mellea.backends.adapters.adapter import IntrinsicAdapter
 from mellea.backends.cache import SimpleLRUCache
 from mellea.backends.huggingface import LocalHFBackend
-from mellea.core import GenerateLog
+from mellea.core import GenerateLog, ValidationResult
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import ALoraRequirement, LLMaJRequirement, Requirement
 
@@ -29,8 +31,12 @@ backend = LocalHFBackend(model_id="ibm-granite/granite-4.1-3b", cache=SimpleLRUC
 m = MelleaSession(backend=backend, ctx=ChatContext())
 
 # Register the aLoRA variant of the catalog's requirement-check adapter. Without
-# this, ALoraRequirement finds no matching adapter and silently falls back to
-# regular generation (a warning is logged, but validation still "succeeds").
+# this, ALoraRequirement logs a warning, falls back to regular generation, and
+# then fails: the fallback prompt asks for a plain "yes"/"no", but
+# ALoraRequirement always parses results as JSON via requirement_check_to_bool,
+# so it raises json.JSONDecodeError on that fallback output. The ALORA type is
+# also load-bearing here: routing only looks up ("alora",), so registering the
+# LORA variant instead would hit the same failure.
 backend.add_adapter(
     IntrinsicAdapter(
         "requirement-check",
@@ -43,12 +49,10 @@ description = "The summary must mention the suspected cause of failure."
 
 # define a requirement
 failure_check = ALoraRequirement(description)
-failure_check.check_only = True
 
 res = m.instruct(
     "Write a triage summary based on this technician note: Oil seepage around "
     "piston rings suggests seal degradation.",
-    requirements=[failure_check],
     strategy=None,
 )
 
@@ -59,7 +63,9 @@ print(
 )  # retrieve prompt information from session context
 
 
-def validate_reqs(reqs: list[Requirement], label: str):
+def validate_reqs(
+    reqs: list[Requirement], label: str
+) -> tuple[float, list[ValidationResult]]:
     """Validate the requirements against the last output in the session."""
     print(f"==== Validation ({label}) =====")
 
@@ -90,27 +96,28 @@ def validate_reqs(reqs: list[Requirement], label: str):
 
 llmaj_check = LLMaJRequirement(description)
 
-# Warm up both paths first: the *first* call against a freshly-registered aLoRA
-# adapter also pays a one-time PEFT weight-load cost that has nothing to do with
-# per-call latency, so timing a cold call would overstate the difference below.
+# Warm up both paths before timing. The *first* call against a freshly-registered
+# aLoRA adapter pays a one-time PEFT weight-load cost that has nothing to do with
+# per-call latency; the LLM-as-judge call has no such cost, but gets a warm-up too
+# so both measurements below are on equal footing.
 m.validate([failure_check])
 m.validate([llmaj_check])
 
 # ALoraRequirement always routes through the registered aLoRA adapter.
-computetime_alora, alora_result = validate_reqs([failure_check], "aLoRA")
+computetime_alora, _ = validate_reqs([failure_check], "aLoRA")
 
 # LLMaJRequirement always bypasses adapters, regardless of what's registered --
 # the only way to get a genuine no-adapter timing comparison for the same check.
-computetime_llmaj, llmaj_result = validate_reqs([llmaj_check], "LLM-as-judge")
+computetime_llmaj, _ = validate_reqs([llmaj_check], "LLM-as-judge")
 
 print(f"aLoRA validation:        {computetime_alora:.3f}s")
 print(f"LLM-as-judge validation: {computetime_llmaj:.3f}s")
 print(
-    "NOTE: these numbers do not demonstrate a speedup either way, and that's "
-    "expected. aLoRA's architectural advantage is reusing an already-computed "
-    "KV cache instead of recomputing the context under adapter-modified weights -- "
-    "mellea's adapter-activation path doesn't exercise that yet (KV-cache reuse is "
-    "experimental and gated behind `cache=True` context blocks, not wired into "
-    "intrinsics). Over one short call, the token-count difference between a "
-    "JSON+score output and a one-word yes/no answer dominates instead."
+    "NOTE: whichever way these numbers land, they are not measuring aLoRA's "
+    "architectural advantage -- reusing an already-computed KV cache instead of "
+    "recomputing the context under adapter-modified weights. `generate_from_context` "
+    "never routes through that KV-cache-reuse path (`_generate_from_context_with_kv_cache`; "
+    "reachable today only by calling it directly, see `docs/kv_smash/hf_example.py`), so "
+    "neither call above reuses anything. What actually separates them here is mostly the "
+    "token-count difference between a JSON+score output and a one-word yes/no answer."
 )

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -33,11 +33,12 @@ m = MelleaSession(backend=backend, ctx=ChatContext())
 # Register the aLoRA variant of the catalog's requirement-check adapter. Without
 # this, ALoraRequirement logs a warning and falls back to regular generation,
 # whose prompt asks for a plain "yes"/"no" answer — but the result is still
-# parsed as JSON by requirement_check_to_bool, so a plain yes/no reply fails
-# validation in practice (a JSON reply that doesn't match the schema instead
-# raises AdapterSchemaMismatchError). The ALORA type is also load-bearing here:
-# routing only looks up ("alora",), so registering the LORA variant instead
-# would hit the same failure.
+# parsed as JSON by requirement_check_to_bool: a plain yes/no reply raises
+# json.JSONDecodeError (it is not JSON), and a JSON reply that doesn't match
+# the schema raises AdapterSchemaMismatchError — either way the error
+# propagates out of validate() instead of returning a failed check. The ALORA
+# type is also load-bearing here: routing only looks up ("alora",), so
+# registering the LORA variant instead would hit the same failure.
 backend.add_adapter(
     IntrinsicAdapter(  # emits a DeprecationWarning — see module docstring, #1144
         "requirement-check",

--- a/docs/examples/aLora/102_example.py
+++ b/docs/examples/aLora/102_example.py
@@ -1,5 +1,5 @@
 # pytest: skip, huggingface, e2e
-# SKIP REASON: Requires user input; tests same functionality as 101_example.py.
+# SKIP REASON: Requires user input (blocks on stdin in an infinite loop).
 
 from stembolts_intrinsic import (
     async_stembolt_failure_analysis,

--- a/docs/examples/aLora/102_example.py
+++ b/docs/examples/aLora/102_example.py
@@ -11,6 +11,8 @@ from mellea.backends.huggingface import LocalHFBackend
 from mellea.stdlib.context import ChatContext
 
 if __name__ == "__main__":
+    # nfulton/stembolts currently provides this adapter for Granite 3.3 2B;
+    # no Granite 4.0 or 4.1 variant is available in the repository.
     backend = LocalHFBackend(
         model_id="ibm-granite/granite-3.3-2b-instruct", cache=SimpleLRUCache(5)
     )

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -131,6 +131,9 @@ Demonstrates:
 Interactive loop that exercises the custom `stembolts` adapter — skip-marked
 because it blocks on stdin in an infinite loop.
 
+The example uses Granite 3.3 2B because that is the available `stembolts`
+adapter variant; Granite 4.0 and 4.1 variants are not currently available.
+
 Demonstrates:
 - Loading a fully custom, non-catalog adapter via `stembolts_intrinsic.py`
 - Running the adapter-backed intrinsic repeatedly with a fresh `ChatContext`
@@ -159,4 +162,3 @@ Demonstrates:
 - Auto-generating adapter documentation
 - Using the `m alora add-readme` command programmatically
 - Documenting custom adapters
-

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -84,7 +84,7 @@ m alora add-readme \
     stembolt_failure_dataset.jsonl
 ```
 
-The generator will display the README and ask for confirmation before uploading it to your Hugging Face repo. You can also call the generator programmatically from Python -- see `test_readme_generator.py` for an example.
+The generator will display the README and ask for confirmation before uploading it to your Hugging Face repo. You can also call the generator programmatically from Python -- see `example_readme_generator.py` for an example.
 
 ## Using Adapter Functions
 
@@ -105,6 +105,7 @@ class StemboltAdapter(CustomIntrinsicAdapter):
 Using this adapter requires adding it to a backend:
 
 ```python
+from mellea.backends.cache import SimpleLRUCache
 from mellea.backends.huggingface import LocalHFBackend
 
 backend = LocalHFBackend(
@@ -127,12 +128,12 @@ Demonstrates:
 - Timing both validation paths
 
 ### 102_example.py
-Advanced example with multiple adapters and composition.
+Interactive, stdin-driven loop that exercises the custom `stembolts` adapter
+(skip-marked because it blocks on user input).
 
 Demonstrates:
-- Combining multiple adapters
-- Adapter composition patterns
-- Complex validation scenarios
+- Loading a fully custom, non-catalog adapter via `stembolts_intrinsic.py`
+- Running the adapter-backed intrinsic repeatedly with a fresh `ChatContext`
 
 ### make_training_data.py
 Utility for preparing training datasets for adapter training.
@@ -143,12 +144,13 @@ Demonstrates:
 - Preprocessing for training
 
 ### stembolts_intrinsic.py
-Example custom adapter function implementation.
+Helper module for loading and calling the fully custom `stembolts` adapter
+(no standalone entry point — `102_example.py` consumes it).
 
 Demonstrates:
-- Custom adapter class definition
-- Integration with backend
-- Production usage patterns
+- Custom adapter class definition (`StemboltAdapter`)
+- Registering the adapter on a backend, guarded by qualified name
+- Calling the intrinsic directly via `mfuncs.act`
 
 ### example_readme_generator.py
 Programmatic README generation for adapters.

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -84,7 +84,7 @@ m alora add-readme \
     stembolt_failure_dataset.jsonl
 ```
 
-The generator will display the README and ask for confirmation before uploading it to your Hugging Face repo. You can also call the generator programmatically from Python -- see `example_readme_generator.py` for an example.
+The generator will display the README and ask for confirmation before uploading it to your Hugging Face repo. You can also call the generator programmatically from Python — see `example_readme_generator.py` for an example.
 
 ## Using Adapter Functions
 
@@ -128,8 +128,8 @@ Demonstrates:
 - Timing both validation paths
 
 ### 102_example.py
-Interactive, stdin-driven loop that exercises the custom `stembolts` adapter
-(skip-marked because it blocks on user input).
+Interactive loop that exercises the custom `stembolts` adapter — skip-marked
+because it blocks on stdin in an infinite loop.
 
 Demonstrates:
 - Loading a fully custom, non-catalog adapter via `stembolts_intrinsic.py`

--- a/docs/examples/aLora/README.md
+++ b/docs/examples/aLora/README.md
@@ -117,12 +117,14 @@ backend.add_adapter(StemboltAdapter(base_model_name="granite-4.1-3b"))
 ## Example Files
 
 ### 101_example.py
-Basic example of using a trained aLoRA adapter as a requirement.
+Comparing aLoRA-backed requirement validation against LLM-as-a-judge, using the
+catalog-native `requirement-check` adapter (not a custom one — see
+`stembolts_intrinsic.py` for loading your own).
 
 Demonstrates:
-- Loading a custom adapter
-- Using adapter with requirements
-- Validating adapter output
+- Registering a catalog adapter as an aLoRA
+- `ALoraRequirement` vs `LLMaJRequirement` routing
+- Timing both validation paths
 
 ### 102_example.py
 Advanced example with multiple adapters and composition.

--- a/docs/examples/aLora/make_training_data.py
+++ b/docs/examples/aLora/make_training_data.py
@@ -1,5 +1,5 @@
 # pytest: skip, huggingface, e2e
-# SKIP REASON: documentation only.import argparse
+# SKIP REASON: documentation only.
 import argparse
 import json
 import sys

--- a/docs/examples/aLora/stembolts_intrinsic.py
+++ b/docs/examples/aLora/stembolts_intrinsic.py
@@ -1,13 +1,13 @@
 # type: ignore
 """Helper functions for loading and calling a fully custom, non-catalog adapter.
 
-`stembolts` (Hugging Face: `nfulton/stembolts`) is a custom aLoRA adapter for
-`granite-3.3-2b-instruct` with its own output schema
-(`{"defective_part": str, "diag_likelihood": float, ...}`) rather than the
-generic `{"requirement_check": {"score": ...}}` shape most catalog adapters use.
-It is invoked directly via `Intrinsic`/`mfuncs.act()` and the raw JSON is parsed
-by the caller — it is not a pass/fail `ALoraRequirement` validator. Consumed by
-`102_example.py` in this directory.
+`stembolts` (Hugging Face: `nfulton/stembolts`) is a custom aLoRA adapter trained
+against several base models (`base_model_name` is a constructor argument here,
+not fixed) with its own output schema (`{"defective_part": str, "diag_likelihood":
+float}`) rather than the generic `{"requirement_check": {"score": ...}}` shape
+most catalog adapters use. It is invoked directly via `Intrinsic`/`mfuncs.act()`
+and the raw JSON is returned to the caller — it is not a pass/fail
+`ALoraRequirement` validator. Consumed by `102_example.py` in this directory.
 """
 
 import mellea.stdlib.functional as mfuncs

--- a/docs/examples/aLora/stembolts_intrinsic.py
+++ b/docs/examples/aLora/stembolts_intrinsic.py
@@ -1,6 +1,14 @@
 # type: ignore
-# pytest: skip, huggingface, e2e
-# SKIP REASON: needs to update.
+"""Helper functions for loading and calling a fully custom, non-catalog adapter.
+
+`stembolts` (Hugging Face: `nfulton/stembolts`) is a custom aLoRA adapter for
+`granite-3.3-2b-instruct` with its own output schema
+(`{"defective_part": str, "diag_likelihood": float, ...}`) rather than the
+generic `{"requirement_check": {"score": ...}}` shape most catalog adapters use.
+It is invoked directly via `Intrinsic`/`mfuncs.act()` and the raw JSON is parsed
+by the caller — it is not a pass/fail `ALoraRequirement` validator. Consumed by
+`102_example.py` in this directory.
+"""
 
 import mellea.stdlib.functional as mfuncs
 from mellea.backends import Backend
@@ -9,7 +17,6 @@ from mellea.backends.adapters.adapter import CustomIntrinsicAdapter
 from mellea.core import Context
 from mellea.stdlib.components import Message
 from mellea.stdlib.components.intrinsic import Intrinsic
-from mellea.stdlib.components.simple import SimpleComponent
 
 _INTRINSIC_MODEL_ID = "nfulton/stembolts"
 _INTRINSIC_ADAPTER_NAME = "stembolts"

--- a/docs/examples/aLora/stembolts_intrinsic.py
+++ b/docs/examples/aLora/stembolts_intrinsic.py
@@ -40,14 +40,15 @@ async def async_stembolt_failure_analysis(
     notes: str, ctx: Context, backend: Backend | AdapterMixin
 ):
     # Backend.add_adapter should be idempotent, but we'll go ahead and check just in case.
-    if _INTRINSIC_ADAPTER_NAME not in backend.list_adapters():
-        backend.add_adapter(StemboltAdapter(backend.base_model_name))
+    adapter = StemboltAdapter(backend.base_model_name)
+    if adapter.qualified_name not in backend.list_adapters():
+        backend.add_adapter(adapter)
 
     ctx = ctx.add(Message("user", content=notes))
 
     action = StemboltIntrinsic()
-    mot = await backend.generate_from_context(action, ctx)
-    return mot
+    mot, ctx = await backend.generate_from_context(action, ctx)
+    return mot, ctx
 
 
 def stembolt_failure_analysis(

--- a/docs/examples/aLora/stembolts_intrinsic.py
+++ b/docs/examples/aLora/stembolts_intrinsic.py
@@ -39,7 +39,7 @@ class StemboltIntrinsic(Intrinsic):
 async def async_stembolt_failure_analysis(
     notes: str, ctx: Context, backend: Backend | AdapterMixin
 ):
-    # Backend.add_adapter should be idempotent, but we'll go ahead and check just in case.
+    # add_adapter() refuses a duplicate qualified name with a warning, so guard first.
     adapter = StemboltAdapter(backend.base_model_name)
     if adapter.qualified_name not in backend.list_adapters():
         backend.add_adapter(adapter)
@@ -54,7 +54,7 @@ async def async_stembolt_failure_analysis(
 def stembolt_failure_analysis(
     notes: str, ctx: Context, backend: Backend | AdapterMixin
 ):
-    # Backend.add_adapter should be idempotent, but we'll go ahead and check just in case.
+    # add_adapter() refuses a duplicate qualified name with a warning, so guard first.
     adapter = StemboltAdapter(backend.base_model_name)
     if adapter.qualified_name not in backend.list_adapters():
         backend.add_adapter(adapter)


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #385.

## Description

The aLoRA 101 example still imported the removed pre-intrinsics backend and, after a partial migration, paired a custom diagnostic adapter with `ALoraRequirement`'s incompatible requirement-check schema. The example was therefore skipped instead of teaching a working path.

This PR rewrites the example around the current intrinsics API. It uses the catalogue `requirement-check` adapter for `ALoraRequirement`, provides a genuine non-adapter comparison, and moves the custom `stembolts` demonstration to a direct intrinsic example with its own schema.

## Where this fits

This repairs the documentation/example slice of Epic #929 after the LocalFile/PEFT path in #1141. Broader shim removal and tutorial consolidation remain with #1144; training CLI work remains with #212.

## What changed

- Rewrite `101_example.py` to use supported intrinsic registration and requirement checking.
- Separate the custom `stembolts` adapter into its own direct-invocation example.
- Update the surrounding examples, training-data helper, and README to match the current API.
- Remove the fabricated performance comparison and document the limits of the example's timing output.

## Caveat

These are model-backed examples. They require the documented local dependencies, model access, and hardware; they are not part of the default test suite.

## Testing

The rewritten examples were run end-to-end with the supported intrinsic path. Required GitHub checks pass.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
