### PR TITLE
fix(hf): handle ModelOption.THINKING chat templates

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -270,9 +270,6 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 )
 
 _CHAT_TEMPLATE_THINKING_VARS: tuple[str, ...] = ("think", "thinking", "enable_thinking")
-_CHAT_TEMPLATE_THINKING_OPTION_MAP: dict[str, str] = dict.fromkeys(
-    _CHAT_TEMPLATE_THINKING_VARS, ModelOption.THINKING
-)
 
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
@@ -454,7 +451,6 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
             "stop_strings": ModelOption.STOP_SEQUENCES,
-            **_CHAT_TEMPLATE_THINKING_OPTION_MAP,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -2355,6 +2351,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if (
             thinking_template_var is not None
             and type(model_options.get(ModelOption.THINKING)) is bool
+            and thinking_template_var not in backend_opts
         ):
             backend_opts[thinking_template_var] = model_options[ModelOption.THINKING]
         return {

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -269,6 +269,8 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
     }
 )
 
+_CHAT_TEMPLATE_THINKING_VARS: tuple[str, ...] = ("think", "thinking", "enable_thinking")
+
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
     """Names that `transformers`' `model.generate` accepts as keyword arguments.
@@ -2338,6 +2340,16 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         backend_opts = self._make_backend_specific_and_remove(
             model_options, for_generate=False
         )
+        thinking_template_var = next(
+            (
+                variable
+                for variable in _CHAT_TEMPLATE_THINKING_VARS
+                if variable in self._chat_template_allowlist
+            ),
+            None,
+        )
+        if thinking_template_var is not None and ModelOption.THINKING in model_options:
+            backend_opts[thinking_template_var] = model_options[ModelOption.THINKING]
         return {
             k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist
         }

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -451,6 +451,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
             "stop_strings": ModelOption.STOP_SEQUENCES,
+            "think": ModelOption.THINKING,
+            "thinking": ModelOption.THINKING,
+            "enable_thinking": ModelOption.THINKING,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -2348,12 +2351,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             ),
             None,
         )
-        if (
-            thinking_template_var is not None
-            and type(model_options.get(ModelOption.THINKING)) is bool
-            and thinking_template_var not in backend_opts
-        ):
-            backend_opts[thinking_template_var] = model_options[ModelOption.THINKING]
+        # Deliberately read THINKING from model_options, not backend_opts:
+        # _make_backend_specific_and_remove already stripped the @@@thinking@@@
+        # sentinel (HF has no from_mellea_model_opts_map entry for it, so
+        # remove_special_keys discards it), but model_options still has it.
+        # The resolved sentinel must win outright over whatever alias name is
+        # already in backend_opts, to match the other backends' precedence
+        # (e.g. Ollama reads ModelOption.THINKING directly at the generate
+        # call site rather than deferring to a backend-specific key).
+        thinking_value = model_options.get(ModelOption.THINKING)
+        if thinking_template_var is not None and type(thinking_value) is bool:
+            backend_opts[thinking_template_var] = thinking_value
         return {
             k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist
         }

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -270,6 +270,9 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 )
 
 _CHAT_TEMPLATE_THINKING_VARS: tuple[str, ...] = ("think", "thinking", "enable_thinking")
+_CHAT_TEMPLATE_THINKING_OPTION_MAP: dict[str, str] = dict.fromkeys(
+    _CHAT_TEMPLATE_THINKING_VARS, ModelOption.THINKING
+)
 
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
@@ -451,6 +454,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             "tools": ModelOption.TOOLS,
             "stream": ModelOption.STREAM,
             "stop_strings": ModelOption.STOP_SEQUENCES,
+            **_CHAT_TEMPLATE_THINKING_OPTION_MAP,
         }
 
         # A mapping of Mellea specific ModelOptions to the specific names for this backend.
@@ -2348,7 +2352,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             ),
             None,
         )
-        if thinking_template_var is not None and ModelOption.THINKING in model_options:
+        if (
+            thinking_template_var is not None
+            and type(model_options.get(ModelOption.THINKING)) is bool
+        ):
             backend_opts[thinking_template_var] = model_options[ModelOption.THINKING]
         return {
             k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -75,8 +75,9 @@ class ModelOption:
     * `"low"` / `"medium"` / `"high"` — passed directly as `reasoning_effort`
       (OpenAI-compatible backends only; no-op on vLLM).
 
-    HuggingFace supports boolean values only. If its chat template does not
-    expose a recognised thinking variable, the option is ignored.
+    HuggingFace supports boolean values only; a non-boolean value (e.g.
+    `"low"`) is silently ignored. If its chat template does not expose a
+    recognised thinking variable, the option is ignored regardless of value.
     """
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -63,6 +63,8 @@ class ModelOption:
       `reasoning_effort="medium"`. Use this to engage reasoning on vLLM-served
       models such as Qwen3, Gemma 4, and GLM-4.5 — `"medium"` alone is
       silently ignored by those servers.
