### PR TITLE
feat(backends): support embedded adapters on LocalHFBackend

### DIFF
--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -299,7 +299,7 @@ implementations, not whether a composed `Adapter` can be registered directly:
 
 | Backend | `LocalFileBinding` (LocalFile/PEFT) | `EmbeddedBinding` (Embedded/Granite Switch) | `ServerMediatedBinding` |
 | --- | --- | --- | --- |
-| `LocalHFBackend` | ✅ shipping — `add_adapter` accepts a `LocalFileBinding` directly | ✅ shipping — `load_embedded_adapters=True` registers embedded adapter functions | — |
+| `LocalHFBackend` | ✅ shipping — `add_adapter` accepts a `LocalFileBinding` directly | ✅ shipping — `load_embedded_adapters=True`, via the deprecated `EmbeddedIntrinsicAdapter` shim | — |
 | `OpenAIBackend` | — | ✅ shipping, via the deprecated `EmbeddedIntrinsicAdapter` shim above, which builds an `EmbeddedBinding` internally | — |
 
 `ServerMediatedBinding` has no backend implementation yet — see discussion #1486.

--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -5,11 +5,10 @@ description: "Adapter-accelerated RAG quality checks using LoRA/aLoRA adapters w
 ---
 
 **Prerequisites:** use `uv sync --extra hf` for runtime LoRA/aLoRA adapter
