### PR TITLE
fix(backends): reject OpenAI model option overrides

### DIFF
--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -461,16 +461,27 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
 
         Returns:
             a new dict
+
+        Raises:
+            ValueError: If `model_options` attempts to select a model. An
+                OpenAIBackend's model is fixed when the backend is constructed.
         """
         remap_dict = self.to_mellea_model_opts_map_chats
         if not is_chat_context:
             remap_dict = self.to_mellea_model_opts_map_completions
 
-        return resolve_model_options(
+        resolved_options = resolve_model_options(
             backend_defaults=self.model_options,
             remap=remap_dict,
             call_options=model_options,
         )
+        if "model" in resolved_options:
+            raise ValueError(
+                "model cannot be set via model_options on OpenAIBackend — model "
+                "selection happens at the backend/session level (construct a backend "
+                "per model, or start a session against the chosen model_id)."
+            )
+        return resolved_options
 
     def _make_backend_specific_and_remove(
         self, model_options: dict[str, Any], is_chat_context: bool

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -326,6 +326,25 @@ async def test_model_options_override_io_yaml_defaults():
     assert call_kwargs.kwargs.get("max_completion_tokens") == 64
 
 
+async def test_openai_backend_rejects_model_option_on_intrinsic_path():
+    """Regression (#1575): intrinsic calls reject per-call model selection.
+
+    Without this check, `model` survives the user option overlay after adapter
+    activation and collides with the backend's fixed OpenAI client argument.
+    """
+    backend = _make_backend_with_adapter(_SIMPLE_CONFIG)
+    ctx = _make_context()
+
+    with pytest.raises(ValueError, match="model cannot be set via model_options"):
+        await mfuncs.aact(
+            Intrinsic("answerability"),
+            ctx,
+            backend,
+            strategy=None,
+            model_options={"model": "answerability_alora"},
+        )
+
+
 async def test_model_options_forwarded():
     """All applicable model options are forwarded to the API call."""
     backend = _make_backend_with_adapter(_SIMPLE_CONFIG)

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -212,6 +212,23 @@ def test_simplify_and_merge_per_call_overrides_backend():
     assert result[ModelOption.MAX_NEW_TOKENS] == 512
 
 
+async def test_openai_backend_rejects_model_option_on_standard_chat_path():
+    """Regression (#1575): standard chat rejects per-call model selection.
+
+    Without this check, the user-supplied `model` collides with the backend's
+    fixed `model` keyword argument at the OpenAI client call site.
+    """
+    from mellea.core.base import CBlock
+    from mellea.stdlib.context import ChatContext
+
+    backend = _make_backend()
+
+    with pytest.raises(ValueError, match="model cannot be set via model_options"):
+        await backend.generate_from_chat_context(
+            CBlock(value="hello"), ChatContext(), model_options={"model": "other-model"}
+        )
+
+
 # --- _make_backend_specific_and_remove ---
 
 
@@ -714,6 +731,7 @@ async def test_standard_chat_path_applies_default_extra_body_without_per_call_ov
         await mot.avalue()
 
     call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-4o"
     assert call_kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
 
 

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -212,6 +212,21 @@ def test_simplify_and_merge_per_call_overrides_backend():
     assert result[ModelOption.MAX_NEW_TOKENS] == 512
 
 
+@pytest.mark.parametrize("is_chat_context", [True, False])
+def test_simplify_and_merge_rejects_model_option(
+    backend: OpenAIBackend, is_chat_context: bool
+) -> None:
+    """Regression (#1575): model selection is rejected for both OpenAI APIs.
+
+    Without this check, the raw `model` option reaches the API call alongside
+    OpenAIBackend's fixed model argument and raises a duplicate-keyword error.
+    """
+    with pytest.raises(ValueError, match="model cannot be set via model_options"):
+        backend._simplify_and_merge(
+            {"model": "other-model"}, is_chat_context=is_chat_context
+        )
+
+
 async def test_openai_backend_rejects_model_option_on_standard_chat_path():
     """Regression (#1575): standard chat rejects per-call model selection.
 


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #1575.

## Description

`OpenAIBackend` accepted a raw `model` entry in `model_options` even though its
model is fixed when the backend is constructed. The option then reached an
OpenAI client call alongside the backend's explicit `model=` argument, producing
an unhelpful duplicate-keyword `TypeError`. This PR rejects that option during
shared model-option resolution with a clear `ValueError` that directs callers to
select the model at the backend or session level.

The guard covers standard chat, embedded-intrinsic, and raw-completions calls.
Regression tests exercise the chat and intrinsic entry points, plus both
chat-completions and completions option-resolution modes.

### Epic position and design notes

This is a small Phase 2 follow-up in Epic #929's model-option handling work. It
is independent of the in-review activation and output-contract changes in #1142
and #1516, while following the decision recorded in #1575: reject per-call
model selection rather than silently dropping it or introducing a second model
routing mechanism. Users needing multiple models should construct separate
backends or start sessions against the selected model.

### Testing

- `uv run pytest test/backends/test_openai_unit.py test/backends/test_openai_intrinsics_unit.py -q` — 66 passed
- `uv run ruff check test/backends/test_openai_unit.py`
- `uv run ruff format --check test/backends/test_openai_unit.py`
- `uv run mypy .`

- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution

- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
