### PR TITLE
docs: document PR template and checklist bot in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,17 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 Pre-commit runs: ruff, mypy, uv-lock, codespell, license-headers
 
+**Pull request template**: opening a PR fills the body from [`.github/pull_request_template.md`](.github/pull_request_template.md), which ends with four type checkboxes - `Component`, `Requirement`, `Sampling Strategy`, `Tool`. If your PR adds or modifies one of those, check the matching box; the `PR Bot` workflow ([`.github/workflows/pr-update.yml`](.github/workflows/pr-update.yml)) then posts a comment with the type-specific review checklist from `.github/PULL_REQUEST_TEMPLATE/`:
+
+| Checked box | Checklist template |
+|-------------|--------------------|
+| `Component` | `.github/PULL_REQUEST_TEMPLATE/component.md` |
+| `Requirement` | `.github/PULL_REQUEST_TEMPLATE/requirement.md` |
+| `Sampling Strategy` | `.github/PULL_REQUEST_TEMPLATE/sampling.md` |
+| `Tool` | `.github/PULL_REQUEST_TEMPLATE/tool.md` |
+
+This matters when a PR is opened outside the GitHub UI (`gh pr create --body`, from a fork, or by an agent): the template isn't applied automatically. When you open such a PR and it adds or modifies one of the four types, build the body from `.github/pull_request_template.md` with the matching box checked (if relevant) so the bot posts the checklist.
+
 **Review states**: when reviewing a PR, see [CONTRIBUTING.md → Review States](CONTRIBUTING.md#review-states) for when to use `APPROVE` vs `REQUEST CHANGES` vs `COMMENT`.
 
 For AI attribution trailers, see [Section 7 (AI Attribution)](#7-ai-attribution).


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1072

## Description
Documents the PR template and `PR Bot` checklist mechanism in `AGENTS.md` §6 — what the type checkboxes are, the four options and which `.github/PULL_REQUEST_TEMPLATE/*.md` each maps to, and that the bot posts a review-checklist *comment* rather than gating the PR.

Note: issue #1072's description is stale. The old `update-pr-body` check that hard-failed with "No PR type selected" and rewrote the PR body was replaced (PRs #1082/#1083) by the current `PR Bot`, which posts a checklist comment and never fails a PR. This change documents the current behavior and the four (not five — there is no "Misc") type options.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.