### PR TITLE
fix(tools): stop validate_tool_arguments padding tool-call args with null

### DIFF
--- a/mellea/backends/tools.py
+++ b/mellea/backends/tools.py
@@ -729,7 +729,10 @@ def validate_tool_arguments(
     try:
         # Validate using Pydantic
         validated_model = ValidatorModel(**args)
-        validated_args = validated_model.model_dump()
+        # Only emit fields the model actually sent. A bare model_dump() would
+        # pad the output with a None for every unset optional field (at every
+        # nesting depth), inventing arguments the model never produced.
+        validated_args = validated_model.model_dump(exclude_unset=True)
 
         # In lenient mode with extra="allow", Pydantic includes extra fields
         # but we need to preserve them from the original args

--- a/test/backends/test_pydantic_tool_parameters.py
+++ b/test/backends/test_pydantic_tool_parameters.py
@@ -262,10 +262,8 @@ class TestPydanticParameterValidation:
 
         validated = validate_tool_arguments(tool, args, coerce_types=True)
         assert validated["person"]["name"] == "Jane Doe"
-        assert (
-            "address" not in validated["person"]
-            or validated["person"].get("address") is None
-        )
+        # The unset optional nested field must not be padded back in as None.
+        assert "address" not in validated["person"]
 
     def test_nested_object_with_all_fields(self):
         """Test validation with all fields including optional nested object."""

--- a/test/backends/test_tool_validation_integration.py
+++ b/test/backends/test_tool_validation_integration.py
@@ -248,7 +248,8 @@ class TestOptionalParameters:
         validated = validate_tool_arguments(tool, args)
 
         assert validated["required"] == "value1"
-        assert "optional" not in validated or validated.get("optional") is None
+        # An omitted optional field must NOT be padded back in as None.
+        assert "optional" not in validated
 
     def test_optional_param_none(self):
         """Test validation when optional parameter is explicitly None."""
@@ -456,6 +457,102 @@ class TestUntypedParameters:
         # Should remain as string since there's no type hint to coerce to
         assert validated["message"] == "123"
         assert isinstance(validated["message"], str)
+
+
+class TestNoNullPadding:
+    """Validation must return only what the model sent, never padding unset fields.
+
+    A bare `model_dump()` used to emit a `None` for every declared-but-unset optional
+    field, at every nesting depth, inventing arguments the model never produced.
+    `model_dump(exclude_unset=True)` fixes this; these tests lock the behavior in.
+    """
+
+    def _nested_object_tool(self) -> MelleaTool:
+        """Build a tool with a nested object whose sub-fields are all optional.
+
+        Constructed directly from an explicit JSON schema (rather than
+        `from_callable`) so the nested object can declare fields the model
+        will not send.
+        """
+        schema = {
+            "type": "function",
+            "function": {
+                "name": "update_profile",
+                "description": "",
+                "parameters": {
+                    "type": "object",
+                    "required": ["user_id", "settings"],
+                    "properties": {
+                        "user_id": {"type": "string"},
+                        "settings": {
+                            "type": "object",
+                            "properties": {
+                                "theme": {"type": "string"},
+                                "language": {"type": "string"},
+                                "timezone": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        return MelleaTool(
+            name="update_profile", tool_call=lambda **k: None, as_json_tool=schema
+        )
+
+    def test_nested_object_not_padded(self):
+        """(a) Unset nested-object fields must not appear as None in the output."""
+        tool = self._nested_object_tool()
+        args = {"user_id": "u1", "settings": {"theme": "dark"}}
+        validated = validate_tool_arguments(tool, args, strict=False)
+
+        # Exactly what the model sent — no language=None / timezone=None padding.
+        assert validated == {"user_id": "u1", "settings": {"theme": "dark"}}
+        for unsent in ("language", "timezone"):
+            assert unsent not in validated["settings"]
+
+    def test_coercion_still_works(self):
+        """(b) Type coercion is unaffected by the no-padding fix."""
+        args = {"name": "Test", "age": "30", "score": "95.5", "active": True}
+        tool = MelleaTool.from_callable(typed_tool)
+        validated = validate_tool_arguments(tool, args, coerce_types=True)
+
+        assert validated["age"] == 30
+        assert isinstance(validated["age"], int)
+        assert validated["score"] == 95.5
+        assert isinstance(validated["score"], float)
+
+    def test_explicit_null_on_nullable_field_preserved(self):
+        """(c) A null the model explicitly sent for a nullable field is kept.
+
+        `optional` is typed `str | None`, so an explicit None is a valid, *set*
+        value and must survive — only *unset* fields are dropped.
+        """
+        args = {"required": "value1", "optional": None}
+        tool = MelleaTool.from_callable(optional_tool)
+        validated = validate_tool_arguments(tool, args, strict=False)
+
+        assert "optional" in validated
+        assert validated["optional"] is None
+
+    def test_required_fields_still_present(self):
+        """(d) Required fields are still validated and emitted."""
+        args = {"required": "value1"}
+        tool = MelleaTool.from_callable(optional_tool)
+        validated = validate_tool_arguments(tool, args, strict=False)
+
+        assert validated["required"] == "value1"
+        # ...and the unset optional field is not padded back in.
+        assert "optional" not in validated
+
+    def test_undeclared_extra_key_survives_in_lenient_mode(self):
+        """(e) Extra keys the model sent that aren't in the schema survive (lenient)."""
+        args = {"message": "hi", "weird_extra": 42}
+        tool = MelleaTool.from_callable(simple_tool)
+        validated = validate_tool_arguments(tool, args, strict=False)
+
+        assert validated["message"] == "hi"
+        assert validated["weird_extra"] == 42
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1572

## Description
`validate_tool_arguments` (`mellea/backends/tools.py`) padded validated tool-call
arguments out to the full JSON schema, emitting `null` for every declared-but-unset
optional field — at every nesting depth. Nested objects were the worst case: the
existing top-level extra-field fixup never descended into them.

This changes the dump to exclude fields the model never set:

```diff
- validated_args = validated_model.model_dump()
+ validated_args = validated_model.model_dump(exclude_unset=True)
```

**Before / after** — model sends one key of a nested object
(`{"user_id": "u1", "settings": {"theme": "dark"}}`):

- Before: `settings` padded with `language=None, timezone=None`.
- After: `{'user_id': 'u1', 'settings': {'theme': 'dark'}}` — only what the model sent.

**Why:** the raw OpenAI SDK treats tool-call `arguments` as an opaque string and never
pads; the function's docstring advertises only type coercion. The injected nulls can break
downstream consumers (OpenAI-compatible proxies, strict function-calling checkers).

**Guarantees preserved:** type coercion (`days: "3"` → `3`); explicitly-sent nulls on
nullable-typed fields; undeclared extra keys under lenient mode. (An explicit `null` on a
*non-nullable* field fails validation on `main` too — orthogonal to this change.)

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Added `TestNoNullPadding` in `test/backends/test_tool_validation_integration.py`
(nested no-padding repro, coercion preserved, explicit null on a nullable field, required
fields present, extra key survives) and tightened two previously-tolerant assertions in
that file and `test_pydantic_tool_parameters.py`.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
