### PR TITLE
fix(backends): serialize resolve_adapter() registration under the activation lock

### DIFF
--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -595,6 +595,14 @@ class AdapterMixin(Backend, abc.ABC):
         `LocalHFBackend`'s underlying PEFT model) override this to return
         their own lock, so callers like `LocalFileBinding.activate()` get
         the same exclusivity `_generate_with_adapter_lock` relies on.
+
+        Callers, including `resolve_adapter()`, may re-enter this lock from a
+        code path that already holds it on the same thread (e.g. an
+        `adapter_scope()` that calls back into a verb guarded by this lock).
+        An override must therefore return a reentrant lock (a
+        `threading.RLock`, as `LocalHFBackend` does) — a plain
+        `threading.Lock` here is a real deadlock hazard, not just a missed
+        optimisation.
         """
         return contextlib.nullcontext()
 
@@ -614,6 +622,20 @@ class AdapterMixin(Backend, abc.ABC):
         Raises:
             ValueError: If the backend has no model ID.
             KeyError: If the adapter cannot be found after registration.
+
+        Note:
+            On `LocalHFBackend`, this holds `_generation_lock` for the whole
+            registration critical section below, including any Hugging Face
+            Hub download it triggers (`obtain_io_yaml`/`get_local_hf_path`
+            for the LORA path; `EmbeddedIntrinsicAdapter.from_source` for the
+            embedded path). A cold first resolve therefore serializes with —
+            and can stall behind, or block — every other caller of that same
+            lock (activation, generation, other resolves), including a
+            resolve made from the asyncio event-loop thread inside a
+            gathered set of coroutines. This mirrors the issue's own
+            suggested design (reuse the existing lock rather than add a
+            second one); a warm cache after the first resolve avoids the
+            download and keeps the critical section fast.
         """
         found = self._find_adapter(name)
         if found is not None:
@@ -630,15 +652,27 @@ class AdapterMixin(Backend, abc.ABC):
         # race under concurrent first-time resolves for the same name: add_adapter's
         # own duplicate-registration check is an unguarded read-then-write on
         # _added_adapters, and catch_warnings() mutates process-global filter state
-        # that is not async/thread-safe. `_adapter_activation_lock()` is the same lock
-        # every other verb on the generation path already holds while touching
-        # _added_adapters (load_peft_adapter, LocalFileBinding.activate/deactivate;
-        # see #1465) — reentrant on LocalHFBackend, so this composes safely with
-        # callers that already hold it, and a no-op nullcontext() for backends (e.g.
-        # OpenAIBackend) that don't need the serialization.
+        # that is not async/thread-safe. `_adapter_activation_lock()` serializes both
+        # races for backends that override it to return a real lock (LocalHFBackend's
+        # reentrant `_generation_lock`, shared with load_peft_adapter and
+        # LocalFileBinding.activate/deactivate; see #1465) — but not universally: it
+        # is a no-op nullcontext() by default (e.g. OpenAIBackend never serializes),
+        # and LocalFileBinding.prepare() and register_embedded_adapter_model() still
+        # call add_adapter() under their own, narrower locks rather than this one.
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
         with self._adapter_activation_lock(), warnings.catch_warnings():
+            # Re-check now that the lock (if any) is held: a concurrent resolve for
+            # this same name may have registered it while we were waiting. Without
+            # this, the loser redundantly re-fetches (LORA: re-downloads io.yaml and
+            # weights; embedded: re-reads the checkpoint) and then hits the backend's
+            # own duplicate-registration guard, which logs a "client code attempted
+            # to add ... not idempotent" warning that misleadingly blames the caller
+            # for what is actually two legitimate concurrent resolve_adapter() calls.
+            found = self._find_adapter(name)
+            if found is not None:
+                return found
+
             warnings.simplefilter("ignore", DeprecationWarning)
             if getattr(self, "_uses_embedded_adapters", False):
                 repo_id = (

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -601,13 +601,11 @@ class AdapterMixin(Backend, abc.ABC):
         `LocalHFBackend`, `_generate_intrinsic_with_adapter_scope` holds
         `_generation_lock` for the whole generation, and the
         `_IntrinsicPeftBinding` verbs it drives through `adapter_scope()`
-        each take `_adapter_activation_lock()` again on the same thread.
-        (`resolve_adapter()` itself is not currently called from inside that
-        hold — `call_intrinsic` resolves before `mfuncs.act` acquires it —
-        but nothing prevents a future caller from doing so.) An override must
-        therefore return a reentrant lock (a `threading.RLock`, as
-        `LocalHFBackend` does) — a plain `threading.Lock` here is a real
-        deadlock hazard, not just a missed optimisation.
+        take `_adapter_activation_lock()` again on the same thread. (No
+        production caller currently reaches `resolve_adapter()` this way, but
+        nothing prevents one.) An override must therefore return a reentrant
+        lock (`threading.RLock`, as `LocalHFBackend` does) — a plain
+        `threading.Lock` here is a real deadlock hazard.
         """
         return contextlib.nullcontext()
 
@@ -629,18 +627,14 @@ class AdapterMixin(Backend, abc.ABC):
             KeyError: If the adapter cannot be found after registration.
 
         Note:
-            On `LocalHFBackend`, this holds `_generation_lock` for the whole
-            registration critical section below, including any Hugging Face
-            Hub download it triggers (`obtain_io_yaml`/`get_local_hf_path`
-            for the LORA path; `EmbeddedIntrinsicAdapter.from_source` for the
-            embedded path). A cold first resolve therefore serializes with —
-            and can stall behind, or block — every other caller of that same
-            lock (activation, generation, other resolves), including a
-            resolve made from the asyncio event-loop thread inside a
-            gathered set of coroutines. This mirrors the issue's own
-            suggested design (reuse the existing lock rather than add a
-            second one); a warm cache after the first resolve avoids the
-            download and keeps the critical section fast.
+            On backends with a real `_adapter_activation_lock()` override
+            (e.g. `LocalHFBackend`), a cold first resolve holds that lock
+            across any Hugging Face Hub download it triggers, so it can stall
+            every other caller of the same lock (activation, generation,
+            other resolves) — including a resolve on the asyncio event-loop
+            thread inside a gathered set of coroutines. This is a deliberate
+            trade-off (reusing the existing lock rather than adding a second
+            one); a warm cache after the first resolve avoids the download.
         """
         found = self._find_adapter(name)
         if found is not None:
@@ -652,30 +646,21 @@ class AdapterMixin(Backend, abc.ABC):
                 f"Backend has no model ID; cannot resolve adapter {name!r}"
             )
 
