### PR TITLE
fix: surface validate parse errors as ValidationResult.error instead of propagating

### DIFF
--- a/docs/docs/advanced/lora-and-alora-adapters.md
+++ b/docs/docs/advanced/lora-and-alora-adapters.md
@@ -179,8 +179,10 @@ adapter is preferred whenever one is loaded, with three exceptions:
    asking for LLM-as-a-judge regardless of what adapters are loaded.
 3. The adapter is unavailable (e.g. cannot be loaded) — Mellea falls back to
    LLM-as-a-judge automatically. This is the *only* fallback case: if the
-   adapter runs but its output fails schema validation, the error propagates
-   rather than silently falling back.
+   adapter runs but its output fails schema validation, `validate()` does not
+   fall back. Instead it surfaces the schema error on `ValidationResult.error`
+   and fails the check closed (`bool(result)` is `False`), so callers can tell
+   an unparsable adapter response apart from an ordinary "requirement not met".
 
 If you want to force the adapter path even when using `generate_from_context`
 directly (bypassing the normal `validate()` call), use `ALoraRequirement` from

--- a/docs/docs/concepts/requirements-system.md
+++ b/docs/docs/concepts/requirements-system.md
@@ -162,6 +162,7 @@ last output.
 | `score` | `float \| None` | Optional numeric score from your validator. |
 | `thunk` | `ModelOutputThunk \| None` | The model output used, if your validator ran a backend call. |
 | `context` | `Context \| None` | The context snapshot at validation time. |
+| `error` | `Exception \| None` | The exception raised while parsing validator output, if any. When set, `bool(result)` is `False` (fails closed) and `reason` is `None`; lets callers tell an unparsable response apart from an ordinary "requirement not met". |
 
 The `reason` field is the most useful in practice — a clear reason string helps the
 model make a targeted repair rather than regenerating blindly.

--- a/docs/examples/aLora/101_example.py
+++ b/docs/examples/aLora/101_example.py
@@ -35,8 +35,9 @@ m = MelleaSession(backend=backend, ctx=ChatContext())
 # whose prompt asks for a plain "yes"/"no" answer — but the result is still
 # parsed as JSON by requirement_check_to_bool: a plain yes/no reply raises
 # json.JSONDecodeError (it is not JSON), and a JSON reply that doesn't match
