### PR TITLE
fix: preserve optional status and default values in tool serialization

### DIFF
--- a/mellea/backends/tools.py
+++ b/mellea/backends/tools.py
@@ -638,9 +638,16 @@ def validate_tool_arguments(
             item_type = _build_pydantic_type_from_schema(item_schema)
             return list[item_type]  # type: ignore
 
-        # Handle comma-separated types (Union types)
-        if isinstance(json_type, str) and "," in json_type:
-            type_list = [t.strip() for t in json_type.split(",")]
+        # Handle multi-type unions. JSON Schema expresses these as a list
+        # (`["string", "integer"]`); older code paths may still hand us a
+        # comma-joined string, so accept both.
+        if isinstance(json_type, list) or (
+            isinstance(json_type, str) and "," in json_type
+        ):
+            if isinstance(json_type, list):
+                type_list = [str(t).strip() for t in json_type]
+            else:
+                type_list = [t.strip() for t in json_type.split(",")]
             python_types = [JSON_TYPE_TO_PYTHON.get(t, Any) for t in type_list]
             seen = set()
             unique_types = []
@@ -1353,18 +1360,25 @@ def convert_function_to_ollama_tool(
     # This schema never consumes the return annotation, so an unresolvable one
     # is left as a string rather than being allowed to fail the conversion.
     sig = resolve_signature_annotations(func)
-    schema = type(
-        func.__name__,
-        (BaseModel,),
-        {
-            "__annotations__": {
-                k: v.annotation if v.annotation != inspect._empty else str
-                for k, v in sig.parameters.items()
-            },
-            "__signature__": sig,
-            "__doc__": parsed_docstring[doc_string_hash],
+    model_attrs: dict[str, Any] = {
+        "__annotations__": {
+            k: v.annotation if v.annotation != inspect._empty else str
+            for k, v in sig.parameters.items()
         },
-    ).model_json_schema()  # type: ignore
+        "__signature__": sig,
+        "__doc__": parsed_docstring[doc_string_hash],
+    }
+    # Set each parameter's default as a field value on the dynamic model.
+    # Pydantic derives a field's required-ness and schema `default` from the
+    # value assigned on the model, not from `__signature__` (which is only
+    # informational). Without this, every parameter is treated as required and
+    # default values are dropped from the emitted schema. Compare against
+    # `inspect._empty` (not truthiness) so falsy defaults like 0/""/False are
+    # preserved.
+    for param_name, param in sig.parameters.items():
+        if param.default is not inspect._empty:
+            model_attrs[param_name] = param.default
+    schema = type(func.__name__, (BaseModel,), model_attrs).model_json_schema()  # type: ignore
 
     defs = schema.get("$defs", schema.get("definitions", {}))
 
@@ -1380,8 +1394,14 @@ def convert_function_to_ollama_tool(
             # Resolve the reference and inline it
             ref_schema = _resolve_ref(v["$ref"], defs)
             if ref_schema:
-                # Inline the referenced schema (deep copy to avoid mutations)
+                # Inline the referenced schema (deep copy to avoid mutations),
+                # then merge in the wrapper's sibling metadata (e.g. `default`).
+                # Rebuilding from the $ref alone would drop keys Pydantic
+                # attaches alongside it, such as a complex parameter's default.
                 inlined = copy.deepcopy(ref_schema)
+                for wrapper_key, wrapper_value in v.items():
+                    if wrapper_key != "$ref":
+                        inlined[wrapper_key] = wrapper_value
                 # Add description from docstring if available
                 if parsed_docstring.get(k):
                     inlined["description"] = parsed_docstring[k]
@@ -1430,10 +1450,22 @@ def convert_function_to_ollama_tool(
                     schema["required"].remove(k)
                 types.discard("null")
 
-            schema["properties"][k] = {
+            # JSON Schema emits multiple types as a list (`["string",
+            # "integer"]`), not the comma-joined string the vendored Ollama
+            # source used. Sort for determinism; collapse one type to a scalar.
+            sorted_types = sorted(types)
+            type_value: str | list[str] = (
+                sorted_types[0] if len(sorted_types) == 1 else sorted_types
+            )
+            simple_prop: dict[str, Any] = {
                 "description": parsed_docstring.get(k, ""),
-                "type": ", ".join(types),
+                "type": type_value,
             }
+            # Preserve the parameter's default value; rebuilding the property
+            # from scratch would otherwise drop it.
+            if "default" in v:
+                simple_prop["default"] = v["default"]
+            schema["properties"][k] = simple_prop
 
     # Final pass: recursively inline all remaining $refs at any depth.
     # This catches dangling references in nested model properties that weren't

--- a/test/backends/test_tool_optional_defaults_unit.py
+++ b/test/backends/test_tool_optional_defaults_unit.py
@@ -1,0 +1,261 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for tool schema serialization of optional/defaulted parameters.
+
+Regression tests for the bug where parameters with default values were losing
+their optional status (incorrectly listed as required) and their default values
+during conversion to the OpenAI-compatible tool schema. The conversion is shared
+by every backend via `convert_tools_to_json`, so a fix here applies to all of
+them (OpenAI, LiteLLM, HF, Watsonx, Ollama).
+
+See: https://github.com/generative-computing/mellea/issues/1569
+"""
+
+from mellea.backends.tools import (
+    MelleaTool,
+    convert_function_to_ollama_tool,
+    convert_tools_to_json,
+)
+
+
+def _params(func, name=None):
+    """Return the serialized `parameters` block for a callable."""
+    schema = convert_function_to_ollama_tool(func, name or func.__name__).model_dump(
+        exclude_none=True
+    )
+    return schema["function"]["parameters"]
+
+
+def test_defaulted_param_not_required():
+    """A parameter with a default value must not appear in `required`."""
+
+    def get_weather(location: str, units: str = "celsius") -> dict:
+        """Get weather.
+
+        Args:
+            location: City name
+            units: Temperature units
+        """
+        return {}
+
+    params = _params(get_weather)
+
+    assert "location" in params["required"]
+    assert "units" not in params["required"], (
+        "Parameter with a default value should not be required"
+    )
+
+
+def test_defaulted_param_preserves_default_value():
+    """Default values must be carried into the serialized schema."""
+
+    def get_weather(location: str, units: str = "celsius", days: int = 1) -> dict:
+        """Get weather.
+
+        Args:
+            location: City name
+            units: Temperature units
+            days: Number of days
+        """
+        return {}
+
+    props = _params(get_weather)["properties"]
+
+    assert props["units"].get("default") == "celsius"
+    assert props["days"].get("default") == 1
+
+
+def test_defaulted_param_correct_type():
+    """Defaulted simple params keep a scalar type, not an anyOf structure."""
+
+    def get_weather(location: str, units: str = "celsius", days: int = 1) -> dict:
+        """Get weather.
+
+        Args:
+            location: City name
+            units: Temperature units
+            days: Number of days
+        """
+        return {}
+
+    props = _params(get_weather)["properties"]
+
+    assert props["units"]["type"] == "string"
+    assert "anyOf" not in props["units"]
+    assert props["days"]["type"] == "integer"
+    assert "anyOf" not in props["days"]
+
+
+def test_required_param_has_no_default():
+    """A parameter with no default must be required and carry no default key."""
+
+    def get_weather(location: str, units: str = "celsius") -> dict:
+        """Get weather.
+
+        Args:
+            location: City name
+            units: Temperature units
+        """
+        return {}
+
+    params = _params(get_weather)
+
+    assert "location" in params["required"]
+    assert "default" not in params["properties"]["location"]
+
+
+def test_optional_typed_with_default_value():
+    """`x: str | None = "hi"` is optional, keeps its default, and is a scalar."""
+
+    def process(x: str, y: str | None = "hi") -> str:
+        """Process text.
+
+        Args:
+            x: Required text
+            y: Optional text
+        """
+        return f"{x} {y}"
+
+    params = _params(process)
+
+    assert "y" not in params["required"]
+    y_prop = params["properties"]["y"]
+    assert y_prop["type"] == "string"
+    assert "anyOf" not in y_prop
+    assert y_prop.get("default") == "hi"
+
+
+def test_falsy_defaults_are_preserved():
+    """Falsy defaults (0, "", False) must still be emitted and be optional."""
+
+    def configure(count: int = 0, label: str = "", enabled: bool = False) -> dict:
+        """Configure.
+
+        Args:
+            count: A count
+            label: A label
+            enabled: A flag
+        """
+        return {}
+
+    params = _params(configure)
+    props = params["properties"]
+
+    assert params.get("required", []) == []
+    assert props["count"].get("default") == 0
+    assert props["label"].get("default") == ""
+    assert props["enabled"].get("default") is False
+
+
+def test_no_default_params_unchanged():
+    """Regression: an all-required signature keeps every param required."""
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers.
+
+        Args:
+            a: First number
+            b: Second number
+        """
+        return a + b
+
+    params = _params(add)
+
+    assert set(params["required"]) == {"a", "b"}
+    assert "default" not in params["properties"]["a"]
+    assert "default" not in params["properties"]["b"]
+
+
+def test_union_type_serialized_as_list():
+    """A multi-type union emits a JSON Schema type list, not a comma-joined string."""
+
+    def pick(value: str | int) -> dict:
+        """Pick.
+
+        Args:
+            value: A string or integer
+        """
+        return {}
+
+    props = _params(pick)["properties"]
+
+    assert props["value"]["type"] == ["integer", "string"]
+
+
+def test_single_type_serialized_as_scalar():
+    """A single-type param keeps a scalar type string (not a one-element list)."""
+
+    def echo(value: str) -> dict:
+        """Echo.
+
+        Args:
+            value: A string
+        """
+        return {}
+
+    props = _params(echo)["properties"]
+
+    assert props["value"]["type"] == "string"
+
+
+def test_optional_union_drops_null_and_lists_remaining():
+    """`str | int | None` is optional and serializes the non-null types as a list."""
+
+    def pick(value: str | int | None = None) -> dict:
+        """Pick.
+
+        Args:
+            value: A string, integer, or nothing
+        """
+        return {}
+
+    params = _params(pick)
+
+    assert "value" not in params.get("required", [])
+    assert params["properties"]["value"]["type"] == ["integer", "string"]
+
+
+def test_complex_param_default_preserved():
+    """A complex (Pydantic model) parameter's default survives $ref inlining."""
+    from pydantic import BaseModel
+
+    class Config(BaseModel):
+        verbose: bool = False
+
+    def run(cfg: Config = Config()) -> dict:
+        """Run.
+
+        Args:
+            cfg: Configuration object
+        """
+        return {}
+
+    props = _params(run)["properties"]
+
+    assert props["cfg"].get("default") == {"verbose": False}
+    assert "cfg" not in _params(run).get("required", [])
+
+
+def test_mixed_signature_via_convert_tools_to_json():
+    """End-to-end through the path every backend uses (`convert_tools_to_json`)."""
+
+    def get_weather(location: str, units: str = "celsius", days: int = 1) -> dict:
+        """Get weather.
+
+        Args:
+            location: City name
+            units: Temperature units
+            days: Number of days
+        """
+        return {}
+
+    tool = MelleaTool.from_callable(get_weather)
+    serialized = convert_tools_to_json({"get_weather": tool})
+
+    params = serialized[0]["function"]["parameters"]
+    props = params["properties"]
+
+    assert params["required"] == ["location"]
+    assert props["units"].get("default") == "celsius"
+    assert props["days"].get("default") == 1

--- a/test/backends/test_tool_validation_integration.py
+++ b/test/backends/test_tool_validation_integration.py
@@ -261,6 +261,58 @@ class TestOptionalParameters:
         assert validated["optional"] is None
 
 
+class TestDefaultedParameters:
+    """Test that omitted defaulted parameters fall through to Python defaults."""
+
+    def test_omitted_default_not_materialized_as_none(self):
+        """An omitted defaulted parameter must not be forced to None.
+
+        Materializing it as None would override the callable's own default
+        (e.g. weather(location="London") reaching the function as units=None).
+        """
+
+        def weather(location: str, units: str = "celsius", days: int = 1) -> dict:
+            """Get weather.
+
+            Args:
+                location: City name
+                units: Temperature units
+                days: Number of days
+            """
+            return {"location": location, "units": units, "days": days}
+
+        tool = MelleaTool.from_callable(weather)
+        validated = validate_tool_arguments(tool, {"location": "London"})
+
+        assert validated == {"location": "London"}
+        assert "units" not in validated
+        assert "days" not in validated
+
+        # The Python defaults take effect when the callable actually runs.
+        result = ModelToolCall("weather", tool, validated).call_func()
+        assert result == {"location": "London", "units": "celsius", "days": 1}
+
+    def test_supplied_default_param_preserved(self):
+        """A defaulted parameter that IS supplied is kept (and coerced)."""
+
+        def weather(location: str, days: int = 1) -> dict:
+            """Get weather.
+
+            Args:
+                location: City name
+                days: Number of days
+            """
+            return {"location": location, "days": days}
+
+        tool = MelleaTool.from_callable(weather)
+        validated = validate_tool_arguments(
+            tool, {"location": "London", "days": "3"}, coerce_types=True
+        )
+
+        assert validated["days"] == 3
+        assert isinstance(validated["days"], int)
+
+
 class TestComplexTypes:
     """Test validation with complex types."""
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1569 

## Description
<!-- What does this PR do and why? -->
1. Parameter defaults are now set as field values on the dynamically-built Pydantic model. Pydantic derives required-ness and the schema default from model field values, not from `__signature__`  - previously, every parameter (even units: str = "celsius") was wrongly marked required and defaults were dropped.
2. The "simple type" post-processing branch, which rebuilds each property dict from scratch, now preserves the default key.

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
