### PR TITLE
refactor: split annotation and documentation cleanup from #1558

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ Use the tool's common name (e.g., GitHub Copilot, Cursor, etc.).
 | Telemetry import errors | Run `uv sync` to install OpenTelemetry deps |
 | Silent empty strings from async backends | Check for `asyncio.gather(..., return_exceptions=True)` — exceptions become values silently; use `return_exceptions=False` unless callers explicitly handle `BaseException` values |
 | GitHub Actions workflow injection warning | Never use `${{ expression }}` directly inside `run:` shell commands — always route through `env:` (`env: MY_VAR: ${{ expr }}` then `"$MY_VAR"` in the script). This rule applies only to `run:` steps; `${{ }}` in `if:` conditions and `with:` action inputs is fine. |
+| Docstring quality gate false-flags "missing Raises section" with no actual `raise` in the function | `tooling/docs-autogen/audit_coverage.py`'s check is `if "raise " in source` — a substring match over the whole function source, including comments and docstrings. A comment containing the literal text `raise ` triggers it. Reword the comment; don't add a fake `Raises:` section. |
 
 ## 10. Self-Review (before notifying user)
 1. `uv run pytest test/ -m "not qualitative"` passes?

--- a/docs/docs/how-to/execute-tool-calls.md
+++ b/docs/docs/how-to/execute-tool-calls.md
@@ -175,10 +175,10 @@ from mellea.stdlib.context import ChatContext
 async def simple_react(goal: str, backend, tools: list, max_steps: int = 5):
     """Simple ReACT: Think → Act → Observe → Repeat"""
     ctx = ChatContext().add(Message("user", f"Goal: {goal}"))
-    
+
     for step in range(max_steps):
         print(f"\n--- Step {step + 1} ---")
-        
+
         # Think & Act: Generate with tool calls enabled
         result, ctx = await aact(
             Message("system", "Reason about the goal, then call a tool if needed."),
@@ -188,22 +188,22 @@ async def simple_react(goal: str, backend, tools: list, max_steps: int = 5):
             await_result=True,
         )
         print(f"Thought: {result.value[:200]}...")
-        
+
         # Check for final answer
         if "FINAL ANSWER" in result.value:
             return result.value
-        
+
         # Observe: Execute tools
         tool_messages = await acall_tools(result, backend)
         if not tool_messages:
             print("No tools called. Stopping.")
             break
-        
+
         # Add observations to context
         for msg in tool_messages:
             ctx = ctx.add(msg)
             print(f"Observation: {msg.name} → {msg.content[:100]}...")
-    
+
     return "Max steps reached"
 ```
 

--- a/docs/docs/how-to/primitives-vs-high-level.md
+++ b/docs/docs/how-to/primitives-vs-high-level.md
@@ -137,16 +137,16 @@ if safe_calls:
 ```python
 async def custom_react(goal, backend, tools):
     ctx = ChatContext().add(Message("user", goal))
-    
+
     for step in range(max_steps):
         # Think
         result, ctx = await aact(
             system_prompt, ctx, backend, tool_calls=True
         )
-        
+
         # Act (manual tool execution gives you control)
         tool_messages = await acall_tools(result, backend)
-        
+
         # Observe
         for msg in tool_messages:
             ctx = ctx.add(msg)

--- a/docs/examples/m_serve/pii/pii_serve.py
+++ b/docs/examples/m_serve/pii/pii_serve.py
@@ -40,7 +40,7 @@ def pii_remove_validate(
     text: str,
     requirements: list[str] | None = None,
     loop_budget: int = 3,
-    model_options: None | dict = None,
+    model_options: dict | None = None,
 ) -> ModelOutputThunk | SamplingResult | str:
     """PII scrubbing in mellea with validation."""
     # Extra requirements if any.
