### PR TITLE
feat(streaming): add EventStreamer for iterating stream events

### DIFF
--- a/docs/dev/migrate-streaming-v0.8.md
+++ b/docs/dev/migrate-streaming-v0.8.md
@@ -8,9 +8,10 @@ finish.
 
 That two-task model is replaced by a single-task primitive: `stream()` returns a
 `Streamer` you consume directly with `async for`, on your own task. There is no
-background orchestrator and no `acomplete()`. Typed events now come from the
-`streaming_event` plugin hook rather than an iterator on the result. This is a
-**breaking change with no deprecation shim** — call sites must be updated.
+background orchestrator and no `acomplete()`. Typed events now come from an
+`EventStreamer`, returned by `stream(as_events=True)` and iterated with `async
+for`. This is a **breaking change with no deprecation shim** — call sites must be
+updated.
 
 ## API mapping
 
@@ -19,7 +20,7 @@ background orchestrator and no `acomplete()`. Typed events now come from the
 | `stream_with_chunking(...)` | `stream(...)` | Same arguments, except `chunking` now defaults to `None` (raw deltas) instead of `"sentence"`; pass `chunking="sentence"` to preserve v0.7 chunk boundaries |
 | returns `StreamChunkingResult` | returns `Streamer` | Consume with `async for`, ideally inside `async with` |
 | `async for chunk in result.astream()` | `async for chunk in streamer` | Iterate the `Streamer` directly |
-| `async for event in result.events()` | `@hook("streaming_event")` plugin | Events move to the hook (see below) |
+| `async for event in result.events()` | `async for event in streamer` | Iterate the `EventStreamer` directly (`stream(as_events=True)`) |
 | `await result.acomplete()` | *(removed)* | Consuming the stream drives it to completion |
 | `STREAMING_ORCHESTRATION_START`/`_END` hooks | *(removed)* | No replacement — the whole run is on one task now, so there is nothing to reattach a span across |
 | `result.completed` | `not streamer.failed_early` | |
@@ -55,10 +56,11 @@ subclass it or pass an instance). Passing a string alias — `chunking="sentence
 
 ## Before and after: observing events
 
-If you consumed typed events with `result.events()`, the events move to a
-`streaming_event` plugin. Both snippets below produce the same output — they are
-the `main()` from `docs/examples/streaming/validated_streaming.py`, v0.7 then
-v0.8, using the same requirement, prompt, and chunking.
+If you consumed typed events with `result.events()`, you now iterate an
+`EventStreamer` (`stream(as_events=True)`). Both snippets below produce the same
+output — they are the `main()` from
+`docs/examples/streaming/validated_streaming.py`, v0.7 then v0.8, using the same
+requirement, prompt, and chunking.
 
 ### v0.7
 
@@ -97,38 +99,29 @@ print(f"Full text: {result.full_text!r}")
 ### v0.8
 
 ```python
-@hook("streaming_event")
-async def print_events(payload, ctx) -> None:
-    event = payload.event
-    match event:
-        case ChunkEvent():
-            print(f"  CHUNK[{event.chunk_index}]: {event.text!r}")
-        case QuickCheckEvent(passed=False):
-            print(
-                f"  QUICK_CHECK[{event.chunk_index}]: FAIL — "
-                f"{event.results[0].reason if event.results else 'unknown reason'}"
-            )
-        case QuickCheckEvent():
-            print(f"  QUICK_CHECK[{event.chunk_index}]: pass")
-        case StreamingDoneEvent():
-            print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
-        case FullValidationEvent():
-            print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
-        case CompletedEvent():
-            print(f"  COMPLETED: success={event.success}")
-        case _:
-            pass
-
-
-register(print_events)
-
 print("Stream events as they arrive:")
 async with await stream(
-    action, backend, ctx, requirements=[req], chunking="sentence"
+    action, backend, ctx, requirements=[req], chunking="sentence", as_events=True
 ) as streamer:
-    # Draining the stream fires the events; the hook does the printing.
-    async for _chunk in streamer:
-        pass
+    async for event in streamer:
+        match event:
+            case ChunkEvent():
+                print(f"  CHUNK[{event.chunk_index}]: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(
+                    f"  QUICK_CHECK[{event.chunk_index}]: FAIL — "
+                    f"{event.results[0].reason if event.results else 'unknown reason'}"
+                )
+            case QuickCheckEvent():
+                print(f"  QUICK_CHECK[{event.chunk_index}]: pass")
+            case StreamingDoneEvent():
+                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+            case FullValidationEvent():
+                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+            case CompletedEvent():
+                print(f"  COMPLETED: success={event.success}")
+            case _:
+                pass
 
 print(f"\nCompleted normally: {streamer.completed_normally}")
 print(f"Full text: {streamer.full_text!r}")
@@ -136,13 +129,11 @@ print(f"Full text: {streamer.full_text!r}")
 
 The three transformations to make:
 
-1. **`stream_with_chunking(...)` → `async with await stream(...) as streamer:`**,
-   and iterate `streamer` directly. The `async with` replaces `acomplete()` for
-   cleanup.
-2. **The `result.events()` match loop → a `@hook("streaming_event")` plugin.**
-   The event vocabulary and payloads are unchanged; register the plugin (with
-   `register()` or a `plugin_scope`) before consuming. Draining the stream is
-   what fires the events.
+1. **`stream_with_chunking(...)` → `async with await stream(..., as_events=True)
+   as streamer:`**, and iterate `streamer` directly. The `async with` replaces
+   `acomplete()` for cleanup.
+2. **`async for event in result.events()` → `async for event in streamer`.** The
+   event vocabulary and payloads are unchanged.
 3. **`result.<attr>` → `streamer.<attr>`**. `result.completed` maps directly to
    `not streamer.failed_early`; prefer the new `streamer.completed_normally` if
    you need a signal that also excludes an early `break` (used above).

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -310,9 +310,36 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-To observe the run through typed `StreamEvent` objects instead, register a
-plugin on the `streaming_event` hook — see the
-[streaming validation tutorial](../tutorials/06-streaming-validation.md).
+### Consuming events with `EventStreamer`
+
+The `Streamer` above yields validated chunks. To consume the run's typed events
+instead, pass `as_events=True` to `stream()`: it returns an `EventStreamer` you
+iterate the same way, each step yielding an event rather than a chunk:
+
+```python
+async with await stream(
+    action, m.backend, m.ctx, requirements=[req], chunking="sentence", as_events=True
+) as streamer:
+    async for event in streamer:
+        match event:
+            case ChunkEvent():
+                print(f"  chunk[{event.chunk_index}]: {event.text!r}")
+            case QuickCheckEvent(passed=False):
+                print(f"  quick-check[{event.chunk_index}]: FAIL")
+            case StreamingDoneEvent():
+                print(f"  done — {len(event.full_text)} chars")
+            case FullValidationEvent():
+                print(f"  final validation: {'pass' if event.passed else 'fail'}")
+            case CompletedEvent():
+                print(f"  completed — success={event.success}")
+            case _:
+                pass  # ErrorEvent
+
+print(f"Completed normally: {streamer.completed_normally}")
+```
+
+See the [Streaming Validation tutorial](../tutorials/06-streaming-validation.md)
+for a full walkthrough.
 
 ### The `stream_validate` tri-state
 

