### PR TITLE
fix(backends): fire adapter_function_invocation_complete for embedded adapter calls

### DIFF
--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -848,11 +848,30 @@ async def _fire_embedded_invocation_complete(
 
     `EmbeddedBinding.apply_activation` cannot know the real outcome at
     request-mutation time (see its docstring), so this is called instead by
-    the backend once generation and parsing actually resolve — from inside
-    the `granite_formatters_processing` closure in `openai.py`/`huggingface.py`,
-    the single synchronous point where a malformed/unparsable response
-    (`outcome="schema_error"`) is distinguishable from any other failure
-    (`outcome="error"`) or from success.
+    the backend at one of two points: `_await_embedded_generation` below, if
+    the generation call itself fails (network error, timeout, model error —
+    `outcome="error"`), or the `granite_formatters_processing` closure in
+    `openai.py`/`huggingface.py`, once a response exists and
+    `json.JSONDecodeError` on unparsable output (`outcome="schema_error"`) is
+    distinguishable from any other parse-time failure (`outcome="error"`) or
+    success. The two call sites are mutually exclusive: a generation failure
+    means no response ever reaches the closure.
+
+    Contract-level schema mismatches (an adapter's declared `IOContract`
+    rejecting output that *did* parse as JSON) are not classified here — that
+    validation runs later, in `call_intrinsic`, after this function has
+    already fired `outcome="success"`. `mellea.adapter_function.parse_failures`
+    therefore only counts malformed-JSON output for `binding_type="embedded"`,
+    not contract-level drift; tracked as a follow-up (issue #1560).
+
+    Not merged with `adapter.py`'s `_fire_invocation_complete`, despite the
+    duplicated payload construction: `adapter.py` imports from this module
+    (for `EmbeddedBinding`, `Identity`, etc.), so a shared helper would have
+    to live here — but this one is always called from an already-running
+    coroutine and `await`s `invoke_hook` directly, while that one also
+    serves sync callers via `_run_async_in_thread`. Keeping them separate
+    avoids threading that sync-bridging concern through this simpler,
+    async-only call shape.
 
     Args:
         identity: Identifies the adapter that was invoked.
@@ -884,6 +903,36 @@ async def _fire_embedded_invocation_complete(
             f"outcome ({outcome!r}).",
             exc_info=True,
         )
+
+
+async def _await_embedded_generation(coro: Any, identity: Identity) -> Any:
+    """Awaits `coro`, firing `outcome="error"` if generation itself fails.
+
+    `granite_formatters_processing` only runs once a response object exists,
+    so a failure in the generation call itself — a network error, timeout, or
+    provider error — never reaches it: `ModelOutputThunk.avalue()` raises a
+    queue-carried exception before `_gen.process` is ever invoked. Wrap the
+    coroutine handed to `send_to_queue` with this so that case still fires
+    `adapter_function_invocation_complete`. The two fire sites are mutually
+    exclusive: if `coro` succeeds, this returns normally and
+    `granite_formatters_processing` fires later; if it raises, that closure
+    never runs.
+
+    Args:
+        coro: The backend's generation call (e.g. the OpenAI SDK coroutine, or
+            an `asyncio.to_thread` call wrapping local generation).
+        identity: Identifies the adapter being invoked.
+
+    Returns:
+        `coro`'s result, unchanged.
+    """
+    try:
+        return await coro
+    except BaseException as e:
+        await _fire_embedded_invocation_complete(
+            identity=identity, outcome="error", error=e
+        )
+        raise
 
 
 class ServerMediatedBinding(WeightsBinding):

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -905,6 +905,11 @@ async def _await_embedded_generation(coro: Any, identity: Identity) -> Any:
     `granite_formatters_processing` fires later; if it raises, that closure
     never runs.
 
+    Catches `BaseException`, not `Exception`, so a cancellation
+    (`asyncio.CancelledError`) is also recorded as `outcome="error"` rather
+    than left unclassified — deliberate, matching `adapter.py`'s
+    `local_file`-binding sibling helper.
+
     Args:
         coro: The backend's generation call (e.g. the OpenAI SDK coroutine, or
             an `asyncio.to_thread` call wrapping local generation).

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -847,31 +847,22 @@ async def _fire_embedded_invocation_complete(
     """Fires `adapter_function_invocation_complete` for an Embedded adapter call.
 
     `EmbeddedBinding.apply_activation` cannot know the real outcome at
-    request-mutation time (see its docstring), so this is called instead by
-    the backend at one of two points: `_await_embedded_generation` below, if
-    the generation call itself fails (network error, timeout, model error —
-    `outcome="error"`), or the `granite_formatters_processing` closure in
-    `openai.py`/`huggingface.py`, once a response exists and
-    `json.JSONDecodeError` on unparsable output (`outcome="schema_error"`) is
-    distinguishable from any other parse-time failure (`outcome="error"`) or
-    success. The two call sites are mutually exclusive: a generation failure
-    means no response ever reaches the closure.
+    request-mutation time (see its docstring), so this is called instead from
+    two mutually-exclusive points: `_await_embedded_generation` below, on a
+    generation failure (`outcome="error"`), or the
+    `granite_formatters_processing` closure in `openai.py`/`huggingface.py`,
+    once a response exists (`outcome="schema_error"` on unparsable JSON,
+    `"error"` otherwise, `"success"` if parsing succeeds).
 
-    Contract-level schema mismatches (an adapter's declared `IOContract`
-    rejecting output that *did* parse as JSON) are not classified here — that
-    validation runs later, in `call_intrinsic`, after this function has
-    already fired `outcome="success"`. `mellea.adapter_function.parse_failures`
-    therefore only counts malformed-JSON output for `binding_type="embedded"`,
-    not contract-level drift; tracked as a follow-up (issue #1560).
+    Contract-level schema mismatches (a declared `IOContract` rejecting output
+    that *did* parse as JSON) aren't classified here — that check runs later,
+    in `call_intrinsic`, after this already fired `"success"`. Tracked as a
+    follow-up (issue #1560).
 
-    Not merged with `adapter.py`'s `_fire_invocation_complete`, despite the
-    duplicated payload construction: `adapter.py` imports from this module
-    (for `EmbeddedBinding`, `Identity`, etc.), so a shared helper would have
-    to live here — but this one is always called from an already-running
-    coroutine and `await`s `invoke_hook` directly, while that one also
-    serves sync callers via `_run_async_in_thread`. Keeping them separate
-    avoids threading that sync-bridging concern through this simpler,
-    async-only call shape.
+    Kept separate from `adapter.py`'s `_fire_invocation_complete` (rather than
+    sharing the payload-construction code) because that one also serves sync
+    callers via `_run_async_in_thread`; this one always runs inside an
+    already-running coroutine and can just `await invoke_hook` directly.
 
     Args:
         identity: Identifies the adapter that was invoked.

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -846,23 +846,19 @@ async def _fire_embedded_invocation_complete(
 ) -> None:
     """Fires `adapter_function_invocation_complete` for an Embedded adapter call.
 
-    `EmbeddedBinding.apply_activation` cannot know the real outcome at
-    request-mutation time (see its docstring), so this is called instead from
-    two mutually-exclusive points: `_await_embedded_generation` below, on a
-    generation failure (`outcome="error"`), or the
-    `granite_formatters_processing` closure in `openai.py`/`huggingface.py`,
-    once a response exists (`outcome="schema_error"` on unparsable JSON,
-    `"error"` otherwise, `"success"` if parsing succeeds).
+    Called from one of two mutually-exclusive points, since
+    `EmbeddedBinding.apply_activation` can't know the outcome yet at
+    request-mutation time (see its docstring): `_await_embedded_generation`
+    below, on a generation failure, or `granite_formatters_processing` in
+    `openai.py`/`huggingface.py`, once a response exists.
 
-    Contract-level schema mismatches (a declared `IOContract` rejecting output
-    that *did* parse as JSON) aren't classified here — that check runs later,
-    in `call_intrinsic`, after this already fired `"success"`. Tracked as a
-    follow-up (issue #1560).
+    Doesn't classify contract-level `IOContract` mismatches on already-valid
+    JSON — that check runs later, in `call_intrinsic`, after this already
+    fired `"success"` (tracked in #1611).
 
-    Kept separate from `adapter.py`'s `_fire_invocation_complete` (rather than
-    sharing the payload-construction code) because that one also serves sync
-    callers via `_run_async_in_thread`; this one always runs inside an
-    already-running coroutine and can just `await invoke_hook` directly.
+    Kept separate from `adapter.py`'s `_fire_invocation_complete`: that one
+    also serves sync callers via `_run_async_in_thread`, while this always
+    runs inside an already-running coroutine and can just `await invoke_hook`.
 
     Args:
         identity: Identifies the adapter that was invoked.

--- a/mellea/backends/adapters/_core.py
+++ b/mellea/backends/adapters/_core.py
@@ -776,10 +776,11 @@ class EmbeddedBinding:
         caller awaits the resulting `ModelOutputThunk`. Firing an
         invocation-complete event here would have to guess an `outcome` that
         this method cannot know, which is worse than not firing it: it would
-        report `outcome="success"` for calls that go on to fail. Wiring a
-        real invocation-complete signal requires the caller to fire it once
-        generation and parsing resolve — tracked as a follow-up, not part of
-        this method.
+        report `outcome="success"` for calls that go on to fail. Instead, the
+        caller fires `_fire_embedded_invocation_complete` once generation and
+        parsing resolve — see its use in `OpenAIBackend`'s and
+        `LocalHFBackend`'s `granite_formatters_processing` closures (issue
+        #1560).
 
         This method is `async` (unlike the rest of `EmbeddedBinding`'s
         surface) purely because hook dispatch (`invoke_hook`) is async; its
@@ -835,6 +836,54 @@ class EmbeddedBinding:
                 "request edit into an operation failure.",
                 exc_info=True,
             )
+
+
+async def _fire_embedded_invocation_complete(
+    *,
+    identity: Identity,
+    outcome: Literal["success", "schema_error", "error"],
+    error: BaseException | None,
+) -> None:
+    """Fires `adapter_function_invocation_complete` for an Embedded adapter call.
+
+    `EmbeddedBinding.apply_activation` cannot know the real outcome at
+    request-mutation time (see its docstring), so this is called instead by
+    the backend once generation and parsing actually resolve — from inside
+    the `granite_formatters_processing` closure in `openai.py`/`huggingface.py`,
+    the single synchronous point where a malformed/unparsable response
+    (`outcome="schema_error"`) is distinguishable from any other failure
+    (`outcome="error"`) or from success.
+
+    Args:
+        identity: Identifies the adapter that was invoked.
+        outcome: The resolved invocation outcome.
+        error: The exception raised during generation/parsing, or `None` on
+            success.
+    """
+    if not has_plugins(HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE):
+        return
+
+    from ...plugins.hooks.adapter_function import (
+        AdapterFunctionInvocationCompletePayload,
+    )
+
+    try:
+        payload = AdapterFunctionInvocationCompletePayload(
+            name=identity.name,
+            revision=None,
+            binding_type=EmbeddedBinding.binding_type,
+            adapter_type=identity.adapter_type,
+            outcome=outcome,
+            error=error,
+        )
+        await invoke_hook(HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE, payload)
+    except Exception:
+        MelleaLogger.get_logger().warning(
+            f"adapter_function_invocation_complete hook dispatch failed for "
+            f"{identity.name!r}; ignoring so it does not mask the real "
+            f"outcome ({outcome!r}).",
+            exc_info=True,
+        )
 
 
 class ServerMediatedBinding(WeightsBinding):

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -96,9 +96,11 @@ from .adapters import (
 )
 from .adapters._core import (
     Adapter as _AdapterCore,
+    Identity,
     IOContract,
     LocalFileBinding,
     WeightsBinding,
+    _fire_embedded_invocation_complete,
 )
 from .adapters.adapter import AdapterInput, EmbeddedIntrinsicAdapter
 from .backend import FormatterBackend
@@ -1044,11 +1046,34 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             rewritten: granite_formatters.ChatCompletion,
             result_processor: granite_formatters.IntrinsicsResultProcessor,
             input_ids,
+            embedded_identity: Identity | None,
         ):
+            # embedded_identity is set only for EmbeddedIntrinsicAdapter calls.
+            # This is the single synchronous point where the Embedded call's
+            # real outcome becomes known, so it also fires
+            # adapter_function_invocation_complete for that case (apply_activation
+            # could not have known the outcome earlier). The legacy PEFT path
+            # (embedded_identity=None) already gets this signal from
+            # adapter_scope, so it must not be fired again here.
             try:
                 res = result_processor.transform(chunk, rewritten)  # type: ignore
             except json.JSONDecodeError as e:
+                if embedded_identity is not None:
+                    await _fire_embedded_invocation_complete(
+                        identity=embedded_identity, outcome="schema_error", error=e
+                    )
                 raise Exception(f"Intrinsic did not return a JSON: {chunk}") from e
+            except Exception as e:
+                if embedded_identity is not None:
+                    await _fire_embedded_invocation_complete(
+                        identity=embedded_identity, outcome="error", error=e
+                    )
+                raise
+            else:
+                if embedded_identity is not None:
+                    await _fire_embedded_invocation_complete(
+                        identity=embedded_identity, outcome="success", error=None
+                    )
 
             # If logits were requested, stash the intercepted raw output so that
             # post_processing/_surface_logits can populate generation.logits/raw_logits.
@@ -1076,6 +1101,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             rewritten=rewritten,
             result_processor=result_processor,
             input_ids=generate_input["input_tokens"],
+            embedded_identity=(
+                adapter.identity
+                if isinstance(adapter, EmbeddedIntrinsicAdapter)
+                else None
+            ),
         )
 
         # TODO: Post-processing should release the lock for this generation.

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -1052,21 +1052,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             input_ids,
             embedded_identity: Identity | None,
         ):
