### PR TITLE
test(backends): add real-model GPU e2e for intrinsic adapter_scope routing

### DIFF
--- a/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
+++ b/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
@@ -18,7 +18,13 @@ public API end to end against a real Granite model and the real
 the `ADAPTER_FUNCTION_*` hook payloads and real model adapter state — never on
 the generated certainty score itself. See test/README.md's e2e rules and #1291
 (the flakiness class that score-content assertions produced in GPU intrinsic
-tests).
+tests). This does not make the test immune to model output: `check_certainty`
+still requires the adapter's raw output to parse as JSON containing a
+`certainty` key (`core.py`), so a real parse failure surfaces as an
+exception from the `core.check_certainty(...)` call itself, before any hook
+assertion runs — `hf_skip()` only converts Hub network errors to skips, not
+this. `call_intrinsic` pins `temperature=0.0` for exactly this reason, which
+keeps this residual risk low but not zero.
 
 Also proves, against the real PEFT model, that a second call to the same
 intrinsic succeeds: `load_peft_adapter`'s tolerance of PEFT's "Adapter with
@@ -39,6 +45,8 @@ pytestmark = [
     pytest.mark.huggingface,
     pytest.mark.e2e,
     pytest.mark.slow,
+    # 12GB, not test_local_file_e2e.py's 20GB: matches the existing bound for
+    # this same model (granite-4.1-3b) in test_core.py, not drift.
     require_gpu(min_vram_gb=12),
     pytest.mark.skipif(
         int(os.environ.get("CICD", 0)) == 1,
@@ -79,7 +87,8 @@ def chat_context(backend):
 
 
 def _assert_single_success_invocation(mock_invoke):
-    """Asserts exactly one activate/deactivate phase pair and success invocation."""
+    """Asserts exactly one activate/deactivate phase pair, and one invocation
+    with the expected outcome, name, adapter_type, binding_type, and revision."""
     phases = [p.phase for p in phase_payloads(mock_invoke)]
     assert phases == ["activate", "deactivate"]
 
@@ -88,6 +97,12 @@ def _assert_single_success_invocation(mock_invoke):
     invocation = invocations[0]
     assert invocation.outcome == "success"
     assert invocation.name == "uncertainty"
+    # resolve_adapter's lazy registration always registers AdapterType.LORA
+    # for this (non-embedded) path, regardless of which types the catalog
+    # lists as available (adapter.py's resolve_adapter, "pre-Phase-1
+    # default" comment) — "lora" is the real value on this call path, not
+    # "unknown" (the payload field's default if this were ever omitted).
+    assert invocation.adapter_type == "lora"
     assert invocation.binding_type == "local_file"
     assert invocation.revision == _UNCERTAINTY_REVISION
 

--- a/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
+++ b/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
@@ -1,0 +1,122 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real e2e test: the intrinsic `adapter_scope` path against a real PEFT model.
+
+PR #1555 (#1465) routed `LocalHFBackend`'s LoRA/aLoRA intrinsic generation
+through `AdapterMixin.adapter_scope()`, via `_generate_intrinsic_with_adapter_scope`
+and `_IntrinsicPeftBinding`. That plumbing is covered by `MagicMock`-based unit
+tests (`test/backends/test_huggingface_unit.py`) that pin verb order, lock
+behaviour, and hook payload shape precisely, but never against a real
+`PeftModel` or a real downloaded adapter. `test_local_file_e2e.py` proves
+`adapter_scope()` against a real model, but drives `LocalFileBinding` directly,
+not the intrinsic path.
+
+This test drives one real intrinsic call (`core.check_certainty`) through the
+public API end to end against a real Granite model and the real
+`ibm-granite/granitelib-core-r1.0` "uncertainty" adapter, and asserts only on
+the `ADAPTER_FUNCTION_*` hook payloads and real model adapter state — never on
+the generated certainty score itself. See test/README.md's e2e rules and #1291
+(the flakiness class that score-content assertions produced in GPU intrinsic
+tests).
+
+Also proves, against the real PEFT model, that a second call to the same
+intrinsic succeeds: `load_peft_adapter`'s tolerance of PEFT's "Adapter with
+name ... already exists" `ValueError` on a repeat load is a path the mocks in
+`test_huggingface_unit.py` cannot exercise, since nothing there ever loads
+twice into a real `PeftModel`.
+"""
+
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
+
+from test.predicates import require_gpu
+
+pytestmark = [
+    pytest.mark.huggingface,
+    pytest.mark.e2e,
+    pytest.mark.slow,
+    require_gpu(min_vram_gb=12),
+    pytest.mark.skipif(
+        int(os.environ.get("CICD", 0)) == 1,
+        reason="Skipping HuggingFace e2e tests in CI",
+    ),
+]
+
+from mellea.backends import model_ids
+from mellea.backends.adapters.catalog import fetch_intrinsic_metadata
+from mellea.backends.huggingface import LocalHFBackend
+from mellea.stdlib import functional as mfuncs
+from mellea.stdlib.components.intrinsic import core
+from mellea.stdlib.context import ChatContext
+from test.backends.test_adapters._hook_capture import (
+    capture_adapter_hooks,
+    invocation_payloads,
+    phase_payloads,
+)
+from test.conftest import cleanup_gpu_backend, hf_skip
+
+_UNCERTAINTY_REVISION = fetch_intrinsic_metadata("uncertainty").revision
+
+
+@pytest.fixture
+def backend():
+    with hf_skip():
+        backend_ = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B)
+    yield backend_
+    cleanup_gpu_backend(backend_, backend_name="intrinsic_adapter_scope_e2e")
+
+
+@pytest.fixture
+def chat_context(backend):
+    """A real user+assistant turn, satisfying `_assert_context_forwards_history`."""
+    with hf_skip():
+        _, ctx = mfuncs.chat("What is 2 + 2?", ChatContext(), backend, model_options={})
+    return ctx
+
+
+def _assert_single_success_invocation(mock_invoke):
+    """Asserts exactly one activate/deactivate phase pair and success invocation."""
+    phases = [p.phase for p in phase_payloads(mock_invoke)]
+    assert phases == ["activate", "deactivate"]
+
+    invocations = invocation_payloads(mock_invoke)
+    assert len(invocations) == 1
+    invocation = invocations[0]
+    assert invocation.outcome == "success"
+    assert invocation.name == "uncertainty"
+    assert invocation.binding_type == "local_file"
+    assert invocation.revision == _UNCERTAINTY_REVISION
+
+
+def test_check_certainty_adapter_scope_fires_hooks_and_activates_real_adapter(
+    backend, chat_context
+):
+    with hf_skip(), capture_adapter_hooks() as mock_invoke:
+        core.check_certainty(chat_context, backend)
+
+    _assert_single_success_invocation(mock_invoke)
+
+    # Real PEFT model, cleanly deactivated after the scope exits.
+    assert backend._model.active_adapters() == []  # type: ignore[union-attr]
+
+
+def test_check_certainty_adapter_scope_repeat_call_is_idempotent(backend, chat_context):
+    """A second call proves `load_peft_adapter`'s already-loaded tolerance
+    against a real model, not just the mocked `ValueError` string match."""
+    with hf_skip(), capture_adapter_hooks() as first_invoke:
+        core.check_certainty(chat_context, backend)
+    _assert_single_success_invocation(first_invoke)
+
+    with hf_skip(), capture_adapter_hooks() as second_invoke:
+        core.check_certainty(chat_context, backend)
+    _assert_single_success_invocation(second_invoke)
+
+    assert backend._model.active_adapters() == []  # type: ignore[union-attr]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
+++ b/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Real e2e test: `LocalHFBackend`'s intrinsic `adapter_scope` path against a
-real PEFT model.
+real PEFT-loaded model.
 
 Drives one real intrinsic call (`core.check_certainty`) through the public
 API against a real Granite model and the real "uncertainty" adapter, and
@@ -14,8 +14,8 @@ containing a `certainty` key, so a parse failure surfaces as an exception
 from the call itself, before any hook assertion runs; `call_intrinsic` pins
 `temperature=0.0` to keep that residual risk low.
 
-A second call proves adapter re-loading is tolerated against a real
-`PeftModel`, not just a mocked error-message match.
+A second call proves adapter re-loading is tolerated against the real model,
+not just a mocked error-message match.
 """
 
 import os
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-torch = pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
+pytest.importorskip("torch", reason="torch not installed — install mellea[hf]")
 
 from test.predicates import require_gpu
 
@@ -31,7 +31,8 @@ pytestmark = [
     pytest.mark.huggingface,
     pytest.mark.e2e,
     pytest.mark.slow,
-    # Matches the VRAM bound used elsewhere for this same base model.
+    # Matches the VRAM bound used elsewhere for this same base model;
+    # test_local_file_e2e.py's 20GB is for a heavier adapter+generation pattern.
     require_gpu(min_vram_gb=12),
     pytest.mark.skipif(
         int(os.environ.get("CICD", 0)) == 1,
@@ -42,7 +43,7 @@ pytestmark = [
 from mellea.backends import model_ids
 from mellea.backends.adapters.catalog import fetch_intrinsic_metadata
 from mellea.backends.huggingface import LocalHFBackend
-from mellea.stdlib import functional as mfuncs
+from mellea.stdlib.components import Message
 from mellea.stdlib.components.intrinsic import core
 from mellea.stdlib.context import ChatContext
 from test.backends.test_adapters._hook_capture import (
@@ -55,7 +56,7 @@ from test.conftest import cleanup_gpu_backend, hf_skip
 _UNCERTAINTY_REVISION = fetch_intrinsic_metadata("uncertainty").revision
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def backend():
     with hf_skip():
         backend_ = LocalHFBackend(model_id=model_ids.IBM_GRANITE_4_1_3B)
@@ -64,11 +65,13 @@ def backend():
 
 
 @pytest.fixture
-def chat_context(backend):
-    """A real user+assistant turn, satisfying `_assert_context_forwards_history`."""
-    with hf_skip():
-        _, ctx = mfuncs.chat("What is 2 + 2?", ChatContext(), backend, model_options={})
-    return ctx
+def chat_context():
+    """A minimal user+assistant turn, satisfying `_assert_context_forwards_history`."""
+    return (
+        ChatContext()
+        .add(Message("user", "What is 2 + 2?"))
+        .add(Message("assistant", "4."))
+    )
 
 
 def _assert_single_success_invocation(mock_invoke: MagicMock) -> None:
@@ -90,6 +93,7 @@ def _assert_single_success_invocation(mock_invoke: MagicMock) -> None:
 def test_check_certainty_adapter_scope_fires_hooks_and_activates_real_adapter(
     backend, chat_context
 ):
+    """The first call resolves and downloads the adapter, so it needs `hf_skip`."""
     with hf_skip(), capture_adapter_hooks() as mock_invoke:
         core.check_certainty(chat_context, backend)
 
@@ -105,7 +109,10 @@ def test_check_certainty_adapter_scope_repeat_call_is_idempotent(backend, chat_c
         core.check_certainty(chat_context, backend)
     _assert_single_success_invocation(first_invoke)
 
-    with hf_skip(), capture_adapter_hooks() as second_invoke:
+    # The adapter is already loaded from the call above, so this second call
+    # does no network I/O — not wrapped in hf_skip, so a real failure here
+    # can't be misread as a skip.
+    with capture_adapter_hooks() as second_invoke:
         core.check_certainty(chat_context, backend)
     _assert_single_success_invocation(second_invoke)
 

--- a/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
+++ b/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
@@ -34,6 +34,7 @@ twice into a real `PeftModel`.
 """
 
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -86,7 +87,7 @@ def chat_context(backend):
     return ctx
 
 
-def _assert_single_success_invocation(mock_invoke):
+def _assert_single_success_invocation(mock_invoke: MagicMock) -> None:
     """Asserts exactly one activate/deactivate phase pair, and one invocation
     with the expected outcome, name, adapter_type, binding_type, and revision."""
     phases = [p.phase for p in phase_payloads(mock_invoke)]

--- a/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
+++ b/test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py
@@ -1,36 +1,21 @@
 # Copyright IBM Corp. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Real e2e test: the intrinsic `adapter_scope` path against a real PEFT model.
+"""Real e2e test: `LocalHFBackend`'s intrinsic `adapter_scope` path against a
+real PEFT model.
 
-PR #1555 (#1465) routed `LocalHFBackend`'s LoRA/aLoRA intrinsic generation
-through `AdapterMixin.adapter_scope()`, via `_generate_intrinsic_with_adapter_scope`
-and `_IntrinsicPeftBinding`. That plumbing is covered by `MagicMock`-based unit
-tests (`test/backends/test_huggingface_unit.py`) that pin verb order, lock
-behaviour, and hook payload shape precisely, but never against a real
-`PeftModel` or a real downloaded adapter. `test_local_file_e2e.py` proves
-`adapter_scope()` against a real model, but drives `LocalFileBinding` directly,
-not the intrinsic path.
+Drives one real intrinsic call (`core.check_certainty`) through the public
+API against a real Granite model and the real "uncertainty" adapter, and
+asserts on the `ADAPTER_FUNCTION_*` hook payloads and real model adapter
+state — never on the generated certainty score itself.
 
-This test drives one real intrinsic call (`core.check_certainty`) through the
-public API end to end against a real Granite model and the real
-`ibm-granite/granitelib-core-r1.0` "uncertainty" adapter, and asserts only on
-the `ADAPTER_FUNCTION_*` hook payloads and real model adapter state — never on
-the generated certainty score itself. See test/README.md's e2e rules and #1291
-(the flakiness class that score-content assertions produced in GPU intrinsic
-tests). This does not make the test immune to model output: `check_certainty`
-still requires the adapter's raw output to parse as JSON containing a
-`certainty` key (`core.py`), so a real parse failure surfaces as an
-exception from the `core.check_certainty(...)` call itself, before any hook
-assertion runs — `hf_skip()` only converts Hub network errors to skips, not
-this. `call_intrinsic` pins `temperature=0.0` for exactly this reason, which
-keeps this residual risk low but not zero.
+`check_certainty` still requires the adapter's raw output to parse as JSON
+containing a `certainty` key, so a parse failure surfaces as an exception
+from the call itself, before any hook assertion runs; `call_intrinsic` pins
+`temperature=0.0` to keep that residual risk low.
 
-Also proves, against the real PEFT model, that a second call to the same
-intrinsic succeeds: `load_peft_adapter`'s tolerance of PEFT's "Adapter with
-name ... already exists" `ValueError` on a repeat load is a path the mocks in
-`test_huggingface_unit.py` cannot exercise, since nothing there ever loads
-twice into a real `PeftModel`.
+A second call proves adapter re-loading is tolerated against a real
+`PeftModel`, not just a mocked error-message match.
 """
 
 import os
@@ -46,8 +31,7 @@ pytestmark = [
     pytest.mark.huggingface,
     pytest.mark.e2e,
     pytest.mark.slow,
-    # 12GB, not test_local_file_e2e.py's 20GB: matches the existing bound for
-    # this same model (granite-4.1-3b) in test_core.py, not drift.
+    # Matches the VRAM bound used elsewhere for this same base model.
     require_gpu(min_vram_gb=12),
     pytest.mark.skipif(
         int(os.environ.get("CICD", 0)) == 1,
@@ -98,11 +82,6 @@ def _assert_single_success_invocation(mock_invoke: MagicMock) -> None:
     invocation = invocations[0]
     assert invocation.outcome == "success"
     assert invocation.name == "uncertainty"
-    # resolve_adapter's lazy registration always registers AdapterType.LORA
-    # for this (non-embedded) path, regardless of which types the catalog
-    # lists as available (adapter.py's resolve_adapter, "pre-Phase-1
-    # default" comment) — "lora" is the real value on this call path, not
-    # "unknown" (the payload field's default if this were ever omitted).
     assert invocation.adapter_type == "lora"
     assert invocation.binding_type == "local_file"
     assert invocation.revision == _UNCERTAINTY_REVISION
@@ -121,8 +100,7 @@ def test_check_certainty_adapter_scope_fires_hooks_and_activates_real_adapter(
 
 
 def test_check_certainty_adapter_scope_repeat_call_is_idempotent(backend, chat_context):
-    """A second call proves `load_peft_adapter`'s already-loaded tolerance
-    against a real model, not just the mocked `ValueError` string match."""
+    """A repeat call to the same intrinsic on the same backend succeeds cleanly."""
     with hf_skip(), capture_adapter_hooks() as first_invoke:
         core.check_certainty(chat_context, backend)
     _assert_single_success_invocation(first_invoke)


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1574 — part of the adapter-functions epic (#929), phase 2+.

## Description

The intrinsic adapter-scope routing that #1555 added (`LocalHFBackend._generate_intrinsic_with_adapter_scope` / `_IntrinsicPeftBinding`) is only tested against a mocked model, or on real hardware through a different code path (`test_local_file_e2e.py` drives `LocalFileBinding` directly, not the intrinsic path). A real-model regression in this wiring wouldn't show up until an HPC qualitative run — nothing sits between the mocks and that.

This PR closes that gap with `test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py`: a GPU e2e test that calls `core.check_certainty()` — the public API, not an internal method — against a real Granite model and the real "uncertainty" adapter, and checks the `ADAPTER_FUNCTION_*` hook payloads and the adapter's real activation state. It deliberately never asserts on the generated score itself (per `test/README.md`'s e2e rules — see #1291 for the flakiness that caused).

Test-only, no production code touched. It's GPU-gated (`e2e`, `huggingface`, `slow`), so it's skipped in CI and by default — same tier as the existing GPU e2e test, and CI gating for this path is explicitly out of scope per #1574.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Since this needs real hardware and skips everywhere else, I ran it directly rather than trusting CI:
- Apple Silicon (MPS): `uv run pytest test/backends/test_adapters/test_intrinsic_adapter_scope_e2e.py -m slow` — 3 runs in a row, 2 passed every time.
- An internal IBM LSF GPU cluster (real CUDA GPU): 2 separate job submissions, also 2 passed both times.
- `ruff format`/`ruff check`/`mypy` clean, and the full fast suite (`pytest test/ -m "not qualitative and not slow"`) is unaffected: 3890 passed.

### A couple of things worth knowing
- The second test proves `load_peft_adapter` genuinely tolerates re-loading an already-active adapter (PEFT's "Adapter with name ... already exists" `ValueError`) against a real model — the mocked unit tests can't reach this path since they never load an adapter twice.
- `check_certainty` still needs the adapter's raw output to parse as valid JSON with a `certainty` key. If that parsing ever fails for real, it'll show up as an exception from the call itself rather than from anything this test asserts. `call_intrinsic` pins `temperature=0.0` to keep that risk low, though not zero.
- `require_gpu(min_vram_gb=12)` matches the bound used elsewhere for this model; `test_local_file_e2e.py`'s 20GB is for a heavier adapter/generation pattern, not a stricter baseline for the same model.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