--- a/docs/docs/how-to/use-async-and-streaming.md
+++ b/docs/docs/how-to/use-async-and-streaming.md
@@ -317,6 +317,14 @@ instead, pass `as_events=True` to `stream()`: it returns an `EventStreamer` you
 iterate the same way, each step yielding an event rather than a chunk:
 
 ```python
+from mellea.stdlib.streaming import (
+    ChunkEvent,
+    CompletedEvent,
+    FullValidationEvent,
+    QuickCheckEvent,
+    StreamingDoneEvent,
+)
+
 async with await stream(
     action, m.backend, m.ctx, requirements=[req], chunking="sentence", as_events=True
 ) as streamer:

--- a/docs/docs/tutorials/06-streaming-validation.md
+++ b/docs/docs/tutorials/06-streaming-validation.md
@@ -18,7 +18,7 @@ By the end you will have covered:
 - Early-exit cancellation and reading `streaming_failures`
 - Choosing between `"word"`, `"sentence"`, and `"paragraph"` chunking
 - Observing the typed event vocabulary (`ChunkEvent`, `QuickCheckEvent`, …)
-  through the `streaming_event` hook
+  by iterating `stream(as_events=True)`
 - Subclassing `ChunkingStrategy` to define a custom split boundary
 
 **Prerequisites:** [Tutorial 02](./streaming-and-async) (async and streaming),
@@ -322,11 +322,10 @@ common English word like `"and"` or `"the"`.
 
 ## Step 4: Observing the event lifecycle
 
-The `async for` loop gives you validated chunks. To observe the full lifecycle —
-per-chunk validation results, stream completion, final validation, errors —
-subscribe to the `streaming_event` hook. `stream()` fires one typed `StreamEvent`
-per lifecycle moment through this hook, so a plugin can watch a run without
-touching the chunk iterator.
+The `async for` loop above yields validated chunks. To observe the full lifecycle
+instead — per-chunk validation results, stream completion, final validation,
+errors — pass `as_events=True`: `stream()` then returns an `EventStreamer` that
+yields one typed `StreamEvent` per lifecycle moment in place of chunks.
 
 ```python
 # Requires: mellea
@@ -337,7 +336,6 @@ import re
 from mellea.core.backend import Backend
 from mellea.core.base import Context
 from mellea.core.requirement import PartialValidationResult, Requirement, ValidationResult