-            # embedded_identity is set only for EmbeddedIntrinsicAdapter calls.
-            # This is the point where a malformed response is distinguishable
-            # from any other failure or from success, so it also fires
-            # adapter_function_invocation_complete for that case
-            # (apply_activation could not have known the outcome earlier; a
-            # failure in generation itself, before a response exists, is
-            # instead reported by _await_embedded_generation around the
-            # asyncio.to_thread call above). The legacy PEFT path
-            # (embedded_identity=None) already gets this signal from
-            # adapter_scope, so it must not be fired again here.
-            # Kept in one try so any failure here — including from the tail
-            # logits-stash/processing work below, not just the transform
-            # itself — fires outcome="error" rather than reporting success
-            # and then raising. That's the exact "success for a call that
-            # goes on to fail" shape #1559 reverted.
+            # embedded_identity is set only for EmbeddedIntrinsicAdapter calls
+            # (the legacy PEFT path already gets this signal via adapter_scope).
+            # Kept in one try so any failure below — not just from transform
+            # itself — fires outcome="error" instead of reporting success and
+            # then raising, the exact bug #1559 reverted.
             try:
                 res = result_processor.transform(chunk, rewritten)  # type: ignore
 

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -91,15 +91,16 @@ from .adapters import (
     AdapterMixin,
     EmbeddedActivationRequest,
     EmbeddedBinding,
+    Identity,
     IntrinsicAdapter,
     LocalHFAdapter,
 )
 from .adapters._core import (
     Adapter as _AdapterCore,
-    Identity,
     IOContract,
     LocalFileBinding,
     WeightsBinding,
+    _await_embedded_generation,
     _fire_embedded_invocation_complete,
 )
 from .adapters.adapter import AdapterInput, EmbeddedIntrinsicAdapter
@@ -1023,14 +1024,17 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                 other_input,
             )
         else:
-            chat_response = asyncio.to_thread(
-                self._generate_embedded_with_generation_lock,
-                granite_formatters.base.util.generate_with_transformers,  # type: ignore
-                # Passed as args/kwargs to generate.
-                self._tokenizer,
-                model_arg,
-                generate_input,
-                other_input,
+            chat_response = _await_embedded_generation(
+                asyncio.to_thread(
+                    self._generate_embedded_with_generation_lock,
+                    granite_formatters.base.util.generate_with_transformers,  # type: ignore
+                    # Passed as args/kwargs to generate.
+                    self._tokenizer,
+                    model_arg,
+                    generate_input,
+                    other_input,
+                ),
+                adapter.identity,
             )
 
         output = ModelOutputThunk(None)
@@ -1049,14 +1053,44 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             embedded_identity: Identity | None,
         ):
             # embedded_identity is set only for EmbeddedIntrinsicAdapter calls.
-            # This is the single synchronous point where the Embedded call's
-            # real outcome becomes known, so it also fires
-            # adapter_function_invocation_complete for that case (apply_activation
-            # could not have known the outcome earlier). The legacy PEFT path
+            # This is the point where a malformed response is distinguishable
+            # from any other failure or from success, so it also fires
+            # adapter_function_invocation_complete for that case
+            # (apply_activation could not have known the outcome earlier; a
+            # failure in generation itself, before a response exists, is
+            # instead reported by _await_embedded_generation around the
+            # asyncio.to_thread call above). The legacy PEFT path
             # (embedded_identity=None) already gets this signal from
             # adapter_scope, so it must not be fired again here.
+            # Kept in one try so any failure here — including from the tail
+            # logits-stash/processing work below, not just the transform
+            # itself — fires outcome="error" rather than reporting success
+            # and then raising. That's the exact "success for a call that
+            # goes on to fail" shape #1559 reverted.
             try:
                 res = result_processor.transform(chunk, rewritten)  # type: ignore
