### PR TITLE
feat: add OrcaRouter as a first-class backend provider

### DIFF
--- a/docs/docs/how-to/backends-and-configuration.md
+++ b/docs/docs/how-to/backends-and-configuration.md
@@ -32,6 +32,7 @@ The following table shows all available backends, their class names, import path
 | ------- | ----- | ------ | --------------- | ----------------- |
 | [Ollama](../integrations/ollama.md) | `OllamaModelBackend` | `mellea.backends.ollama` | base | `backend_name="ollama"` |
 | [OpenAI](../integrations/openai.md) | `OpenAIBackend` | `mellea.backends.openai` | base | `backend_name="openai"` |
+| [OrcaRouter](../integrations/orcarouter.md) | `OrcaRouterBackend` | `mellea.backends.orcarouter` | base | `backend_name="orcarouter"` |
 | [LiteLLM](../integrations/litellm.md) | `LiteLLMBackend` | `mellea.backends.litellm` | `mellea[litellm]` | `backend_name="litellm"` |
 | [Hugging Face](../integrations/huggingface.md) | `LocalHFBackend` | `mellea.backends.huggingface` | `mellea[hf]` | `backend_name="hf"` |
 | [WatsonX](../integrations/watsonx.md) | `WatsonxAIBackend` | `mellea.backends.watsonx` | `mellea[watsonx]` | `backend_name="watsonx"` (deprecated) |
@@ -253,7 +254,7 @@ m = mellea.start_session(
 )
 ```
 
-Valid `backend_name` values: `"ollama"`, `"openai"`, `"hf"`, `"litellm"`, `"watsonx"`.
+Valid `backend_name` values: `"ollama"`, `"openai"`, `"orcarouter"`, `"hf"`, `"litellm"`, `"watsonx"`.
 
 ---
 

--- a/docs/docs/integrations/orcarouter.md
+++ b/docs/docs/integrations/orcarouter.md
@@ -1,0 +1,109 @@
+---
+title: "OrcaRouter"
+description: "Use OrcaRouter — an OpenAI-compatible AI gateway with adaptive routing, failover, and gateway-level security — through Mellea's named OrcaRouterBackend."
+sidebar_label: "OrcaRouter"
+# diataxis: how-to
+---
+
+[`OrcaRouterBackend`](../reference/glossary.md#backend) connects Mellea to the
+[OrcaRouter](https://www.orcarouter.ai) gateway — a single OpenAI-compatible
+endpoint in front of many hosted models. Like OpenAI, OrcaRouter exposes a
+provider/model namespace across many models; on top of that it adds adaptive
+routing, automatic failover, zero-markup inference, observability, guardrails,
+and agent-tool governance behind the same endpoint. Because the endpoint is
+OpenAI-compatible, Mellea reuses its full OpenAI backend machinery — structured
+output, tool calling, thinking-mode handling, and streaming all work unchanged.
+
+**Prerequisites:** `pip install mellea`, an [OrcaRouter](https://www.orcarouter.ai) API key.
+
+## Setup
+
+Set your API key as an environment variable (recommended):
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+```
+
+## Using the named backend
+
+`start_session()` accepts `backend_name="orcarouter"` and defaults to OrcaRouter's
+adaptive-routing model, which grades each prompt and routes to the best frontier
+or open-weights model:
+
+```python
+# Requires: mellea
+# Returns: ModelOutputThunk
+import mellea
+
+m = mellea.start_session(
+    backend_name="orcarouter",
+    model_id="orcarouter/auto",
+    context_type="chat",
+)
+reply = m.chat("What is the capital of France?")
+print(str(reply))
+# Output will vary — LLM responses depend on model and temperature.
+```
+
+Or construct the backend directly:
+
+```python
+# Requires: mellea
+# Returns: MelleaSession
+from mellea import MelleaSession
+from mellea.backends.orcarouter import OrcaRouterBackend
+
+m = MelleaSession(
+    OrcaRouterBackend(model_id="orcarouter/auto"),
+    ctx=ChatContext(),
+)
+```
+
+`OrcaRouterBackend` reads `ORCAROUTER_API_KEY` from the environment and defaults
+`base_url` to `https://api.orcarouter.ai/v1`. Pass the key or a different base
+URL directly to override either:
+
+```python
+# Requires: mellea
+# Returns: MelleaSession
+from mellea import MelleaSession
+from mellea.backends.orcarouter import OrcaRouterBackend
+
+m = MelleaSession(
+    OrcaRouterBackend(
+        model_id="orcarouter/auto",
+        api_key="sk-orca-...",
+    ),
+)
+```
+
+## Available models
+
+OrcaRouter's `orcarouter/auto` routes each prompt to the best-suited model. You
+can also target a specific model by name; pass any model string OrcaRouter
+serves to the `model_id` argument. The `ModelIdentifier` constant
+`model_ids.ORCAROUTER_AUTO` carries the auto-routing name for type-checked use.
+
+## Security and governance
+
+OrcaRouter runs gateway-level, zero-trust security for AI agents on the same
+endpoint — screening every prompt and response and governing every tool call on
+a default-deny basis, with no application code changes. Mellea's tool calling and
+structured-output features are forwarded as normal OpenAI-compatible requests, so
+the same Mellea code gains those safeguards when pointed at OrcaRouter.
+
+## Troubleshooting
+
+### `ORCAROUTER_API_KEY` not set error
+
+Either export the environment variable or pass `api_key` directly to
+`OrcaRouterBackend`.
+
+### Model not found
+
+The model string must exactly match a model name OrcaRouter serves. Use
+`orcarouter/auto` for adaptive routing, or list models from OrcaRouter's API.
+
+---
+
+**See also:** [Backends and Configuration](../how-to/backends-and-configuration) | [OpenAI and OpenAI-Compatible APIs](./openai)