-from mellea.plugins import hook, register
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.streaming import (
     ChunkEvent,
@@ -376,40 +374,33 @@ class MaxSentencesReq(Requirement):
         return ValidationResult(result=self._count <= self._limit)
 
 
-@hook("streaming_event")
-async def print_events(payload, ctx) -> None:
-    event = payload.event
-    match event:
-        case ChunkEvent():
-            print(f"  chunk[{event.chunk_index}]: {event.text!r}")
-        case QuickCheckEvent(passed=False):
-            print(f"  FAIL at chunk {event.chunk_index}: {event.results[0].reason}")
-        case StreamingDoneEvent():
-            print(f"  stream done — {len(event.full_text)} chars")
-        case FullValidationEvent():
-            print(f"  final validation: {'pass' if event.passed else 'fail'}")
-        case CompletedEvent():
-            print(f"  completed — success={event.success}")
-        case _:
-            pass
-
-
 async def main() -> None:
     from mellea.stdlib.session import start_session
 
     m = start_session()
-    register(print_events)
 
-    # Draining the stream drives generation; print_events fires per event.
     async with await stream(
         Instruction("Write a two-sentence summary of the water cycle."),
         m.backend,
         m.ctx,
         requirements=[MaxSentencesReq(limit=3)],
         chunking="sentence",
+        as_events=True,
     ) as streamer:
-        async for _chunk in streamer:
-            pass
+        async for event in streamer:
+            match event:
+                case ChunkEvent():
+                    print(f"  chunk[{event.chunk_index}]: {event.text!r}")
+                case QuickCheckEvent(passed=False):
+                    print(f"  FAIL at chunk {event.chunk_index}: {event.results[0].reason}")
+                case StreamingDoneEvent():
+                    print(f"  stream done — {len(event.full_text)} chars")
+                case FullValidationEvent():
+                    print(f"  final validation: {'pass' if event.passed else 'fail'}")
+                case CompletedEvent():
+                    print(f"  completed — success={event.success}")
+                case _:
+                    pass
 
 
 asyncio.run(main())
@@ -577,7 +568,7 @@ explicitly or subclass to override `flush()`.
 | `stream()` + `requirements=` | Per-chunk validation with automatic early exit |
 | `async for chunk in streamer` | Validated chunks as they arrive, inside `async with` for safe cleanup |
 | `streamer.failed_early` / `streamer.streaming_failures` | Detect and inspect a mid-stream requirement failure |
-| `streaming_event` hook | Typed event stream — observe every chunk, validation result, and lifecycle signal |
+| `stream(as_events=True)` | Typed event stream (an `EventStreamer`) — observe every chunk, validation result, and lifecycle signal |
 | `"word"` / `"sentence"` / `"paragraph"` | Built-in chunking strategies trading reaction speed for context |
 | `ChunkingStrategy` subclass | Custom split boundaries for structured output (lists, code, CSV) |
 

--- a/docs/examples/streaming/README.md
+++ b/docs/examples/streaming/README.md
@@ -22,7 +22,7 @@ Demonstrates:
 - Streaming token-by-token generation
 - Sentence-level chunking via `stream()`
 - Per-chunk validation with custom `stream_validate()` methods
-- Accessing stream events via the STREAMING_EVENT hook
+- Iterating typed stream events via `stream(as_events=True)`
 - Early exit on validation failure
 
 ### Word-Level Chunking
@@ -76,7 +76,7 @@ Demonstrates:
 
 **Stream Validation**: Apply requirements at chunk level for early exit—stop generation when a constraint is violated.
 
-**Stream Events**: Process stream events through the `STREAMING_EVENT` hook to monitor generation progress:
+**Stream Events**: Observe a run's lifecycle as typed events — iterate them for one stream with `stream(as_events=True)`, or subscribe the `STREAMING_EVENT` hook to watch many streams at once:
 - `ChunkEvent` — A new chunk of text
 - `QuickCheckEvent` — Initial validation result
 - `FullValidationEvent` — Complete validation after full generation

--- a/docs/examples/streaming/custom_chunking.py
+++ b/docs/examples/streaming/custom_chunking.py
@@ -26,7 +26,6 @@ Extension pattern:
 
 import asyncio
 import re
-from typing import Any
 
 from mellea.core.backend import Backend
 from mellea.core.base import Context
@@ -35,7 +34,6 @@ from mellea.core.requirement import (
     Requirement,
     ValidationResult,
 )
-from mellea.plugins import hook, register
 from mellea.stdlib.chunking import ChunkingStrategy
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.streaming import (
@@ -143,37 +141,29 @@ async def main() -> None:
     chunker = LineChunking()
     req = NumberedLineReq()
 
-    @hook("streaming_event")
-    async def print_events(payload: Any, ctx: Any) -> None:
-        event = payload.event
-        match event:
-            case ChunkEvent():
-                print(f"  LINE[{event.chunk_index}]: {event.text!r}")
-            case QuickCheckEvent(passed=False):
-                print(
-                    f"  QUICK_CHECK[line {event.chunk_index}]: FAIL — "
-                    f"{event.results[0].reason if event.results else 'unknown'}"
-                )
-            case QuickCheckEvent():
-                print(f"  QUICK_CHECK[line {event.chunk_index}]: pass")
-            case StreamingDoneEvent():
-                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
-            case FullValidationEvent():
-                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
-            case CompletedEvent():
-                print(f"  COMPLETED: success={event.success}")
-            case _:
-                pass
-
-    register(print_events)
-
-    print("Stream events as they arrive (one per line):")
+    print("Stream events as they arrive (one ChunkEvent per line):")
     async with await stream(
-        action, backend, ctx, requirements=[req], chunking=chunker
+        action, backend, ctx, requirements=[req], chunking=chunker, as_events=True
     ) as streamer:
-        # Draining the stream fires the events; the hook does the printing.
-        async for _line in streamer:
-            pass
+        async for event in streamer:
+            match event:
+                case ChunkEvent():
+                    print(f"  LINE[{event.chunk_index}]: {event.text!r}")
+                case QuickCheckEvent(passed=False):
+                    print(
+                        f"  QUICK_CHECK[line {event.chunk_index}]: FAIL — "
+                        f"{event.results[0].reason if event.results else 'unknown'}"
+                    )
+                case QuickCheckEvent():
+                    print(f"  QUICK_CHECK[line {event.chunk_index}]: pass")
+                case StreamingDoneEvent():
+                    print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+                case FullValidationEvent():
+                    print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+                case CompletedEvent():
+                    print(f"  COMPLETED: success={event.success}")
+                case _:
+                    pass
 
     print(f"\nCompleted normally: {streamer.completed_normally}")
     if streamer.streaming_failures:

--- a/docs/examples/streaming/multi_stream_events.py
+++ b/docs/examples/streaming/multi_stream_events.py
@@ -5,7 +5,8 @@
 `stream()` yields validated chunks through `async for`, but its typed lifecycle
 events (`ChunkEvent`, `QuickCheckEvent`, `StreamingDoneEvent`,
 `FullValidationEvent`, `CompletedEvent`, `ErrorEvent`) are surfaced through the
-`STREAMING_EVENT` plugin hook rather than the iterator.
+`STREAMING_EVENT` plugin hook — or, for a single stream, from
+`stream(as_events=True)`.
 
 Demonstrates:
 - Registering a `@hook("streaming_event")` function to receive every stream's events

--- a/docs/examples/streaming/paragraph_chunking.py
+++ b/docs/examples/streaming/paragraph_chunking.py
@@ -20,7 +20,6 @@ heading structure, citation presence, or overall paragraph quality.
 """
 
 import asyncio
-from typing import Any
 
 from mellea.core.backend import Backend
 from mellea.core.base import Context
@@ -29,7 +28,6 @@ from mellea.core.requirement import (
     Requirement,
     ValidationResult,
 )
-from mellea.plugins import hook, register
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.streaming import (
     ChunkEvent,
@@ -101,42 +99,34 @@ async def main() -> None:
     )
     req = ParagraphLengthReq(max_words=_MAX_PARAGRAPH_WORDS)
 
-    @hook("streaming_event")
-    async def print_events(payload: Any, ctx: Any) -> None:
-        event = payload.event
-        match event:
-            case ChunkEvent():
-                word_count = len(event.text.split())
-                preview = event.text[:80].replace("\n", "↵")
-                print(
-                    f"  PARAGRAPH[{event.chunk_index}]: {word_count} words — "
-                    f"{preview!r}..."
-                )
-            case QuickCheckEvent(passed=False):
-                print(
-                    f"  QUICK_CHECK[para {event.chunk_index}]: FAIL — "
-                    f"{event.results[0].reason if event.results else 'unknown'}"
-                )
-            case QuickCheckEvent():
-                print(f"  QUICK_CHECK[para {event.chunk_index}]: pass")
-            case StreamingDoneEvent():
-                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
-            case FullValidationEvent():
-                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
-            case CompletedEvent():
-                print(f"  COMPLETED: success={event.success}")
-            case _:
-                pass
-
-    register(print_events)
-
-    print("Stream events as they arrive (one per paragraph):")
+    print("Stream events as they arrive (one ChunkEvent per paragraph):")
     async with await stream(
-        action, backend, ctx, requirements=[req], chunking="paragraph"
+        action, backend, ctx, requirements=[req], chunking="paragraph", as_events=True
     ) as streamer:
-        # Draining the stream fires the events; the hook does the printing.
-        async for _paragraph in streamer:
-            pass
+        async for event in streamer:
+            match event:
+                case ChunkEvent():
+                    word_count = len(event.text.split())
+                    preview = event.text[:80].replace("\n", "↵")
+                    print(
+                        f"  PARAGRAPH[{event.chunk_index}]: {word_count} words — "
+                        f"{preview!r}..."
+                    )
+                case QuickCheckEvent(passed=False):
+                    print(
+                        f"  QUICK_CHECK[para {event.chunk_index}]: FAIL — "
+                        f"{event.results[0].reason if event.results else 'unknown'}"
+                    )
+                case QuickCheckEvent():
+                    print(f"  QUICK_CHECK[para {event.chunk_index}]: pass")
+                case StreamingDoneEvent():
+                    print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+                case FullValidationEvent():
+                    print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+                case CompletedEvent():
+                    print(f"  COMPLETED: success={event.success}")
+                case _:
+                    pass
 
     print(f"\nCompleted normally: {streamer.completed_normally}")
     if streamer.streaming_failures:

--- a/docs/examples/streaming/validated_streaming.py
+++ b/docs/examples/streaming/validated_streaming.py
@@ -5,14 +5,13 @@
 Demonstrates:
 - Subclassing Requirement to override stream_validate() for early-exit checks
 - Calling stream() with sentence-level chunking
-- Observing the typed StreamEvents via the STREAMING_EVENT hook as they arrive
+- Iterating the typed StreamEvents from an EventStreamer (stream(as_events=True))
 - Driving the stream with `async with` + `async for` for safe cleanup
 - Reading terminal state (failed_early, full_text, final_validations) after the loop
 """
 
 import asyncio
 import re
-from typing import Any
 
 from mellea.core.backend import Backend
 from mellea.core.base import Context
@@ -21,7 +20,6 @@ from mellea.core.requirement import (
     Requirement,
     ValidationResult,
 )
-from mellea.plugins import hook, register
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.streaming import (
     ChunkEvent,
@@ -95,37 +93,29 @@ async def main() -> None:
     )
     req = MaxSentencesReq(limit=3)
 
-    @hook("streaming_event")
-    async def print_events(payload: Any, ctx: Any) -> None:
-        event = payload.event
-        match event:
-            case ChunkEvent():
-                print(f"  CHUNK[{event.chunk_index}]: {event.text!r}")
-            case QuickCheckEvent(passed=False):
-                print(
-                    f"  QUICK_CHECK[{event.chunk_index}]: FAIL — "
-                    f"{event.results[0].reason if event.results else 'unknown reason'}"
-                )
-            case QuickCheckEvent():
-                print(f"  QUICK_CHECK[{event.chunk_index}]: pass")
-            case StreamingDoneEvent():
-                print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
-            case FullValidationEvent():
-                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
-            case CompletedEvent():
-                print(f"  COMPLETED: success={event.success}")
-            case _:
-                pass  # RetryEvent and any future event types
-
-    register(print_events)
-
     print("Stream events as they arrive:")
     async with await stream(
-        action, backend, ctx, requirements=[req], chunking="sentence"
+        action, backend, ctx, requirements=[req], chunking="sentence", as_events=True
     ) as streamer:
-        # Draining the stream fires the events; the hook does the printing.
-        async for _chunk in streamer:
-            pass
+        async for event in streamer:
+            match event:
+                case ChunkEvent():
+                    print(f"  CHUNK[{event.chunk_index}]: {event.text!r}")
+                case QuickCheckEvent(passed=False):
+                    print(
+                        f"  QUICK_CHECK[{event.chunk_index}]: FAIL — "
+                        f"{event.results[0].reason if event.results else 'unknown reason'}"
+                    )
+                case QuickCheckEvent():
+                    print(f"  QUICK_CHECK[{event.chunk_index}]: pass")
+                case StreamingDoneEvent():
+                    print(f"  STREAMING_DONE: {len(event.full_text)} chars accumulated")
+                case FullValidationEvent():
+                    print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+                case CompletedEvent():
+                    print(f"  COMPLETED: success={event.success}")
+                case _:
+                    pass  # RetryEvent and any future event types
 
     print(f"\nCompleted normally: {streamer.completed_normally}")
     print(f"Full text: {streamer.full_text!r}")

--- a/docs/examples/streaming/word_chunking.py
+++ b/docs/examples/streaming/word_chunking.py
@@ -20,7 +20,6 @@ token-local — forbidden words, length budgets, numeric thresholds.
 """
 
 import asyncio
-from typing import Any
 
 from mellea.core.backend import Backend
 from mellea.core.base import Context
@@ -29,7 +28,6 @@ from mellea.core.requirement import (
     Requirement,
     ValidationResult,
 )
-from mellea.plugins import hook, register
 from mellea.stdlib.components import Instruction
 from mellea.stdlib.streaming import (
     ChunkEvent,
@@ -96,41 +94,32 @@ async def main() -> None:
 
     word_count = 0
 
-    @hook("streaming_event")
-    async def print_events(payload: Any, ctx: Any) -> None:
-        nonlocal word_count
-        event = payload.event
-        match event:
-            case ChunkEvent():
-                word_count += 1
-                # Only print every 5th word to keep output readable
-                if word_count % 5 == 1:
-                    print(f"  ...word {word_count}: {event.text!r}")
-            case QuickCheckEvent(passed=False):
-                print(
-                    f"  QUICK_CHECK[word {event.chunk_index}]: FAIL — "
-                    f"{event.results[0].reason if event.results else 'unknown'}"
-                )
-            case StreamingDoneEvent():
-                print(
-                    f"  STREAMING_DONE: {word_count} words, {len(event.full_text)} chars"
-                )
-            case FullValidationEvent():
-                print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
-            case CompletedEvent():
-                print(f"  COMPLETED: success={event.success}")
-            case _:
-                pass
-
-    register(print_events)
-
-    print("Stream events as they arrive (one per word):")
+    print("Stream events as they arrive (one ChunkEvent per word):")
     async with await stream(
-        action, backend, ctx, requirements=[req], chunking="word"
+        action, backend, ctx, requirements=[req], chunking="word", as_events=True
     ) as streamer:
-        # Draining the stream fires the events; the hook does the printing.
-        async for _word in streamer:
-            pass
+        async for event in streamer:
+            match event:
+                case ChunkEvent():
+                    word_count += 1
+                    # Only print every 5th word to keep output readable
+                    if word_count % 5 == 1:
+                        print(f"  ...word {word_count}: {event.text!r}")
+                case QuickCheckEvent(passed=False):
+                    print(
+                        f"  QUICK_CHECK[word {event.chunk_index}]: FAIL — "
+                        f"{event.results[0].reason if event.results else 'unknown'}"
+                    )
+                case StreamingDoneEvent():
+                    print(
+                        f"  STREAMING_DONE: {word_count} words, {len(event.full_text)} chars"
+                    )
+                case FullValidationEvent():
+                    print(f"  FULL_VALIDATION: {'PASS' if event.passed else 'FAIL'}")
+                case CompletedEvent():
+                    print(f"  COMPLETED: success={event.success}")
+                case _:
+                    pass
 
     print(f"\nCompleted normally: {streamer.completed_normally}")
     if streamer.streaming_failures:

--- a/mellea/stdlib/__init__.py
+++ b/mellea/stdlib/__init__.py
@@ -16,7 +16,9 @@ Streaming chunking strategies (for use with streaming validation) are available 
 `mellea.stdlib.chunking` and re-exported here for convenience, alongside the
 `Chunker` that drives them over a stream.  The core streaming primitive `stream()`
 and its async-iterable handle `Streamer` are also re-exported here, alongside the
-full `StreamEvent` vocabulary for typed event observation.
+full `StreamEvent` vocabulary for typed event observation.  Passing `as_events=True`
+to `stream()` yields an `EventStreamer` that iterates those events in place of
+chunks.
 
 Low-level primitives for tool execution are available in `mellea.stdlib.functional`:
 `call_tools` and `acall_tools` for executing model-requested tool calls with full
@@ -36,6 +38,7 @@ from .streaming import (
     ChunkEvent,
     CompletedEvent,
     ErrorEvent,
+    EventStreamer,
     FullValidationEvent,
     QuickCheckEvent,
     Streamer,
@@ -50,6 +53,7 @@ __all__ = [
     "ChunkingStrategy",
     "CompletedEvent",
     "ErrorEvent",
+    "EventStreamer",
     "FullValidationEvent",
     "ParagraphChunking",
     "QuickCheckEvent",

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -443,7 +443,11 @@ class EventStreamer:
                 try:
                     await self._pump_task
                 except asyncio.CancelledError:
-                    pass  # we cancelled it; consume the resulting CancelledError
+                    # Consume the pump's own cancellation; propagate an external
+                    # cancel of this task (cancelling() > 0).
+                    cur = asyncio.current_task()
+                    if cur is not None and cur.cancelling() > 0:
+                        raise
             elif not self._pump_task.cancelled():
                 # Retrieve the stored exception so it isn't "never retrieved" at GC.
                 self._pump_task.exception()

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -12,7 +12,9 @@ task, and leaving the block — normally, on early `break`, or on exception —
 cancels the generation and fires the `STREAMING_END` hook.
 
 Typed `StreamEvent` objects are emitted via the `STREAMING_EVENT` hook; subscribe a
-plugin to observe them (see `docs/examples/streaming/`).
+plugin to observe them (see `docs/examples/streaming/`). To iterate them directly
+instead, `stream(as_events=True)` returns an `EventStreamer` that yields events in
+place of chunks.
 """
 
 from __future__ import annotations
@@ -23,7 +25,7 @@ import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, overload
 
 from ..backends.model_options import ModelOption
 from ..core.backend import Backend
@@ -203,6 +205,8 @@ class Streamer:
         chunking: Resolved chunking strategy, or `None` for raw deltas.
         requirements: Requirements to validate against; pre-copied by `stream`.
         validation_backend: Backend used for validation calls.
+        event_queue: Optional queue; when set, every emitted `StreamEvent` is
+            also pushed onto it. `None` for the plain chunk-iterating path.
 
     Attributes:
         failed_early: `True` if a requirement returned `"fail"` during streaming
@@ -231,6 +235,7 @@ class Streamer:
         requirements: list[Requirement],
         validation_backend: Backend,
         streaming_id: str,
+        event_queue: asyncio.Queue[StreamEvent | None] | None = None,
     ) -> None:
         """Wrap an in-flight generation; iterating the `Streamer` drives it."""
         self.failed_early: bool = False
@@ -243,6 +248,7 @@ class Streamer:
         # Correlates this stream's START/EVENT/END hooks; created in `stream()`
         # so START can fire before generation opens the backend span.
         self.streaming_id: str = streaming_id
+        self._event_queue = event_queue
         # The in-flight thunk, for teardown. Held separately from the public `mot`,
         # which is only set once the stream completes.
         self._mot = mot
@@ -286,6 +292,7 @@ class Streamer:
                     CompletedEvent(
                         success=success, full_text=self.full_text, attempts_used=1
                     ),
+                    event_queue=self._event_queue,
                 )
             finally:
                 if has_plugins(HookType.STREAMING_END):