-# the schema raises AdapterSchemaMismatchError — either way the error
-# propagates out of validate() instead of returning a failed check. The ALORA
+# the schema raises AdapterSchemaMismatchError — either way validate() surfaces
+# the error on ValidationResult.error and fails the check closed rather than
+# returning an ordinary failed check or propagating the exception. The ALORA
 # type is also load-bearing here: routing only looks up ("alora",), so
 # registering the LORA variant instead would hit the same failure.
 backend.add_adapter(

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -344,9 +344,16 @@ class Requirement(Component[str]):
                 # Surface that as a third outcome rather than propagating: the
                 # result fails closed and carries the exception for callers that
                 # want to distinguish it from an ordinary failure.
+                #
+                # reason is deliberately None here. Repair strategies treat a
+                # truthy reason as literal prompt text; the judge output that
+                # triggered the parse error is malformed and would make useless
+                # repair guidance. None routes repair to the existing
+                # requirement-description fallback, while error and thunk retain
+                # the diagnostic for callers that inspect the result directly.
                 return ValidationResult(
                     result=False,
-                    reason=reason,
+                    reason=None,
                     thunk=llm_as_a_judge_result,
                     context=val_ctx,
                     error=exc,

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -38,6 +38,11 @@ class ValidationResult:
         score (float | None): Optional numeric score returned by the validator.
         thunk (ModelOutputThunk | None): The `ModelOutputThunk` produced during LLM-as-a-Judge validation, if applicable.
         context (Context | None): The context associated with the validation backend call, if applicable.
+        error (Exception | None): Set when validation could not produce a verdict because the
+            output could not be parsed — for example an `AdapterSchemaMismatchError` from a
+            custom `output_to_bool`. When set, `bool(result)` fails closed to `False`
+            regardless of `result`, so callers that ignore errors do not silently pass.
+            Inspect `error` to distinguish "requirement not met" from "output unparsable".
 
     """
 
@@ -49,6 +54,7 @@ class ValidationResult:
         score: float | None = None,
         thunk: ModelOutputThunk | None = None,
         context: Context | None = None,
+        error: Exception | None = None,
     ):
         """Initialize ValidationResult with a pass/fail boolean and optional metadata."""
         self._result = result
@@ -56,6 +62,7 @@ class ValidationResult:
         self._score = score
         self._thunk = thunk
         self._context = context
+        self._error = error
 
     @property
     def reason(self) -> str | None:
@@ -77,12 +84,29 @@ class ValidationResult:
         """The context associated with validation if a backend was used to generate the final result."""
         return self._context
 
+    @property
+    def error(self) -> Exception | None:
+        """The exception raised while parsing the validation output, if any.
+
+        Set when `validate()` could not produce a verdict because the output was
+        unparsable (e.g. an `AdapterSchemaMismatchError` from a custom
+        `output_to_bool`). `None` for an ordinary pass or fail. When set,
+        `as_bool()` returns `False` regardless of the underlying result.
+        """
+        return self._error
+
     def as_bool(self) -> bool:
         """Return a boolean value based on the validation result.
 
+        Fails closed when an `error` is set: an unparsable output is never
+        treated as a pass, so callers that only check the boolean fail safely
+        rather than silently accepting a result that was never computed.
+
         Returns:
-            bool: `True` if the requirement passed, `False` otherwise.
+            bool: `True` if the requirement passed and no error is set, `False` otherwise.
         """
+        if self._error is not None:
+            return False
         return self._result
 
     def __bool__(self) -> bool:
@@ -91,7 +115,10 @@ class ValidationResult:
 
     def __repr__(self) -> str:
         """Return a developer-readable representation of the validation result."""
-        return f"ValidationResult({self._result!r}, reason={self._reason!r}, score={self._score!r})"
+        return (
+            f"ValidationResult({self._result!r}, reason={self._reason!r}, "
+            f"score={self._score!r}, error={self._error!r})"
+        )
 
 
 class PartialValidationResult:
@@ -266,15 +293,16 @@ class Requirement(Component[str]):
             model_options (dict | None): Optional model options to pass to the backend during the judgement call.
 
         Returns:
-            ValidationResult: The result of the validation, including a boolean pass/fail and optional metadata.
+            ValidationResult: The result of the validation, including a boolean pass/fail
+            and optional metadata. If `output_to_bool` raises while parsing the judgement
+            output (e.g. `AdapterSchemaMismatchError` on an unexpected adapter schema), the
+            exception is caught and stored on `result.error` rather than propagated: the
+            result fails closed (`bool(result)` is `False`), and callers can inspect
+            `result.error` to distinguish "requirement not met" from "output unparsable".
 
         Raises:
-            Exception: Any exception raised by `output_to_bool` propagates to the caller.
-                Custom `output_to_bool` functions (including adapter-backed ones such as
-                `requirement_check_to_bool`) may raise on malformed output — e.g.
-                `AdapterSchemaMismatchError` when the adapter returns an unexpected schema.
-                Callers that previously treated all non-`True` outcomes as "requirement not
-                met" must now catch these exceptions separately.
+            AssertionError: If the LLM-as-a-Judge strategy is selected but `output_to_bool`
+                is `None`, or if the context has no `ModelOutputThunk` as its last output.
         """
         if self.validation_fn is not None:
             # Python validation strategy
@@ -308,8 +336,24 @@ class Requirement(Component[str]):
                 if judge_output_str in ("yes", "no"):
                     reason = self.description
 
+            try:
+                result = self.output_to_bool(llm_as_a_judge_result)
+            except Exception as exc:
+                # A custom output_to_bool (e.g. the adapter-backed
+                # requirement_check_to_bool) can raise on unparsable output.
+                # Surface that as a third outcome rather than propagating: the
+                # result fails closed and carries the exception for callers that
+                # want to distinguish it from an ordinary failure.
+                return ValidationResult(
+                    result=False,
+                    reason=reason,
+                    thunk=llm_as_a_judge_result,
+                    context=val_ctx,
+                    error=exc,
+                )
+
             return ValidationResult(
-                result=self.output_to_bool(llm_as_a_judge_result),
+                result=result,
                 reason=reason,
                 thunk=llm_as_a_judge_result,
                 context=val_ctx,

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -71,9 +71,12 @@ class ALoraRequirement(Requirement, Intrinsic):
 
     If the adapter generates output but the output **fails schema validation**
     (`requirement_check_to_bool` raises `AdapterSchemaMismatchError`), the
-    exception propagates to the caller — it is not caught and does not trigger
-    the LLMaJ fallback.  This is intentional: schema drift should surface
-    loudly rather than silently return a wrong result.
+    error is surfaced on the returned `ValidationResult.error` by
+    `Requirement.validate` — it is not caught here and does not trigger the
+    LLMaJ fallback, which covers only generation errors.  The result fails
+    closed (`bool(result)` is `False`), so schema drift is neither silently
+    treated as a pass nor raised as an unexpected exception; callers can inspect
+    `result.error` to tell it apart from an ordinary "requirement not met".
 
     Args:
         description (str): Human-readable requirement description.

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -219,11 +219,13 @@ async def test_validate_yes_in_sentence_preserves_output(mock_backend):
 # --- validate() surfaces parse errors as a third outcome (issue #1358) ---
 
 
-async def _validate_with_output_to_bool(backend, output_to_bool):
+async def _validate_with_output_to_bool(
+    backend, output_to_bool, judge_value: str = "some judge output"
+):
     """Run Requirement.validate with a mocked backend and a custom output_to_bool."""
     req = Requirement("some requirement", output_to_bool=output_to_bool)
     ctx = ChatContext().add(ModelOutputThunk("some output"))
-    judge_thunk = ModelOutputThunk(value="some judge output")
+    judge_thunk = ModelOutputThunk(value=judge_value)
     val_ctx = ctx.add(judge_thunk)
 
     with patch.object(
@@ -245,6 +247,30 @@ async def test_validate_returns_error_state_on_schema_mismatch(mock_backend):
 
     assert result.error is exc
     assert bool(result) is False
+
+
+async def test_validate_error_state_has_no_reason(mock_backend):
+    """Parse-error results carry reason=None so repair uses the description fallback.
+
+    Repair strategies treat a truthy reason as literal prompt text. The judge
+    output that triggered the parse error is malformed, so surfacing it as a
+    reason would produce useless repair guidance; reason must be None even when
+    the judge produced non-binary, truthy text.
+    """
+
+    def raising_output_to_bool(x):
+        raise ValueError("unrecognizable adapter output")
+
+    result = await _validate_with_output_to_bool(
+        mock_backend,
+        raising_output_to_bool,
+        judge_value="malformed non-binary judge output that is truthy",
+    )
+
+    assert result.error is not None
+    assert result.reason is None
+    # The diagnostic thunk is still retained for direct inspection.
+    assert result.thunk is not None
 
 
 async def test_validate_happy_path_unaffected(mock_backend):

--- a/test/core/test_requirement_helpers.py
+++ b/test/core/test_requirement_helpers.py
@@ -56,6 +56,45 @@ def test_validation_result_defaults_none():
     assert r.score is None
     assert r.thunk is None
     assert r.context is None
+    assert r.error is None
+
+
+# --- ValidationResult error state (issue #1358) ---
+
+
+def test_validation_result_error_field():
+    """The error field stores an exception and defaults to None."""
+    exc = ValueError("bad output")
+    r = ValidationResult(result=False, error=exc)
+    assert r.error is exc
+
+
+def test_bool_result_false_when_error_set():
+    """`bool(result)` / `as_bool()` fail closed when error is set, even if result=True."""
+    r = ValidationResult(result=True, error=RuntimeError("parse failed"))
+    assert r.as_bool() is False
+    assert bool(r) is False
+
+
+def test_bool_result_uses_result_when_no_error():
+    """Without an error, as_bool reflects the underlying result verbatim."""
+    assert ValidationResult(result=True).as_bool() is True
+    assert ValidationResult(result=False).as_bool() is False
+
+
+def test_callers_can_distinguish_failure_from_error():
+    """A plain failure has error=None; a parse failure carries the exception."""
+    plain_failure = ValidationResult(result=False)
+    parse_failure = ValidationResult(result=False, error=KeyError("score"))
+
+    assert plain_failure.error is None
+    assert isinstance(parse_failure.error, KeyError)
+
+
+def test_validation_result_repr_includes_error():
+    """repr surfaces the error so a swallowed exception is still visible in logs."""
+    r = ValidationResult(result=False, error=ValueError("boom"))
+    assert "error=" in repr(r)
 
 
 # --- default_output_to_bool ---
@@ -175,6 +214,45 @@ async def test_validate_yes_in_sentence_preserves_output(mock_backend):
     )
     assert result.as_bool() is True
     assert result.reason == "Yes, the email has a salutation"
+
+
+# --- validate() surfaces parse errors as a third outcome (issue #1358) ---
+
+
+async def _validate_with_output_to_bool(backend, output_to_bool):
+    """Run Requirement.validate with a mocked backend and a custom output_to_bool."""
+    req = Requirement("some requirement", output_to_bool=output_to_bool)
+    ctx = ChatContext().add(ModelOutputThunk("some output"))
+    judge_thunk = ModelOutputThunk(value="some judge output")
+    val_ctx = ctx.add(judge_thunk)
+
+    with patch.object(
+        backend,
+        "generate_from_context",
+        new=AsyncMock(return_value=(judge_thunk, val_ctx)),
+    ):
+        return await req.validate(backend, ctx)
+
+
+async def test_validate_returns_error_state_on_schema_mismatch(mock_backend):
+    """A raising output_to_bool becomes a ValidationResult carrying the exception."""
+    exc = ValueError("unrecognizable adapter output")
+
+    def raising_output_to_bool(x):
+        raise exc
+
+    result = await _validate_with_output_to_bool(mock_backend, raising_output_to_bool)
+
+    assert result.error is exc
+    assert bool(result) is False
+
+
+async def test_validate_happy_path_unaffected(mock_backend):
+    """A non-raising output_to_bool leaves error unset and honors the result."""
+    result = await _validate_with_output_to_bool(mock_backend, lambda x: True)
+
+    assert result.error is None
+    assert bool(result) is True
 
 
 if __name__ == "__main__":

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -243,11 +243,14 @@ def test_alora_requirement_custom_intrinsic(mock_intrinsic_init):
 
 
 @patch("mellea.stdlib.requirements.requirement.Intrinsic.__init__")
-async def test_alora_validate_propagates_schema_mismatch(mock_intrinsic_init):
-    """AdapterSchemaMismatchError from output_to_bool propagates uncaught through validate().
+async def test_alora_validate_surfaces_schema_mismatch_as_error(mock_intrinsic_init):
+    """AdapterSchemaMismatchError from output_to_bool is surfaced on the result, not raised.
 
-    This documents that the LLMaJ fallback in ALoraRequirement covers only
-    generation errors, not output-parsing schema mismatches.
+    `validate()` catches the parse error, stores it on `result.error`, and
+    returns a fail-closed result rather than propagating. This lets callers
+    distinguish "requirement not met" from "adapter produced unrecognizable
+    output" (issue #1358). The LLMaJ fallback in ALoraRequirement still covers
+    only generation errors, not output-parsing schema mismatches.
     """
     mock_intrinsic_init.return_value = None
     req = ALoraRequirement("must satisfy requirement")
@@ -260,8 +263,10 @@ async def test_alora_validate_propagates_schema_mismatch(mock_intrinsic_init):
     mock_backend = MagicMock()
     mock_backend.generate_from_context = AsyncMock(return_value=(mock_thunk, ctx))
 
-    with pytest.raises(AdapterSchemaMismatchError):
-        await req.validate(mock_backend, ctx=ctx)
+    result = await req.validate(mock_backend, ctx=ctx)
+
+    assert isinstance(result.error, AdapterSchemaMismatchError)
+    assert bool(result) is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1358 

## Description
<!-- What does this PR do and why? -->
surface validate parse errors as ValidationResult.error instead of propagating

### Testing
- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