+      HuggingFace: forwards the value to the recognised chat-template variable
+      (`think`, `thinking`, or `enable_thinking`).
     * `False` — native Ollama backend: sends `think=False`.
       OpenAI-compatible backends: sets `chat_template_kwargs.enable_thinking=False`
       and `reasoning_effort="none"` to suppress the think block. Both are sent so
@@ -73,7 +75,8 @@ class ModelOption:
     * `"low"` / `"medium"` / `"high"` — passed directly as `reasoning_effort`
       (OpenAI-compatible backends only; no-op on vLLM).
 
-    Not yet supported by the HuggingFace backend (#1212).
+    HuggingFace supports boolean values only. If its chat template does not
+    expose a recognised thinking variable, the option is ignored.
     """
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"

--- a/test/backends/test_acall_tools_parallel_execution.py
+++ b/test/backends/test_acall_tools_parallel_execution.py
@@ -21,12 +21,10 @@ from mellea.backends.tools import MelleaTool
 from mellea.core.base import ModelOutputThunk, ModelToolCall
 from mellea.stdlib.functional import acall_tools
 
-pytestmark = [pytest.mark.integration]
-
 
 @pytest.fixture
 def backend(mock_ollama_backend):
-    """Create an OllamaModelBackend for formatter.print() only.
+    """Create an Ollama backend with its external boundary mocked.
 
     Note: acall_tools() only uses backend.formatter, not inference.
     Tests use local Python functions as tool implementations, no model calls.

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -565,14 +565,23 @@ _GRANITE_THINKING_MODEL_ID = "ibm-granite/granite-4.2-3b"
 
 
 def _try_load_granite_tokenizer(model_id: str):
-    """Return a Granite tokenizer from the local cache, or None."""
+    """Return a Granite tokenizer from the local cache, or None.
+
+    A cached `config.json` does not guarantee the tokenizer's own files
+    (`tokenizer.json`, etc.) are also cached — e.g. after an interrupted or
+    partial download. `local_files_only=True` raises `OSError` in that case;
+    treat it the same as an absent cache rather than letting the test error.
+    """
     from huggingface_hub import _CACHED_NO_EXIST, try_to_load_from_cache
     from transformers import AutoTokenizer
 
     cached_config = try_to_load_from_cache(model_id, "config.json")
     if cached_config is None or cached_config is _CACHED_NO_EXIST:
         return None
-    return AutoTokenizer.from_pretrained(model_id, local_files_only=True)
+    try:
+        return AutoTokenizer.from_pretrained(model_id, local_files_only=True)
+    except OSError:
+        return None
 
 
 @pytest.mark.integration

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -520,14 +520,15 @@ def test_generate_kwargs_allowlist_includes_known_generate_kwargs() -> None:
 # ---------------------------------------------------------------------------
 
 _GRANITE_MODEL_ID = "ibm-granite/granite-3.3-8b-instruct"
+_GRANITE_THINKING_MODEL_ID = "ibm-granite/granite-4.2-3b"
 
 
-def _try_load_granite_tokenizer():
-    """Return the Granite tokenizer if cached locally, else None."""
+def _try_load_granite_tokenizer(model_id: str):
+    """Return a Granite tokenizer from the local cache, or None."""
     try:
         from transformers import AutoTokenizer
 
-        return AutoTokenizer.from_pretrained(_GRANITE_MODEL_ID, local_files_only=True)
+        return AutoTokenizer.from_pretrained(model_id, local_files_only=True)
     except Exception:
         return None
 
@@ -544,7 +545,7 @@ def test_granite_allowlist_includes_known_template_vars() -> None:
     it means either the Granite template changed or _HF_INTERNAL_TEMPLATE_VARS
     is now incorrectly excluding something it should not.
     """
-    tok = _try_load_granite_tokenizer()
+    tok = _try_load_granite_tokenizer(_GRANITE_MODEL_ID)
     if tok is None:
         pytest.skip(
             f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
@@ -575,7 +576,7 @@ def test_granite_allowlist_excludes_generate_only_options() -> None:
     Failure here means the Granite template now references a GenerationConfig
     parameter name as a Jinja variable, which would require revisiting the design.
     """
-    tok = _try_load_granite_tokenizer()
+    tok = _try_load_granite_tokenizer(_GRANITE_MODEL_ID)
     if tok is None:
         pytest.skip(
             f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
@@ -614,7 +615,7 @@ def test_granite_allowlist_excludes_hf_internal_vars() -> None:
     leaks into the allowlist, forwarding it from model_options would duplicate
     a kwarg that apply_chat_template already provides, causing a TypeError.
     """
-    tok = _try_load_granite_tokenizer()
+    tok = _try_load_granite_tokenizer(_GRANITE_MODEL_ID)
     if tok is None:
         pytest.skip(
             f"{_GRANITE_MODEL_ID} not in local HF cache — run qualitative tests first"
@@ -631,6 +632,38 @@ def test_granite_allowlist_excludes_hf_internal_vars() -> None:
             f"HF-internal var '{var}' leaked into Granite allowlist — "
             f"check _HF_INTERNAL_TEMPLATE_VARS against the installed transformers version"
         )
+
+
+@pytest.mark.huggingface
+def test_granite_thinking_option_uses_detected_template_variable() -> None:
+    """Granite 4.2 receives THINKING under its detected template variable."""
+    tok = _try_load_granite_tokenizer(_GRANITE_THINKING_MODEL_ID)
+    if tok is None:
+        pytest.skip(
+            f"{_GRANITE_THINKING_MODEL_ID} not in local HF cache — "
+            "run the Granite 4.2 HF test lane first"
+        )
+
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = tok
+    b._model_id = _GRANITE_THINKING_MODEL_ID
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+
+    expected_key = next(
+        (
+            variable
+            for variable in _CHAT_TEMPLATE_THINKING_VARS
+            if variable in b._chat_template_allowlist
+        ),
+        None,
+    )
+
+    assert expected_key is not None, (
+        f"no recognised thinking variable in {sorted(b._chat_template_allowlist)}"
+    )
+    assert b._filter_for_chat_template({ModelOption.THINKING: False}) == {
+        expected_key: False
+    }
 
 
 if __name__ == "__main__":

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -24,6 +24,7 @@ torch = pytest.importorskip("torch", reason="torch not installed — install mel
 
 from mellea.backends import ModelOption
 from mellea.backends.huggingface import (
+    _CHAT_TEMPLATE_THINKING_OPTION_MAP,
     _CHAT_TEMPLATE_THINKING_VARS,
     _GENERATE_KWARGS_ALLOWLIST,
     _HF_INTERNAL_TEMPLATE_VARS,
@@ -45,6 +46,8 @@ def _make_backend(template: object) -> LocalHFBackend:
     b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
     object.__setattr__(b, "_tokenizer", _FakeTokenizer())
     b._model_id = "test-org/test-model"
+    b.model_options = {}
+    b.to_mellea_model_opts_map = _CHAT_TEMPLATE_THINKING_OPTION_MAP
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 
@@ -312,6 +315,26 @@ def test_filter_for_chat_template_drops_thinking_without_template_variable() -> 
     b = _make_backend("{{ custom_tools }}")
 
     result = b._filter_for_chat_template({ModelOption.THINKING: True})
+
+    assert result == {}
+
+
+def test_filter_for_chat_template_uses_per_call_thinking_alias_over_default() -> None:
+    """A per-call alias overrides a backend THINKING default before template filtering."""
+    b = _make_backend("{{ thinking }}")
+    b.model_options = {ModelOption.THINKING: False}
+
+    model_options = b._simplify_and_merge({"thinking": True})
+    result = b._filter_for_chat_template(model_options)
+
+    assert result == {"thinking": True}
+
+
+def test_filter_for_chat_template_drops_thinking_effort_level() -> None:
+    """HF does not send string THINKING levels to boolean chat-template variables."""
+    b = _make_backend("{{ thinking }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
 
     assert result == {}
 

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -24,7 +24,6 @@ torch = pytest.importorskip("torch", reason="torch not installed — install mel
 
 from mellea.backends import ModelOption
 from mellea.backends.huggingface import (
-    _CHAT_TEMPLATE_THINKING_OPTION_MAP,
     _CHAT_TEMPLATE_THINKING_VARS,
     _GENERATE_KWARGS_ALLOWLIST,
     _HF_INTERNAL_TEMPLATE_VARS,
@@ -47,7 +46,7 @@ def _make_backend(template: object) -> LocalHFBackend:
     object.__setattr__(b, "_tokenizer", _FakeTokenizer())
     b._model_id = "test-org/test-model"
     b.model_options = {}
-    b.to_mellea_model_opts_map = _CHAT_TEMPLATE_THINKING_OPTION_MAP
+    b.to_mellea_model_opts_map = {}
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 
@@ -339,6 +338,16 @@ def test_filter_for_chat_template_drops_thinking_effort_level() -> None:
     assert result == {}
 
 
+def test_filter_for_chat_template_preserves_native_thinking_value() -> None:
+    """A native template variable is not restricted to ModelOption boolean values."""
+    b = _make_backend("{{ thinking }}")
+
+    model_options = b._simplify_and_merge({"thinking": "low"})
+    result = b._filter_for_chat_template(model_options)
+
+    assert result == {"thinking": "low"}
+
+
 def test_filter_for_chat_template_empty_input() -> None:
     """Empty model_options produces an empty dict."""
     b = _make_backend("{{ think }}")
@@ -525,14 +534,16 @@ _GRANITE_THINKING_MODEL_ID = "ibm-granite/granite-4.2-3b"
 
 def _try_load_granite_tokenizer(model_id: str):
     """Return a Granite tokenizer from the local cache, or None."""
-    try:
-        from transformers import AutoTokenizer
+    from huggingface_hub import _CACHED_NO_EXIST, try_to_load_from_cache
+    from transformers import AutoTokenizer
 
-        return AutoTokenizer.from_pretrained(model_id, local_files_only=True)
-    except Exception:
+    cached_config = try_to_load_from_cache(model_id, "config.json")
+    if cached_config is None or cached_config is _CACHED_NO_EXIST:
         return None
+    return AutoTokenizer.from_pretrained(model_id, local_files_only=True)
 
 
+@pytest.mark.integration
 @pytest.mark.huggingface
 def test_granite_allowlist_includes_known_template_vars() -> None:
     """Granite's chat template exposes 'thinking' as a Jinja var.
@@ -565,6 +576,7 @@ def test_granite_allowlist_includes_known_template_vars() -> None:
     )
 
 
+@pytest.mark.integration
 @pytest.mark.huggingface
 def test_granite_allowlist_excludes_generate_only_options() -> None:
     """The Granite template does not reference GenerationConfig param names as Jinja vars.
@@ -606,6 +618,7 @@ def test_granite_allowlist_excludes_generate_only_options() -> None:
         )
 
 
+@pytest.mark.integration
 @pytest.mark.huggingface
 def test_granite_allowlist_excludes_hf_internal_vars() -> None:
     """HF-internal vars are excluded from the Granite allowlist.
@@ -634,6 +647,7 @@ def test_granite_allowlist_excludes_hf_internal_vars() -> None:
         )
 
 
+@pytest.mark.integration
 @pytest.mark.huggingface
 def test_granite_thinking_option_uses_detected_template_variable() -> None:
     """Granite 4.2 receives THINKING under its detected template variable."""

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -46,7 +46,14 @@ def _make_backend(template: object) -> LocalHFBackend:
     object.__setattr__(b, "_tokenizer", _FakeTokenizer())
     b._model_id = "test-org/test-model"
     b.model_options = {}
-    b.to_mellea_model_opts_map = {}
+    # Mirrors LocalHFBackend.__init__'s real to_mellea_model_opts_map (huggingface.py)
+    # rather than an empty stand-in — the thinking aliases are load-bearing for
+    # _simplify_and_merge's precedence behaviour, exercised by the tests below.
+    b.to_mellea_model_opts_map = {
+        "think": ModelOption.THINKING,
+        "thinking": ModelOption.THINKING,
+        "enable_thinking": ModelOption.THINKING,
+    }
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
     return b
 
@@ -338,14 +345,39 @@ def test_filter_for_chat_template_drops_thinking_effort_level() -> None:
     assert result == {}
 
 
-def test_filter_for_chat_template_preserves_native_thinking_value() -> None:
-    """A native template variable is not restricted to ModelOption boolean values."""
+def test_filter_for_chat_template_drops_thinking_effort_level_via_alias() -> None:
+    """A recognised alias (`thinking`) folds into THINKING and is bool-gated too.
+
+    `to_mellea_model_opts_map` maps `thinking` to `ModelOption.THINKING`, so a
+    non-boolean value supplied via the alias is subject to the same
+    boolean-only restriction as one supplied via the sentinel directly
+    (see `test_filter_for_chat_template_drops_thinking_effort_level`) — there
+    is no separate unconstrained "native" path once the alias is recognised.
+    """
     b = _make_backend("{{ thinking }}")
 
     model_options = b._simplify_and_merge({"thinking": "low"})
     result = b._filter_for_chat_template(model_options)
 
-    assert result == {"thinking": "low"}
+    assert result == {}
+
+
+def test_filter_for_chat_template_sentinel_overrides_conflicting_alias_key() -> None:
+    """ModelOption.THINKING wins over an already-resolved alias key in backend_opts.
+
+    Regression test for an ordering bug: if a caller-supplied model_options
+    dict already contains both the ModelOption.THINKING sentinel and a
+    backend-specific alias key with a conflicting value, the sentinel must
+    still take precedence, matching the other backends (e.g. Ollama reads
+    ModelOption.THINKING directly at the generate call site).
+    """
+    b = _make_backend("{{ thinking }}")
+
+    result = b._filter_for_chat_template(
+        {ModelOption.THINKING: True, "thinking": False}
+    )
+
+    assert result == {"thinking": True}
 
 
 def test_filter_for_chat_template_empty_input() -> None:

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -24,6 +24,7 @@ torch = pytest.importorskip("torch", reason="torch not installed — install mel
 
 from mellea.backends import ModelOption
 from mellea.backends.huggingface import (
+    _CHAT_TEMPLATE_THINKING_VARS,
     _GENERATE_KWARGS_ALLOWLIST,
     _HF_INTERNAL_TEMPLATE_VARS,
     LocalHFBackend,
@@ -285,6 +286,34 @@ def test_filter_for_chat_template_renames_sentinel() -> None:
     b = _make_backend(template)
     result = b._filter_for_chat_template({ModelOption.MAX_NEW_TOKENS: 256})
     assert result == {"max_new_tokens": 256}
+
+
+@pytest.mark.parametrize(
+    "template", ["{{ think }}", "{{ thinking }}", "{{ enable_thinking }}"]
+)
+def test_filter_for_chat_template_maps_thinking_to_template_variable(
+    template: str,
+) -> None:
+    """THINKING reaches the thinking variable detected from the template."""
+    b = _make_backend(template)
+    expected_key = next(
+        variable
+        for variable in _CHAT_TEMPLATE_THINKING_VARS
+        if variable in b._chat_template_allowlist
+    )
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: True})
+
+    assert result == {expected_key: True}
+
+
+def test_filter_for_chat_template_drops_thinking_without_template_variable() -> None:
+    """THINKING does not invent a chat-template variable when none is recognised."""
+    b = _make_backend("{{ custom_tools }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: True})
+
+    assert result == {}
 
 
 def test_filter_for_chat_template_empty_input() -> None:


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #1212

## Description

`LocalHFBackend` previously removed `ModelOption.THINKING` before applying the
tokenizer chat template. This change detects the template's supported thinking
variable (`think`, `thinking`, or `enable_thinking`) and forwards boolean
values under that name. It also canonicalises native aliases during option
resolution, so per-call options correctly override backend defaults.

Following review, `to_mellea_model_opts_map` now maps `think`/`thinking`/
`enable_thinking` to `ModelOption.THINKING` (it previously had no entries for
these, so a raw alias never folded into the sentinel the way it does for
Ollama). `_filter_for_chat_template` now lets the resolved sentinel value win
outright over any leftover alias key instead of deferring to whichever
happened to already be present, matching Ollama's precedence for the same
input. The `ModelOption.THINKING` docstring now notes that non-boolean values
are silently ignored on HF.

This PR deliberately does not add Granite 4.2 model identifiers or change
defaults; #1587 owns that work and its GPU span coverage. The tokenizer-only
integration test uses the public Granite 4.2 3B ID directly to prove the
generic mapping works with the template that first exposes a thinking control.
Its cache-presence check now also tolerates a partial local cache (cached
`config.json` without the tokenizer's own files) by treating an `OSError` from
`AutoTokenizer.from_pretrained(local_files_only=True)` as "not cached" rather
than letting the test error.

During validation, the parallel tool-call regression tests were found to create
a live Ollama backend despite exercising only formatter behaviour. This PR
switches them to the existing mocked backend fixture so the local suite does
not require Ollama for those tests.

### Testing

- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)
  - `uv run pytest test/backends/test_huggingface_filter_options.py -q`: 34 passed, 3 skipped; Granite 4.2 tokenizer regression executed
  - `uv run pytest test/backends/test_acall_tools_parallel_execution.py -q`: 4 passed without Ollama
  - `uv run ruff format --check . && uv run ruff check .`: passed
  - `uv run mypy .`: passed
  - `uv run pytest test/ -m "not qualitative"`: 4,146 passed, 19 skipped, 128 deselected, 4 xpassed

### Attribution

- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