-functions, or `uv sync --extra hf --extra switch` for a local
-[Granite Switch](/reference/glossary#granite-switch) checkpoint. Both local
-paths require a GPU or Apple Silicon Mac. An OpenAIBackend using a Granite
-Switch model served via vLLM only needs the base package plus the `switch` extra
-when it downloads embedded adapter metadata.
+functions and local [Granite Switch](/reference/glossary#granite-switch)
+checkpoints. Both local paths require a GPU or Apple Silicon Mac. An
+OpenAIBackend using a Granite Switch model served via vLLM uses
+`uv sync --extra switch` when it downloads embedded adapter metadata.
 
 Adapter functions are adapter-accelerated operations for RAG quality checks. They use
 LoRA/aLoRA adapters loaded directly into the Hugging Face backend — faster and more
@@ -19,7 +18,7 @@ reliable than prompting a general-purpose model for these specialized micro-task
 >
 > - **LocalHFBackend** — loads LoRA/aLoRA adapters from the catalog at runtime.
 >   A local Granite Switch checkpoint can instead use
->   `load_embedded_adapters=True`; install `mellea[hf,switch]` first. Only
+>   `load_embedded_adapters=True`; install `mellea[hf]` first. Only
 >   adapter functions embedded in the checkpoint are then available. Requires a
 >   GPU or Apple Silicon Mac.
 > - **OpenAIBackend** — uses a Granite Switch model served via vLLM with
@@ -46,7 +45,7 @@ checkpoint to `LocalHFBackend` with `load_embedded_adapters=True`; existing
 helper functions such as `rag.check_answerability()` work unchanged.
 
 ```python
-# Requires: mellea[hf,switch]
+# Requires: mellea[hf]
 # Returns: LocalHFBackend
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW

--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -4,9 +4,12 @@ description: "Adapter-accelerated RAG quality checks using LoRA/aLoRA adapters w
 # diataxis: how-to
 ---
 
-**Prerequisites:** `pip install "mellea[hf]"` for LocalHFBackend (GPU or Apple
-Silicon Mac recommended), or `pip install mellea` for OpenAIBackend with a
-[Granite Switch](/reference/glossary#granite-switch) model served via vLLM.
+**Prerequisites:** use `uv sync --extra hf` for runtime LoRA/aLoRA adapter
+functions, or `uv sync --extra hf --extra switch` for a local
+[Granite Switch](/reference/glossary#granite-switch) checkpoint. Both local
+paths require a GPU or Apple Silicon Mac. An OpenAIBackend using a Granite
+Switch model served via vLLM only needs the base package plus the `switch` extra
+when it downloads embedded adapter metadata.
 
 Adapter functions are adapter-accelerated operations for RAG quality checks. They use
 LoRA/aLoRA adapters loaded directly into the Hugging Face backend — faster and more
@@ -35,6 +38,29 @@ from mellea.backends.huggingface import LocalHFBackend
 
 backend = LocalHFBackend(model_id="ibm-granite/granite-4.1-3b")
 ```
+
+## Use a local Granite Switch checkpoint
+
+Granite Switch checkpoints contain their adapter functions already. Pass the
+checkpoint to `LocalHFBackend` with `load_embedded_adapters=True`; existing
+helper functions such as `rag.check_answerability()` work unchanged.
+
+```python
+# Requires: mellea[hf,switch]
+# Returns: LocalHFBackend
+from mellea.backends.huggingface import LocalHFBackend
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
+
+backend = LocalHFBackend(
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW,
+    load_embedded_adapters=True,
+)
+```
+
+Only adapter functions listed in the checkpoint's `adapter_index.json` are
+available. Mellea warns once if Granite Switch's installed package metadata
+does not yet include Mellea's resolved Transformers version; the warning
+disappears after Granite Switch publishes compatible metadata.
 
 Or, with a Granite Switch model via the OpenAI backend:
 

--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -15,7 +15,9 @@ reliable than prompting a general-purpose model for these specialized micro-task
 > **Backend note:** Adapter functions work with two backends:
 >
 > - **LocalHFBackend** — loads LoRA/aLoRA adapters from the catalog at runtime.
->   All adapter functions are available. Requires a GPU or Apple Silicon Mac.
+>   A local Granite Switch checkpoint can instead use
+>   `load_embedded_adapters=True`; then only adapter functions embedded in the
+>   checkpoint are available. Requires a GPU or Apple Silicon Mac.
 > - **OpenAIBackend** — uses a Granite Switch model served via vLLM with
 >   `load_embedded_adapters=True`. Only adapter functions embedded in the model are
 >   available — check the model's `adapter_index.json` for the list.
@@ -297,7 +299,7 @@ implementations, not whether a composed `Adapter` can be registered directly:
 
 | Backend | `LocalFileBinding` (LocalFile/PEFT) | `EmbeddedBinding` (Embedded/Granite Switch) | `ServerMediatedBinding` |
 | --- | --- | --- | --- |
-| `LocalHFBackend` | ✅ shipping — `add_adapter` accepts a `LocalFileBinding` directly | 🔜 planned (#1018) | — |
+| `LocalHFBackend` | ✅ shipping — `add_adapter` accepts a `LocalFileBinding` directly | ✅ shipping — `load_embedded_adapters=True` registers embedded adapter functions | — |
 | `OpenAIBackend` | — | ✅ shipping, via the deprecated `EmbeddedIntrinsicAdapter` shim above, which builds an `EmbeddedBinding` internally | — |
 
 `ServerMediatedBinding` has no backend implementation yet — see discussion #1486.

--- a/docs/docs/advanced/intrinsics.md
+++ b/docs/docs/advanced/intrinsics.md
@@ -16,8 +16,9 @@ reliable than prompting a general-purpose model for these specialized micro-task
 >
 > - **LocalHFBackend** — loads LoRA/aLoRA adapters from the catalog at runtime.
 >   A local Granite Switch checkpoint can instead use
->   `load_embedded_adapters=True`; then only adapter functions embedded in the
->   checkpoint are available. Requires a GPU or Apple Silicon Mac.
+>   `load_embedded_adapters=True`; install `mellea[hf,switch]` first. Only
+>   adapter functions embedded in the checkpoint are then available. Requires a
+>   GPU or Apple Silicon Mac.
 > - **OpenAIBackend** — uses a Granite Switch model served via vLLM with
 >   `load_embedded_adapters=True`. Only adapter functions embedded in the model are
 >   available — check the model's `adapter_index.json` for the list.

--- a/docs/docs/advanced/lora-and-alora-adapters.md
+++ b/docs/docs/advanced/lora-and-alora-adapters.md
@@ -19,7 +19,8 @@ Hugging Face account.
 > They do not work with Ollama, OpenAI, or other remote backends.
 >
 > Granite Switch models ship with pre-trained adapter functions embedded in the
-> model weights, which can be used via `OpenAIBackend` with
+> model weights. Use them through `OpenAIBackend` with a served checkpoint, or
+> through `LocalHFBackend` with a local checkpoint and
 > `load_embedded_adapters=True`. See [Adapter functions](./intrinsics.md) for details.
 
 ## LoRA vs aLoRA

--- a/docs/docs/reference/glossary.md
+++ b/docs/docs/reference/glossary.md
@@ -273,7 +273,7 @@ Granite Libraries is the collective name for the three curated collections of
 [adapter functions](#adapter-function) published by IBM Granite:
 
 | Collection | Purpose |
-|-----------|---------|
+| ---------- | --------- |
 | **Granite Libraries Core** | General-purpose capabilities: certainty checking, requirement verification, context attribution |
 | **Granite Libraries RAG** | Retrieval-Augmented Generation pipeline: answerability, citations, hallucination detection, query rewriting |
 | **Granite Libraries Guardian** | Safety and compliance: guardian checks, policy guardrails, factuality detection and correction |
@@ -472,10 +472,11 @@ See: [Safety Guardrails](../how-to/safety-guardrails#policy-compliance)
 Granite Switch is the architecture and toolchain for composing adapter functions into a
 single deployable Granite model. The composer embeds LoRA/aLoRA adapter function weights
 directly into a base Granite model checkpoint, producing a self-contained model file that
-carries its adapter functions with it. When that checkpoint is served via vLLM and
-accessed through `OpenAIBackend` with `load_embedded_adapters=True`, adapter functions
-are available without runtime adapter loading. Only adapter functions embedded in the
-checkpoint are available — check the model's `adapter_index.json`.
+carries its adapter functions with it. It can be used through `OpenAIBackend`
+when served via vLLM, or directly through `LocalHFBackend`; both use
+`load_embedded_adapters=True` to register the checkpoint's adapter functions
+without runtime adapter loading. Only adapter functions embedded in the checkpoint
+are available — check the model's `adapter_index.json`.
 
 The resulting model file is sometimes called a **Granite Switch checkpoint** or simply a
 **checkpoint**. The toolchain that produces it is the **Granite Switch composer**.
@@ -567,8 +568,9 @@ See: [Use Images and Vision Models](../how-to/use-images-and-vision)
 in Mellea's implementation. It is a backend-level primitive — a structured generation
 operation backed by a LoRA/aLoRA adapter with special input/output handling (e.g.,
 constrained decoding, RAG retrieval). `LocalHFBackend` loads `Intrinsic` adapters at
-runtime; `OpenAIBackend` uses them when backed by a [Granite Switch](#granite-switch)
-checkpoint with `load_embedded_adapters=True`.
+runtime or uses adapter functions embedded in a local [Granite Switch](#granite-switch)
+checkpoint with `load_embedded_adapters=True`. `OpenAIBackend` also supports
+embedded adapter functions when backed by a Granite Switch deployment.
 
 > **Note:** The Python symbol `Intrinsic` (and related classes such as `IntrinsicAdapter`)
 > will be renamed to `AdapterFunction` / `Adapter` in a future phase of Epic #929

--- a/docs/examples/granite-switch/README.md
+++ b/docs/examples/granite-switch/README.md
@@ -19,13 +19,17 @@ weights are transferred.
 Run the local example on a GPU or Apple Silicon Mac:
 
 ```bash
-uv sync --extra hf --extra switch
+uv sync --extra hf
 ```
 
 ### OpenAI-compatible inference
 
 1. Host a Granite Switch model with [vLLM](https://docs.vllm.ai/).
-2. Install the `switch` extra to download embedded adapter metadata.
+2. Install the `switch` extra to download embedded adapter metadata:
+
+```bash
+uv sync --extra switch
+```
 
 ## Available adapters
 

--- a/docs/examples/granite-switch/README.md
+++ b/docs/examples/granite-switch/README.md
@@ -1,34 +1,44 @@
 # Granite Switch Examples
 
-This directory contains examples for running Mellea adapter functions through an
-OpenAI-compatible backend using Granite Switch models.
+This directory contains examples for running Mellea adapter functions with
+Granite Switch models, either locally through `LocalHFBackend` or through an
+OpenAI-compatible vLLM deployment.
 
 ## What is Granite Switch?
 
 Granite Switch models ship with LoRA and aLoRA adapters pre-baked into the model
-weights. Instead of loading adapters at runtime (as `LocalHFBackend` does), these
-embedded adapters are activated via control tokens injected by the model's chat
-template. Only the I/O transformation configs are downloaded — no adapter weights
-are transferred.
+weights. Unlike runtime LoRA/aLoRA adapters on a standard `LocalHFBackend`,
+these embedded adapters are activated via control tokens injected by the model's
+chat template. Only the I/O transformation configs are downloaded — no adapter
+weights are transferred.
 
 ## Prerequisites
 
-1. A Granite Switch model hosted via [vLLM](https://docs.vllm.ai/):
+### Local Hugging Face inference
+
+Run the local example on a GPU or Apple Silicon Mac:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-    --model <granite-switch-model-id> \
-    --dtype bfloat16 \
-    --enable-prefix-caching
+uv sync --extra hf --extra switch
 ```
 
-2. `pip install mellea`
+### OpenAI-compatible inference
+
+1. Host a Granite Switch model with [vLLM](https://docs.vllm.ai/).
+2. Install the `switch` extra to download embedded adapter metadata.
 
 ## Available adapters
 
-Not all adapter functions are embedded in every Granite Switch model. You should check the model's `adapter_index.json` file for a definitive list. For granite switch models pre-built by IBM, we include a list of models in the Mellea `model_id`.
+Not all adapter functions are embedded in every Granite Switch model. Check the
+model's `adapter_index.json` for a definitive list. For Granite Switch models
+pre-built by IBM, Mellea includes a list of models in `model_id`.
 
 ## Files
+
+### answerability_local_hf.py
+
+Demonstrates `rag.check_answerability()` against a local Granite Switch
+checkpoint using `LocalHFBackend(load_embedded_adapters=True)`.
 
 ### answerability_openai.py
 
@@ -49,10 +59,11 @@ you only need a subset of adapters or want more control over adapter
 registration.
 
 ## Architecture
+
 ![Granite Libraries Software Stack Architecture in Mellea](../../docs/images/granite-libraries-mellea-architecture.png)
 
 ## Related
 
-- [`../intrinsics/`](../intrinsics/) — the same adapter functions using `LocalHFBackend`
+- [`../intrinsics/`](../intrinsics/) — runtime LoRA/aLoRA adapter functions
 - [Adapter Functions Documentation](../../docs/docs/advanced/intrinsics.md)
-- [Official Granite Switch Documentation](https://github.com/generative-computing/granite-switch) 
+- [Official Granite Switch Documentation](https://github.com/generative-computing/granite-switch)

--- a/docs/examples/granite-switch/answerability_local_hf.py
+++ b/docs/examples/granite-switch/answerability_local_hf.py
@@ -1,0 +1,29 @@
+# pytest: e2e, huggingface, skip
+
+"""Run the answerability adapter function through a local Granite Switch checkpoint.
+
+Requires a GPU or Apple Silicon Mac and:
+
+    uv sync --extra hf --extra switch
+
+To run from the Mellea source tree:
+
+    uv run python docs/examples/granite-switch/answerability_local_hf.py
+"""
+
+from mellea.backends.huggingface import LocalHFBackend
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
+from mellea.stdlib.components import Document, Message
+from mellea.stdlib.components.intrinsic import rag
+from mellea.stdlib.context import ChatContext
+
+backend = LocalHFBackend(
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW, load_embedded_adapters=True
+)
+
+context = ChatContext().add(Message("assistant", "Hello! How can I help you?"))
+question = "What is the square root of 4?"
+documents = [Document("The square root of 4 is 2.")]
+
+result = rag.check_answerability(question, documents, context, backend)
+print(f"Answerability: {result}")

--- a/docs/examples/granite-switch/answerability_local_hf.py
+++ b/docs/examples/granite-switch/answerability_local_hf.py
@@ -4,7 +4,7 @@
 
 Requires a GPU or Apple Silicon Mac and:
 
-    uv sync --extra hf --extra switch
+    uv sync --extra hf
 
 To run from the Mellea source tree:
 

--- a/docs/examples/intrinsics/README.md
+++ b/docs/examples/intrinsics/README.md
@@ -8,7 +8,9 @@ This directory contains examples for using Mellea's adapter functions - speciali
 - **Adapter System**: Using LoRA/aLoRA adapters for specific tasks
 - **RAG Evaluation**: Assessing retrieval-augmented generation quality
 - **Quality Metrics**: Measuring relevance, groundedness, and accuracy
-- **Backend Integration**: Adding adapters to different backend types (LocalHFBackend with runtime adapters, OpenAIBackend with Granite Switch embedded adapters)
+- **Backend Integration**: Running adapter functions through LocalHFBackend
+  (runtime adapters or local Granite Switch checkpoints) and OpenAIBackend
+  (Granite Switch deployments)
 
 ## Basic Usage
 
@@ -29,16 +31,22 @@ result = core.check_certainty(ctx, backend)
 print(f"Certainty score: {result}")
 ```
 
-OpenAIBackends also support a type of embedded adapter for Granite Switch models:
+Granite Switch models can run locally with `LocalHFBackend`:
+
 ```python
-backend = OpenAIBackend(
-        model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
-        load_embedded_adapters=True,  # Auto-loads adapters from Hugging Face repo.
-        ...
+from mellea.backends.huggingface import LocalHFBackend
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
+
+backend = LocalHFBackend(
+    model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW,
+    load_embedded_adapters=True,
 )
 ```
 
+Install this path with `uv sync --extra hf --extra switch`.
+
 The underlying adapter functions can also be utilized directly when generating:
+
 ```python
 from mellea.stdlib.components import Intrinsic
 import mellea.stdlib.functional as mfuncs
@@ -54,8 +62,8 @@ out, new_ctx = mfuncs.act(
 )
 ```
 
-For complete runnable examples using the OpenAI backend with Granite Switch,
-see [`../granite-switch/`](../granite-switch/).
+For complete runnable Granite Switch examples, see
+[`../granite-switch/`](../granite-switch/).
 
 > **Note:** Not all adapter functions are embedded in every Granite Switch model. You should check
 > the model's `adapter_index.json` file for a definitive list. For granite switch models

--- a/docs/examples/intrinsics/README.md
+++ b/docs/examples/intrinsics/README.md
@@ -43,7 +43,7 @@ backend = LocalHFBackend(
 )
 ```
 
-Install this path with `uv sync --extra hf --extra switch`.
+Install this path with `uv sync --extra hf`.
 
 The underlying adapter functions can also be utilized directly when generating:
 

--- a/docs/examples/intrinsics/intrinsics.py
+++ b/docs/examples/intrinsics/intrinsics.py
@@ -12,7 +12,7 @@ from mellea.stdlib.context import ChatContext
 
 backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B)
 # --- Alternative: local Granite Switch checkpoint ---
-# Requires: uv sync --extra hf --extra switch
+# Requires: uv sync --extra hf
 # See docs/examples/granite-switch/answerability_local_hf.py for a runnable example.
 # from mellea.backends.huggingface import LocalHFBackend
 # from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW

--- a/docs/examples/intrinsics/intrinsics.py
+++ b/docs/examples/intrinsics/intrinsics.py
@@ -11,18 +11,14 @@ from mellea.stdlib.context import ChatContext
 # for helper functions.
 
 backend = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B)
-# --- Alternative: OpenAI backend with Granite Switch (requires vLLM server) ---
-# Requires the adapter for this intrinsic to be embedded in the Granite Switch
-# model. See docs/examples/granite-switch/ for a full runnable example.
-# from mellea.backends.openai import OpenAIBackend
+# --- Alternative: local Granite Switch checkpoint ---
+# Requires: uv sync --extra hf --extra switch
+# See docs/examples/granite-switch/answerability_local_hf.py for a runnable example.
+# from mellea.backends.huggingface import LocalHFBackend
 # from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
-# from mellea.formatters import TemplateFormatter
 #
-# backend = OpenAIBackend(
-#     model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name,
-#     formatter=TemplateFormatter(model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW.hf_model_name),
-#     base_url="http://localhost:8000/v1",  # vLLM server URL
-#     api_key="EMPTY",
+# backend = LocalHFBackend(
+#     model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW,
 #     load_embedded_adapters=True,
 # )
 # --- End alternative ---

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -725,7 +725,8 @@ class EmbeddedBinding:
         source (str): Base model identifier this binding activates adapters
             against — the backend's `base_model_name` (e.g. `granite-4.1-3b`
             for a backend built against `ibm-granite/granite-4.1-3b`).
-            Stamped by `OpenAIBackend.add_adapter` at registration; not
+            Stamped by `OpenAIBackend.add_adapter` or
+            `LocalHFBackend.add_adapter` at registration; not
             otherwise used by `apply_activation`.
     """
 
@@ -776,14 +777,13 @@ class EmbeddedBinding:
         invocation-complete event here would have to guess an `outcome` that
         this method cannot know, which is worse than not firing it: it would
         report `outcome="success"` for calls that go on to fail. Wiring a
-        real invocation-complete signal in requires the caller (currently
-        `OpenAIBackend._generate_from_intrinsic`) to fire it once generation
-        and parsing resolve — tracked as a follow-up, not part of this method.
+        real invocation-complete signal requires the caller to fire it once
+        generation and parsing resolve — tracked as a follow-up, not part of
+        this method.
 
         This method is `async` (unlike the rest of `EmbeddedBinding`'s
         surface) purely because hook dispatch (`invoke_hook`) is async; its
-        own work is synchronous. Its one caller,
-        `OpenAIBackend._generate_from_intrinsic`, is already a coroutine, so
+        own work is synchronous. Its callers already run in coroutines, so
         `await`ing here — rather than bridging through
         `_run_async_in_thread`, which is for calling async code from sync
         code — avoids spawning a throwaway event loop and thread per call.

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -644,10 +644,10 @@ class AdapterMixin(Backend, abc.ABC):
                 for a in EmbeddedIntrinsicAdapter.from_source(
                     repo_id, intrinsic_name=name
                 ):
-                    # EmbeddedIntrinsicAdapter is only valid for backends whose
-                    # add_adapter accepts the full Adapter type (e.g. OpenAIBackend).
-                    # LocalHFBackend.add_adapter expects LocalHFAdapter; HF backends
-                    # never set _uses_embedded_adapters=True.
+                    # EmbeddedIntrinsicAdapter is valid only for backends whose
+                    # add_adapter supports the Embedded/Granite Switch reality
+                    # (currently OpenAIBackend and LocalHFBackend when configured
+                    # with load_embedded_adapters=True).
                     self.add_adapter(a)
             else:
                 # AdapterType.LORA is the pre-Phase-1 default (mirrors old _util.py).

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -81,14 +81,20 @@ from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import ALoraRequirement, LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
 from ._options import resolve_model_options
-from .adapters import AdapterMixin, IntrinsicAdapter, LocalHFAdapter
+from .adapters import (
+    AdapterMixin,
+    EmbeddedActivationRequest,
+    EmbeddedBinding,
+    IntrinsicAdapter,
+    LocalHFAdapter,
+)
 from .adapters._core import (
     Adapter as _AdapterCore,
     IOContract,
     LocalFileBinding,
     WeightsBinding,
 )
-from .adapters.adapter import AdapterInput
+from .adapters.adapter import AdapterInput, EmbeddedIntrinsicAdapter
 from .backend import FormatterBackend
 from .cache import Cache, SimpleLRUCache
 from .model_ids import ModelIdentifier
@@ -344,6 +350,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             tokenizer/model/device; if provided, `model_id` is not used for loading.
         default_to_constraint_checking_alora (bool): If `False`, aLoRA constraint
             checking is deactivated; mainly for benchmarking and debugging.
+        load_embedded_adapters (bool): If `True`, register adapter functions
+            embedded in the Granite Switch checkpoint named by `adapter_source`
+            (or `model_id` when `adapter_source` is not set).
+        adapter_source (str | None): Local checkpoint directory or Hugging Face
+            Hub repository used to discover embedded adapter functions.
         model_options (dict | None): Default model options for generation requests.
 
     Attributes:
@@ -368,6 +379,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         cache: Cache | None = None,
         custom_config: TransformersTorchConfig | None = None,
         default_to_constraint_checking_alora: bool = True,
+        load_embedded_adapters: bool = False,
+        adapter_source: str | None = None,
         model_options: dict | None = None,
     ):
         """Load model weights from the given model ID, or from a custom config if provided."""
@@ -459,8 +472,12 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         )
 
         # Adapters can be made known to the backend (added) and loaded.
-        self._added_adapters: dict[str, LocalHFAdapter | LocalFileBinding] = {}
+        self._added_adapters: dict[
+            str, LocalHFAdapter | LocalFileBinding | EmbeddedIntrinsicAdapter
+        ] = {}
         self._loaded_adapters: dict[str, LocalHFAdapter | LocalFileBinding] = {}
+        self._adapter_source = adapter_source
+        self._uses_embedded_adapters = load_embedded_adapters
 
         self._generation_lock = threading.RLock()
         """Forces generation requests to be non-concurrent, and guards adapter
@@ -473,6 +490,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         inside that section, on the same thread, via `_adapter_activation_lock()`.
         A plain `Lock` deadlocks on that same-thread re-acquisition (#1465).
         """
+
+        if load_embedded_adapters:
+            self.register_embedded_adapter_model(self._adapter_source or self._model_id)
 
     def _make_dc_cache(self, toks, **model_options):
         dc = DynamicCache()
@@ -610,6 +630,27 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             _assert_correct_adapters("", self._model)
             return out
 
+    def _generate_embedded_with_generation_lock(
+        self, generate_func: Callable[..., _T], *args: Any, **kwargs: Any
+    ) -> _T:
+        """Run embedded-adapter generation while serialising model access.
+
+        Embedded adapter functions select their control token while rendering
+        the chat template. They must not use the PEFT lifecycle, but local
+        Transformers generation still shares the backend's model and therefore
+        remains serialised with every other generation path.
+
+        Args:
+            generate_func: The synchronous generation callable to invoke.
+            *args: Positional arguments forwarded to `generate_func`.
+            **kwargs: Keyword arguments forwarded to `generate_func`.
+
+        Returns:
+            Whatever `generate_func` returns.
+        """
+        with self._generation_lock:
+            return generate_func(*args, **kwargs)
+
     def _generate_intrinsic_with_adapter_scope(
         self,
         adapter: IntrinsicAdapter,
@@ -718,7 +759,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             ValueError: If no adapter is registered for the requested intrinsic,
                 or if the context contains images or audio; `LocalHFBackend`
                 does not support multimodal inputs.
-            TypeError: If the adapter isn't an IntrinsicAdapter.
+            TypeError: If the adapter is neither an `IntrinsicAdapter` nor an
+                `EmbeddedIntrinsicAdapter`, or if an embedded adapter does not
+                have an `EmbeddedBinding`.
         """
         if not ctx.is_chat_context:
             raise Exception("Does not yet support non-chat contexts.")
@@ -780,9 +823,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         # TODO: Code below this point is mostly specific to RagIntrinsics
         #       It should be refactored into a specific adapter.transform() function.
-        if not isinstance(adapter, IntrinsicAdapter):
+        if not isinstance(adapter, (IntrinsicAdapter, EmbeddedIntrinsicAdapter)):
             raise TypeError(
-                f"LocalHFBackend only supports IntrinsicAdapters, got: {type(adapter).__name__}"
+                "LocalHFBackend only supports IntrinsicAdapter or "
+                f"EmbeddedIntrinsicAdapter, got: {type(adapter).__name__}"
             )
 
         intrinsic_config = adapter.config
@@ -819,9 +863,26 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         #       so we will have to invalidate the cache on our side. This requires
         #       us having specific caching for each Component/Message.
 
+        rewritten_request = rewritten.model_dump()
+        if isinstance(adapter, EmbeddedIntrinsicAdapter):
+            if not isinstance(adapter.weights, EmbeddedBinding):
+                raise TypeError(
+                    "EmbeddedIntrinsicAdapter.weights must be an EmbeddedBinding; "
+                    f"got {type(adapter.weights).__name__}. Activation cannot proceed."
+                )
+            extra_body = rewritten_request.setdefault("extra_body", {})
+            if not isinstance(extra_body, dict):
+                raise TypeError(
+                    "Embedded adapter generation requires extra_body to be a dict."
+                )
+            await adapter.weights.apply_activation(
+                EmbeddedActivationRequest(extra_body=extra_body, api_params={}),
+                adapter.identity,
+            )
+
         generate_input, other_input = (
             granite_formatters.base.util.chat_completion_request_to_transformers_inputs(  # type: ignore
-                rewritten,
+                rewritten_request,
                 self._tokenizer,
                 self._model,
                 ll_tokenizer=self._llguidance_tokenizer,
@@ -881,16 +942,27 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
             model_arg = _CapturingModelProxy()  # type: ignore[assignment]
 
-        chat_response = asyncio.to_thread(
-            self._generate_intrinsic_with_adapter_scope,
-            adapter,
-            granite_formatters.base.util.generate_with_transformers,  # type: ignore
-            # Passed as args/kwargs to generate.
-            self._tokenizer,
-            model_arg,
-            generate_input,
-            other_input,
-        )
+        if isinstance(adapter, IntrinsicAdapter):
+            chat_response = asyncio.to_thread(
+                self._generate_intrinsic_with_adapter_scope,
+                adapter,
+                granite_formatters.base.util.generate_with_transformers,  # type: ignore
+                # Passed as args/kwargs to generate.
+                self._tokenizer,
+                model_arg,
+                generate_input,
+                other_input,
+            )
+        else:
+            chat_response = asyncio.to_thread(
+                self._generate_embedded_with_generation_lock,
+                granite_formatters.base.util.generate_with_transformers,  # type: ignore
+                # Passed as args/kwargs to generate.
+                self._tokenizer,
+                model_arg,
+                generate_input,
+                other_input,
+            )
 
         output = ModelOutputThunk(None)
         output._gen.start = datetime.datetime.now()
@@ -2212,32 +2284,36 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
     @property
     def base_model_name(self):
         """Returns the base_model_id of the model used by the backend. For example, `granite-3.3-8b-instruct` for `ibm-granite/granite-3.3-8b-instruct`."""
-        return self._model_id.split("/")[1]
+        return self._model_id.rsplit("/", maxsplit=1)[-1]
 
     def add_adapter(self, adapter: AdapterInput) -> None:
-        """Register a LoRA/aLoRA adapter with this backend so it can be loaded later.
+        """Register an adapter function with this backend.
 
         Downloads the adapter weights (via `adapter.get_local_hf_path`) and records
         the adapter in the backend's registry. The adapter must not already be
         registered with a different backend.
 
         Accepts the full `AdapterInput` union to honour the mixin contract, but
-        only the LocalFile/PEFT reality is supported here — other realities are
-        rejected at runtime rather than narrowing the signature.
+        LocalFile/PEFT and Embedded/Granite Switch realities are supported.
+        Embedded adapter functions are already present in the model, so they
+        are registered without downloading or loading PEFT weights.
 
         Args:
             adapter (AdapterInput): The adapter to register. Must be a
-                `LocalHFAdapter` or `LocalFileBinding`; other adapter realities
-                are rejected.
+                `LocalHFAdapter`, `LocalFileBinding`, or
+                `EmbeddedIntrinsicAdapter`; other adapter realities are
+                rejected.
 
         Raises:
-            TypeError: If `adapter` is not a `LocalHFAdapter` or `LocalFileBinding`.
+            TypeError: If `adapter` is not a supported local or embedded adapter.
             Exception: If `adapter` has already been added to a different backend.
         """
-        if not isinstance(adapter, (LocalHFAdapter, LocalFileBinding)):
+        if not isinstance(
+            adapter, (LocalHFAdapter, LocalFileBinding, EmbeddedIntrinsicAdapter)
+        ):
             raise TypeError(
-                f"LocalHFBackend requires a LocalHFAdapter or LocalFileBinding; got "
-                f"{type(adapter).__name__}."
+                "LocalHFBackend requires a LocalHFAdapter, LocalFileBinding, or "
+                f"EmbeddedIntrinsicAdapter; got {type(adapter).__name__}."
             )
         if adapter.backend is not None:
             if adapter.backend is self:
@@ -2262,9 +2338,40 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             )
             return None
 
+        if isinstance(adapter, EmbeddedIntrinsicAdapter):
+            adapter.backend = self
+            if not isinstance(adapter.weights, EmbeddedBinding):
+                raise TypeError(
+                    "EmbeddedIntrinsicAdapter.weights must be an EmbeddedBinding; "
+                    f"got {type(adapter.weights).__name__}."
+                )
+            adapter.weights.source = self.base_model_name
+            self._added_adapters[adapter.qualified_name] = adapter
+            return
+
         adapter.path = adapter.get_local_hf_path(self.base_model_name)
         adapter.backend = self
         self._added_adapters[adapter.qualified_name] = adapter
+
+    def register_embedded_adapter_model(
+        self, source: str, *, revision: str = "main", cache_dir: str | None = None
+    ) -> list[str]:
+        """Register embedded adapter functions from a Granite Switch checkpoint.
+
+        Args:
+            source: Local checkpoint directory or Hugging Face Hub repository ID.
+            revision: Git revision when loading from the Hub.
+            cache_dir: Cache directory for Hub downloads.
+
+        Returns:
+            Names of the registered adapter functions.
+        """
+        adapters = EmbeddedIntrinsicAdapter.from_source(
+            source, revision=revision, cache_dir=cache_dir
+        )
+        for adapter in adapters:
+            self.add_adapter(adapter)
+        return [adapter.intrinsic_name for adapter in adapters]
 
     def load_peft_adapter(self, adapter_qualified_name: str) -> None:
         """Load a previously registered adapter into the underlying Hugging Face model.
@@ -2284,6 +2391,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if adapter is None:
             raise ValueError(
                 f"could not load adapter {adapter_qualified_name} for backend {self}: adapter was not previously added"
+            )
+        if isinstance(adapter, EmbeddedIntrinsicAdapter):
+            raise TypeError(
+                f"cannot load embedded adapter {adapter_qualified_name} through PEFT; "
+                "it is activated by the chat template"
             )
 
         try:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -15,6 +15,7 @@ import datetime
 import functools
 import importlib
 import json
+import pathlib
 import threading
 import warnings
 from collections import OrderedDict
@@ -325,22 +326,25 @@ def _warn_if_granite_switch_transformers_override_is_active() -> None:
     except (metadata.PackageNotFoundError, InvalidVersion):
         return
 
-    for requirement_text in requirements:
-        requirement = PackagingRequirement(requirement_text)
-        if requirement.name != "transformers":
-            continue
-        if requirement.marker is not None and not requirement.marker.evaluate():
-            continue
-        if installed_version not in requirement.specifier:
-            warnings.warn(
-                "granite-switch declares a Transformers range that excludes "
-                f"{installed_version}; Mellea is using its explicit compatibility "
-                "override for local Granite Switch support. This warning will "
-                "disappear once Granite Switch publishes widened metadata.",
-                UserWarning,
-                stacklevel=3,
-            )
-            _SWITCH_TRANSFORMERS_WARNING_EMITTED = True
+    try:
+        for requirement_text in requirements:
+            requirement = PackagingRequirement(requirement_text)
+            if requirement.name != "transformers":
+                continue
+            if requirement.marker is not None and not requirement.marker.evaluate():
+                continue
+            if installed_version not in requirement.specifier:
+                warnings.warn(
+                    "granite-switch declares a Transformers range that excludes "
+                    f"{installed_version}; Mellea is using its explicit compatibility "
+                    "override for local Granite Switch support. This warning will "
+                    "disappear once Granite Switch publishes widened metadata.",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                _SWITCH_TRANSFORMERS_WARNING_EMITTED = True
+            return
+    except Exception:
         return
 
 
@@ -391,14 +395,12 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             `SimpleLRUCache(0, on_evict=_cleanup_kv_cache)`.
         custom_config (TransformersTorchConfig | None): Override for
             tokenizer/model/device; if provided, `model_id` is not used for loading.
-            Callers providing a Granite Switch model this way are responsible
-            for importing `granite_switch.hf` before constructing the model.
         default_to_constraint_checking_alora (bool): If `False`, aLoRA constraint
             checking is deactivated; mainly for benchmarking and debugging.
         load_embedded_adapters (bool): If `True`, register adapter functions
             embedded in the Granite Switch checkpoint named by `adapter_source`
-            (or `model_id` when `adapter_source` is not set). Automatic model
-            loading requires `mellea[hf,switch]`.
+            (or `model_id` when `adapter_source` is not set). Requires the
+            `hf` extra.
         adapter_source (str | None): Local checkpoint directory or Hugging Face
             Hub repository used to discover embedded adapter functions.
         model_options (dict | None): Default model options for generation requests.
@@ -410,8 +412,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             HF-specific option names.
 
     Raises:
-        ImportError: If automatic Granite Switch model loading is requested
-            without the `switch` extra installed.
+        ImportError: If embedded adapter loading is requested without the `hf`
+            extra installed.
         OSError: If the model cannot be loaded from Hugging Face Hub (bad ID,
             missing access, or local filesystem/cache error).
     """
@@ -471,18 +473,18 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     "model_id is None. This can also happen if the ModelIdentifier has no hf_model_id name set."
                 )
                 self._model_id = model_id.hf_model_name
+        if load_embedded_adapters:
+            try:
+                importlib.import_module("granite_switch.hf")
+            except ImportError as e:
+                raise ImportError(
+                    "Loading Granite Switch checkpoints with LocalHFBackend "
+                    'requires the Hugging Face extra. Install it with: pip install "mellea[hf]"'
+                ) from e
+            _warn_if_granite_switch_transformers_override_is_active()
+
         match custom_config:
             case None:
-                if load_embedded_adapters:
-                    try:
-                        importlib.import_module("granite_switch.hf")
-                    except ImportError as e:
-                        raise ImportError(
-                            "Loading Granite Switch checkpoints with LocalHFBackend "
-                            "requires the switch extra. Install it with: "
-                            'pip install "mellea[hf,switch]"'
-                        ) from e
-                    _warn_if_granite_switch_transformers_override_is_active()
                 # Choose a device.
                 self._device = torch.device(
                     "cuda"
@@ -2344,7 +2346,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
     @property
     def base_model_name(self):
         """Returns the base_model_id of the model used by the backend. For example, `granite-3.3-8b-instruct` for `ibm-granite/granite-3.3-8b-instruct`."""
-        return self._model_id.rsplit("/", maxsplit=1)[-1]
+        return pathlib.PurePath(self._model_id).name
 
     def add_adapter(self, adapter: AdapterInput) -> None:
         """Register an adapter function with this backend.
@@ -2425,6 +2427,13 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
 
         Returns:
             Names of the registered adapter functions.
+
+        Raises:
+            ImportError: If Hugging Face Hub support is not installed.
+            PermissionError: If the model repository is private or gated.
+            FileNotFoundError: If the source has no adapter index.
+            ValueError: If the source has no matching embedded adapter functions.
+            TypeError: If an adapter from the source has an unsupported binding.
         """
         adapters = EmbeddedIntrinsicAdapter.from_source(
             source, revision=revision, cache_dir=cache_dir

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -391,11 +391,14 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             `SimpleLRUCache(0, on_evict=_cleanup_kv_cache)`.
         custom_config (TransformersTorchConfig | None): Override for
             tokenizer/model/device; if provided, `model_id` is not used for loading.
+            Callers providing a Granite Switch model this way are responsible
+            for importing `granite_switch.hf` before constructing the model.
         default_to_constraint_checking_alora (bool): If `False`, aLoRA constraint
             checking is deactivated; mainly for benchmarking and debugging.
         load_embedded_adapters (bool): If `True`, register adapter functions
             embedded in the Granite Switch checkpoint named by `adapter_source`
-            (or `model_id` when `adapter_source` is not set).
+            (or `model_id` when `adapter_source` is not set). Automatic model
+            loading requires `mellea[hf,switch]`.
         adapter_source (str | None): Local checkpoint directory or Hugging Face
             Hub repository used to discover embedded adapter functions.
         model_options (dict | None): Default model options for generation requests.
@@ -407,6 +410,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             HF-specific option names.
 
     Raises:
+        ImportError: If automatic Granite Switch model loading is requested
+            without the `switch` extra installed.
         OSError: If the model cannot be loaded from Hugging Face Hub (bad ID,
             missing access, or local filesystem/cache error).
     """

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -607,12 +607,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         Standard (non-intrinsic) generation runs without adapters: any active
         adapter is deactivated before the model call, and the model's active
         state is asserted before and after. Adapter-active generation goes
-        elsewhere — `_generate_intrinsic_with_adapter_scope` for intrinsics
-        (routed through `adapter_scope`, with its lifecycle hooks). Granite
-        Switch's `EmbeddedBinding.apply_activation()` is implemented for the
-        OpenAI backend; local Hugging Face integration remains pending (#1018).
-        No current path activates through this method, which is why it takes no
-        adapter name.
+        elsewhere — `_generate_intrinsic_with_adapter_scope` for runtime PEFT
+        adapters (routed through `adapter_scope`, with its lifecycle hooks) and
+        `_generate_embedded_with_generation_lock` for Granite Switch adapters,
+        which are activated while rendering the chat template.
 
         Args:
             generate_func: The synchronous generation callable to invoke.
@@ -649,6 +647,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             Whatever `generate_func` returns.
         """
         with self._generation_lock:
+            self.deactivate_peft_adapter("")
+            _assert_correct_adapters("", self._model)
             return generate_func(*args, **kwargs)
 
     def _generate_intrinsic_with_adapter_scope(
@@ -876,7 +876,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     "Embedded adapter generation requires extra_body to be a dict."
                 )
             await adapter.weights.apply_activation(
-                EmbeddedActivationRequest(extra_body=extra_body, api_params={}),
+                EmbeddedActivationRequest(
+                    extra_body=extra_body, api_params=rewritten_request
+                ),
                 adapter.identity,
             )
 
@@ -2339,12 +2341,12 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             return None
 
         if isinstance(adapter, EmbeddedIntrinsicAdapter):
-            adapter.backend = self
             if not isinstance(adapter.weights, EmbeddedBinding):
                 raise TypeError(
                     "EmbeddedIntrinsicAdapter.weights must be an EmbeddedBinding; "
                     f"got {type(adapter.weights).__name__}."
                 )
+            adapter.backend = self
             adapter.weights.source = self.base_model_name
             self._added_adapters[adapter.qualified_name] = adapter
             return
@@ -2386,6 +2388,8 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         Raises:
             ValueError: If no adapter with the given qualified name has been added to
                 this backend.
+            TypeError: If the named adapter is embedded in the model and therefore
+                activated through the chat template rather than loaded through PEFT.
         """
         adapter = self._added_adapters.get(adapter_qualified_name, None)
         if adapter is None:

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -13,14 +13,19 @@ import contextlib
 import dataclasses
 import datetime
 import functools
+import importlib
 import json
 import threading
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Coroutine, Sequence
+from importlib import metadata
 from typing import Any, ClassVar, TypeVar, cast
 
 import jinja2
 import jinja2.meta
+from packaging.requirements import Requirement as PackagingRequirement
+from packaging.version import InvalidVersion, Version
 
 try:
     import llguidance
@@ -299,6 +304,44 @@ def _compute_generate_kwargs_allowlist() -> frozenset[str]:
 
 
 _GENERATE_KWARGS_ALLOWLIST: frozenset[str] = _compute_generate_kwargs_allowlist()
+_SWITCH_TRANSFORMERS_WARNING_EMITTED = False
+
+
+def _warn_if_granite_switch_transformers_override_is_active() -> None:
+    """Warn once when Granite Switch metadata excludes the installed Transformers.
+
+    Mellea intentionally overrides Granite Switch's restrictive Transformers
+    metadata for the local embedded-adapter path. The warning is self-retiring:
+    an upstream package release that widens its declared range makes the
+    installed version satisfy the requirement and prevents the warning.
+    """
+    global _SWITCH_TRANSFORMERS_WARNING_EMITTED
+    if _SWITCH_TRANSFORMERS_WARNING_EMITTED:
+        return
+
+    try:
+        installed_version = Version(metadata.version("transformers"))
+        requirements = metadata.requires("granite-switch") or []
+    except (metadata.PackageNotFoundError, InvalidVersion):
+        return
+
+    for requirement_text in requirements:
+        requirement = PackagingRequirement(requirement_text)
+        if requirement.name != "transformers":
+            continue
+        if requirement.marker is not None and not requirement.marker.evaluate():
+            continue
+        if installed_version not in requirement.specifier:
+            warnings.warn(
+                "granite-switch declares a Transformers range that excludes "
+                f"{installed_version}; Mellea is using its explicit compatibility "
+                "override for local Granite Switch support. This warning will "
+                "disappear once Granite Switch publishes widened metadata.",
+                UserWarning,
+                stacklevel=3,
+            )
+            _SWITCH_TRANSFORMERS_WARNING_EMITTED = True
+        return
 
 
 def _check_no_multimodal_blocks(action: Span | None, ctx: Context | None) -> None:
@@ -425,6 +468,16 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 self._model_id = model_id.hf_model_name
         match custom_config:
             case None:
+                if load_embedded_adapters:
+                    try:
+                        importlib.import_module("granite_switch.hf")
+                    except ImportError as e:
+                        raise ImportError(
+                            "Loading Granite Switch checkpoints with LocalHFBackend "
+                            "requires the switch extra. Install it with: "
+                            'pip install "mellea[hf,switch]"'
+                        ) from e
+                    _warn_if_granite_switch_transformers_override_is_active()
                 # Choose a device.
                 self._device = torch.device(
                     "cuda"

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -246,6 +246,7 @@ def chat_completion_request_to_transformers_inputs(
                 "tools",
                 "documents",
                 "add_generation_prompt",
+                "return_tensors",
             }
             overridden_keys = reserved_template_kwargs.intersection(
                 chat_template_kwargs

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -199,9 +199,11 @@ def chat_completion_request_to_transformers_inputs(
     Raises:
        ImportError: If `torch`, `transformers`, or `llguidance` packages
             are not installed (the latter only when constrained decoding is used).
-        TypeError: If `tokenizer.apply_chat_template()` returns an unexpected type.
-        ValueError: If padding or end-of-sequence token IDs cannot be determined
-            from the tokenizer.
+        TypeError: If `extra_body.chat_template_kwargs` is not a dict, or if
+            `tokenizer.apply_chat_template()` returns an unexpected type.
+        ValueError: If template kwargs override framework-owned inputs, or if
+            padding or end-of-sequence token IDs cannot be determined from the
+            tokenizer.
     """
     with import_optional("torch"):
         # Third Party

--- a/mellea/formatters/granite/base/util.py
+++ b/mellea/formatters/granite/base/util.py
@@ -10,7 +10,7 @@ import itertools
 import json
 import os
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 # Third Party
 import pydantic
@@ -232,6 +232,30 @@ def chat_completion_request_to_transformers_inputs(
         and request["extra_body"].get("documents") is not None
     ):
         tokenizer_input["documents"] = request["extra_body"]["documents"]
+
+    if request.get("extra_body") is not None:
+        chat_template_kwargs = request["extra_body"].get("chat_template_kwargs")
+        if chat_template_kwargs is not None:
+            if not isinstance(chat_template_kwargs, dict):
+                raise TypeError(
+                    "extra_body.chat_template_kwargs must be a dict for "
+                    "Hugging Face chat-template rendering"
+                )
+            reserved_template_kwargs = {
+                "conversation",
+                "tools",
+                "documents",
+                "add_generation_prompt",
+            }
+            overridden_keys = reserved_template_kwargs.intersection(
+                chat_template_kwargs
+            )
+            if overridden_keys:
+                raise ValueError(
+                    "extra_body.chat_template_kwargs cannot override Hugging Face "
+                    "chat-template inputs: " + ", ".join(sorted(overridden_keys))
+                )
+            tokenizer_input.update(cast(dict[str, Any], chat_template_kwargs))
 
     input_tokens = tokenizer.apply_chat_template(**tokenizer_input, return_tensors="pt")  # type: ignore[union-attr]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sandbox = [
 ]
 
 switch = [
-    "huggingface-hub>=0.33.4",
+    "granite-switch[hf]>=0.1.0",
 ]
 
 backends = ["mellea[watsonx,hf,litellm]"]
@@ -427,6 +427,10 @@ directory = "htmlcov"
 
 [tool.uv]
 constraint-dependencies = ["click>=8.3.3"]
+# granite-switch 0.1.0 declares transformers<5.10.0. Mellea's local Granite
+# Switch e2e passes on 5.10.2; retain Mellea's tested HF range until upstream
+# publishes widened Granite Switch metadata.
+override-dependencies = ["transformers>5.5.0,<6.0.0"]
 
 [tool.uv.sources]
 mellea = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ m = "cli.m:cli"
 hf = [
     "accelerate>=1.9.0",
     "datasets>=4.0.0",
+    "granite-switch[hf]>=0.1.0",
     "llguidance",
     "peft>=0.18.1", # Native aLoRA support added in PEFT 0.18.0
     "transformers>5.5.0,<6.0.0", # 5.5.0 broke granite 4.0
@@ -104,7 +105,7 @@ sandbox = [
 ]
 
 switch = [
-    "granite-switch[hf]>=0.1.0",
+    "huggingface-hub>=0.33.4",
 ]
 
 backends = ["mellea[watsonx,hf,litellm]"]

--- a/test/backends/test_huggingface_embedded.py
+++ b/test/backends/test_huggingface_embedded.py
@@ -49,11 +49,26 @@ def backend() -> Iterator[LocalHFBackend]:
 
 
 def test_embedded_answerability_runs_on_local_hf(backend: LocalHFBackend) -> None:
-    """The local HF path renders the embedded adapter control token and parses output."""
+    """The local template renders an embedded control token and parses output."""
+    messages = [{"role": "user", "content": "Can these documents answer my question?"}]
+    base_prompt = backend._tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=False
+    )
+    adapter_prompt = backend._tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        adapter_name="answerability",
+        tokenize=False,
+    )
+    assert adapter_prompt != base_prompt, (
+        "Granite Switch ignored adapter_name; the embedded adapter control token "
+        "was not rendered."
+    )
+
     result = rag.check_answerability(
         "What is the square root of 4?",
         ["The square root of 4 is 2."],
-        ChatContext().add(Message("user", "Can these documents answer my question?")),
+        ChatContext().add(Message("user", messages[0]["content"])),
         backend,
     )
 

--- a/test/backends/test_huggingface_embedded.py
+++ b/test/backends/test_huggingface_embedded.py
@@ -3,9 +3,8 @@
 
 """E2E coverage for embedded adapter functions on LocalHFBackend.
 
-Set `GRANITE_SWITCH_MODEL_ID` to a local-HF-compatible Granite Switch
-checkpoint before running this module. It is skipped by default because the
-checkpoint requires a GPU and is not part of normal CI.
+Uses the project's standard 3B Granite Switch checkpoint. It runs in normal
+local pytest on supported GPU hardware and is skipped in CI.
 """
 
 import os
@@ -24,15 +23,15 @@ from test.predicates import require_gpu
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.huggingface,
-    pytest.mark.slow,
     require_gpu(min_vram_gb=12),
     pytest.mark.skipif(
-        not os.environ.get("GRANITE_SWITCH_MODEL_ID"),
-        reason="Set GRANITE_SWITCH_MODEL_ID to run LocalHF embedded-adapter tests",
+        int(os.environ.get("CICD", 0)) == 1,
+        reason="Skipping local Granite Switch e2e test in CI",
     ),
 ]
 
 from mellea.backends.huggingface import LocalHFBackend
+from mellea.backends.model_ids import IBM_GRANITE_SWITCH_4_1_3B_PREVIEW
 from mellea.stdlib.components import Message
 from mellea.stdlib.components.intrinsic import rag
 from mellea.stdlib.context import ChatContext
@@ -43,7 +42,7 @@ def backend() -> Iterator[LocalHFBackend]:
     """Load a Granite Switch checkpoint with embedded adapters registered."""
     with hf_skip():
         backend = LocalHFBackend(
-            model_id=os.environ["GRANITE_SWITCH_MODEL_ID"], load_embedded_adapters=True
+            model_id=IBM_GRANITE_SWITCH_4_1_3B_PREVIEW, load_embedded_adapters=True
         )
     yield backend
     cleanup_gpu_backend(backend, "huggingface")

--- a/test/backends/test_huggingface_embedded.py
+++ b/test/backends/test_huggingface_embedded.py
@@ -1,0 +1,61 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E coverage for embedded adapter functions on LocalHFBackend.
+
+Set `GRANITE_SWITCH_MODEL_ID` to a local-HF-compatible Granite Switch
+checkpoint before running this module. It is skipped by default because the
+checkpoint requires a GPU and is not part of normal CI.
+"""
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
+pytest.importorskip(
+    "transformers", reason="transformers not installed — install mellea[hf]"
+)
+
+from test.conftest import cleanup_gpu_backend, hf_skip
+from test.predicates import require_gpu
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.huggingface,
+    pytest.mark.slow,
+    require_gpu(min_vram_gb=12),
+    pytest.mark.skipif(
+        not os.environ.get("GRANITE_SWITCH_MODEL_ID"),
+        reason="Set GRANITE_SWITCH_MODEL_ID to run LocalHF embedded-adapter tests",
+    ),
+]
+
+from mellea.backends.huggingface import LocalHFBackend
+from mellea.stdlib.components import Message
+from mellea.stdlib.components.intrinsic import rag
+from mellea.stdlib.context import ChatContext
+
+
+@pytest.fixture(scope="module")
+def backend() -> Iterator[LocalHFBackend]:
+    """Load a Granite Switch checkpoint with embedded adapters registered."""
+    with hf_skip():
+        backend = LocalHFBackend(
+            model_id=os.environ["GRANITE_SWITCH_MODEL_ID"], load_embedded_adapters=True
+        )
+    yield backend
+    cleanup_gpu_backend(backend, "huggingface")
+
+
+def test_embedded_answerability_runs_on_local_hf(backend: LocalHFBackend) -> None:
+    """The local HF path renders the embedded adapter control token and parses output."""
+    result = rag.check_answerability(
+        "What is the square root of 4?",
+        ["The square root of 4 is 2."],
+        ChatContext().add(Message("user", "Can these documents answer my question?")),
+        backend,
+    )
+
+    assert result in {"answerable", "unanswerable"}

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -337,7 +337,7 @@ def test_load_embedded_adapters_requires_granite_switch_package():
         "mellea.backends.huggingface.importlib.import_module",
         side_effect=ImportError("granite_switch is unavailable"),
     ):
-        with pytest.raises(ImportError, match=r'pip install "mellea\[hf,switch\]"'):
+        with pytest.raises(ImportError, match=r'pip install "mellea\[hf\]"'):
             LocalHFBackend(
                 model_id="ibm-granite/granite-switch-4.1-3b-preview",
                 load_embedded_adapters=True,
@@ -359,7 +359,24 @@ def test_granite_switch_transformers_override_warning_is_self_retiring(monkeypat
     with pytest.warns(UserWarning, match="explicit compatibility override"):
         huggingface._warn_if_granite_switch_transformers_override_is_active()
 
-    huggingface._warn_if_granite_switch_transformers_override_is_active()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        huggingface._warn_if_granite_switch_transformers_override_is_active()
+
+
+def test_granite_switch_transformers_override_warning_ignores_bad_metadata(monkeypatch):
+    """Malformed Granite Switch metadata must not prevent backend construction."""
+    import mellea.backends.huggingface as huggingface
+
+    monkeypatch.setattr(huggingface, "_SWITCH_TRANSFORMERS_WARNING_EMITTED", False)
+    monkeypatch.setattr(
+        huggingface.metadata, "requires", lambda distribution: ["transformers @@@"]
+    )
+    monkeypatch.setattr(huggingface.metadata, "version", lambda distribution: "5.10.2")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        huggingface._warn_if_granite_switch_transformers_override_is_active()
 
 
 def test_granite_switch_transformers_override_warning_clears_when_metadata_updates(
@@ -379,6 +396,14 @@ def test_granite_switch_transformers_override_warning_clears_when_metadata_updat
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
         huggingface._warn_if_granite_switch_transformers_override_is_active()
+
+
+def test_base_model_name_strips_trailing_path_separator():
+    """A local checkpoint path keeps its final directory name."""
+    backend = _make_backend()
+    backend._model_id = "/tmp/granite-switch-checkpoint/"
+
+    assert backend.base_model_name == "granite-switch-checkpoint"
 
 
 def test_chat_completion_request_forwards_template_kwargs_to_transformers():

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -331,6 +331,56 @@ def test_load_embedded_adapters_registers_checkpoint_adapters():
     backend._model.load_adapter.assert_not_called()
 
 
+def test_load_embedded_adapters_requires_granite_switch_package():
+    """Automatic Switch checkpoint loading fails with an actionable dependency error."""
+    with patch(
+        "mellea.backends.huggingface.importlib.import_module",
+        side_effect=ImportError("granite_switch is unavailable"),
+    ):
+        with pytest.raises(ImportError, match=r'pip install "mellea\[hf,switch\]"'):
+            LocalHFBackend(
+                model_id="ibm-granite/granite-switch-4.1-3b-preview",
+                load_embedded_adapters=True,
+            )
+
+
+def test_granite_switch_transformers_override_warning_is_self_retiring(monkeypatch):
+    """The compatibility warning appears only while Switch metadata excludes Transformers."""
+    import mellea.backends.huggingface as huggingface
+
+    monkeypatch.setattr(huggingface, "_SWITCH_TRANSFORMERS_WARNING_EMITTED", False)
+    monkeypatch.setattr(
+        huggingface.metadata,
+        "requires",
+        lambda distribution: ["transformers>=5.5.1,<5.10.0"],
+    )
+    monkeypatch.setattr(huggingface.metadata, "version", lambda distribution: "5.10.2")
+
+    with pytest.warns(UserWarning, match="explicit compatibility override"):
+        huggingface._warn_if_granite_switch_transformers_override_is_active()
+
+    huggingface._warn_if_granite_switch_transformers_override_is_active()
+
+
+def test_granite_switch_transformers_override_warning_clears_when_metadata_updates(
+    monkeypatch,
+):
+    """No warning remains after Granite Switch declares the installed version compatible."""
+    import mellea.backends.huggingface as huggingface
+
+    monkeypatch.setattr(huggingface, "_SWITCH_TRANSFORMERS_WARNING_EMITTED", False)
+    monkeypatch.setattr(
+        huggingface.metadata,
+        "requires",
+        lambda distribution: ["transformers>=5.5.1,<6.0.0"],
+    )
+    monkeypatch.setattr(huggingface.metadata, "version", lambda distribution: "5.10.2")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        huggingface._warn_if_granite_switch_transformers_override_is_active()
+
+
 def test_chat_completion_request_forwards_template_kwargs_to_transformers():
     """Template kwargs survive request conversion for local Granite Switch inference."""
     tokenizer = MagicMock()

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -6,6 +6,7 @@
 import asyncio
 import threading
 import time
+import warnings
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -32,8 +33,14 @@ from transformers.generation.utils import (
 )
 
 from mellea.backends import ModelOption
-from mellea.backends.adapters import AdapterMixin, AdapterType, IntrinsicAdapter
+from mellea.backends.adapters import (
+    AdapterMixin,
+    AdapterType,
+    EmbeddedBinding,
+    IntrinsicAdapter,
+)
 from mellea.backends.adapters._core import Identity
+from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
 from mellea.backends.adapters.catalog import IntrinsicsCatalogEntry
 from mellea.backends.huggingface import LocalHFBackend
 from mellea.core import ModelOutputThunk
@@ -169,6 +176,9 @@ class _FakeRewrittenRequest:
             setattr(copied, key, value)
         return copied
 
+    def model_dump(self):
+        return {"messages": [], "extra_body": {}, "temperature": self.temperature}
+
 
 class _FakeRewriter:
     def __init__(self, *args, **kwargs):
@@ -218,6 +228,24 @@ def _make_intrinsic_adapter_stub():
     return adapter
 
 
+def _make_embedded_adapter_stub() -> EmbeddedIntrinsicAdapter:
+    """Build an embedded adapter without exposing its deprecation warning in tests."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return EmbeddedIntrinsicAdapter(
+            intrinsic_name="answerability",
+            config={
+                "model": None,
+                "response_format": None,
+                "transformations": None,
+                "instruction": None,
+                "parameters": {"max_completion_tokens": 8},
+                "sentence_boundaries": None,
+            },
+            technology="alora",
+        )
+
+
 def _make_intrinsic_backend_stub(stub_backend):
     stub_backend.formatter = SimpleNamespace(
         to_chat_messages=lambda linearized_ctx: [Message("user", "Is the sky blue?")]
@@ -238,10 +266,168 @@ def _make_intrinsic_backend_stub(stub_backend):
     stub_backend._generate_intrinsic_with_adapter_scope = (
         lambda adapter, generate_func, *args, **kwargs: generate_func(*args, **kwargs)
     )
+    stub_backend._generate_embedded_with_generation_lock = (
+        lambda generate_func, *args, **kwargs: generate_func(*args, **kwargs)
+    )
     stub_backend._find_adapter = lambda cap, types=None: AdapterMixin._find_adapter(
         stub_backend, cap, types
     )
     return stub_backend
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("ibm-granite/granite-3.3-8b-instruct", "granite-3.3-8b-instruct"),
+        ("granite-switch", "granite-switch"),
+        ("/tmp/granite-switch-checkpoint", "granite-switch-checkpoint"),
+    ],
+)
+def test_base_model_name_handles_hub_ids_and_local_checkpoints(model_id, expected):
+    """Embedded registration accepts local checkpoint paths and unqualified model IDs."""
+    backend = _make_backend()
+    backend._model_id = model_id
+
+    assert backend.base_model_name == expected
+
+
+def test_load_embedded_adapters_registers_checkpoint_adapters():
+    """The constructor registers embedded adapters without invoking PEFT loading."""
+    adapter = _make_embedded_adapter_stub()
+    mock_tok = MagicMock(eos_token_id=0, vocab_size=32000)
+    mock_tok._tokenizer = MagicMock()
+    mock_tok._tokenizer.get_vocab_size.return_value = 32000
+    mock_tok.__len__ = MagicMock(return_value=32000)
+    mock_model = MagicMock(vocab_size=32000)
+
+    with (
+        patch("mellea.backends.huggingface.llguidance") as mock_llg,
+        patch.object(
+            EmbeddedIntrinsicAdapter, "from_source", return_value=[adapter]
+        ) as mock_from_source,
+    ):
+        mock_llg.hf.from_tokenizer.return_value = MagicMock(vocab_size=32000)
+        backend = LocalHFBackend(
+            model_id="ibm-granite/granite-3.3-8b-instruct",
+            custom_config=(mock_tok, mock_model, torch.device("cpu")),
+            load_embedded_adapters=True,
+            adapter_source="/tmp/switch-checkpoint",
+        )
+
+    mock_from_source.assert_called_once_with(
+        "/tmp/switch-checkpoint", revision="main", cache_dir=None
+    )
+    assert backend.list_adapters() == ["answerability_alora"]
+    assert backend._added_adapters["answerability_alora"] is adapter
+    assert adapter.backend is backend
+    assert isinstance(adapter.weights, EmbeddedBinding)
+    assert adapter.weights.source == backend.base_model_name
+    backend._model.load_adapter.assert_not_called()
+
+
+def test_chat_completion_request_forwards_template_kwargs_to_transformers():
+    """Template kwargs survive request conversion for local Granite Switch inference."""
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template.return_value = torch.zeros(1, 4, dtype=torch.long)
+    tokenizer.pad_token_id = 0
+    tokenizer.eos_token_id = 1
+    model = MagicMock()
+    model.device = "cpu"
+
+    chat_completion_request_to_transformers_inputs(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "adapter_name": "answerability",
+                    "template_option": "preserved",
+                }
+            },
+        },
+        tokenizer,
+        model,
+    )
+
+    tokenizer.apply_chat_template.assert_called_once_with(
+        conversation=[{"role": "user", "content": "hello"}],
+        add_generation_prompt=True,
+        adapter_name="answerability",
+        template_option="preserved",
+        return_tensors="pt",
+    )
+
+
+@pytest.mark.parametrize(
+    "reserved_name", ["conversation", "tools", "documents", "add_generation_prompt"]
+)
+def test_chat_completion_request_rejects_reserved_template_kwargs(reserved_name):
+    """Template kwargs must not overwrite framework-owned chat-template inputs."""
+    tokenizer = MagicMock()
+    model = MagicMock()
+
+    with pytest.raises(ValueError, match="cannot override Hugging Face"):
+        chat_completion_request_to_transformers_inputs(
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "extra_body": {"chat_template_kwargs": {reserved_name: "bad"}},
+            },
+            tokenizer,
+            model,
+        )
+
+    tokenizer.apply_chat_template.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_embedded_intrinsic_activates_template_without_peft(stub_backend):
+    """Embedded calls select the template control token without PEFT lifecycle work."""
+    backend = _make_intrinsic_backend_stub(stub_backend)
+    adapter = _make_embedded_adapter_stub()
+    backend._added_adapters = {adapter.qualified_name: adapter}
+    peft_scope = MagicMock()
+    backend._generate_intrinsic_with_adapter_scope = peft_scope
+    captured: dict[str, object] = {}
+
+    def fake_transformers_inputs(request, tokenizer, model, ll_tokenizer=None):
+        captured["request"] = request
+        return {"input_tokens": object()}, {}
+
+    def fake_generate_with_transformers(tokenizer, model, generate_input, other_input):
+        return object()
+
+    with (
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsRewriter",
+            _FakeRewriter,
+        ),
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsResultProcessor",
+            _FakeResultProcessor,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.chat_completion_request_to_transformers_inputs",
+            side_effect=fake_transformers_inputs,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.generate_with_transformers",
+            side_effect=fake_generate_with_transformers,
+        ),
+    ):
+        output = await LocalHFBackend._generate_from_intrinsic(
+            backend,
+            Intrinsic("answerability"),
+            ChatContext().add(Message("user", "Is the sky blue?")),
+            model_options={},
+        )
+        assert output._gen.generate is not None
+        await output._gen.generate
+
+    request = captured["request"]
+    assert isinstance(request, dict)
+    assert request["extra_body"]["chat_template_kwargs"]["adapter_name"] == (
+        "answerability"
+    )
+    peft_scope.assert_not_called()
 
 
 def test_generate_with_adapter_lock_deactivates_and_calls_generate_func():
@@ -828,7 +1014,7 @@ async def test_intrinsic_seed_with_zero_temperature_keeps_greedy(stub_backend):
     captured = {}
 
     def fake_transformers_inputs(rewritten, tokenizer, model, ll_tokenizer=None):
-        assert rewritten.temperature == 0.0
+        assert rewritten["temperature"] == 0.0
         generate_input = {"input_tokens": object(), "do_sample": False}
         captured["generate_input"] = generate_input
         return generate_input, {}

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -38,6 +38,7 @@ from mellea.backends.adapters import (
     AdapterType,
     EmbeddedBinding,
     IntrinsicAdapter,
+    ServerMediatedBinding,
 )
 from mellea.backends.adapters._core import Identity
 from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
@@ -177,7 +178,12 @@ class _FakeRewrittenRequest:
         return copied
 
     def model_dump(self):
-        return {"messages": [], "extra_body": {}, "temperature": self.temperature}
+        return {
+            "messages": [],
+            "extra_body": {},
+            "model": "adapter-model",
+            "temperature": self.temperature,
+        }
 
 
 class _FakeRewriter:
@@ -358,7 +364,8 @@ def test_chat_completion_request_forwards_template_kwargs_to_transformers():
 
 
 @pytest.mark.parametrize(
-    "reserved_name", ["conversation", "tools", "documents", "add_generation_prompt"]
+    "reserved_name",
+    ["conversation", "tools", "documents", "add_generation_prompt", "return_tensors"],
 )
 def test_chat_completion_request_rejects_reserved_template_kwargs(reserved_name):
     """Template kwargs must not overwrite framework-owned chat-template inputs."""
@@ -376,6 +383,19 @@ def test_chat_completion_request_rejects_reserved_template_kwargs(reserved_name)
         )
 
     tokenizer.apply_chat_template.assert_not_called()
+
+
+def test_chat_completion_request_rejects_non_dict_template_kwargs():
+    """Template kwargs must be a mapping before they reach the tokenizer."""
+    with pytest.raises(TypeError, match="must be a dict"):
+        chat_completion_request_to_transformers_inputs(
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "extra_body": {"chat_template_kwargs": ["not", "a", "dict"]},
+            },
+            MagicMock(),
+            MagicMock(),
+        )
 
 
 @pytest.mark.asyncio
@@ -427,7 +447,47 @@ async def test_embedded_intrinsic_activates_template_without_peft(stub_backend):
     assert request["extra_body"]["chat_template_kwargs"]["adapter_name"] == (
         "answerability"
     )
+    assert "model" not in request
     peft_scope.assert_not_called()
+
+
+def test_generate_embedded_with_generation_lock_deactivates_peft_state():
+    """Embedded generation clears stale PEFT state before running the checkpoint."""
+    backend = _make_backend()
+    backend._model.active_adapters.return_value = []  # type: ignore[union-attr]
+
+    with patch.object(backend, "deactivate_peft_adapter") as mock_deactivate:
+        assert (
+            backend._generate_embedded_with_generation_lock(lambda: "output")
+            == "output"
+        )
+
+    mock_deactivate.assert_called_once_with("")
+
+
+def test_add_embedded_adapter_rejects_mutated_weights_without_binding_backend():
+    """A malformed shim must not retain this backend after registration fails."""
+    backend = _make_backend()
+    adapter = _make_embedded_adapter_stub()
+    adapter.weights = ServerMediatedBinding()
+
+    with pytest.raises(TypeError, match="must be an EmbeddedBinding"):
+        backend.add_adapter(adapter)
+
+    assert adapter.backend is None
+    assert adapter.qualified_name not in backend._added_adapters
+
+
+def test_load_peft_adapter_rejects_embedded_adapter():
+    """Embedded adapters are selected by the chat template, not loaded by PEFT."""
+    backend = _make_backend()
+    adapter = _make_embedded_adapter_stub()
+    backend.add_adapter(adapter)
+
+    with pytest.raises(TypeError, match="through PEFT"):
+        backend.load_peft_adapter(adapter.qualified_name)
+
+    backend._model.load_adapter.assert_not_called()
 
 
 def test_generate_with_adapter_lock_deactivates_and_calls_generate_func():

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [{ name = "click", specifier = ">=8.3.3" }]
+overrides = [{ name = "transformers", specifier = ">5.5.0,<6.0.0" }]
 
 [[package]]
 name = "absl-py"
@@ -1589,6 +1590,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
+name = "granite-switch"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/e6/8f3a7d59c8de8fb26f3612ed71a7a6d2e434627c620ba2c20193c21ee5d5/granite_switch-0.1.0.tar.gz", hash = "sha256:2535a6d0501b36213204150e5f0125db154b7607b23431f93fda9b4b2d5a8407", size = 110952, upload-time = "2026-07-07T14:53:39.345Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/9c/c8790201bd44953f6113b77e1cd4a42598389cec89dc17c5bb90ad3dceeb/granite_switch-0.1.0-py3-none-any.whl", hash = "sha256:800935ce446b631b2ed1fc3d27bc6e371568baa42f687e1fd02e228492db6803", size = 123691, upload-time = "2026-07-07T14:53:37.796Z" },
+]
+
+[package.optional-dependencies]
+hf = [
+    { name = "accelerate" },
 ]
 
 [[package]]
@@ -3236,6 +3255,7 @@ all = [
     { name = "docling" },
     { name = "elasticsearch" },
     { name = "fastapi" },
+    { name = "granite-switch", extra = ["hf"] },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
@@ -3315,8 +3335,7 @@ server = [
     { name = "uvicorn" },
 ]
 switch = [
-    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "huggingface-hub", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "granite-switch", extra = ["hf"] },
 ]
 telemetry = [
     { name = "cpex" },
@@ -3413,10 +3432,10 @@ requires-dist = [
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.45.0" },
     { name = "elasticsearch", marker = "extra == 'granite-retriever'", specifier = ">=8.0.0,<9.0.0" },
     { name = "fastapi", marker = "extra == 'server'" },
+    { name = "granite-switch", extras = ["hf"], marker = "extra == 'switch'", specifier = ">=0.1.0" },
     { name = "grpcio", marker = "extra == 'hooks'", specifier = ">=1.78.0" },
     { name = "httpx", marker = "extra == 'tools'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.33.4" },
-    { name = "huggingface-hub", marker = "extra == 'switch'", specifier = ">=0.33.4" },
     { name = "ibm-watsonx-ai", marker = "extra == 'watsonx'", specifier = ">=1.3.31" },
     { name = "jinja2" },
     { name = "langchain-core", marker = "extra == 'tools'", specifier = ">=1.2.28" },

--- a/uv.lock
+++ b/uv.lock
@@ -3286,6 +3286,7 @@ backends = [
     { name = "accelerate" },
     { name = "boto3" },
     { name = "datasets" },
+    { name = "granite-switch", extra = ["hf"] },
     { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "huggingface-hub", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "ibm-watsonx-ai" },
@@ -3311,6 +3312,7 @@ granite-retriever = [
 hf = [
     { name = "accelerate" },
     { name = "datasets" },
+    { name = "granite-switch", extra = ["hf"] },
     { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
     { name = "huggingface-hub", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
     { name = "llguidance" },
@@ -3335,7 +3337,8 @@ server = [
     { name = "uvicorn" },
 ]
 switch = [
-    { name = "granite-switch", extra = ["hf"] },
+    { name = "huggingface-hub", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "huggingface-hub", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 telemetry = [
     { name = "cpex" },
@@ -3432,10 +3435,11 @@ requires-dist = [
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.45.0" },
     { name = "elasticsearch", marker = "extra == 'granite-retriever'", specifier = ">=8.0.0,<9.0.0" },
     { name = "fastapi", marker = "extra == 'server'" },
-    { name = "granite-switch", extras = ["hf"], marker = "extra == 'switch'", specifier = ">=0.1.0" },
+    { name = "granite-switch", extras = ["hf"], marker = "extra == 'hf'", specifier = ">=0.1.0" },
     { name = "grpcio", marker = "extra == 'hooks'", specifier = ">=1.78.0" },
     { name = "httpx", marker = "extra == 'tools'", specifier = ">=0.27" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.33.4" },
+    { name = "huggingface-hub", marker = "extra == 'switch'", specifier = ">=0.33.4" },
     { name = "ibm-watsonx-ai", marker = "extra == 'watsonx'", specifier = ">=1.3.31" },
     { name = "jinja2" },
     { name = "langchain-core", marker = "extra == 'tools'", specifier = ">=1.2.28" },


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #1018

## Description

Before this change, a Mellea user with a Granite Switch checkpoint could use its
embedded adapter functions only through a vLLM deployment and `OpenAIBackend`.
They could not point `LocalHFBackend` at the checkpoint and use the existing
adapter-function helpers locally.

After installing `mellea[hf]`, a user can construct
`LocalHFBackend(..., load_embedded_adapters=True)` around a local Granite Switch
checkpoint and call the same adapter-function helpers. Mellea discovers the
embedded functions, renders the selected control token through the checkpoint's
chat template, and parses the result. No separate adapter weights need to be
downloaded, loaded, or activated through PEFT.

Existing LocalHF runtime LoRA/aLoRA behaviour is unchanged: the Granite Switch
dependency and registration import run only when
`load_embedded_adapters=True` is selected.

### What changes

1. `LocalHFBackend(load_embedded_adapters=True)` discovers embedded adapter functions from a local checkpoint or Hugging Face source.
2. Embedded calls run `EmbeddedBinding.apply_activation()` after request rewriting. The resulting `adapter_name` is forwarded into `tokenizer.apply_chat_template()`.
3. Embedded calls use the generation lock, clear any stale PEFT selection, and never download, load, or activate PEFT weights or enter `adapter_scope()`.
4. The shared Transformers request converter forwards safe template kwargs and rejects attempts to overwrite framework-owned values.
5. Local paths and unqualified model IDs now derive a valid base model name during embedded registration.
6. The adapter-functions how-to and Granite Switch examples document the
   `mellea[hf]` local install path and include a runnable local example.

### Granite Switch dependency compatibility

The local checkpoint path installs through `mellea[hf]`, which imports
the Granite Switch HF registration package only when embedded adapter functions
are requested. Granite Switch 0.1.0 currently declares a Transformers range
that excludes Mellea's resolved version, even though the consolidated local 3B
e2e passes on that version. Mellea therefore records an explicit resolver
override and emits a one-time warning while the installed Granite Switch
metadata still excludes the resolved Transformers version. The warning
automatically disappears when Granite Switch publishes widened metadata.

Current runtime warning:

```text
UserWarning: granite-switch declares a Transformers range that excludes 5.10.2;
Mellea is using its explicit compatibility override for local Granite Switch
support. This warning will disappear once Granite Switch publishes widened metadata.
```

Follow-up: validate the wider range with the Granite Switch maintainers before
the next release.

### Effect

Users can run adapter functions against a local Granite Switch checkpoint through `LocalHFBackend`. Only adapter functions listed in that checkpoint's `adapter_index.json` are available; the existing runtime LoRA/aLoRA path is unchanged.

### Deliberately out of scope

- New telemetry or lifecycle spans. Existing binding behaviour is unchanged; broader lifecycle observability remains in #1466.
- Replacing the deprecated `EmbeddedIntrinsicAdapter` compatibility shim with
  direct composed `Adapter(..., EmbeddedBinding(...))` execution. That public
  migration is documented for #1144.
- Running the GPU-backed Granite Switch check in CI. It runs by default in local GPU environments and is skipped when `CICD=1`.

### Testing

- [x] `uv run pytest test/backends/test_huggingface_unit.py -q` — 98 passed
- [x] `uv run mypy mellea/backends/huggingface.py mellea/backends/adapters/adapter.py test/backends/test_huggingface_unit.py`
- [x] `uv run ruff check` and `uv run ruff format --check` on changed Python files
- [x] `npx markdownlint-cli2 "docs/docs/advanced/intrinsics.md"`
- [x] `uv run pytest test/backends/test_huggingface_embedded.py -q -rs` — real
  3B LocalHF e2e passed on Apple Silicon (1 passed, 30.93 s)
- [x] Same targeted e2e on a Linux GPU runner (1 passed, 60.18 s), including
  the assertion that the Switch template changes when `adapter_name` is set
- [x] `uv sync --extra hf` followed by the new local example —
  returned `Answerability: answerable`
- [x] Markdownlint plus API-doc build and 100% docstring-quality audit
- [ ] `uv run pytest test/ -m "not qualitative"` — 4,130 passed, 1 failed. The unrelated `test_matplotlib_agg_injected` timed out while creating its isolated matplotlib environment; its requested targeted rerun passed.

- [x] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution

- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