@@ -74,7 +74,7 @@ def pii_remove_validate(
 def serve(
     input: list[ChatMessage],
     requirements: list[str] | None = None,
-    model_options: None | dict = None,
+    model_options: dict | None = None,
 ) -> ModelOutputThunk | SamplingResult | str:
     """Simple serve example to do PII stuff."""
     message = input[-1].get_text_content()

--- a/docs/examples/m_serve/simple/m_serve_example_simple.py
+++ b/docs/examples/m_serve/simple/m_serve_example_simple.py
@@ -20,7 +20,7 @@ def validate_email_len(email: str) -> bool:
 def serve(
     input: list[ChatMessage],
     requirements: list[str] | None = None,
-    model_options: None | dict = None,
+    model_options: dict | None = None,
 ) -> ModelOutputThunk | SamplingResult:
     """Takes a prompt as input and runs it through an M program."""
     requirements = requirements if requirements else []

--- a/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
+++ b/docs/examples/m_serve/tool-calling/m_serve_example_tool_calling.py
@@ -187,7 +187,7 @@ def _extract_mellea_tools_from_model_options(
 def serve(
     input: list[ChatMessage],
     requirements: list[str] | None = None,
-    model_options: None | dict = None,
+    model_options: dict | None = None,
 ) -> ModelOutputThunk:
     """Serve function that handles tool calling.
 

--- a/docs/examples/notebooks/m_serve_example.ipynb
+++ b/docs/examples/notebooks/m_serve_example.ipynb
@@ -108,7 +108,7 @@
     "def serve(\n",
     "    input: list[ChatMessage],\n",
     "    requirements: list[str] | None = None,\n",
-    "    model_options: None | dict = None,\n",
+    "    model_options: dict | None = None,\n",
     ") -> ModelOutputThunk | SamplingResult:\n",
     "    \"\"\"Takes a prompt as input and runs it through an M program.\"\"\"\n",
     "    requirements = requirements if requirements else []\n",

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -2079,7 +2079,7 @@ def blockify(s: str | Span) -> Span:
             raise Exception("Type Error")
 
 
-def get_images_from_component(c: Component) -> None | list[ImageBlock | ImageUrlBlock]:
+def get_images_from_component(c: Component) -> list[ImageBlock | ImageUrlBlock] | None:
     """Return the images attached to a `Component`, or `None` if absent or empty.
 
     Args:
@@ -2107,7 +2107,7 @@ def get_images_from_component(c: Component) -> None | list[ImageBlock | ImageUrl
         return None
 
 
-def get_audio_from_component(c: Component) -> None | list[AudioBlock | AudioUrlBlock]:
+def get_audio_from_component(c: Component) -> list[AudioBlock | AudioUrlBlock] | None:
     """Return the audio attached to a `Component`, or `None` if absent or empty.
 
     Args:

--- a/mellea/helpers/async_helpers.py
+++ b/mellea/helpers/async_helpers.py
@@ -147,7 +147,7 @@ async def wait_for_all_mots(mots: list[ModelOutputThunk]) -> None:
     await asyncio.gather(*coroutines)
 
 
-def get_current_event_loop() -> None | asyncio.AbstractEventLoop:
+def get_current_event_loop() -> asyncio.AbstractEventLoop | None:
     """Get the current event loop without having to catch exceptions.
 
     Returns:

--- a/mellea/stdlib/components/chat.py
+++ b/mellea/stdlib/components/chat.py
@@ -83,9 +83,9 @@ class Message(Component["Message"]):
         role: "Message.Role",
         content: str,
         *,
-        images: None | list[ImageBlock | ImageUrlBlock] = None,
-        audio: None | list[AudioBlock | AudioUrlBlock] = None,
-        documents: None | Iterable[str | Document] = None,
+        images: list[ImageBlock | ImageUrlBlock] | None = None,
+        audio: list[AudioBlock | AudioUrlBlock] | None = None,
+        documents: Iterable[str | Document] | None = None,
         tool_calls: list[dict[str, Any]] | None = None,
         tool_call_id: str | None = None,
         tool_name: str | None = None,
@@ -108,12 +108,12 @@ class Message(Component["Message"]):
         self._tool_name = tool_name
 
     @property
-    def images(self) -> None | list[ImageBlock | ImageUrlBlock]:
+    def images(self) -> list[ImageBlock | ImageUrlBlock] | None:
         """Returns the images associated with this message."""
         return self._images
 
     @property
-    def audio(self) -> None | list[AudioBlock | AudioUrlBlock]:
+    def audio(self) -> list[AudioBlock | AudioUrlBlock] | None:
         """Returns the audio associated with this message."""
         return self._audio
 


### PR DESCRIPTION
# Pull Request

## Issue
Split from #1558 to keep the adapter lifecycle tracing review focused.

## Description

This PR contains the annotation ordering, documentation whitespace, notebook example, and contributor-guidance updates that were previously mixed into #1558. None of these changes alters adapter lifecycle hooks or tracing behaviour.

### Testing
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run ruff check` on changed Python files
- [x] `uv run mypy .` via pre-commit
- [x] Pre-commit: SPDX, Ruff, Mypy, codespell, and markdownlint

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