+
+                # If logits were requested, stash the intercepted raw output
+                # so post_processing/_surface_logits can populate
+                # generation.logits/raw_logits.
+                if want_scores:
+                    if raw_hf_output_cell[0] is not None:
+                        mot.raw.response = raw_hf_output_cell[0]
+                        raw_hf_output_cell[0] = None
+                    else:
+                        warn_key = "intrinsic_no_hf_output"
+                        if warn_key not in self._warned_about:
+                            self._warned_about.add(warn_key)
+                            MelleaLogger.get_logger().warning(
+                                "ModelOption.LOGITS/RAW_LOGITS requested on intrinsic path but "
+                                "generate_with_transformers did not return a GenerateDecoderOnlyOutput; "
+                                "generation.logits and generation.raw_logits will be None."
+                            )
+
+                # processing expects a str or a GenerateDecoderOnlyOutput. Extract the str.
+                result = await self.processing(
+                    mot, res.choices[0].message.content, input_ids=input_ids
+                )
             except json.JSONDecodeError as e:
                 if embedded_identity is not None:
                     await _fire_embedded_invocation_complete(
@@ -1074,27 +1108,7 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     await _fire_embedded_invocation_complete(
                         identity=embedded_identity, outcome="success", error=None
                     )
-
-            # If logits were requested, stash the intercepted raw output so that
-            # post_processing/_surface_logits can populate generation.logits/raw_logits.
-            if want_scores:
-                if raw_hf_output_cell[0] is not None:
-                    mot.raw.response = raw_hf_output_cell[0]
-                    raw_hf_output_cell[0] = None
-                else:
-                    warn_key = "intrinsic_no_hf_output"
-                    if warn_key not in self._warned_about:
-                        self._warned_about.add(warn_key)
-                        MelleaLogger.get_logger().warning(
-                            "ModelOption.LOGITS/RAW_LOGITS requested on intrinsic path but "
-                            "generate_with_transformers did not return a GenerateDecoderOnlyOutput; "
-                            "generation.logits and generation.raw_logits will be None."
-                        )
-
-            # processing expects a str or a GenerateDecoderOnlyOutput. Extract the str.
-            return await self.processing(
-                mot, res.choices[0].message.content, input_ids=input_ids
-            )
+                return result
 
         output._gen.process = functools.partial(
             granite_formatters_processing,

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -54,6 +54,7 @@ from ..stdlib.requirements import LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
 from ._options import resolve_model_options
 from .adapters import EmbeddedActivationRequest, EmbeddedBinding
+from .adapters._core import Identity, _fire_embedded_invocation_complete
 from .adapters.adapter import AdapterInput, AdapterMixin, EmbeddedIntrinsicAdapter
 from .backend import FormatterBackend
 from .model_options import ModelOption
@@ -907,6 +908,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             chunk: ChatCompletion,
             rewritten: granite_formatters.ChatCompletion,
             result_processor: granite_formatters.IntrinsicsResultProcessor,
+            identity: Identity,
         ):
             """Accumulate content and apply intrinsic result processing."""
             import json as _json
@@ -914,15 +916,30 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # Delegate standard metadata storage to the shared processing method.
             await self.processing(mot, chunk)
 
-            # Apply intrinsic-specific result transformation on top.
+            # Apply intrinsic-specific result transformation on top. This is the
+            # single synchronous point where the Embedded call's real outcome
+            # becomes known, so it also fires adapter_function_invocation_complete
+            # (apply_activation could not have known the outcome earlier).
             response_dict = chunk.model_dump()
             try:
                 res = result_processor.transform(response_dict, rewritten)
             except _json.JSONDecodeError as e:
+                await _fire_embedded_invocation_complete(
+                    identity=identity, outcome="schema_error", error=e
+                )
                 raise Exception(
                     f"Intrinsic did not return a JSON: "
                     f"{chunk.choices[0].message.content}"
                 ) from e
+            except Exception as e:
+                await _fire_embedded_invocation_complete(
+                    identity=identity, outcome="error", error=e
+                )
+                raise
+            else:
+                await _fire_embedded_invocation_complete(
+                    identity=identity, outcome="success", error=None
+                )
 
             # Overwrite the value accumulated by processing() with the
             # post-processed intrinsic output.
@@ -934,6 +951,7 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             granite_formatters_processing,
             rewritten=rewritten,
             result_processor=result_processor,
+            identity=adapter.identity,
         )
 
         output._gen.post_process = functools.partial(

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -919,15 +919,16 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             """Accumulate content and apply intrinsic result processing."""
             import json as _json
 
-            # Delegate standard metadata storage to the shared processing method.
-            await self.processing(mot, chunk)
-
-            # Apply intrinsic-specific result transformation and fire
-            # adapter_function_invocation_complete with the resolved outcome
-            # (a generation failure is reported separately, by
-            # _await_embedded_generation above).
-            response_dict = chunk.model_dump()
+            # Kept in one try, including the self.processing() call: a
+            # response with an empty choices list raises IndexError there
+            # (openai.py's processing() indexes chunk.choices[0].message
+            # unguarded), and that must still fire outcome="error" rather
+            # than skip the fire site entirely.
             try:
+                # Delegate standard metadata storage to the shared processing method.
+                await self.processing(mot, chunk)
+
+                response_dict = chunk.model_dump()
                 res = result_processor.transform(response_dict, rewritten)
                 # Kept inside the try: a malformed `res` (e.g. an empty
                 # choices list) must still fire outcome="error", not success

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -53,8 +53,11 @@ from ..stdlib.components import Intrinsic, Message
 from ..stdlib.requirements import LLMaJRequirement
 from ..telemetry.context import generate_request_id, with_context
 from ._options import resolve_model_options
-from .adapters import EmbeddedActivationRequest, EmbeddedBinding
-from .adapters._core import Identity, _fire_embedded_invocation_complete
+from .adapters import EmbeddedActivationRequest, EmbeddedBinding, Identity
+from .adapters._core import (
+    _await_embedded_generation,
+    _fire_embedded_invocation_complete,
+)
 from .adapters.adapter import AdapterInput, AdapterMixin, EmbeddedIntrinsicAdapter
 from .backend import FormatterBackend
 from .model_options import ModelOption
@@ -888,12 +891,15 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 d["role"] = m.role
             messages_dicts.append(d)
 
-        chat_response = self._async_client.chat.completions.create(
-            model=self._model_id,
-            messages=messages_dicts,  # type: ignore
-            tools=formatted_tools if use_tools else None,  # type: ignore
-            extra_body=extra_body,
-            **api_params,
+        chat_response = _await_embedded_generation(
+            self._async_client.chat.completions.create(
+                model=self._model_id,
+                messages=messages_dicts,  # type: ignore
+                tools=formatted_tools if use_tools else None,  # type: ignore
+                extra_body=extra_body,
+                **api_params,
+            ),
+            adapter.identity,
         )
 
         # --- wire up ModelOutputThunk with intrinsic post-processing ------
@@ -916,13 +922,23 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # Delegate standard metadata storage to the shared processing method.
             await self.processing(mot, chunk)
 
-            # Apply intrinsic-specific result transformation on top. This is the
-            # single synchronous point where the Embedded call's real outcome
-            # becomes known, so it also fires adapter_function_invocation_complete
-            # (apply_activation could not have known the outcome earlier).
+            # Apply intrinsic-specific result transformation on top. This is
+            # the point where a malformed response is distinguishable from
+            # any other failure or from success, so it also fires
+            # adapter_function_invocation_complete (apply_activation could
+            # not have known the outcome earlier; a failure in generation
+            # itself, before a response exists, is instead reported by
+            # _await_embedded_generation around the API call above).
             response_dict = chunk.model_dump()
             try:
                 res = result_processor.transform(response_dict, rewritten)
+                # Overwrite the value accumulated by processing() with the
+                # post-processed intrinsic output. Kept inside this try so a
+                # malformed `res` (e.g. an empty choices list) still fires
+                # outcome="error" rather than reporting success and then
+                # raising — the exact "success for a call that goes on to
+                # fail" shape #1559 reverted.
+                mot._underlying_value = res.choices[0].message.content
             except _json.JSONDecodeError as e:
                 await _fire_embedded_invocation_complete(
                     identity=identity, outcome="schema_error", error=e
@@ -940,10 +956,6 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                 await _fire_embedded_invocation_complete(
                     identity=identity, outcome="success", error=None
                 )
-
-            # Overwrite the value accumulated by processing() with the
-            # post-processed intrinsic output.
-            mot._underlying_value = res.choices[0].message.content
 
         # Processing functions only pass the ModelOutputThunk (and current chunk
         # of response). Bind the other vars necessary for each processing step.

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -922,22 +922,16 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             # Delegate standard metadata storage to the shared processing method.
             await self.processing(mot, chunk)
 
-            # Apply intrinsic-specific result transformation on top. This is
-            # the point where a malformed response is distinguishable from
-            # any other failure or from success, so it also fires
-            # adapter_function_invocation_complete (apply_activation could
-            # not have known the outcome earlier; a failure in generation
-            # itself, before a response exists, is instead reported by
-            # _await_embedded_generation around the API call above).
+            # Apply intrinsic-specific result transformation and fire
+            # adapter_function_invocation_complete with the resolved outcome
+            # (a generation failure is reported separately, by
+            # _await_embedded_generation above).
             response_dict = chunk.model_dump()
             try:
                 res = result_processor.transform(response_dict, rewritten)
-                # Overwrite the value accumulated by processing() with the
-                # post-processed intrinsic output. Kept inside this try so a
-                # malformed `res` (e.g. an empty choices list) still fires
-                # outcome="error" rather than reporting success and then
-                # raising — the exact "success for a call that goes on to
-                # fail" shape #1559 reverted.
+                # Kept inside the try: a malformed `res` (e.g. an empty
+                # choices list) must still fire outcome="error", not success
+                # then raise — the exact bug #1559 reverted.
                 mot._underlying_value = res.choices[0].message.content
             except _json.JSONDecodeError as e:
                 await _fire_embedded_invocation_complete(

--- a/mellea/plugins/hooks/adapter_function.py
+++ b/mellea/plugins/hooks/adapter_function.py
@@ -24,15 +24,15 @@ class AdapterFunctionInvocationCompletePayload(MelleaBasePayload):
 
     Note:
         The span of work `outcome` covers differs by `binding_type`, so
-        aggregating this metric across bindings mixes events with different
-        scope. For `"local_file"`, `AdapterMixin.adapter_scope` closes once
-        generation returns — parsing happens later, outside its `finally` —
-        so its outcome covers activate→generate→deactivate only. For
-        `"embedded"`, the outcome covers generate+JSON-parse (see
-        `_fire_embedded_invocation_complete` in
-        `mellea.backends.adapters._core`), but not the later contract-level
-        `IOContract` validation in `call_intrinsic` — a contract-mismatch on
-        already-valid JSON still records `"success"` for either binding.
+        aggregating across bindings mixes events with different scope.
+        `"local_file"` covers activate→generate→deactivate only
+        (`AdapterMixin.adapter_scope` closes before parsing runs);
+        `"embedded"` covers generate+JSON-parse
+        (`_fire_embedded_invocation_complete` in
+        `mellea.backends.adapters._core`). Neither covers the later
+        contract-level `IOContract` validation in `call_intrinsic` — a
+        contract-mismatch on already-valid JSON records `"success"` for
+        either binding (tracked in #1611).
     """
 
     name: str

--- a/mellea/plugins/hooks/adapter_function.py
+++ b/mellea/plugins/hooks/adapter_function.py
@@ -21,6 +21,18 @@ class AdapterFunctionInvocationCompletePayload(MelleaBasePayload):
         adapter_type: Adapter mechanism (e.g. `"lora"`, `"alora"`).
         outcome: `"success"`, `"schema_error"`, or `"error"`.
         error: The exception raised during invocation, or `None` on success.
+
+    Note:
+        The span of work `outcome` covers differs by `binding_type`, so
+        aggregating this metric across bindings mixes events with different
+        scope. For `"local_file"`, `AdapterMixin.adapter_scope` closes once
+        generation returns — parsing happens later, outside its `finally` —
+        so its outcome covers activate→generate→deactivate only. For
+        `"embedded"`, the outcome covers generate+JSON-parse (see
+        `_fire_embedded_invocation_complete` in
+        `mellea.backends.adapters._core`), but not the later contract-level
+        `IOContract` validation in `call_intrinsic` — a contract-mismatch on
+        already-valid JSON still records `"success"` for either binding.
     """
 
     name: str

--- a/test/backends/test_adapters/test_embedded_binding.py
+++ b/test/backends/test_adapters/test_embedded_binding.py
@@ -17,6 +17,7 @@ from mellea.backends.adapters import (
     EmbeddedBinding,
     Identity,
 )
+from mellea.backends.adapters._core import _fire_embedded_invocation_complete
 from mellea.plugins.types import HookType
 
 
@@ -157,3 +158,34 @@ async def test_apply_activation_does_not_fire_invocation_complete():
 
     fired_hook_types = [call.args[0] for call in mock_invoke.call_args_list]
     assert HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE not in fired_hook_types
+
+
+@pytest.mark.parametrize("outcome", ["success", "schema_error", "error"])
+async def test_fire_embedded_invocation_complete_swallows_hook_dispatch_failure(
+    outcome,
+):
+    """A failing invocation-complete hook dispatch must not raise out of the helper.
+
+    Regression guard for `_fire_embedded_invocation_complete` (issue #1560):
+    its callers in `openai.py`/`huggingface.py` `await` this from inside their
+    own `except`/`else` branches. If `invoke_hook` raising propagated out of
+    this helper unguarded, it would replace the real outcome being reported
+    (or, from an `except` branch, mask the body's real exception) with a
+    hook-dispatch failure — mirrors `test_adapter_scope_swallows_invocation_hook_failure_on_clean_run`
+    for the `local_file` binding's sibling helper.
+    """
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+    with (
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook",
+            side_effect=RuntimeError("invocation hook dispatch blew up"),
+        ),
+    ):
+        # Must not raise despite the hook dispatch failing.
+        await _fire_embedded_invocation_complete(
+            identity=_identity("answerability"),
+            outcome=outcome,
+            error=ValueError("boom") if outcome != "success" else None,
+        )

--- a/test/backends/test_adapters/test_embedded_binding.py
+++ b/test/backends/test_adapters/test_embedded_binding.py
@@ -137,13 +137,12 @@ async def test_apply_activation_fires_phase_complete_metric():
 
 async def test_apply_activation_does_not_fire_invocation_complete():
     # apply_activation only edits the request — the real generate+parse
-    # outcome isn't known yet at this point (OpenAIBackend resolves it later,
-    # lazily, when the caller awaits the ModelOutputThunk). Firing
-    # `adapter_function_invocation_complete` here would have to guess an
-    # `outcome`, which would misreport failed calls as "success". Pin that it
-    # doesn't, so nobody "fixes" this back to a hardcoded success outcome
-    # without solving the underlying problem (see the docstring on
-    # apply_activation for the follow-up this needs).
+    # outcome isn't known yet at this point. Both backends fire
+    # `adapter_function_invocation_complete` later instead, once generation
+    # and parsing resolve (see _fire_embedded_invocation_complete and its
+    # callers in openai.py/huggingface.py, issue #1560). Pin that
+    # apply_activation itself still doesn't fire it, so nobody "fixes" this
+    # back to a hardcoded success outcome guessed at request-mutation time.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     binding = EmbeddedBinding()
     request = EmbeddedActivationRequest(extra_body={}, api_params={})

--- a/test/backends/test_adapters/test_embedded_binding.py
+++ b/test/backends/test_adapters/test_embedded_binding.py
@@ -164,16 +164,7 @@ async def test_apply_activation_does_not_fire_invocation_complete():
 async def test_fire_embedded_invocation_complete_swallows_hook_dispatch_failure(
     outcome,
 ):
-    """A failing invocation-complete hook dispatch must not raise out of the helper.
-
-    Regression guard for `_fire_embedded_invocation_complete` (issue #1560):
-    its callers in `openai.py`/`huggingface.py` `await` this from inside their
-    own `except`/`else` branches. If `invoke_hook` raising propagated out of
-    this helper unguarded, it would replace the real outcome being reported
-    (or, from an `except` branch, mask the body's real exception) with a
-    hook-dispatch failure — mirrors `test_adapter_scope_swallows_invocation_hook_failure_on_clean_run`
-    for the `local_file` binding's sibling helper.
-    """
+    """A failing hook dispatch must not mask the real outcome/exception it's reporting."""
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
 
     with (

--- a/test/backends/test_adapters/test_embedded_integration.py
+++ b/test/backends/test_adapters/test_embedded_integration.py
@@ -21,6 +21,8 @@ from openai.types.completion_usage import CompletionUsage
 from mellea.backends.adapters import EmbeddedBinding, ServerMediatedBinding
 from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
 from mellea.backends.openai import OpenAIBackend
+from mellea.formatters.granite import IntrinsicsResultProcessor
+from mellea.plugins.types import HookType
 from mellea.stdlib import functional as mfuncs
 from mellea.stdlib.components import Intrinsic, Message
 from mellea.stdlib.context import ChatContext
@@ -114,6 +116,121 @@ async def test_activation_goes_through_embedded_binding(technology):
         "answerability"
     )
     assert call_kwargs["model"] == "granite-switch"
+
+
+def _invocation_complete_payloads(mock_invoke: AsyncMock) -> list:
+    return [
+        call.args[1]
+        for call in mock_invoke.call_args_list
+        if call.args[0] is HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE
+    ]
+
+
+async def test_invocation_complete_fires_success_for_embedded_call():
+    # Issue #1560: apply_activation cannot know the real outcome, so the
+    # backend must fire adapter_function_invocation_complete once generation
+    # and parsing resolve, inside granite_formatters_processing.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _backend_with_adapter("alora")
+    mock_create = AsyncMock(return_value=_chat_completion())
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        ctx = ChatContext().add(Message("user", "What is the square root of 4?"))
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"), ctx, backend, strategy=None
+        )
+        await mot.avalue()
+
+    payloads = _invocation_complete_payloads(mock_invoke)
+    assert len(payloads) == 1
+    assert payloads[0].name == "answerability"
+    assert payloads[0].binding_type == "embedded"
+    assert payloads[0].adapter_type == "alora"
+    assert payloads[0].outcome == "success"
+    assert payloads[0].error is None
+
+
+async def test_invocation_complete_fires_schema_error_on_malformed_json():
+    # Regression test for the exact bug #1142/PR #1559 review caught: a
+    # malformed/non-JSON response must record outcome="schema_error", not
+    # "success" (the hardcoded value that was reverted).
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _backend_with_adapter("alora")
+    mock_create = AsyncMock(return_value=_chat_completion(content="not valid json"))
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        ctx = ChatContext().add(Message("user", "What is the square root of 4?"))
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"), ctx, backend, strategy=None
+        )
+        with pytest.raises(Exception, match="did not return a JSON"):
+            await mot.avalue()
+
+    payloads = _invocation_complete_payloads(mock_invoke)
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "schema_error"
+    assert payloads[0].error is not None
+
+
+async def test_invocation_complete_fires_error_on_unrelated_exception():
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _backend_with_adapter("alora")
+    mock_create = AsyncMock(return_value=_chat_completion())
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch.object(
+            IntrinsicsResultProcessor, "transform", side_effect=ValueError("boom")
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        ctx = ChatContext().add(Message("user", "What is the square root of 4?"))
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"), ctx, backend, strategy=None
+        )
+        with pytest.raises(ValueError, match="boom"):
+            await mot.avalue()
+
+    payloads = _invocation_complete_payloads(mock_invoke)
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "error"
+    assert payloads[0].error is not None
 
 
 async def test_reassigned_weights_fail_loudly():

--- a/test/backends/test_adapters/test_embedded_integration.py
+++ b/test/backends/test_adapters/test_embedded_integration.py
@@ -271,6 +271,44 @@ async def test_invocation_complete_fires_error_on_generation_failure():
     assert isinstance(payloads[0].error, RuntimeError)
 
 
+async def test_invocation_complete_fires_error_on_empty_choices():
+    # Regression guard: self.processing(mot, chunk) ran outside the
+    # classification try, so a response with an empty choices list (content
+    # filter rejection, some proxy errors) raised IndexError from
+    # OpenAIBackend.processing() before any fire site — the call silently
+    # dropped out of both invocations and parse_failures.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _backend_with_adapter("alora")
+    empty_choices_response = _chat_completion().model_copy(update={"choices": []})
+    mock_create = AsyncMock(return_value=empty_choices_response)
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        ctx = ChatContext().add(Message("user", "What is the square root of 4?"))
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"), ctx, backend, strategy=None
+        )
+        with pytest.raises(IndexError):
+            await mot.avalue()
+
+    payloads = _invocation_complete_payloads(mock_invoke)
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "error"
+    assert isinstance(payloads[0].error, IndexError)
+
+
 async def test_reassigned_weights_fail_loudly():
     """Reassigning `.weights` off the EmbeddedBinding must fail at generation.
 

--- a/test/backends/test_adapters/test_embedded_integration.py
+++ b/test/backends/test_adapters/test_embedded_integration.py
@@ -127,9 +127,6 @@ def _invocation_complete_payloads(mock_invoke: AsyncMock) -> list:
 
 
 async def test_invocation_complete_fires_success_for_embedded_call():
-    # Issue #1560: apply_activation cannot know the real outcome, so the
-    # backend must fire adapter_function_invocation_complete once generation
-    # and parsing resolve, inside granite_formatters_processing.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _backend_with_adapter("alora")
     mock_create = AsyncMock(return_value=_chat_completion())
@@ -164,9 +161,7 @@ async def test_invocation_complete_fires_success_for_embedded_call():
 
 
 async def test_invocation_complete_fires_schema_error_on_malformed_json():
-    # Regression test for the exact bug #1142/PR #1559 review caught: a
-    # malformed/non-JSON response must record outcome="schema_error", not
-    # "success" (the hardcoded value that was reverted).
+    # Pins #1142/#1559: a non-JSON response must record schema_error, not success.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _backend_with_adapter("alora")
     mock_create = AsyncMock(return_value=_chat_completion(content="not valid json"))
@@ -234,12 +229,9 @@ async def test_invocation_complete_fires_error_on_unrelated_exception():
 
 
 async def test_invocation_complete_fires_error_on_generation_failure():
-    # Regression test for the "generation itself fails" gap: an exception
-    # raised by the OpenAI SDK call (network error, timeout, provider error)
-    # never reaches granite_formatters_processing — ModelOutputThunk.avalue()
-    # raises it directly off the queue — so it must still fire
-    # adapter_function_invocation_complete(outcome="error"), via
-    # _await_embedded_generation, not the closure.
+    # A failure in the SDK call itself never reaches granite_formatters_processing —
+    # avalue() raises it straight off the queue — so _await_embedded_generation
+    # must fire outcome="error" instead.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _backend_with_adapter("alora")
     mock_create = AsyncMock(side_effect=RuntimeError("simulated provider error"))
@@ -272,11 +264,8 @@ async def test_invocation_complete_fires_error_on_generation_failure():
 
 
 async def test_invocation_complete_fires_error_on_empty_choices():
-    # Regression guard: self.processing(mot, chunk) ran outside the
-    # classification try, so a response with an empty choices list (content
-    # filter rejection, some proxy errors) raised IndexError from
-    # OpenAIBackend.processing() before any fire site — the call silently
-    # dropped out of both invocations and parse_failures.
+    # An empty-choices response (content filter, proxy error) raises IndexError
+    # from self.processing() — must still fire outcome="error", not skip firing.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _backend_with_adapter("alora")
     empty_choices_response = _chat_completion().model_copy(update={"choices": []})

--- a/test/backends/test_adapters/test_embedded_integration.py
+++ b/test/backends/test_adapters/test_embedded_integration.py
@@ -233,6 +233,44 @@ async def test_invocation_complete_fires_error_on_unrelated_exception():
     assert payloads[0].error is not None
 
 
+async def test_invocation_complete_fires_error_on_generation_failure():
+    # Regression test for the "generation itself fails" gap: an exception
+    # raised by the OpenAI SDK call (network error, timeout, provider error)
+    # never reaches granite_formatters_processing — ModelOutputThunk.avalue()
+    # raises it directly off the queue — so it must still fire
+    # adapter_function_invocation_complete(outcome="error"), via
+    # _await_embedded_generation, not the closure.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _backend_with_adapter("alora")
+    mock_create = AsyncMock(side_effect=RuntimeError("simulated provider error"))
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        ctx = ChatContext().add(Message("user", "What is the square root of 4?"))
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"), ctx, backend, strategy=None
+        )
+        with pytest.raises(RuntimeError, match="simulated provider error"):
+            await mot.avalue()
+
+    payloads = _invocation_complete_payloads(mock_invoke)
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "error"
+    assert isinstance(payloads[0].error, RuntimeError)
+
+
 async def test_reassigned_weights_fail_loudly():
     """Reassigning `.weights` off the EmbeddedBinding must fail at generation.
 

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -4,12 +4,13 @@
 """Unit tests for HuggingFace backend pure-logic helpers — no model load required."""
 
 import asyncio
+import json
 import threading
 import time
 import warnings
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -48,6 +49,7 @@ from mellea.core import ModelOutputThunk
 from mellea.formatters.granite.base.util import (
     chat_completion_request_to_transformers_inputs,
 )
+from mellea.plugins.types import HookType
 from mellea.stdlib.components import (
     AudioBlock,
     AudioUrlBlock,
@@ -524,6 +526,155 @@ async def test_embedded_intrinsic_activates_template_without_peft(stub_backend):
     )
     assert "model" not in request
     peft_scope.assert_not_called()
+
+
+class _FakeChatCompletionResponseWithContent:
+    def __init__(self, content: str):
+        message = SimpleNamespace(content=content)
+        self.choices = [SimpleNamespace(message=message)]
+
+
+async def _run_embedded_intrinsic_and_collect_invocation_payloads(
+    stub_backend, result_processor_cls: type
+) -> list:
+    """Drives `_generate_from_intrinsic` for an embedded adapter to resolution.
+
+    Returns the `AdapterFunctionInvocationCompletePayload`s fired via
+    `mellea.backends.adapters._core.invoke_hook` while `output._gen.process`
+    (`granite_formatters_processing`) resolves — the closure lives in
+    `_core.py`, not `adapter.py`, so `capture_adapter_hooks()` does not
+    intercept it (see `test_embedded_binding.py`'s equivalent patching).
+    """
+    backend = _make_intrinsic_backend_stub(stub_backend)
+    backend.processing = AsyncMock(return_value=None)
+    adapter = _make_embedded_adapter_stub()
+    backend._added_adapters = {adapter.qualified_name: adapter}
+
+    def fake_transformers_inputs(request, tokenizer, model, ll_tokenizer=None):
+        return {"input_tokens": object()}, {}
+
+    def fake_generate_with_transformers(tokenizer, model, generate_input, other_input):
+        return _FakeChatCompletionResponseWithContent('{"result": "ok"}')
+
+    with (
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsRewriter",
+            _FakeRewriter,
+        ),
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsResultProcessor",
+            result_processor_cls,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.chat_completion_request_to_transformers_inputs",
+            side_effect=fake_transformers_inputs,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.generate_with_transformers",
+            side_effect=fake_generate_with_transformers,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        output = await LocalHFBackend._generate_from_intrinsic(
+            backend,
+            Intrinsic("answerability"),
+            ChatContext().add(Message("user", "Is the sky blue?")),
+            model_options={},
+        )
+        assert output._gen.generate is not None
+        await output._gen.generate
+
+        assert output._gen.process is not None
+        while not output._gen.queue.empty():
+            item = output._gen.queue.get_nowait()
+            if item is not None:
+                # The schema_error/error cases deliberately make
+                # granite_formatters_processing raise; swallow that here so the
+                # loop still drains and `mock_invoke` still has what fired.
+                # The `len(payloads) == 1` assertions below still catch a
+                # process() that silently did nothing.
+                try:
+                    await output._gen.process(output, item)
+                except Exception:
+                    pass
+
+    return [
+        call.args[1]
+        for call in mock_invoke.call_args_list
+        if call.args[0] is HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_embedded_intrinsic_invocation_complete_fires_success(stub_backend):
+    # Issue #1560: LocalHFBackend's embedded path must fire
+    # adapter_function_invocation_complete once generation+parsing resolve,
+    # the same as OpenAIBackend's.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+    class _PassthroughResultProcessor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def transform(self, chunk, rewritten):
+            return chunk
+
+    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+        stub_backend, _PassthroughResultProcessor
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0].name == "answerability"
+    assert payloads[0].binding_type == "embedded"
+    assert payloads[0].adapter_type == "alora"
+    assert payloads[0].outcome == "success"
+    assert payloads[0].error is None
+
+
+@pytest.mark.asyncio
+async def test_embedded_intrinsic_invocation_complete_fires_schema_error(stub_backend):
+    # Regression test for the exact bug #1142/PR #1559 review caught: a
+    # malformed/non-JSON response must record outcome="schema_error", not
+    # "success" (the hardcoded value that was reverted).
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+    class _JSONDecodeErrorResultProcessor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def transform(self, chunk, rewritten):
+            raise json.JSONDecodeError("bad json", "not valid json", 0)
+
+    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+        stub_backend, _JSONDecodeErrorResultProcessor
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "schema_error"
+    assert payloads[0].error is not None
+
+
+@pytest.mark.asyncio
+async def test_embedded_intrinsic_invocation_complete_fires_error(stub_backend):
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+
+    class _RaisingResultProcessor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def transform(self, chunk, rewritten):
+            raise ValueError("boom")
+
+    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+        stub_backend, _RaisingResultProcessor
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "error"
+    assert payloads[0].error is not None
 
 
 def test_generate_embedded_with_generation_lock_deactivates_peft_state():

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -539,15 +539,10 @@ async def _run_embedded_intrinsic_and_collect_invocation_payloads(
 ) -> tuple[list, Exception | None]:
     """Drives `_generate_from_intrinsic` for an embedded adapter to resolution.
 
-    Returns `(payloads, raised)`: the `AdapterFunctionInvocationCompletePayload`s
-    fired via `mellea.backends.adapters._core.invoke_hook` while
-    `output._gen.process` (`granite_formatters_processing`) resolves — the
-    closure lives in `_core.py`, not `adapter.py`, so `capture_adapter_hooks()`
-    does not intercept it (see `test_embedded_binding.py`'s equivalent
-    patching) — and the exception `process()` raised, or `None` on success.
-    Callers must assert on `raised`'s type/message, not just the payloads:
-    otherwise a `process()` that fired the hook but swallowed its own raise
-    (turning a failed intrinsic into a silently empty value) would still pass.
+    Returns `(payloads, raised)`: the invocation-complete payloads fired via
+    `_core.invoke_hook` while `output._gen.process` resolves, and the
+    exception `process()` raised (or `None` on success). Callers must assert
+    on `raised`, not just the payloads, so a swallowed raise can't pass.
     """
     backend = _make_intrinsic_backend_stub(stub_backend)
     backend.processing = AsyncMock(return_value=None)
@@ -614,9 +609,6 @@ async def _run_embedded_intrinsic_and_collect_invocation_payloads(
 
 @pytest.mark.asyncio
 async def test_embedded_intrinsic_invocation_complete_fires_success(stub_backend):
-    # Issue #1560: LocalHFBackend's embedded path must fire
-    # adapter_function_invocation_complete once generation+parsing resolve,
-    # the same as OpenAIBackend's.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
 
     class _PassthroughResultProcessor:
@@ -641,9 +633,7 @@ async def test_embedded_intrinsic_invocation_complete_fires_success(stub_backend
 
 @pytest.mark.asyncio
 async def test_embedded_intrinsic_invocation_complete_fires_schema_error(stub_backend):
-    # Regression test for the exact bug #1142/PR #1559 review caught: a
-    # malformed/non-JSON response must record outcome="schema_error", not
-    # "success" (the hardcoded value that was reverted).
+    # Pins #1142/#1559: a non-JSON response must record schema_error, not success.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
 
     class _JSONDecodeErrorResultProcessor:
@@ -691,12 +681,9 @@ async def test_embedded_intrinsic_invocation_complete_fires_error(stub_backend):
 async def test_embedded_intrinsic_invocation_complete_fires_error_on_generation_failure(
     stub_backend,
 ):
-    # Regression test for the "generation itself fails" gap: an exception
-    # raised by the backend's own generation call (network error, timeout,
-    # model error) never reaches `granite_formatters_processing` — it's
-    # raised directly by `ModelOutputThunk.avalue()` from the queue — so it
-    # must still fire adapter_function_invocation_complete(outcome="error"),
-    # via `_await_embedded_generation`, not the closure.
+    # A failure in the backend's own generation call never reaches
+    # granite_formatters_processing — avalue() raises it straight off the
+    # queue — so _await_embedded_generation must fire outcome="error" instead.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _make_intrinsic_backend_stub(stub_backend)
     backend.processing = AsyncMock(return_value=None)
@@ -757,13 +744,9 @@ async def test_embedded_intrinsic_invocation_complete_fires_error_on_generation_
 async def test_legacy_peft_intrinsic_never_fires_embedded_invocation_complete(
     stub_backend,
 ):
-    # Pins AC5 (issue #1560): granite_formatters_processing is shared between
-    # the embedded and legacy PEFT paths, gated by `embedded_identity`. This
-    # drives the PEFT path (an `IntrinsicAdapter`, not `EmbeddedIntrinsicAdapter`)
-    # and asserts zero `_core`-level invocation-complete payloads — if a future
-    # edit dropped the isinstance guard binding `embedded_identity`, this would
-    # start double-firing (once via `_core` here, once via `adapter_scope` in
-    # `adapter.py`) or firing for a binding that isn't embedded at all.
+    # Drives the legacy PEFT path (embedded_identity=None) and pins that it
+    # never fires the embedded helper — guards the isinstance check that
+    # gates embedded_identity from silently double-firing.
     pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
     backend = _make_intrinsic_backend_stub(stub_backend)
     backend.processing = AsyncMock(return_value=None)

--- a/test/backends/test_huggingface_unit.py
+++ b/test/backends/test_huggingface_unit.py
@@ -536,14 +536,18 @@ class _FakeChatCompletionResponseWithContent:
 
 async def _run_embedded_intrinsic_and_collect_invocation_payloads(
     stub_backend, result_processor_cls: type
-) -> list:
+) -> tuple[list, Exception | None]:
     """Drives `_generate_from_intrinsic` for an embedded adapter to resolution.
 
-    Returns the `AdapterFunctionInvocationCompletePayload`s fired via
-    `mellea.backends.adapters._core.invoke_hook` while `output._gen.process`
-    (`granite_formatters_processing`) resolves — the closure lives in
-    `_core.py`, not `adapter.py`, so `capture_adapter_hooks()` does not
-    intercept it (see `test_embedded_binding.py`'s equivalent patching).
+    Returns `(payloads, raised)`: the `AdapterFunctionInvocationCompletePayload`s
+    fired via `mellea.backends.adapters._core.invoke_hook` while
+    `output._gen.process` (`granite_formatters_processing`) resolves — the
+    closure lives in `_core.py`, not `adapter.py`, so `capture_adapter_hooks()`
+    does not intercept it (see `test_embedded_binding.py`'s equivalent
+    patching) — and the exception `process()` raised, or `None` on success.
+    Callers must assert on `raised`'s type/message, not just the payloads:
+    otherwise a `process()` that fired the hook but swallowed its own raise
+    (turning a failed intrinsic into a silently empty value) would still pass.
     """
     backend = _make_intrinsic_backend_stub(stub_backend)
     backend.processing = AsyncMock(return_value=None)
@@ -588,24 +592,24 @@ async def _run_embedded_intrinsic_and_collect_invocation_payloads(
         await output._gen.generate
 
         assert output._gen.process is not None
+        raised: Exception | None = None
         while not output._gen.queue.empty():
             item = output._gen.queue.get_nowait()
             if item is not None:
                 # The schema_error/error cases deliberately make
-                # granite_formatters_processing raise; swallow that here so the
-                # loop still drains and `mock_invoke` still has what fired.
-                # The `len(payloads) == 1` assertions below still catch a
-                # process() that silently did nothing.
+                # granite_formatters_processing raise; capture it (rather than
+                # swallowing it) so callers can assert on it directly.
                 try:
                     await output._gen.process(output, item)
-                except Exception:
-                    pass
+                except Exception as e:
+                    raised = e
 
-    return [
+    payloads = [
         call.args[1]
         for call in mock_invoke.call_args_list
         if call.args[0] is HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE
     ]
+    return payloads, raised
 
 
 @pytest.mark.asyncio
@@ -622,10 +626,11 @@ async def test_embedded_intrinsic_invocation_complete_fires_success(stub_backend
         def transform(self, chunk, rewritten):
             return chunk
 
-    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+    payloads, raised = await _run_embedded_intrinsic_and_collect_invocation_payloads(
         stub_backend, _PassthroughResultProcessor
     )
 
+    assert raised is None
     assert len(payloads) == 1
     assert payloads[0].name == "answerability"
     assert payloads[0].binding_type == "embedded"
@@ -648,10 +653,13 @@ async def test_embedded_intrinsic_invocation_complete_fires_schema_error(stub_ba
         def transform(self, chunk, rewritten):
             raise json.JSONDecodeError("bad json", "not valid json", 0)
 
-    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+    payloads, raised = await _run_embedded_intrinsic_and_collect_invocation_payloads(
         stub_backend, _JSONDecodeErrorResultProcessor
     )
 
+    assert isinstance(raised, Exception)
+    assert "did not return a JSON" in str(raised)
+    assert isinstance(raised.__cause__, json.JSONDecodeError)
     assert len(payloads) == 1
     assert payloads[0].outcome == "schema_error"
     assert payloads[0].error is not None
@@ -668,13 +676,152 @@ async def test_embedded_intrinsic_invocation_complete_fires_error(stub_backend):
         def transform(self, chunk, rewritten):
             raise ValueError("boom")
 
-    payloads = await _run_embedded_intrinsic_and_collect_invocation_payloads(
+    payloads, raised = await _run_embedded_intrinsic_and_collect_invocation_payloads(
         stub_backend, _RaisingResultProcessor
     )
 
+    assert isinstance(raised, ValueError)
+    assert str(raised) == "boom"
     assert len(payloads) == 1
     assert payloads[0].outcome == "error"
     assert payloads[0].error is not None
+
+
+@pytest.mark.asyncio
+async def test_embedded_intrinsic_invocation_complete_fires_error_on_generation_failure(
+    stub_backend,
+):
+    # Regression test for the "generation itself fails" gap: an exception
+    # raised by the backend's own generation call (network error, timeout,
+    # model error) never reaches `granite_formatters_processing` — it's
+    # raised directly by `ModelOutputThunk.avalue()` from the queue — so it
+    # must still fire adapter_function_invocation_complete(outcome="error"),
+    # via `_await_embedded_generation`, not the closure.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _make_intrinsic_backend_stub(stub_backend)
+    backend.processing = AsyncMock(return_value=None)
+    adapter = _make_embedded_adapter_stub()
+    backend._added_adapters = {adapter.qualified_name: adapter}
+
+    def fake_transformers_inputs(request, tokenizer, model, ll_tokenizer=None):
+        return {"input_tokens": object()}, {}
+
+    def failing_generate_with_transformers(
+        tokenizer, model, generate_input, other_input
+    ):
+        raise RuntimeError("simulated model error")
+
+    with (
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsRewriter",
+            _FakeRewriter,
+        ),
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsResultProcessor",
+            _FakeResultProcessor,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.chat_completion_request_to_transformers_inputs",
+            side_effect=fake_transformers_inputs,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.generate_with_transformers",
+            side_effect=failing_generate_with_transformers,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        output = await LocalHFBackend._generate_from_intrinsic(
+            backend,
+            Intrinsic("answerability"),
+            ChatContext().add(Message("user", "Is the sky blue?")),
+            model_options={},
+        )
+        assert output._gen.generate is not None
+        with pytest.raises(RuntimeError, match="simulated model error"):
+            await output.avalue()
+
+    payloads = [
+        call.args[1]
+        for call in mock_invoke.call_args_list
+        if call.args[0] is HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE
+    ]
+    assert len(payloads) == 1
+    assert payloads[0].outcome == "error"
+    assert isinstance(payloads[0].error, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_legacy_peft_intrinsic_never_fires_embedded_invocation_complete(
+    stub_backend,
+):
+    # Pins AC5 (issue #1560): granite_formatters_processing is shared between
+    # the embedded and legacy PEFT paths, gated by `embedded_identity`. This
+    # drives the PEFT path (an `IntrinsicAdapter`, not `EmbeddedIntrinsicAdapter`)
+    # and asserts zero `_core`-level invocation-complete payloads — if a future
+    # edit dropped the isinstance guard binding `embedded_identity`, this would
+    # start double-firing (once via `_core` here, once via `adapter_scope` in
+    # `adapter.py`) or firing for a binding that isn't embedded at all.
+    pytest.importorskip("cpex", reason="cpex not installed — install mellea[hooks]")
+    backend = _make_intrinsic_backend_stub(stub_backend)
+    backend.processing = AsyncMock(return_value=None)
+    adapter = _make_intrinsic_adapter_stub()
+    backend._added_adapters = {adapter.qualified_name: adapter}
+
+    def fake_transformers_inputs(request, tokenizer, model, ll_tokenizer=None):
+        return {"input_tokens": object()}, {}
+
+    def fake_generate_with_transformers(tokenizer, model, generate_input, other_input):
+        return _FakeChatCompletionResponseWithContent('{"result": "ok"}')
+
+    class _PassthroughResultProcessor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def transform(self, chunk, rewritten):
+            return chunk
+
+    with (
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsRewriter",
+            _FakeRewriter,
+        ),
+        patch(
+            "mellea.backends.huggingface.granite_formatters.IntrinsicsResultProcessor",
+            _PassthroughResultProcessor,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.chat_completion_request_to_transformers_inputs",
+            side_effect=fake_transformers_inputs,
+        ),
+        patch(
+            "mellea.formatters.granite.base.util.generate_with_transformers",
+            side_effect=fake_generate_with_transformers,
+        ),
+        patch("mellea.backends.adapters._core.has_plugins", return_value=True),
+        patch(
+            "mellea.backends.adapters._core.invoke_hook", new_callable=AsyncMock
+        ) as mock_invoke,
+    ):
+        output = await LocalHFBackend._generate_from_intrinsic(
+            backend,
+            Intrinsic("answerability"),
+            ChatContext().add(Message("user", "Is the sky blue?")),
+            model_options={},
+        )
+        assert output._gen.generate is not None
+        await output._gen.generate
+
+        assert output._gen.process is not None
+        while not output._gen.queue.empty():
+            item = output._gen.queue.get_nowait()
+            if item is not None:
+                await output._gen.process(output, item)
+
+    fired_hook_types = [call.args[0] for call in mock_invoke.call_args_list]
+    assert HookType.ADAPTER_FUNCTION_INVOCATION_COMPLETE not in fired_hook_types
 
 
 def test_generate_embedded_with_generation_lock_deactivates_peft_state():


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1560

## Description

If you call an Embedded/Granite Switch adapter function (e.g.
`answerability`) on `OpenAIBackend` or `LocalHFBackend`, it doesn't show up
in `mellea.adapter_function.invocations`/`.parse_failures` — those metrics
just sit at zero, whether the calls succeed or fail. Nothing crashes; the
telemetry is quietly missing, so a real failure rate (e.g. the model
returning malformed JSON) is invisible on a dashboard.

That's because the code that activates an Embedded adapter only edits the
outgoing request, before the call happens — it genuinely can't know yet
whether the call will succeed. An earlier fix guessed `success` anyway
(#1142/PR #1559) and got reverted for marking broken calls as successful,
and the right fix — firing once the outcome is actually known — never got
done.

This PR does that: it fires once each backend has a real answer, after the
response comes back and is parsed, recording `success`, `schema_error`
(invalid JSON), or `error` (anything else, including the call never getting
a response at all).

**Impact**: `binding_type="embedded"` invocation/parse-failure metrics now
work for both backends. No change for `local_file`/PEFT, which already had
this signal.

## Epic position

Epic #929, Phase 2, depends on #1465 (merged). Follows #1142 (PR #1559),
which built `apply_activation` but deferred this signal. Scope widened
2026-09-02 to also cover `LocalHFBackend`'s embedded path (#1018/PR #1593).

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

New regression tests on both backends cover all three outcomes, plus guards
against double-firing on the legacy PEFT path and a failing hook dispatch
masking the real outcome:
- `test/backends/test_adapters/test_embedded_integration.py` (`OpenAIBackend`)
- `test/backends/test_adapters/test_embedded_binding.py`
- `test/backends/test_huggingface_unit.py` (`LocalHFBackend`)

Locally: `uv run pytest test/backends/ test/plugins/ test/telemetry/ -m "not qualitative"`
— all passing. `ruff format`/`check` and `mypy .` clean.

GPU e2e on BlueVela against the real `ibm-granite/granite-switch-4.1-3b-preview`
checkpoint (both suites skipped in CI):
- `test/backends/test_huggingface_embedded.py` (`LocalHFBackend`, real H100) — 1 passed.
- `test/backends/test_openai_intrinsics.py` (`OpenAIBackend` + real vLLM) —
  21 passed, 1 unrelated failure (a server config gap that rejects the
  request before this PR's code runs).

### Caveats

One known gap, tracked separately: contract-level `IOContract` mismatches
still record `success` — see #1611.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.