--- a/docs/docs/reference/glossary.md
+++ b/docs/docs/reference/glossary.md
@@ -94,7 +94,7 @@ See: [Generative Functions](/how-to/generative-functions)
 ## Backend
 
 A backend is an inference engine that Mellea uses to run LLM calls. Examples:
-`OllamaModelBackend`, `OpenAIBackend`, `LocalHFBackend`, `WatsonxAIBackend`. Backends are configured via `MelleaSession` or
+`OllamaModelBackend`, `OpenAIBackend`, `OrcaRouterBackend`, `LocalHFBackend`, `WatsonxAIBackend`. Backends are configured via `MelleaSession` or
 `start_session()`.
 
 See: [Backends and Configuration](/how-to/backends-and-configuration)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -79,6 +79,7 @@ const sidebars: SidebarsConfig = {
         'integrations/ollama',
         'integrations/huggingface',
         'integrations/openai',
+        'integrations/orcarouter',
         'integrations/litellm',
         'integrations/vertex-ai',
         'integrations/bedrock',

--- a/mellea/backends/model_ids.py
+++ b/mellea/backends/model_ids.py
@@ -433,6 +433,17 @@ OPENAI_GPT_5_1 = ModelIdentifier(
     openai_name="gpt-5.1"  # OpenAI GPT-5.1
 )
 
+###########################
+#### OrcaRouter models ####
+###########################
+
+# `orcarouter/auto` is OrcaRouter's adaptive-routing model: it grades each prompt
+# and routes to the best frontier or open-weights model, with automatic failover.
+# Served from `https://api.orcarouter.ai/v1` via `OrcaRouterBackend`.
+ORCAROUTER_AUTO = ModelIdentifier(
+    openai_name="orcarouter/auto"  # OrcaRouter adaptive routing
+)
+
 #####################
 #### Misc models ####
 #####################

--- a/mellea/backends/orcarouter.py
+++ b/mellea/backends/orcarouter.py
@@ -1,0 +1,95 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A first-class OrcaRouter backend built on the OpenAI-compatible client.
+
+OrcaRouter (https://www.orcarouter.ai) exposes a single OpenAI-compatible
+endpoint (`https://api.orcarouter.ai/v1`) in front of many hosted models, with
+adaptive routing, automatic failover, and gateway-level security. This backend
+is a thin, provider-branded subclass of `OpenAIBackend` that pins the base URL
+and API key environment variable, so callers get the OrcaRouter stack as a named
+provider instead of an anonymous custom base URL.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..formatters import ChatFormatter, TemplateFormatter
+from . import model_ids
+from .openai import OpenAIBackend
+
+#: Default OrcaRouter endpoint. Mirrors how ``OpenAIBackend`` defaults to the
+#: OpenAI API; OrcaRouter is OpenAI-compatible, so the chat completions schema
+#: is identical.
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+
+class OrcaRouterBackend(OpenAIBackend):
+    """An OpenAI-compatible backend for OrcaRouter's hosted model gateway.
+
+    OrcaRouter serves many models behind a single OpenAI-compatible endpoint and
+    adds adaptive routing, automatic failover, observability, and gateway-level
+    security on top. This backend points at that endpoint by default, so the
+    OrcaRouter stack can be used as a named provider instead of an anonymous
+    custom base URL.
+
+    Args:
+        model_id (str | ModelIdentifier): OpenAI-compatible model identifier.
+            Defaults to `model_ids.ORCAROUTER_AUTO`.
+        formatter (ChatFormatter | None): Formatter for rendering components.
+            Defaults to `TemplateFormatter`.
+        base_url (str | None): Base URL for the API endpoint; defaults to the
+            OrcaRouter endpoint (`https://api.orcarouter.ai/v1`) if not set.
+        model_options (dict | None): Default model options for generation requests.
+        api_key (str | None): API key; falls back to `ORCAROUTER_API_KEY` env var.
+        kwargs: Additional keyword arguments forwarded to the OpenAI client.
+
+    Raises:
+        ValueError: If neither `api_key` nor `ORCAROUTER_API_KEY` is set.
+        TypeError: If `model_id` is neither a `str` nor a `ModelIdentifier`.
+    """
+
+    def __init__(
+        self,
+        model_id: str | model_ids.ModelIdentifier = model_ids.ORCAROUTER_AUTO,
+        formatter: ChatFormatter | None = None,
+        base_url: str | None = None,
+        model_options: dict | None = None,
+        *,
+        default_to_constraint_checking_alora: bool = True,
+        load_embedded_adapters: bool = False,
+        adapter_source: str | None = None,
+        api_key: str | None = None,
+        default_extra_body: dict | None = None,
+        **kwargs,
+    ):
+        """Initialize an OrcaRouter backend with the given model and credentials."""
+        if api_key is None:
+            api_key = os.getenv("ORCAROUTER_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "ORCAROUTER_API_KEY or api_key is required but not set. Please either:\n"
+                "  1. Set the environment variable: export ORCAROUTER_API_KEY='your-key-here'\n"
+                "  2. Pass it as a parameter: OrcaRouterBackend(api_key='your-key-here')"
+            )
+
+        super().__init__(
+            model_id=model_id,
+            formatter=(
+                formatter
+                if formatter is not None
+                else TemplateFormatter(model_id=model_id)
+            ),
+            base_url=base_url
+            or os.getenv("ORCAROUTER_BASE_URL")
+            or ORCAROUTER_BASE_URL,
+            model_options=model_options,
+            default_to_constraint_checking_alora=default_to_constraint_checking_alora,
+            load_embedded_adapters=load_embedded_adapters,
+            adapter_source=adapter_source,
+            api_key=api_key,
+            default_extra_body=default_extra_body,
+            **kwargs,
+        )
+        self._provider: str = "orcarouter"

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -93,7 +93,9 @@ def get_session() -> MelleaSession:
 
 
 def start_session(
-    backend_name: Literal["ollama", "hf", "openai", "watsonx", "litellm"] = "ollama",
+    backend_name: Literal[
+        "ollama", "hf", "openai", "watsonx", "litellm", "orcarouter"
+    ] = "ollama",
     model_id: str | ModelIdentifier = IBM_GRANITE_4_1_3B,
     ctx: Context | None = None,
     *,
@@ -115,6 +117,7 @@ def start_session(
             - "ollama": Use Ollama backend for local models
             - "hf" or "huggingface": Use Hugging Face transformers backend
             - "openai": Use OpenAI API backend
+            - "orcarouter": Use the OrcaRouter gateway backend
             - "watsonx": Use IBM WatsonX backend, WARNING: this defaults to the IBM_GRANITE_4_HYBRID_SMALL model for now.
             - "litellm": Use the LiteLLM backend
         model_id: Model identifier or name. Can be a `ModelIdentifier` from
@@ -182,7 +185,7 @@ def start_session(
     if backend_class is None:
         raise Exception(
             f"Backend name {backend_name} unknown. Valid options are: "
-            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`."
+            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`, `orcarouter`."
         )
 
     # Pre-generate so the startup span and session_pre_init payload share an id.

--- a/mellea/stdlib/start_backend.py
+++ b/mellea/stdlib/start_backend.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ..backends.litellm import LiteLLMBackend
     from ..backends.ollama import OllamaModelBackend
     from ..backends.openai import OpenAIBackend
+    from ..backends.orcarouter import OrcaRouterBackend
     from ..backends.watsonx import WatsonxAIBackend
 
 CtxT = typing_extensions.TypeVar("CtxT", bound=Context, default=SimpleContext)
@@ -28,7 +29,7 @@ def backend_name_to_class(name: str) -> Any:
 
     Args:
         name: Short backend name, e.g. `"ollama"`, `"hf"`, `"openai"`,
-            `"watsonx"`, or `"litellm"`.
+            `"watsonx"`, `"litellm"`, or `"orcarouter"`.
 
     Returns:
         The corresponding `Backend` class, or `None` if the name is unrecognised.
@@ -42,6 +43,10 @@ def backend_name_to_class(name: str) -> Any:
         from ..backends.ollama import OllamaModelBackend
 
         return OllamaModelBackend
+    elif name == "orcarouter":
+        from ..backends.orcarouter import OrcaRouterBackend
+
+        return OrcaRouterBackend
     elif name == "hf" or name == "huggingface":
         try:
             from mellea.backends.huggingface import LocalHFBackend
@@ -107,6 +112,7 @@ def _resolve_model_id_str(model_id: str | ModelIdentifier, backend_name: str) ->
             "hf": "hf_model_name",
             "huggingface": "hf_model_name",
             "openai": "openai_name",
+            "orcarouter": "openai_name",
             "watsonx": "watsonx_name",
             "litellm": "hf_model_name",
         }
@@ -233,6 +239,45 @@ def start_backend(
 
 
 # ---------------------------------------------------------------------------
+# Overloads: orcarouter
+# ---------------------------------------------------------------------------
+@overload
+def start_backend(
+    backend_name: Literal["orcarouter"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: Literal["chat"],
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[ChatContext, OrcaRouterBackend]: ...
+
+
+@overload
+def start_backend(
+    backend_name: Literal["orcarouter"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: Literal["simple"],
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[SimpleContext, OrcaRouterBackend]: ...
+
+
+@overload
+def start_backend(
+    backend_name: Literal["orcarouter"],
+    model_id: str | ModelIdentifier = ...,
+    ctx: CtxT = ...,
+    *,
+    context_type: None = ...,
+    model_options: dict | None = ...,
+    **backend_kwargs: Any,
+) -> tuple[CtxT, OrcaRouterBackend]: ...
+
+
+# ---------------------------------------------------------------------------
 # Overloads: watsonx
 # ---------------------------------------------------------------------------
 @overload
@@ -314,7 +359,9 @@ def start_backend(
 # Implementation
 # ---------------------------------------------------------------------------
 def start_backend(
-    backend_name: Literal["ollama", "hf", "openai", "watsonx", "litellm"] = "ollama",
+    backend_name: Literal[
+        "ollama", "hf", "openai", "watsonx", "litellm", "orcarouter"
+    ] = "ollama",
     model_id: str | ModelIdentifier = IBM_GRANITE_4_MICRO_3B,
     ctx: Context | None = None,
     *,
@@ -330,7 +377,7 @@ def start_backend(
 
     Args:
         backend_name: The backend to use (`"ollama"`, `"hf"`, `"openai"`,
-            `"watsonx"`, or `"litellm"`).
+            `"watsonx"`, `"litellm"`, or `"orcarouter"`).
         model_id: Model identifier or name.
         ctx: An explicit `Context` instance. Mutually exclusive with
             `context_type`.
@@ -355,7 +402,7 @@ def start_backend(
     if backend_class is None:
         raise Exception(
             f"Backend name {backend_name} unknown. Valid options are: "
-            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`."
+            "`ollama`, `hf`, `openai`, `watsonx`, `litellm`, `orcarouter`."
         )
     backend = backend_class(model_id, model_options=model_options, **backend_kwargs)
     return resolved_ctx, backend

--- a/test/backends/test_orcarouter_unit.py
+++ b/test/backends/test_orcarouter_unit.py
@@ -1,0 +1,68 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OrcaRouterBackend — no API calls required.
+
+Covers the provider-branded defaults (base URL, env var, provider tag) and the
+model_id resolution shared with the OpenAI backend.
+"""
+
+import pytest
+
+from mellea.backends import model_ids
+from mellea.backends.orcarouter import ORCAROUTER_BASE_URL, OrcaRouterBackend
+
+
+def _make_backend(**kwargs) -> OrcaRouterBackend:
+    """Return an OrcaRouterBackend with a fake API key."""
+    model_id = kwargs.pop("model_id", "orcarouter/auto")
+    return OrcaRouterBackend(
+        model_id=model_id, api_key=kwargs.pop("api_key", "fake-key"), **kwargs
+    )
+
+
+def test_defaults_to_orcarouter_base_url():
+    backend = _make_backend()
+    assert backend._base_url == ORCAROUTER_BASE_URL
+    assert backend._base_url == "https://api.orcarouter.ai/v1"
+
+
+def test_provider_tag_is_orcarouter():
+    backend = _make_backend()
+    assert backend._provider == "orcarouter"
+
+
+def test_repr_masks_api_key():
+    backend = _make_backend()
+    r = repr(backend)
+    assert "fake-key" not in r
+    assert "***" in r
+
+
+def test_default_model_id_is_orcarouter_auto():
+    backend = OrcaRouterBackend(api_key="fake-key")
+    assert backend._model_id == model_ids.ORCAROUTER_AUTO.openai_name
+    assert backend._model_id == "orcarouter/auto"
+
+
+def test_model_identifier_resolves_to_openai_name():
+    backend = _make_backend(model_id=model_ids.ORCAROUTER_AUTO)
+    assert backend._model_id == "orcarouter/auto"
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY"):
+        OrcaRouterBackend()
+
+
+def test_api_key_reads_from_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+    backend = OrcaRouterBackend()
+    assert backend._api_key == "env-key"
+
+
+def test_explicit_api_key_takes_precedence(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "env-key")
+    backend = OrcaRouterBackend(api_key="explicit-key")
+    assert backend._api_key == "explicit-key"

--- a/test/stdlib/test_session_unit.py
+++ b/test/stdlib/test_session_unit.py
@@ -14,6 +14,7 @@ import pytest
 from mellea import start_backend
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
+from mellea.backends.orcarouter import OrcaRouterBackend
 from mellea.stdlib.context import ChatContext, SimpleContext
 from mellea.stdlib.session import (
     _resolve_context,
@@ -33,6 +34,11 @@ def test_ollama_resolves_to_ollama_backend():
 def test_openai_resolves_to_openai_backend():
     cls = backend_name_to_class("openai")
     assert cls is OpenAIBackend
+
+
+def test_orcarouter_resolves_to_orcarouter_backend():
+    cls = backend_name_to_class("orcarouter")
+    assert cls is OrcaRouterBackend
 
 
 def test_unknown_name_returns_none():

--- a/test/typing/check_start_backend.py
+++ b/test/typing/check_start_backend.py
@@ -9,6 +9,7 @@ from mellea.backends.huggingface import LocalHFBackend
 from mellea.backends.litellm import LiteLLMBackend
 from mellea.backends.ollama import OllamaModelBackend
 from mellea.backends.openai import OpenAIBackend
+from mellea.backends.orcarouter import OrcaRouterBackend
 from mellea.backends.watsonx import WatsonxAIBackend
 from mellea.stdlib.context import ChatContext, SimpleContext
 from mellea.stdlib.start_backend import start_backend
@@ -95,6 +96,21 @@ def check_openai_default() -> None:
     ctx, backend = start_backend("openai")
     assert_type(ctx, SimpleContext)
     assert_type(backend, OpenAIBackend)
+
+
+# ---------------------------------------------------------------------------
+# orcarouter
+# ---------------------------------------------------------------------------
+def check_orcarouter_chat() -> None:
+    ctx, backend = start_backend("orcarouter", context_type="chat")
+    assert_type(ctx, ChatContext)
+    assert_type(backend, OrcaRouterBackend)
+
+
+def check_orcarouter_default() -> None:
+    ctx, backend = start_backend("orcarouter")
+    assert_type(ctx, SimpleContext)
+    assert_type(backend, OrcaRouterBackend)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Mellea's "Multiple backends" story — Ollama, OpenAI, HuggingFace, WatsonX, LiteLLM, Bedrock — is what lets a generative program target whatever LLM server you want. Today, OrcaRouter can only be reached by hand-wiring its URL into `OpenAIBackend` as an anonymous custom `base_url`. This PR makes it a named provider so Mellea users get the OrcaRouter stack as a first-class `backend_name="orcarouter"`, exactly like `"openai"` or `"litellm"`.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

### Changes

- **New `OrcaRouterBackend`** (`mellea/backends/orcarouter.py`) — a thin, provider-branded subclass of `OpenAIBackend` that pins `base_url` to `https://api.orcarouter.ai/v1` and reads `ORCAROUTER_API_KEY` from the environment, mirroring how `OpenAIBackend` defaults to the OpenAI API. It inherits Mellea's full OpenAI-compatible machinery — structured output, tool calling, thinking-mode handling, and streaming.
- **`model_ids.ORCAROUTER_AUTO`** — a new `ModelIdentifier` carrying OrcaRouter's adaptive-routing model name (`orcarouter/auto`), so the constant can be passed to any backend without a manual string.
- **`start_session()` / `start_backend()` registration** — `"orcarouter"` is now a valid `backend_name` with the same overload-resolution, `_resolve_model_id_str` mapping, and error-message updates as the other named providers.
- **Docs** — new [OrcaRouter integration page](docs/docs/integrations/orcarouter.md), added to the Integrations sidebar and the Backends & Configuration comparison table.
- **Tests** — unit tests for the new backend (`test_orcarouter_unit.py`), the `backend_name_to_class` resolution, and the `start_backend` mypy overloads (`check_start_backend.py`).

### Verification

- `ruff format` / `ruff check` clean on all changed files
- `mypy` clean on the changed source and the new `check_start_backend.py` overload checks
- `uv run pytest` unit tests pass (8 new OrcaRouter + existing OpenAI/session unit tests)
- Docstring quality gate (`audit_coverage.py --quality --fail-on-quality`) passes
- markdownlint passes on the new/changed docs pages
- **Live L3 test**: `start_session(backend_name="orcarouter", model_id="orcarouter/auto")` returned a real `200` with `response='pong'` against `https://api.orcarouter.ai/v1`

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