@@ -331,14 +338,178 @@ class Streamer:
 
 
 # ---------------------------------------------------------------------------
+# EventStreamer handle
+# ---------------------------------------------------------------------------
+
+
+class EventStreamer:
+    """Async-iterator handle over a stream's `StreamEvent` objects.
+
+    Returned by `stream(..., as_events=True)`; iterate with `async for` inside
+    `async with`. It is its own iterator, so `break` then iterating again
+    resumes from the next queued event. Events are produced eagerly, independent
+    of consumption, so the stream can run ahead of iteration; outcome attributes
+    (`full_text`, `completed_normally`, …) mirror the wrapped `Streamer`. Do not
+    instantiate directly.
+    """
+
+    def __init__(self) -> None:
+        """Create an idle handle; `stream()` spawns the pump task."""
+        self._queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
+        self._streamer: Streamer | None = None
+        self._pump_task: asyncio.Task[None] | None = None
+        self._ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self._exhausted: bool = False  # set when the terminating None is drained
+
+    async def _pump(
+        self,
+        action: Component[Any] | CBlock,
+        backend: Backend,
+        ctx: Context,
+        *,
+        chunking: str | ChunkingStrategy | None,
+        requirements: Sequence[Requirement] | None,
+        validation_backend: Backend | None,
+    ) -> None:
+        """Drive the stream to completion, funnelling its events into the queue."""
+        try:
+            self._streamer = await _stream(
+                action,
+                backend,
+                ctx,
+                chunking=chunking,
+                requirements=requirements,
+                validation_backend=validation_backend,
+                event_queue=self._queue,
+            )
+        except BaseException as exc:
+            # Resolve _ready on every setup exit so `await _ready` can't hang.
+            if isinstance(exc, Exception):
+                self._ready.set_exception(exc)
+            else:
+                self._ready.cancel()
+            self._queue.put_nowait(None)
+            if not isinstance(exc, Exception):
+                raise
+            return
+        self._ready.set_result(None)
+        try:
+            async for _ in self._streamer:
+                pass
+        finally:
+            self._queue.put_nowait(None)
+
+    def __aiter__(self) -> AsyncIterator[StreamEvent]:
+        """Return this handle as its own event iterator."""
+        return self
+
+    async def __anext__(self) -> StreamEvent:
+        """Return the next queued event, stopping once the queue is drained.
+
+        Returns:
+            StreamEvent: The next event from the queue.
+
+        Raises:
+            StopAsyncIteration: Once the terminating `None` has been drained.
+        """
+        if self._exhausted:
+            raise StopAsyncIteration
+        item = await self._queue.get()
+        if item is None:
+            self._exhausted = True
+            assert self._pump_task is not None
+            # A faulted pump re-raises here; skip our own aclose() cancellation.
+            if not self._pump_task.cancelled():
+                await self._pump_task
+            raise StopAsyncIteration
+        return item
+
+    async def __aenter__(self) -> EventStreamer:
+        """Enter the async context manager, returning this `EventStreamer`."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Exit the context manager, releasing the stream via `aclose()`."""
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Cancel the pump and release the underlying stream, idempotently.
+
+        Prefer `async with stream(..., as_events=True) as s:` so this runs
+        automatically on every exit path.
+        """
+        if self._pump_task is not None:
+            if not self._pump_task.done():
+                self._pump_task.cancel()
+                try:
+                    await self._pump_task
+                except asyncio.CancelledError:
+                    pass  # we cancelled it; consume the resulting CancelledError
+            elif not self._pump_task.cancelled():
+                # Retrieve the stored exception so it isn't "never retrieved" at GC.
+                self._pump_task.exception()
+        if self._streamer is not None:
+            await self._streamer.aclose()
+
+    # Outcome properties delegate to the wrapped Streamer, falling back to its
+    # pre-iteration defaults until the pump has created it.
+
+    @property
+    def failed_early(self) -> bool:
+        """`True` if a requirement failed during streaming and stopped it early."""
+        return self._streamer.failed_early if self._streamer is not None else False
+
+    @property
+    def completed_normally(self) -> bool:
+        """`True` only if the stream reached its natural end, prior to final validation."""
+        return (
+            self._streamer.completed_normally if self._streamer is not None else False
+        )
+
+    @property
+    def failure_reason(self) -> str | None:
+        """Human-readable reason when `failed_early` is `True`; else `None`."""
+        return self._streamer.failure_reason if self._streamer is not None else None
+
+    @property
+    def streaming_failures(self) -> list[tuple[Requirement, PartialValidationResult]]:
+        """`(Requirement, PartialValidationResult)` pairs for each failing requirement."""
+        return self._streamer.streaming_failures if self._streamer is not None else []
+
+    @property
+    def full_text(self) -> str:
+        """Validated-and-emitted output; the full text on natural completion."""
+        return self._streamer.full_text if self._streamer is not None else ""
+
+    @property
+    def mot(self) -> ModelOutputThunk | None:
+        """The computed thunk, set on natural completion; `None` otherwise."""
+        return self._streamer.mot if self._streamer is not None else None
+
+    @property
+    def final_validations(self) -> list[ValidationResult]:
+        """`ValidationResult` objects from the stream-end `validate()` calls."""
+        return self._streamer.final_validations if self._streamer is not None else []
+
+    @property
+    def streaming_id(self) -> str | None:
+        """UUID correlating this stream's START/EVENT/END hooks; `None` pre-start."""
+        return self._streamer.streaming_id if self._streamer is not None else None
+
+
+# ---------------------------------------------------------------------------
 # Driver
 # ---------------------------------------------------------------------------
 
 
 async def _emit_event(
-    streaming_id: str, ev: StreamEvent, *, requirements: list[Requirement] | None = None
+    streaming_id: str,
+    ev: StreamEvent,
+    *,
+    requirements: list[Requirement] | None = None,
+    event_queue: asyncio.Queue[StreamEvent | None] | None = None,
 ) -> None:
