### PR TITLE
docs: reframe docstring guidance as public API reference, not prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 ## 5. Coding Standards
 - **Types required** on all core functions
-- **Docstrings are prompts** — be specific, the LLM reads them
+- **Docstrings are published in the public API reference** — be specific and accurate.
 - **Google-style docstrings** — `Args:` on the **class docstring only**; `__init__` gets a single summary sentence. Add `Attributes:` only when a stored value differs in type/behaviour from its constructor input (type transforms, computed values, class constants). See CONTRIBUTING.md for a full example. **No RST directives inside docstrings** — never use `Example::`, `.. deprecated::`, `:param:`, `:type:`, or other RST markup inside a docstring; Google-style sections (`Example:`, `Raises:`, etc.) use plain Markdown. **Code examples use triple-backtick fences** (` ```python `) — not `>>>` doctest prompts (output is not verified). **Inline code uses single backticks** (`` `name` ``) — never double backticks (`` ``name`` ``); Mellea uses Markdown-style docstrings where double backticks are RST syntax and render incorrectly. See CONTRIBUTING.md for the full rationale and examples.
 - **Ruff** for linting/formatting
 - Use `...` in `@generative` function bodies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ mkdir -p .bob && ln -s ../.agents/skills .bob/skills
 
 ## 5. Coding Standards
 - **Types required** on all core functions
-- **Docstrings are published in the public API reference** — be specific and accurate.
+- **Public API docstrings are published in the public API reference** — be specific and accurate.
 - **Google-style docstrings** — `Args:` on the **class docstring only**; `__init__` gets a single summary sentence. Add `Attributes:` only when a stored value differs in type/behaviour from its constructor input (type transforms, computed values, class constants). See CONTRIBUTING.md for a full example. **No RST directives inside docstrings** — never use `Example::`, `.. deprecated::`, `:param:`, `:type:`, or other RST markup inside a docstring; Google-style sections (`Example:`, `Raises:`, etc.) use plain Markdown. **Code examples use triple-backtick fences** (` ```python `) — not `>>>` doctest prompts (output is not verified). **Inline code uses single backticks** (`` `name` ``) — never double backticks (`` ``name`` ``); Mellea uses Markdown-style docstrings where double backticks are RST syntax and render incorrectly. See CONTRIBUTING.md for the full rationale and examples.
 - **Ruff** for linting/formatting
 - Use `...` in `@generative` function bodies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ def process_text(text: str, max_length: int = 100) -> str:
 
 ### Docstrings
 
-**Docstrings are prompts** - the LLM reads them, so be specific.
+**Docstrings are published in the public API reference** — be specific.
 
 Use **[Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings)**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ def process_text(text: str, max_length: int = 100) -> str:
 
 ### Docstrings
 
-**Docstrings are published in the public API reference** — be specific.
+**Public API docstrings are published in the public API reference** — be specific and accurate.
 
 Use **[Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings)**:
 

--- a/docs/docs/community/contributing-guide.md
+++ b/docs/docs/community/contributing-guide.md
@@ -93,7 +93,7 @@ def process_text(text: str, max_length: int = 100) -> str:
 
 ### Docstrings
 
-Docstrings are published in the public API reference — be specific and accurate. Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings):
+Public API docstrings are published in the public API reference — be specific and accurate. Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings):
 
 ```python
 def extract_entities(text: str, entity_types: list[str]) -> dict[str, list[str]]:
@@ -107,8 +107,10 @@ def extract_entities(text: str, entity_types: list[str]) -> dict[str, list[str]]
         Dictionary mapping entity types to lists of extracted entities.
 
     Example:
-        >>> extract_entities("Alice works at IBM", ["PERSON", "ORG"])
-        {"PERSON": ["Alice"], "ORG": ["IBM"]}
+        ```python
+        result = extract_entities("Alice works at IBM", ["PERSON", "ORG"])
+        # {"PERSON": ["Alice"], "ORG": ["IBM"]}
+        ```
     """
     ...
 ```

--- a/docs/docs/community/contributing-guide.md
+++ b/docs/docs/community/contributing-guide.md
@@ -93,7 +93,7 @@ def process_text(text: str, max_length: int = 100) -> str:
 
 ### Docstrings
 
-Docstrings serve as prompts — the LLM reads them, so be specific. Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings):
+Docstrings are published in the public API reference — be specific and accurate. Use [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#381-docstrings):
 
 ```python
 def extract_entities(text: str, entity_types: list[str]) -> dict[str, list[str]]:


### PR DESCRIPTION
## Description
The "Docstrings are prompts — the LLM reads them" framing in AGENTS.md and CONTRIBUTING.md tells contributors (and coding agents) to write docstrings for an LLM audience. In practice docstrings are published verbatim in the public API reference and read by humans, so that framing has two concrete downsides:

- **It steers docstrings toward an LLM audience instead of the humans reading the published reference.** "Write for the LLM" is the wrong default for documentation that ships to users.
- **It encourages leaking session context into docstrings.** Writing a docstring with the intent that another AI will read it invites transient, conversation-specific detail into the published reference — poor practice for documentation that ships to users.

Reframing the guidance to "published in the public API reference — be specific and accurate" keeps docstrings human-facing and accurate for the shipped docs.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
