### PR TITLE
fix(adapters): use effective capabilities in shim identities

### DIFF
--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -37,7 +37,7 @@ from ._core import (
     LocalFileBinding,
     WeightsBinding,
 )
-from .catalog import AdapterType, fetch_intrinsic_metadata
+from .catalog import AdapterType, fetch_intrinsic_metadata, known_intrinsic_names
 from .io_contracts import get_io_contract
 
 
@@ -253,7 +253,7 @@ class IntrinsicAdapter(LocalHFAdapter, _AdapterCore):
                 adapter_type="alora"
                 if self.adapter_type == AdapterType.ALORA
                 else "lora",
-                capability=intrinsic_name,
+                capability=self.intrinsic_metadata.effective_capability,
             ),
             io_contract=get_io_contract(intrinsic_name),
             weights=_ShimWeightsBinding(),
@@ -900,14 +900,19 @@ class AdapterMixin(Backend, abc.ABC):
         adapters = list(getattr(self, "_added_adapters", {}).values())
         if adapter_types is None:
             for a in adapters:
-                if isinstance(a, _AdapterCore) and a.identity.capability == capability:
+                if isinstance(a, _AdapterCore) and (
+                    a.identity.name == capability or a.identity.capability == capability
+                ):
                     return a
             return None
         for preferred_type in adapter_types:
             for a in adapters:
                 if (
                     isinstance(a, _AdapterCore)
-                    and a.identity.capability == capability
+                    and (
+                        a.identity.name == capability
+                        or a.identity.capability == capability
+                    )
                     and a.identity.adapter_type == preferred_type
                 ):
                     return a
@@ -987,13 +992,16 @@ class EmbeddedIntrinsicAdapter(_AdapterCore):
         self.intrinsic_name = intrinsic_name
         self.config = config
         self.technology = technology
+        capability = intrinsic_name
+        if intrinsic_name in known_intrinsic_names():
+            capability = fetch_intrinsic_metadata(intrinsic_name).effective_capability
 
         # Populate the new Adapter triple so isinstance(self, _AdapterCore) holds.
         # technology is validated above; cast to the Literal type mypy expects.
         identity = Identity(
             name=intrinsic_name,
             adapter_type=cast(Literal["lora", "alora"], technology),
-            capability=intrinsic_name,
+            capability=capability,
         )
 
         io_contract = get_io_contract(intrinsic_name)

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -121,6 +121,38 @@ def test_embedded_identity_lora_technology():
     assert adapter.identity.adapter_type == "lora"
 
 
+def test_embedded_catalog_capability_avoids_spurious_registry_warning():
+    """Regression (#1563): catalog aliases use their effective capability.
+
+    Before this fix, the hyphenated catalog name emitted a KNOWN_CAPABILITIES
+    warning even though the adapter function was registered.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter = EmbeddedIntrinsicAdapter(
+            "guardian-core", config={}, technology="alora"
+        )
+
+    assert adapter.identity.capability == "guardian_core"
+    assert not any(
+        warning.category is UserWarning and "KNOWN_CAPABILITIES" in str(warning.message)
+        for warning in caught
+    )
+
+
+def test_embedded_custom_capability_still_emits_registry_warning():
+    """Custom embedded adapters retain their user-provided capability token."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter = EmbeddedIntrinsicAdapter("custom-adapter", config={})
+
+    assert adapter.identity.capability == "custom-adapter"
+    assert any(
+        warning.category is UserWarning and "KNOWN_CAPABILITIES" in str(warning.message)
+        for warning in caught
+    )
+
+
 def test_embedded_legacy_attributes_preserved():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -221,6 +253,27 @@ def test_intrinsic_identity_lora_adapter_type():
             config_dict={"dummy": "config"},
         )
     assert adapter.identity.adapter_type == "lora"
+
+
+def test_intrinsic_catalog_capability_avoids_spurious_registry_warning():
+    """Regression (#1563): catalog aliases use their effective capability.
+
+    Before this fix, the hyphenated catalog name emitted a KNOWN_CAPABILITIES
+    warning even though the adapter function was registered.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter = IntrinsicAdapter(
+            "guardian-core",
+            adapter_type=AdapterType.ALORA,
+            config_dict={"dummy": "config"},
+        )
+
+    assert adapter.identity.capability == "guardian_core"
+    assert not any(
+        warning.category is UserWarning and "KNOWN_CAPABILITIES" in str(warning.message)
+        for warning in caught
+    )
 
 
 def test_intrinsic_legacy_attributes_preserved():
@@ -548,3 +601,48 @@ def test_resolve_adapter_lazy_creates_and_returns():
     assert isinstance(created_adapters[0], IntrinsicAdapter)
     assert created_adapters[0].adapter_type == AdapterType.LORA
     assert result is created_adapters[0]
+
+
+def test_resolve_adapter_catalog_alias_returns_registered_adapter():
+    """Regression (#1563): lookup accepts the catalog's public alias.
+
+    The shim stores `guardian_core` as its canonical capability, while callers
+    resolve the adapter via the catalog name `guardian-core`, including when
+    they constrain the adapter type.
+    """
+    mock_catalog_entry = IntrinsicsCatalogEntry(
+        name="guardian-core",
+        capability="guardian_core",
+        repo_id="ibm-granite/granitelib-guardian-r1.0",
+        revision="abc123",
+        adapter_types=(AdapterType.LORA,),
+    )
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+    mock_backend._added_adapters = {}
+    mock_backend.add_adapter.side_effect = lambda adapter: (
+        mock_backend._added_adapters.__setitem__(adapter.qualified_name, adapter)
+    )
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=mock_catalog_entry,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
+    ):
+        result = AdapterMixin.resolve_adapter(mock_backend, "guardian-core")
+
+    assert result.identity.name == "guardian-core"
+    assert result.identity.capability == "guardian_core"
+    assert (
+        AdapterMixin._find_adapter(mock_backend, "guardian-core", ("lora",)) is result
+    )


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #1563

## Description

Catalog entries separate their public lookup names from their stable capability
tokens. The legacy `IntrinsicAdapter` and `EmbeddedIntrinsicAdapter` shims built
their `Identity` from the lookup name, so hyphenated catalog aliases emitted a
spurious `KNOWN_CAPABILITIES` warning whenever they were resolved. This PR uses
the catalog entry's `effective_capability` for known adapter functions and
preserves raw-name lookup so existing callers can still resolve aliases.

This is a focused Phase 2 correction within Epic #929. It fixes the temporary
shim layer before its planned removal in #1144; it does not change the
catalogue, adapter loading, or the broader Phase 2 lifecycle work.

### Design notes

- Directly constructed embedded adapters with unknown custom names retain their
  raw capability and advisory warning behaviour.
- `_find_adapter()` accepts either the catalog lookup name or the canonical
  capability token, preserving existing alias-based resolution after identity
  canonicalisation.
- Custom-name collision policy is unchanged and intentionally outside this
  warning-only fix.

### Testing

- Targeted adapter shim tests: 68 passed.
- Commit hooks passed: Block Secrets, SPDX headers, Ruff format/check, mypy,
  codespell, DCO sign-off, and generated-MDX validation.
- The full non-qualitative suite is not claimed as green: local package-isolation
  tests encountered a build-environment permission error unrelated to this diff.

- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution

- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