-    """Fire the STREAMING_EVENT hook for `ev`.
+    """Fire the STREAMING_EVENT hook for `ev`, also pushing it onto `event_queue` if set.
 
     For a `QuickCheckEvent`, `requirements` carries the active requirement
     instances in result order so a subscriber can attribute each result.
@@ -348,7 +519,11 @@ async def _emit_event(
         ev: The event to emit.
         requirements: Active requirements for a `QuickCheckEvent`, in result
             order; `None` for other event types.
+        event_queue: Optional queue; when set, `ev` is also pushed onto it.
+            `None` for the plain chunk-iterating path.
     """
+    if event_queue is not None:
+        event_queue.put_nowait(ev)
     if has_plugins(HookType.STREAMING_EVENT):
         from ..plugins.hooks.streaming import StreamingEventPayload
 
@@ -410,6 +585,7 @@ async def _validate_chunk(
             chunk_index=chunk_index, attempt=1, passed=not failures, results=results
         ),
         requirements=requirements,
+        event_queue=streamer._event_queue,
     )
     if not failures:
         return True
@@ -485,6 +661,7 @@ async def _drive(
                 await _emit_event(
                     streamer.streaming_id,
                     ChunkEvent(text=c, chunk_index=chunk_index, attempt=1),
+                    event_queue=streamer._event_queue,
                 )
                 yield c
                 chunk_index += 1
@@ -506,6 +683,7 @@ async def _drive(
                 await _emit_event(
                     streamer.streaming_id,
                     ChunkEvent(text=c, chunk_index=chunk_index, attempt=1),
+                    event_queue=streamer._event_queue,
                 )
                 yield c
                 chunk_index += 1
@@ -514,7 +692,9 @@ async def _drive(
         streamer.mot = mot
         streamer.completed_normally = True
         await _emit_event(
-            streamer.streaming_id, StreamingDoneEvent(attempt=1, full_text=accumulated)
+            streamer.streaming_id,
+            StreamingDoneEvent(attempt=1, full_text=accumulated),
+            event_queue=streamer._event_queue,
         )
 
         # Reached only on natural completion, so every requirement is still
@@ -532,6 +712,7 @@ async def _drive(
                     passed=all(v.as_bool() for v in streamer.final_validations),
                     results=streamer.final_validations,
                 ),
+                event_queue=streamer._event_queue,
             )
         success = True
     except Exception as exc:
@@ -541,6 +722,7 @@ async def _drive(
         await _emit_event(
             streamer.streaming_id,
             ErrorEvent(exception_type=type(exc).__name__, detail=str(exc)),
+            event_queue=streamer._event_queue,
         )
         raise
     finally:
@@ -555,7 +737,7 @@ async def _drive(
 # ---------------------------------------------------------------------------
 
 
-async def stream(
+async def _stream(
     action: Component[Any] | CBlock,
     backend: Backend,
     ctx: Context,
@@ -563,24 +745,12 @@ async def stream(
     chunking: str | ChunkingStrategy | None = None,
     requirements: Sequence[Requirement] | None = None,
     validation_backend: Backend | None = None,
+    event_queue: asyncio.Queue[StreamEvent | None] | None = None,
 ) -> Streamer:
-    """Start a streaming generation.
+    """Start a streaming generation and return its `Streamer`.
 
-    Generation begins eagerly, before this call returns. Consume the returned
-    `Streamer` inside `async with` so the stream is always released. On early
-    exit or `break`, `async with` cancels the in-flight generation:
-
-    ```python
-    async with await stream(action, backend, ctx) as s:
-        async for chunk in s:
-            ...
-    ```
-
-    Each iteration yields a chunk — a unit produced by the `chunking` strategy,
-    or the raw model delta when `chunking` is `None`. A chunk is delivered once it
-    has passed every requirement's `stream_validate`; a `"fail"` stops the stream
-    early and cancels the backend. On natural completion, `validate()` runs on the
-    full output. With no `requirements`, chunks are yielded without validation.
+    The implementation behind the public `stream()`; see it for the full
+    contract.
 
     Args:
         action: The component or content block to generate from.
@@ -593,6 +763,8 @@ async def stream(
             streaming and against the full output at stream end. `None` yields
             chunks without validation.
         validation_backend: Backend for validation calls; defaults to `backend`.
+        event_queue: Optional queue; when set, every emitted `StreamEvent` is
+            also pushed onto it. `None` for the plain chunk-iterating path.
 
     Returns:
         Streamer: An async-iterable handle over the validated chunks.
@@ -649,4 +821,133 @@ async def stream(
             )
         raise
 
-    return Streamer(mot, gen_ctx, strategy, cloned_reqs, resolved_backend, streaming_id)
+    return Streamer(
+        mot, gen_ctx, strategy, cloned_reqs, resolved_backend, streaming_id, event_queue
+    )
+
+
+@overload
+async def stream(
+    action: Component[Any] | CBlock,
+    backend: Backend,
+    ctx: Context,
+    *,
+    chunking: str | ChunkingStrategy | None = ...,
+    requirements: Sequence[Requirement] | None = ...,
+    validation_backend: Backend | None = ...,
+    as_events: Literal[False] = ...,
+) -> Streamer: ...
+
+
+@overload
+async def stream(
+    action: Component[Any] | CBlock,
+    backend: Backend,
+    ctx: Context,
+    *,
+    chunking: str | ChunkingStrategy | None = ...,
+    requirements: Sequence[Requirement] | None = ...,
+    validation_backend: Backend | None = ...,
+    as_events: Literal[True],
+) -> EventStreamer: ...
+
+
+@overload
+async def stream(
+    action: Component[Any] | CBlock,
+    backend: Backend,
+    ctx: Context,
+    *,
+    chunking: str | ChunkingStrategy | None = ...,
+    requirements: Sequence[Requirement] | None = ...,
+    validation_backend: Backend | None = ...,
+    as_events: bool,
+) -> Streamer | EventStreamer: ...
+
+
+async def stream(
+    action: Component[Any] | CBlock,
+    backend: Backend,
+    ctx: Context,
+    *,
+    chunking: str | ChunkingStrategy | None = None,
+    requirements: Sequence[Requirement] | None = None,
+    validation_backend: Backend | None = None,
+    as_events: bool = False,
+) -> Streamer | EventStreamer:
+    """Start a streaming generation.
+
+    Generation begins eagerly, before this call returns. Consume the returned
+    handle inside `async with` so the stream is always released. On early exit or
+    `break`, `async with` cancels the in-flight generation:
+
+    ```python
+    async with await stream(action, backend, ctx) as s:
+        async for chunk in s:
+            ...
+    ```
+
+    By default this yields validated `str` chunks. Each iteration yields a chunk —
+    a unit produced by the `chunking` strategy, or the raw model delta when
+    `chunking` is `None`. A chunk is delivered once it has passed every
+    requirement's `stream_validate`; a `"fail"` stops the stream early and cancels
+    the backend. On natural completion, `validate()` runs on the full output. With
+    no `requirements`, chunks are yielded without validation.
+
+    With `as_events=True`, this returns an `EventStreamer` instead: iterating it
+    yields the stream's typed `StreamEvent` objects (the same events otherwise seen
+    only via the `STREAMING_EVENT` hook). The terminal `CompletedEvent`/`ErrorEvent`
+    come through the iterator too; an early `break` leaves them queued, so iterating
+    again drains them. Each `ChunkEvent` carries its text, so no output is lost.
+
+    Args:
+        action: The component or content block to generate from.
+        backend: Backend used for generation and, unless `validation_backend`
+            is set, validation.
+        ctx: The generation context.
+        chunking: A `ChunkingStrategy`, a recognized alias string, or `None`
+            (default) to yield raw deltas unchunked.
+        requirements: Requirements validated against each chunk during
+            streaming and against the full output at stream end. `None` yields
+            chunks without validation.
+        validation_backend: Backend for validation calls; defaults to `backend`.
+        as_events: When `True`, return an `EventStreamer` that iterates typed
+            `StreamEvent` objects; when `False` (default), return a `Streamer`
+            that iterates validated `str` chunks.
+
+    Returns:
+        Streamer | EventStreamer: A `Streamer` over validated chunks, or — when
+            `as_events=True` — an `EventStreamer` over the stream's events.
+
+    Raises:
+        ValueError: If `chunking` is a string that is not a known alias.
+        RuntimeError: If the backend returns an already-computed thunk instead
+            of a streaming one — i.e. it is not honouring `ModelOption.STREAM`.
+    """
+    if as_events:
+        event_streamer = EventStreamer()
+        event_streamer._pump_task = asyncio.create_task(
+            event_streamer._pump(
+                action,
+                backend,
+                ctx,
+                chunking=chunking,
+                requirements=requirements,
+                validation_backend=validation_backend,
+            )
+        )
+        try:
+            await event_streamer._ready
+        except BaseException:
+            await event_streamer.aclose()
+            raise
+        return event_streamer
+
+    return await _stream(
+        action,
+        backend,
+        ctx,
+        chunking=chunking,
+        requirements=requirements,
+        validation_backend=validation_backend,
+    )

--- a/mellea/stdlib/streaming.py
+++ b/mellea/stdlib/streaming.py
@@ -384,13 +384,12 @@ class EventStreamer:
             )
         except BaseException as exc:
             # Resolve _ready on every setup exit so `await _ready` can't hang.
-            if isinstance(exc, Exception):
-                self._ready.set_exception(exc)
-            else:
+            if isinstance(exc, asyncio.CancelledError):
                 self._ready.cancel()
-            self._queue.put_nowait(None)
-            if not isinstance(exc, Exception):
+                self._queue.put_nowait(None)
                 raise
+            self._ready.set_exception(exc)
+            self._queue.put_nowait(None)
             return
         self._ready.set_result(None)
         try:

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -1705,6 +1705,39 @@ async def test_event_streamer_drain_after_close_is_cancel_tolerant() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_streamer_aclose_propagates_outer_cancellation() -> None:
+    """Outer cancellation of the task running aclose() must propagate, not be absorbed."""
+    inner_cancelled = asyncio.Event()
+
+    async def _absorbs_first_cancel() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            # aclose() has issued its .cancel(); it is now blocked awaiting us.
+            inner_cancelled.set()
+            await asyncio.sleep(60)  # absorb so aclose stays at the await
+
+    es = EventStreamer()
+    es._pump_task = asyncio.create_task(_absorbs_first_cancel())
+    await asyncio.sleep(0)
+
+    close_task = asyncio.create_task(es.aclose())
+    await asyncio.wait_for(inner_cancelled.wait(), timeout=2.0)
+
+    # Cancel the aclose task from outside (simulates a wait_for timeout or an
+    # outer TaskGroup cancelling this coroutine).
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(close_task, timeout=2.0)
+
+    es._pump_task.cancel()
+    try:
+        await asyncio.wait_for(es._pump_task, timeout=1.0)
+    except (TimeoutError, asyncio.CancelledError):
+        pass
+
+
+@pytest.mark.asyncio
 async def test_event_streamer_iteration_after_exhaustion_stops() -> None:
     """A second full iteration terminates immediately, not blocking on an empty queue."""
     backend = StreamingMockBackend("One. Two. ", token_size=2)

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -37,6 +37,7 @@ from mellea.stdlib.streaming import (
     ChunkEvent,
     CompletedEvent,
     ErrorEvent,
+    EventStreamer,
     FullValidationEvent,
     QuickCheckEvent,
     RetryEvent,
@@ -140,6 +141,51 @@ class StreamingMockBackend(Backend):
         _ = task
         new_ctx = ctx.add(action).add(mot)
         return mot, new_ctx
+
+    async def _generate_from_raw(
+        self, actions: Any, ctx: Any, **kwargs: Any
+    ) -> tuple[list[ModelOutputThunk], dict[str, Any] | None]:
+        raise NotImplementedError
+
+
+async def _feed_tokens_then_error(
+    mot: ModelOutputThunk, response: str, token_size: int
+) -> None:
+    """Feed `response` one token at a time, then push an exception onto the queue."""
+    i = 0
+    while i < len(response):
+        await mot._gen.queue.put(response[i : i + token_size])
+        await asyncio.sleep(0)
+        i += token_size
+    await mot._gen.queue.put(RuntimeError("stream boom"))
+
+
+class StreamingErrorBackend(Backend):
+    """Streams a few tokens, then raises mid-generation."""
+
+    _model_id: str = "streaming-error-model"
+    _provider: str = "streaming-error-provider"
+
+    def __init__(self, response: str, token_size: int = 2) -> None:
+        self._response = response
+        self._token_size = token_size
+
+    async def _generate_from_context(
+        self,
+        action: Any,
+        ctx: Context,
+        *,
+        format: Any = None,
+        model_options: dict | None = None,
+        tool_calls: bool = False,
+    ) -> tuple[ModelOutputThunk, Context]:
+        _ = format, model_options, tool_calls
+        mot = _make_mot()
+        task = asyncio.create_task(
+            _feed_tokens_then_error(mot, self._response, self._token_size)
+        )
+        _ = task
+        return mot, ctx.add(action).add(mot)
 
     async def _generate_from_raw(
         self, actions: Any, ctx: Any, **kwargs: Any
@@ -1146,6 +1192,21 @@ async def test_exception_in_stream_validate_propagates_and_cancels() -> None:
 
 
 @pytest.mark.asyncio
+async def test_backend_error_mid_stream_propagates_and_cancels() -> None:
+    """A backend error during generation propagates from the loop and cancels gen."""
+    backend = StreamingErrorBackend("One. Two. ", token_size=2)
+
+    streamer = await stream(_action(), backend, _ctx(), chunking="sentence")
+    with pytest.raises(RuntimeError, match="stream boom"):
+        async with streamer:
+            async for _chunk in streamer:
+                pass
+
+    assert streamer.completed_normally is False
+    assert streamer._mot.is_computed() is True
+
+
+@pytest.mark.asyncio
 async def test_rejects_precomputed_mot() -> None:
     """A backend returning an already-computed MOT raises RuntimeError.
 