-        # Registration (add_adapter, possibly several times for the embedded-adapter
-        # loop below) and the warnings.catch_warnings() filter mutation around it both
-        # race under concurrent first-time resolves for the same name: add_adapter's
-        # own duplicate-registration check is an unguarded read-then-write on
-        # _added_adapters, and catch_warnings() mutates process-global filter state
-        # that is not async/thread-safe. `_adapter_activation_lock()` serializes both
-        # races for backends that override it to return a real lock (LocalHFBackend's
-        # reentrant `_generation_lock` — the same one load_peft_adapter's own callers
-        # already hold, and LocalFileBinding.activate/deactivate; see #1465) — but not
-        # universally: it is a no-op nullcontext() by default (e.g. OpenAIBackend
-        # never serializes), LocalFileBinding.prepare() calls add_adapter() under its
-        # own, narrower `_lifecycle_lock` instead, and register_embedded_adapter_model()
-        # calls add_adapter() under no lock at all (both call sites are backend
-        # __init__ today, so this is benign in practice, not closed by this fix).
+        # add_adapter()'s own duplicate check is an unguarded read-then-write on
+        # _added_adapters, and catch_warnings() below mutates thread-unsafe global
+        # filter state — both race under concurrent first-time resolves for the
+        # same name. `_adapter_activation_lock()` closes both: a no-op by default,
+        # LocalHFBackend's reentrant `_generation_lock` and OpenAIBackend's own
+        # lock otherwise. Not closed here: LocalFileBinding.prepare() (own
+        # `_lifecycle_lock`) and register_embedded_adapter_model() (no lock, but
+        # constructor-only today, so not currently reachable concurrently).
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
         with self._adapter_activation_lock(), warnings.catch_warnings():
-            # Re-check now that the lock (if any) is held: a concurrent resolve for
-            # this same name may have registered it while we were waiting. Without
-            # this, the loser redundantly re-fetches (LORA: re-downloads io.yaml and
-            # weights; embedded: re-reads the checkpoint) and then hits the backend's
-            # own duplicate-registration guard, which logs a "client code attempted
-            # to add ... not idempotent" warning that misleadingly blames the caller
-            # for what is actually two legitimate concurrent resolve_adapter() calls.
+            # Re-check now the lock is held: a concurrent resolve may have already
+            # registered this name. Without this, the loser redundantly re-fetches
+            # and then hits the backend's own duplicate guard, which logs a
+            # misleading "client code ... not idempotent" warning.
             found = self._find_adapter(name)
             if found is not None:
                 return found

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -588,21 +588,26 @@ class AdapterMixin(Backend, abc.ABC):
     def _adapter_activation_lock(
         self,
     ) -> contextlib.AbstractContextManager[bool | None]:
-        """Exclusivity lock to hold while calling activate/deactivate verbs.
+        """Exclusivity lock to hold while calling activate/deactivate and registration verbs.
 
         Default is a no-op (`contextlib.nullcontext()`). Backends whose
         activation verbs mutate shared, non-thread-safe state (e.g.
         `LocalHFBackend`'s underlying PEFT model) override this to return
         their own lock, so callers like `LocalFileBinding.activate()` get
         the same exclusivity `_generate_with_adapter_lock` relies on.
+        `resolve_adapter()` also holds it for its own registration path.
 
-        Callers, including `resolve_adapter()`, may re-enter this lock from a
-        code path that already holds it on the same thread (e.g. an
-        `adapter_scope()` that calls back into a verb guarded by this lock).
-        An override must therefore return a reentrant lock (a
-        `threading.RLock`, as `LocalHFBackend` does) — a plain
-        `threading.Lock` here is a real deadlock hazard, not just a missed
-        optimisation.
+        A code path already holding this lock can re-enter it: on
+        `LocalHFBackend`, `_generate_intrinsic_with_adapter_scope` holds
+        `_generation_lock` for the whole generation, and the
+        `_IntrinsicPeftBinding` verbs it drives through `adapter_scope()`
+        each take `_adapter_activation_lock()` again on the same thread.
+        (`resolve_adapter()` itself is not currently called from inside that
+        hold — `call_intrinsic` resolves before `mfuncs.act` acquires it —
+        but nothing prevents a future caller from doing so.) An override must
+        therefore return a reentrant lock (a `threading.RLock`, as
+        `LocalHFBackend` does) — a plain `threading.Lock` here is a real
+        deadlock hazard, not just a missed optimisation.
         """
         return contextlib.nullcontext()
 
@@ -654,11 +659,13 @@ class AdapterMixin(Backend, abc.ABC):
         # _added_adapters, and catch_warnings() mutates process-global filter state
         # that is not async/thread-safe. `_adapter_activation_lock()` serializes both
         # races for backends that override it to return a real lock (LocalHFBackend's
-        # reentrant `_generation_lock`, shared with load_peft_adapter and
-        # LocalFileBinding.activate/deactivate; see #1465) — but not universally: it
-        # is a no-op nullcontext() by default (e.g. OpenAIBackend never serializes),
-        # and LocalFileBinding.prepare() and register_embedded_adapter_model() still
-        # call add_adapter() under their own, narrower locks rather than this one.
+        # reentrant `_generation_lock` — the same one load_peft_adapter's own callers
+        # already hold, and LocalFileBinding.activate/deactivate; see #1465) — but not
+        # universally: it is a no-op nullcontext() by default (e.g. OpenAIBackend
+        # never serializes), LocalFileBinding.prepare() calls add_adapter() under its
+        # own, narrower `_lifecycle_lock` instead, and register_embedded_adapter_model()
+        # calls add_adapter() under no lock at all (both call sites are backend
+        # __init__ today, so this is benign in practice, not closed by this fix).
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
         with self._adapter_activation_lock(), warnings.catch_warnings():

--- a/mellea/backends/adapters/adapter.py
+++ b/mellea/backends/adapters/adapter.py
@@ -625,15 +625,20 @@ class AdapterMixin(Backend, abc.ABC):
                 f"Backend has no model ID; cannot resolve adapter {name!r}"
             )
 
-        # warnings.catch_warnings() modifies the process-global filter state and is not
-        # async/thread-safe.  Concurrent first-time resolves race on filter restoration;
-        # add_adapter is idempotent so the double-registration hazard is benign, but the
-        # filter race is a known Phase-1 gap: two concurrent first-time call_intrinsic
-        # calls can interleave their catch_warnings contexts, causing a DeprecationWarning
-        # to surface in user code during lazy-registration.  Phase 2 (see epic #929) adds a lock.
+        # Registration (add_adapter, possibly several times for the embedded-adapter
+        # loop below) and the warnings.catch_warnings() filter mutation around it both
+        # race under concurrent first-time resolves for the same name: add_adapter's
+        # own duplicate-registration check is an unguarded read-then-write on
+        # _added_adapters, and catch_warnings() mutates process-global filter state
+        # that is not async/thread-safe. `_adapter_activation_lock()` is the same lock
+        # every other verb on the generation path already holds while touching
+        # _added_adapters (load_peft_adapter, LocalFileBinding.activate/deactivate;
+        # see #1465) — reentrant on LocalHFBackend, so this composes safely with
+        # callers that already hold it, and a no-op nullcontext() for backends (e.g.
+        # OpenAIBackend) that don't need the serialization.
         # Suppress DeprecationWarning: the shim constructors warn user-facing code,
         # not internal registration paths.
-        with warnings.catch_warnings():
+        with self._adapter_activation_lock(), warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             if getattr(self, "_uses_embedded_adapters", False):
                 repo_id = (

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2459,6 +2459,9 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             ValueError: If the source has no matching embedded adapter functions.
             TypeError: If an adapter from the source has an unsupported binding.
         """
+        # No lock here: both call sites (here, and this class's __init__) run
+        # single-threaded during construction, before the backend is exposed to
+        # any other thread — see the matching note on OpenAIBackend's twin.
         adapters = EmbeddedIntrinsicAdapter.from_source(
             source, revision=revision, cache_dir=cache_dir
         )
@@ -2657,10 +2660,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         it is the only thing satisfying the precondition on those paths.
 
         A fourth consumer, unrelated to that precondition: `resolve_adapter()`
-        (base class, `AdapterMixin`) also takes this same lock around its own
-        `add_adapter()`-based registration critical section (#1562), to
-        serialize concurrent first-time resolves rather than to satisfy the
-        activation precondition above.
+        (base class) also takes this lock, to serialize registration.
 
         Caller 3's verb acquisitions therefore nest inside its driver's
         `_generation_lock` hold on the same thread (see

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -2656,6 +2656,12 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         the lock caller 1 (and, on the outer level, caller 3's driver) takes,
         it is the only thing satisfying the precondition on those paths.
 
+        A fourth consumer, unrelated to that precondition: `resolve_adapter()`
+        (base class, `AdapterMixin`) also takes this same lock around its own
+        `add_adapter()`-based registration critical section (#1562), to
+        serialize concurrent first-time resolves rather than to satisfy the
+        activation precondition above.
+
         Caller 3's verb acquisitions therefore nest inside its driver's
         `_generation_lock` hold on the same thread (see
         `_generate_intrinsic_with_adapter_scope`'s docstring), which is

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -4,10 +4,12 @@
 """A generic OpenAI compatible backend that wraps around the openai python sdk."""
 
 import asyncio
+import contextlib
 import datetime
 import functools
 import inspect
 import os
+import threading
 from collections.abc import Coroutine, Sequence
 from typing import Any
 
@@ -274,6 +276,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         self._client_cache = ClientCache(2)
 
         self._added_adapters: dict[str, EmbeddedIntrinsicAdapter] = {}
+        self._adapter_lock = threading.RLock()
 
         # Call once to create an async_client and populate the cache.
         _ = self._async_client
@@ -311,7 +314,8 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         currently only `EmbeddedIntrinsicAdapter` (the Embedded/Granite Switch
         reality) is supported; other realities are rejected at runtime. As a
         side effect, an `EmbeddedBinding` weights handler is stamped with this
-        backend's `base_model_name` in its `source` field.
+        backend's `base_model_name` in its `source` field. Refuses a name
+        already registered instead of silently overwriting it.
 
         Args:
             adapter (AdapterInput): The adapter to register. Must be an
@@ -325,6 +329,12 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 f"OpenAIBackend currently only supports EmbeddedIntrinsicAdapter. "
                 f"Got: {type(adapter).__name__}"
             )
+        if adapter.qualified_name in self._added_adapters:
+            MelleaLogger.get_logger().warning(
+                f"attempted to add adapter {adapter.qualified_name!r} but it is "
+                "already registered; refusing to overwrite it."
+            )
+            return
         adapter.backend = self
         if isinstance(adapter.weights, EmbeddedBinding):
             adapter.weights.source = self.base_model_name
@@ -337,6 +347,12 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             list[str]: Qualified adapter names.
         """
         return list(self._added_adapters.keys())
+
+    def _adapter_activation_lock(
+        self,
+    ) -> contextlib.AbstractContextManager[bool | None]:
+        """Serialize `add_adapter()` / registration for this backend."""
+        return self._adapter_lock
 
     # ------------------------------------------------------------------
     # Convenience registration helpers
@@ -357,6 +373,9 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         """
         import os
 
+        # No lock here: both call sites (here, and this class's __init__) run
+        # single-threaded during construction, before the backend is exposed to
+        # any other thread — see the matching note on LocalHFBackend's twin.
         adapters = EmbeddedIntrinsicAdapter.from_source(
             source, revision=revision, cache_dir=cache_dir
         )

--- a/test/backends/test_adapters/test_adapter_mixin.py
+++ b/test/backends/test_adapters/test_adapter_mixin.py
@@ -78,6 +78,6 @@ def test_hf_backend_overrides_adapter_activation_lock():
     assert "_adapter_activation_lock" in vars(LocalHFBackend)
 
 
-def test_openai_backend_does_not_override_adapter_activation_lock():
-    """OpenAIBackend has no PEFT model state, so it keeps the mixin's no-op default."""
-    assert "_adapter_activation_lock" not in vars(OpenAIBackend)
+def test_openai_backend_overrides_adapter_activation_lock():
+    """OpenAIBackend overrides the lock too, to serialize registration (issue #1562)."""
+    assert "_adapter_activation_lock" in vars(OpenAIBackend)

--- a/test/backends/test_adapters/test_embedded_adapter.py
+++ b/test/backends/test_adapters/test_embedded_adapter.py
@@ -579,7 +579,12 @@ class TestOpenAIBackendRegistration:
         assert set(names) == {"answerability", "citations"}
         assert len(backend._added_adapters) == 2
 
-    def test_register_overwrites_existing(self, backend):
+    def test_add_adapter_refuses_duplicate_name(self, backend):
+        """A second add_adapter() for an already-registered name is refused, not applied.
+
+        Matches LocalHFBackend's own duplicate-registration guard (issue #1562):
+        the first registration wins, the second is a no-op.
+        """
         config1 = {"model": None, "parameters": {"max_completion_tokens": 10}}
         config2 = {"model": None, "parameters": {"max_completion_tokens": 20}}
 
@@ -590,7 +595,7 @@ class TestOpenAIBackendRegistration:
             backend._added_adapters["test_lora"].config["parameters"][
                 "max_completion_tokens"
             ]
-            == 20
+            == 10
         )
 
     def test_embedded_adapters_flag_loads_from_model_id(self, model_dir, hub_cache_dir):

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -767,7 +767,7 @@ def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
     mock_backend = MagicMock(spec=AdapterMixin)
     mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
     mock_backend._uses_embedded_adapters = True
-    mock_backend._adapter_source = "ibm-research/granite-switch-prerelease"
+    mock_backend._adapter_source = "ibm-granite/granite-switch-micro"
     mock_backend._added_adapters = {}
 
     tracking_lock = _TrackingLock()
@@ -791,13 +791,15 @@ def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
         AdapterMixin.resolve_adapter(mock_backend, "answerability")
 
     assert len(depths_seen) == 2, "both embedded adapters must have been registered"
+    # enter_count/exit_count == 1 is the whole signal here: max_depth is set once,
+    # in __enter__, so every depth recorded in depths_seen is 1 whenever
+    # enter_count == 1 holds — a per-adapter re-lock would only show up as
+    # enter_count > 1, never as a depth > 1 (depth only changes on the next
+    # __enter__, which only happens if the lock actually got re-acquired).
     assert tracking_lock.enter_count == 1, (
         "the lock must be acquired once for the whole loop, not per adapter"
     )
     assert tracking_lock.exit_count == 1
-    assert all(depth == 1 for depth in depths_seen), (
-        "every add_adapter call must run at lock depth 1 (single acquisition)"
-    )
 
 
 def test_resolve_adapter_concurrent_first_use_does_not_double_register():
@@ -875,6 +877,14 @@ def test_resolve_adapter_concurrent_first_use_does_not_double_register():
         t2.start()
         t1.join(timeout=5)
         t2.join(timeout=5)
+        # A still-alive thread here would still be running resolve_adapter()
+        # against the patches this `with` block is about to tear down on exit
+        # — exactly the patch-torn-down-while-in-use hazard the comment above
+        # documents. Assert liveness before leaving the patch context, not
+        # after, so a hang surfaces as this failure instead of a flaky
+        # downstream corruption.
+        assert not t1.is_alive(), "t1 did not finish within the join timeout"
+        assert not t2.is_alive(), "t2 did not finish within the join timeout"
 
     assert not errors, f"resolve_adapter raised under concurrency: {errors}"
     assert len(registrations) == 1, (

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -10,6 +10,8 @@ Verifies that IntrinsicAdapter, EmbeddedIntrinsicAdapter, and CustomIntrinsicAda
   - leave AdapterMixin.resolve_adapter and AdapterMixin.adapter_scope callable
 """
 
+import threading
+import time
 import warnings
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -669,4 +671,215 @@ def test_resolve_adapter_catalog_alias_returns_registered_adapter():
     assert result.identity.capability == "guardian_core"
     assert (
         AdapterMixin._find_adapter(mock_backend, "guardian-core", ("lora",)) is result
+    )
+
+
+class _TrackingLock:
+    """Real lock that records how many times it was entered/exited.
+
+    Used in place of a bare `MagicMock()` context manager so a test can
+    assert the lock was acquired exactly once around the whole registration
+    critical section (not once per `add_adapter` call in the embedded loop).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self.enter_count = 0
+        self.exit_count = 0
+        self.max_depth = 0
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.enter_count += 1
+        self.max_depth = max(self.max_depth, self.enter_count - self.exit_count)
+        return None
+
+    def __exit__(self, *exc_info):
+        self.exit_count += 1
+        self._lock.release()
+        return False
+
+
+def test_resolve_adapter_holds_activation_lock_during_lora_registration():
+    """resolve_adapter's single-adapter (LORA) path must run inside `_adapter_activation_lock()`.
+
+    Issue #1562: `add_adapter()` is an unguarded read-then-write on
+    `_added_adapters`; every other verb that touches it already holds this
+    lock (#1465). Pin the lock's use here so it can't regress silently.
+    """
+    mock_catalog_entry = IntrinsicsCatalogEntry(
+        name="answerability",
+        repo_id="ibm-granite/granitelib-rag-r1.0",
+        revision="abc123",
+        adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+    )
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+    mock_backend._added_adapters = {}
+
+    tracking_lock = _TrackingLock()
+    mock_backend._adapter_activation_lock.return_value = tracking_lock
+
+    def fake_add_adapter(a):
+        assert tracking_lock.enter_count == 1 and tracking_lock.exit_count == 0, (
+            "add_adapter must run while the activation lock is held"
+        )
+        mock_backend._added_adapters[a.qualified_name] = a
+
+    mock_backend.add_adapter.side_effect = fake_add_adapter
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=mock_catalog_entry,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
+    ):
+        AdapterMixin.resolve_adapter(mock_backend, "answerability")
+
+    assert tracking_lock.enter_count == 1
+    assert tracking_lock.exit_count == 1
+
+
+def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
+    """The embedded-adapter loop (#1018) must hold the lock across all iterations.
+
+    `resolve_adapter()` calls `add_adapter()` once per adapter discovered by
+    `EmbeddedIntrinsicAdapter.from_source()`. The lock must be acquired once
+    for the whole loop, not re-acquired per adapter (that would reopen the
+    race between iterations).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        embedded_adapters = [
+            EmbeddedIntrinsicAdapter("answerability", config={}, technology="alora"),
+            EmbeddedIntrinsicAdapter("answerability", config={}, technology="lora"),
+        ]
+
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = True
+    mock_backend._adapter_source = "ibm-research/granite-switch-prerelease"
+    mock_backend._added_adapters = {}
+
+    tracking_lock = _TrackingLock()
+    mock_backend._adapter_activation_lock.return_value = tracking_lock
+
+    depths_seen: list[int] = []
+
+    def fake_add_adapter(a):
+        depths_seen.append(tracking_lock.max_depth)
+        mock_backend._added_adapters[a.qualified_name] = a
+
+    mock_backend.add_adapter.side_effect = fake_add_adapter
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    with patch(
+        "mellea.backends.adapters.adapter.EmbeddedIntrinsicAdapter.from_source",
+        return_value=embedded_adapters,
+    ):
+        AdapterMixin.resolve_adapter(mock_backend, "answerability")
+
+    assert len(depths_seen) == 2, "both embedded adapters must have been registered"
+    assert tracking_lock.enter_count == 1, (
+        "the lock must be acquired once for the whole loop, not per adapter"
+    )
+    assert tracking_lock.exit_count == 1
+    assert all(depth == 1 for depth in depths_seen), (
+        "every add_adapter call must run at lock depth 1 (single acquisition)"
+    )
+
+
+def test_resolve_adapter_concurrent_first_use_does_not_double_register():
+    """Two concurrent first-time resolves for the same name must not race (issue #1562).
+
+    Mirrors the real `LocalHFBackend.add_adapter` duplicate-registration
+    check (`existing = registry.get(qualified_name); ...; registry[key] =
+    adapter`) with an injected delay between the read and the write, which
+    makes the unguarded race deterministic: without
+    `_adapter_activation_lock()` serializing the two threads, both would
+    read `existing is None` before either writes, and both would overwrite
+    the registry entry independently rather than one of them reusing the
+    other's registration.
+    """
+    mock_catalog_entry = IntrinsicsCatalogEntry(
+        name="answerability",
+        repo_id="ibm-granite/granitelib-rag-r1.0",
+        revision="abc123",
+        adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+    )
+
+    registry: dict = {}
+    real_lock = threading.RLock()
+    registrations: list = []
+
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+    mock_backend._added_adapters = registry
+    mock_backend._adapter_activation_lock.return_value = real_lock
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    def racy_add_adapter(adapter):
+        existing = registry.get(adapter.qualified_name)
+        if existing is not None:
+            return
+        time.sleep(0.02)  # widen the read-then-write window
+        registry[adapter.qualified_name] = adapter
+        registrations.append(adapter)
+
+    mock_backend.add_adapter.side_effect = racy_add_adapter
+
+    results: list = [None, None]
+    errors: list = []
+
+    def call(index: int) -> None:
+        try:
+            results[index] = AdapterMixin.resolve_adapter(mock_backend, "answerability")
+        except Exception as e:  # pragma: no cover - surfaced via errors list
+            errors.append(e)
+
+    # `unittest.mock.patch`'s save/restore of the patched attribute is not
+    # thread-safe: two threads independently entering/exiting a `patch(...)`
+    # on the same target race on save-then-restore and can leave the target
+    # (e.g. `builtins.open`) permanently monkey-patched for the rest of the
+    # process. Install the patches once here, from the main thread, before
+    # spawning the workers — only `resolve_adapter`'s own registration path
+    # runs concurrently, which is what this test targets.
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=mock_catalog_entry,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
+    ):
+        t1 = threading.Thread(target=call, args=(0,))
+        t2 = threading.Thread(target=call, args=(1,))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+    assert not errors, f"resolve_adapter raised under concurrency: {errors}"
+    assert len(registrations) == 1, (
+        "exactly one adapter must be registered under the never-before-seen name"
+    )
+    assert results[0] is results[1] is registrations[0], (
+        "both concurrent callers must resolve to the single registered adapter"
     )

--- a/test/backends/test_adapters/test_shims.py
+++ b/test/backends/test_adapters/test_shims.py
@@ -679,7 +679,13 @@ class _TrackingLock:
 
     Used in place of a bare `MagicMock()` context manager so a test can
     assert the lock was acquired exactly once around the whole registration
-    critical section (not once per `add_adapter` call in the embedded loop).
+    critical section (not once per `add_adapter` call in the embedded loop),
+    and that `warnings.catch_warnings()` has already restored the filter
+    state by the time this lock releases (`filter_restored_at_exit`) — that
+    ordering is what closes the pre-existing filter-restoration race
+    alongside the registration race; the two context managers must nest with
+    the lock outermost so `catch_warnings().__exit__()` runs before this
+    lock's `__exit__()`.
     """
 
     def __init__(self) -> None:
@@ -687,6 +693,8 @@ class _TrackingLock:
         self.enter_count = 0
         self.exit_count = 0
         self.max_depth = 0
+        self._baseline_filters = list(warnings.filters)
+        self.filter_restored_at_exit: list[bool] = []
 
     def __enter__(self):
         self._lock.acquire()
@@ -695,9 +703,68 @@ class _TrackingLock:
         return None
 
     def __exit__(self, *exc_info):
+        # `simplefilter("ignore", DeprecationWarning)` happens to add an entry
+        # identical to one Python's own default filters already carry, so
+        # scanning `warnings.filters` for that entry can't tell "restored"
+        # apart from "never mutated" — checking against the exact pre-test
+        # snapshot (order included) is what actually distinguishes them.
+        self.filter_restored_at_exit.append(
+            list(warnings.filters) == self._baseline_filters
+        )
         self.exit_count += 1
         self._lock.release()
         return False
+
+
+def test_resolve_adapter_survives_reentrant_activation_lock():
+    """resolve_adapter() must not deadlock when called while the lock is already held.
+
+    `_adapter_activation_lock()`'s docstring documents a reentrancy contract:
+    an override must return a reentrant lock because a caller can already
+    hold it on the same thread. Nothing production calls today puts
+    `resolve_adapter()` on that path (`call_intrinsic` resolves before
+    `mfuncs.act` acquires the lock), so a regression to a non-reentrant
+    override — a real `threading.RLock` swapped for a plain `threading.Lock`
+    — would only surface as a hang the first time some future caller does
+    reenter, not as a test failure today. Simulate that caller directly:
+    hold the real lock this mock backend's `_adapter_activation_lock()`
+    returns, then call `resolve_adapter()` from inside that hold.
+    """
+    mock_catalog_entry = IntrinsicsCatalogEntry(
+        name="answerability",
+        repo_id="ibm-granite/granitelib-rag-r1.0",
+        revision="abc123",
+        adapter_types=(AdapterType.ALORA, AdapterType.LORA),
+    )
+    real_lock = threading.RLock()
+    mock_backend = MagicMock(spec=AdapterMixin)
+    mock_backend.base_model_name = "ibm-granite/granite-4.1-3b"
+    mock_backend._uses_embedded_adapters = False
+    mock_backend._added_adapters = {}
+    mock_backend._adapter_activation_lock.return_value = real_lock
+    mock_backend.add_adapter.side_effect = lambda a: (
+        mock_backend._added_adapters.__setitem__(a.qualified_name, a)
+    )
+    mock_backend._find_adapter.side_effect = lambda cap, types=None: (
+        AdapterMixin._find_adapter(mock_backend, cap, types)
+    )
+
+    with (
+        patch(
+            "mellea.backends.adapters.adapter.fetch_intrinsic_metadata",
+            return_value=mock_catalog_entry,
+        ),
+        patch(
+            "mellea.backends.adapters.adapter.intrinsics.obtain_io_yaml",
+            return_value="/fake/adapter.yaml",
+        ),
+        patch("builtins.open", mock_open(read_data="key: value")),
+        real_lock,  # simulate an already-in-progress caller holding the lock
+    ):
+        result = AdapterMixin.resolve_adapter(mock_backend, "answerability")
+
+    assert result is not None
+    assert result.identity.name == "answerability"
 
 
 def test_resolve_adapter_holds_activation_lock_during_lora_registration():
@@ -747,6 +814,12 @@ def test_resolve_adapter_holds_activation_lock_during_lora_registration():
 
     assert tracking_lock.enter_count == 1
     assert tracking_lock.exit_count == 1
+    assert tracking_lock.filter_restored_at_exit == [True], (
+        "warnings.catch_warnings() must be nested inside the activation lock "
+        "(lock outermost) so its filter restoration runs before the lock "
+        "releases — swapping the nesting order reopens the pre-existing "
+        "filter-restoration race between concurrent first-time resolves"
+    )
 
 
 def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
@@ -773,10 +846,7 @@ def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
     tracking_lock = _TrackingLock()
     mock_backend._adapter_activation_lock.return_value = tracking_lock
 
-    depths_seen: list[int] = []
-
     def fake_add_adapter(a):
-        depths_seen.append(tracking_lock.max_depth)
         mock_backend._added_adapters[a.qualified_name] = a
 
     mock_backend.add_adapter.side_effect = fake_add_adapter
@@ -790,12 +860,9 @@ def test_resolve_adapter_holds_activation_lock_once_across_embedded_loop():
     ):
         AdapterMixin.resolve_adapter(mock_backend, "answerability")
 
-    assert len(depths_seen) == 2, "both embedded adapters must have been registered"
-    # enter_count/exit_count == 1 is the whole signal here: max_depth is set once,
-    # in __enter__, so every depth recorded in depths_seen is 1 whenever
-    # enter_count == 1 holds — a per-adapter re-lock would only show up as
-    # enter_count > 1, never as a depth > 1 (depth only changes on the next
-    # __enter__, which only happens if the lock actually got re-acquired).
+    assert mock_backend.add_adapter.call_count == 2, (
+        "both embedded adapters must have been registered"
+    )
     assert tracking_lock.enter_count == 1, (
         "the lock must be acquired once for the whole loop, not per adapter"
     )
@@ -871,8 +938,8 @@ def test_resolve_adapter_concurrent_first_use_does_not_double_register():
         ),
         patch("builtins.open", mock_open(read_data="key: value")),
     ):
-        t1 = threading.Thread(target=call, args=(0,))
-        t2 = threading.Thread(target=call, args=(1,))
+        t1 = threading.Thread(target=call, args=(0,), daemon=True)
+        t2 = threading.Thread(target=call, args=(1,), daemon=True)
         t1.start()
         t2.start()
         t1.join(timeout=5)
@@ -890,6 +957,12 @@ def test_resolve_adapter_concurrent_first_use_does_not_double_register():
     assert len(registrations) == 1, (
         "exactly one adapter must be registered under the never-before-seen name"
     )
+    # `racy_add_adapter`'s own no-op guard (`if existing is not None: return`)
+    # would keep the assertion above green even without resolve_adapter's
+    # in-lock re-check of `_find_adapter(name)` — the loser would just call
+    # `add_adapter` a second time and no-op there instead. Pin the actual
+    # optimisation directly: the loser must never call `add_adapter` at all.
+    mock_backend.add_adapter.assert_called_once()
     assert results[0] is results[1] is registrations[0], (
         "both concurrent callers must resolve to the single registered adapter"
     )


### PR DESCRIPTION
# Pull Request

**Epic:** #929 | **Depends on:** #1465 | **Phase:** 2

## Issue
Fixes #1562

## Description

Registering an adapter function for the first time could race: two
concurrent requests for the same never-before-used capability could both
try to register it at once, corrupting the registry or logging a confusing
warning that blamed the caller. This closes that race by having
registration take the same lock every other adapter-loading step already
uses, so registrations are serialized instead of interleaved.
`OpenAIBackend` had no protection at all (not even a duplicate check) — it
now gets both, matching what `LocalHFBackend` already did.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Tests reproduce the race directly (two real threads racing to register the
same adapter), confirm the fix, and lock in two supporting behaviours a
reviewer flagged: the losing thread doesn't do redundant work, and the fix
doesn't reopen a related pre-existing warning-filter race. Also updated one
`OpenAIBackend` test that pinned the old silent-overwrite behaviour.
Verified against pre-fix code (fails, as expected) and against the fix
(passes). Full local suite: 4265/4265 passing. Also run on a real CUDA GPU
node, not just local Apple-silicon.

### Caveats
- A cold first-time resolve now holds the lock across the network download
  it may trigger, so other work on that backend can briefly stall. This is
  the trade-off the issue itself proposed (reuse the existing lock rather
  than add a new one) — documented explicitly rather than left implicit.
- `register_embedded_adapter_model()` still runs without a lock in both
  backends, but only during `__init__` (single-threaded, no concurrent
  access possible today) — noted in a code comment rather than tracked as
  an issue, since there's no reachable bug to follow up on.

<details>
<summary>Implementation detail</summary>

`AdapterMixin.resolve_adapter()` registers via `add_adapter()`, which does
an unguarded read-then-write on the registry
(`existing = self._added_adapters.get(...); ...; self._added_adapters[...] = adapter`).
Every other verb touching that registry already serialized on
`self._adapter_activation_lock()`; this method didn't. A later change had
widened the exposure by adding a loop that can call `add_adapter()` several
times per resolve.

Fix: wrap the existing critical section in `self._adapter_activation_lock()`
— `contextlib.nullcontext()` by default, `LocalHFBackend`'s reentrant
`_generation_lock` otherwise, and now `OpenAIBackend`'s own lock too — plus
two follow-on adjustments made during review: a re-check right after
acquiring the lock so the losing thread returns immediately instead of
redundantly re-fetching, and keeping the lock outermost around the
pre-existing `catch_warnings()` block so its filter restoration can't race
either.

</details>

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