@@ -1430,6 +1491,323 @@ async def test_error_event_on_stream_validate_exception() -> None:
     assert len(error_events) == 1
     assert error_events[0].exception_type == "RuntimeError"
     assert "boom" in error_events[0].detail
+
+
+# ---------------------------------------------------------------------------
+# EventStreamer (stream(as_events=True))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_as_events_returns_event_streamer() -> None:
+    """stream(as_events=True) returns an EventStreamer; the default returns a Streamer."""
+    backend = StreamingMockBackend("One. ", token_size=2)
+    es = await stream(_action(), backend, _ctx(), as_events=True, chunking="sentence")
+    assert isinstance(es, EventStreamer)
+    await es.aclose()
+
+    backend2 = StreamingMockBackend("One. ", token_size=2)
+    s = await stream(_action(), backend2, _ctx(), chunking="sentence")
+    assert isinstance(s, Streamer)
+    await s.aclose()
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_natural_completion() -> None:
+    """Iterating events yields per-chunk pairs, then Done/FullValidation/Completed."""
+    response = "One. Two. "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    events: list[StreamEvent] = []
+    async with await stream(
+        _action(),
+        backend,
+        _ctx(),
+        requirements=[AlwaysUnknownReq()],
+        chunking="sentence",
+        as_events=True,
+    ) as es:
+        async for ev in es:
+            events.append(ev)
+
+    types = [type(e) for e in events]
+    # Per-chunk QuickCheck/Chunk pairs precede the terminal trio.
+    assert types[0] is QuickCheckEvent
+    assert types[1] is ChunkEvent
+    assert types[-3:] == [StreamingDoneEvent, FullValidationEvent, CompletedEvent]
+    # Terminal CompletedEvent is delivered through the iterator on success.
+    assert isinstance(events[-1], CompletedEvent)
+    assert events[-1].success is True
+    # ChunkEvent.text carries each chunk — the same chunks a Streamer would yield.
+    chunk_texts = [e.text for e in events if isinstance(e, ChunkEvent)]
+    assert chunk_texts == ["One.", "Two."]
+    # Outcome properties mirror the wrapped Streamer.
+    assert es.completed_normally is True
+    assert es.full_text == response
+    assert es.failed_early is False
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_requirement_fail_no_raise() -> None:
+    """A mid-stream requirement failure yields a failing QuickCheck + Completed, no raise."""
+    response = "one two three four five six "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    events: list[StreamEvent] = []
+    async with await stream(
+        _action(),
+        backend,
+        _ctx(),
+        requirements=[FailAfterWordsReq(threshold=3)],
+        chunking="word",
+        as_events=True,
+    ) as es:
+        async for ev in es:
+            events.append(ev)
+
+    quick_checks = [e for e in events if isinstance(e, QuickCheckEvent)]
+    assert quick_checks[-1].passed is False
+    # No natural-completion events on early exit; Completed is still delivered.
+    assert not any(
+        isinstance(e, (StreamingDoneEvent, FullValidationEvent)) for e in events
+    )
+    assert isinstance(events[-1], CompletedEvent)
+    assert events[-1].success is False
+    assert es.failed_early is True
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_error_reraises() -> None:
+    """A mid-stream error yields Error + Completed, then the loop re-raises."""
+
+    class _RaisingReq(Requirement):
+        def format_for_llm(self) -> str:
+            return "raiser"
+
+        async def stream_validate(
+            self, chunk: str, *, backend: Any, ctx: Any
+        ) -> PartialValidationResult:
+            raise RuntimeError("boom")
+
+        async def validate(
+            self,
+            backend: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: Any = None,
+        ) -> ValidationResult:
+            return ValidationResult(result=True)
+
+    backend = StreamingMockBackend("Hello world. ", token_size=3)
+
+    events: list[StreamEvent] = []
+    with pytest.raises(RuntimeError, match="boom"):
+        async with await stream(
+            _action(),
+            backend,
+            _ctx(),
+            requirements=[_RaisingReq()],
+            chunking="sentence",
+            as_events=True,
+        ) as es:
+            async for ev in es:
+                events.append(ev)
+
+    # The consumer still sees the terminal events before the exception surfaces.
+    error_events = [e for e in events if isinstance(e, ErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].exception_type == "RuntimeError"
+    assert isinstance(events[-1], CompletedEvent)
+    assert events[-1].success is False
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_early_break_releases_pump() -> None:
+    """An early break releases the background pump without leaking the task."""
+    response = "One. Two. Three. Four. Five. "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    seen = 0
+    async with await stream(
+        _action(), backend, _ctx(), chunking="sentence", as_events=True
+    ) as es:
+        async for ev in es:
+            if isinstance(ev, ChunkEvent):
+                seen += 1
+                if seen == 2:
+                    break
+
+    assert seen == 2
+    # aclose() (via __aexit__) cancelled and awaited the pump — no orphan task.
+    assert es._pump_task is not None
+    assert es._pump_task.done() is True
+    assert es.completed_normally is False
+    # A second aclose() on the done+cancelled pump must be an idempotent no-op.
+    assert es._pump_task.cancelled() is True
+    await es.aclose()
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_resume_after_break_drains_remainder() -> None:
+    """Iterating again after an early break resumes and drains the terminal events."""
+    response = "One. Two. Three. Four. Five. "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    first: list[StreamEvent] = []
+    rest: list[StreamEvent] = []
+    async with await stream(
+        _action(), backend, _ctx(), chunking="sentence", as_events=True
+    ) as es:
+        async for ev in es:
+            first.append(ev)
+            if isinstance(ev, ChunkEvent):
+                break  # stop after the first chunk
+        # Same handle, second loop: resumes from the next queued event.
+        async for ev in es:
+            rest.append(ev)
+
+    # Resume drained every remaining chunk — nothing lost between the loops.
+    chunk_texts = [e.text for e in first + rest if isinstance(e, ChunkEvent)]
+    assert chunk_texts == ["One.", "Two.", "Three.", "Four.", "Five."]
+    # It ran to natural completion, ending on a successful CompletedEvent.
+    assert isinstance(rest[-1], CompletedEvent)
+    assert rest[-1].success is True
+    # No event is delivered to both loops.
+    assert not (set(map(id, first)) & set(map(id, rest)))
+    assert es._exhausted is True
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_drain_after_close_is_cancel_tolerant() -> None:
+    """Draining leftover events after the context closes returns them without raising."""
+    response = "One. Two. Three. Four. Five. "
+    backend = StreamingMockBackend(response, token_size=2)
+
+    async with await stream(
+        _action(), backend, _ctx(), chunking="sentence", as_events=True
+    ) as es:
+        async for ev in es:
+            if isinstance(ev, ChunkEvent):
+                break
+
+    # aclose() cancelled the still-running pump on block exit; draining the
+    # queued leftovers must not surface the pump's own CancelledError.
+    tail = [ev async for ev in es]
+    assert es._exhausted is True
+    # Exactly one terminal event, marked unsuccessful — confirming we drained
+    # the cancelled path (finalize queued it during cancellation), not a stream
+    # that happened to finish on its own.
+    completed = [e for e in tail if isinstance(e, CompletedEvent)]
+    assert len(completed) == 1
+    assert completed[0].success is False
+    assert es.completed_normally is False
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_iteration_after_exhaustion_stops() -> None:
+    """A second full iteration terminates immediately, not blocking on an empty queue."""
+    backend = StreamingMockBackend("One. Two. ", token_size=2)
+
+    async with await stream(
+        _action(), backend, _ctx(), chunking="sentence", as_events=True
+    ) as es:
+        async for _ev in es:
+            pass
+        assert es._exhausted is True
+
+        async def _drain_all() -> list[StreamEvent]:
+            return [ev async for ev in es]
+
+        # Would hang on an empty queue without the exhaustion guard.
+        again = await asyncio.wait_for(_drain_all(), timeout=1.0)
+
+    assert again == []
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_abandoned_faulted_pump_retrieved_on_close() -> None:
+    """aclose() retrieves a faulted, undrained pump's exception so it isn't orphaned."""
+    es = await stream(
+        _action(),
+        StreamingErrorBackend("Hi. ", token_size=2),
+        _ctx(),
+        chunking="sentence",
+        as_events=True,
+    )
+    # Let the pump run to its faulted completion WITHOUT draining the queue, so
+    # nothing has retrieved its exception yet.
+    assert es._pump_task is not None
+    for _ in range(1000):
+        if es._pump_task.done():
+            break
+        await asyncio.sleep(0)
+    task = es._pump_task
+    assert task.done() and not task.cancelled()
+    # `_log_traceback` is asyncio's own flag: True while the exception is
+    # unretrieved (and would be logged "never retrieved" at GC), False once read.
+    assert task._log_traceback is True
+
+    await es.aclose()
+
+    assert task._log_traceback is False  # aclose() retrieved it
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_baseexception_in_setup_does_not_hang(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare BaseException during pump setup unblocks stream() instead of hanging."""
+
+    class _SetupBoom(BaseException):
+        pass
+
+    async def _boom(*_a: Any, **_k: Any) -> Streamer:
+        raise _SetupBoom("setup boom")
+
+    monkeypatch.setattr("mellea.stdlib.streaming._stream", _boom)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(
+            stream(
+                _action(),
+                StreamingMockBackend("x", token_size=1),
+                _ctx(),
+                as_events=True,
+            ),
+            timeout=2.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_event_streamer_setup_error_raises_from_stream() -> None:
+    """A setup failure (precomputed MOT) raises eagerly from stream(), like Streamer.
+
+    The pump runs setup before signalling ready; stream() waits on that and
+    re-raises, so a non-streaming backend fails at the call, not on iteration.
+    """
+
+    class PrecomputedBackend(Backend):
+        _model_id: str = "precomputed-mock-model"
+        _provider: str = "precomputed-mock-provider"
+
+        async def _generate_from_context(
+            self,
+            action: Any,
+            ctx: Any,
+            *,
+            format: Any = None,
+            model_options: dict | None = None,
+            tool_calls: bool = False,
+        ) -> tuple[ModelOutputThunk, Any]:
+            return ModelOutputThunk(value="already done"), ctx
+
+        async def _generate_from_raw(
+            self, actions: Any, ctx: Any, **kwargs: Any
+        ) -> tuple[list[ModelOutputThunk], dict[str, Any] | None]:
+            raise NotImplementedError
+
+    with pytest.raises(RuntimeError, match="already-computed MOT"):
+        await stream(_action(), PrecomputedBackend(), _ctx(), as_events=True)
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_streaming.py
+++ b/test/stdlib/test_streaming.py
@@ -1757,7 +1757,7 @@ async def test_event_streamer_abandoned_faulted_pump_retrieved_on_close() -> Non
 async def test_event_streamer_baseexception_in_setup_does_not_hang(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A bare BaseException during pump setup unblocks stream() instead of hanging."""
+    """A bare BaseException during pump setup surfaces to the caller instead of hanging."""
 
     class _SetupBoom(BaseException):
         pass
@@ -1766,7 +1766,7 @@ async def test_event_streamer_baseexception_in_setup_does_not_hang(
         raise _SetupBoom("setup boom")
 
     monkeypatch.setattr("mellea.stdlib.streaming._stream", _boom)
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(_SetupBoom, match="setup boom"):
         await asyncio.wait_for(
             stream(
                 _action(),

--- a/test/typing/check_stream_as_events.py
+++ b/test/typing/check_stream_as_events.py
@@ -1,0 +1,34 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mypy overload-resolution checks for `stream(as_events=...)`."""
+
+from typing import assert_type, cast
+
+from mellea.core import Backend, CBlock, Context
+from mellea.stdlib.streaming import EventStreamer, Streamer, stream
+
+ctx = cast(Context, None)
+backend = cast(Backend, None)
+action: CBlock = cast(CBlock, None)
+
+
+async def check_default_returns_streamer() -> None:
+    s = await stream(action, backend, ctx)
+    assert_type(s, Streamer)
+
+
+async def check_as_events_false_returns_streamer() -> None:
+    s = await stream(action, backend, ctx, as_events=False)
+    assert_type(s, Streamer)
+
+
+async def check_as_events_true_returns_event_streamer() -> None:
+    s = await stream(action, backend, ctx, as_events=True)
+    assert_type(s, EventStreamer)
+
+
+async def check_as_events_dynamic_bool_returns_union() -> None:
+    flag: bool = True
+    s = await stream(action, backend, ctx, as_events=flag)
+    assert_type(s, Streamer | EventStreamer)


### PR DESCRIPTION
## Issue

Follow-up to the design discussion on #1543 (now merged) — streaming event consumption ergonomics.

## Description
Adds an opt-in `EventStreamer`, returned by `stream(..., as_events=True)`, for iterating a single stream's typed `StreamEvent` objects directly with `async for`. The only other route to those events is the process-global `STREAMING_EVENT` hook, which is awkward for a single stream — you register a plugin and demultiplex on `streaming_id`.

Under the hood it wraps a `Streamer`, drives it to completion on a background task, and delivers the events through a queue the consumer drains with `async for`.

It is additive and opt-in: `stream()`'s default chunk-iterating `Streamer` is unchanged, and the `STREAMING_EVENT` hook still fires on every stream, so telemetry and multi-stream observers are unaffected. `EventStreamer` is just the ergonomic way to consume one stream's events inline; the hook remains the right tool for observing many at once.

The streaming examples and docs go back to iterating events, reverting the `streaming_event`-hook workaround #1543 adopted when the iterator was removed; the v0.7→v0.8 migration guide now maps `result.events()` to `stream(as_events=True)` to match.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Unit tests cover `EventStreamer`'s event-mode paths (natural completion, requirement failure, error re-raise, early break), resume-and-drain after a break, teardown edge cases (idempotent `aclose`, a faulted/abandoned pump, a `BaseException` during setup that must not hang), and setup-error surfacing; `test/typing/check_stream_as_events.py` covers the `as_events` overloads including a dynamic `bool`.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
