### PR TITLE
fix(tools): preserve MCP server-side tool name after rename

### DIFF
--- a/mellea/stdlib/tools/mcp.py
+++ b/mellea/stdlib/tools/mcp.py
@@ -57,6 +57,12 @@ class MCPToolSpec:
     Holds everything needed to inspect or instantiate a `MelleaTool` without
     keeping a live session open.
 
+    Reassign `name` and `description` before calling `as_mellea_tool` to
+    disambiguate tools that share a name across multiple servers, or to give the
+    model better selection hints. Reassigning `name` only changes the name shown
+    to the model; the original server-side name is preserved and used for the
+    actual tool invocation.
+
     Args:
         name (str): Tool name as registered on the server.
         description (str): Human-readable description from the server.
@@ -75,6 +81,7 @@ class MCPToolSpec:
     ) -> None:
         """Store the spec fields and the transport config."""
         self.name = name
+        self._server_tool_name = name
         self.description = description
         self.input_schema = input_schema
         self._connection = connection
@@ -93,7 +100,7 @@ class MCPToolSpec:
         """
         return MelleaTool(
             self.name,
-            _make_sync_call(self._connection, self.name),
+            _make_sync_call(self._connection, self._server_tool_name),
             {
                 "type": "function",
                 "function": {

--- a/test/stdlib/tools/test_mcp.py
+++ b/test/stdlib/tools/test_mcp.py
@@ -76,6 +76,31 @@ class TestAsMelleaTool:
         assert tool.name == "get_me"
 
     @pytest.mark.asyncio
+    async def test_reassigned_name_calls_original_server_name(self, connection):
+        """Renaming a spec to disambiguate still invokes the server-side name."""
+        called_with: list[str] = []
+
+        async def _capture(tool_name, *, arguments):
+            called_with.append(tool_name)
+            return _call_result()
+
+        session = _make_session(_make_mcp_tool("get_me"))
+        session.call_tool = _capture
+
+        with _mock_open_session(session):
+            specs = await discover_mcp_tools(connection)
+
+        # A user reassigns name to avoid a collision with another server's tool.
+        specs[0].name = "github_get_me"
+
+        with _mock_open_session(session):
+            tool = specs[0].as_mellea_tool()
+            assert tool.name == "github_get_me"
+            tool.run()
+
+        assert called_with == ["get_me"]
+
+    @pytest.mark.asyncio
     async def test_json_schema_structure(self, connection):
         schema = {"type": "object", "properties": {"q": {"type": "string"}}}
         session = _make_session(_make_mcp_tool("search", "Search", schema))


### PR DESCRIPTION
## Issue
Fixes #1594

## Description
When #1594 was closed, the noted workaround was to reassign `MCPToolSpec.name` (and `.description`) before calling `as_mellea_tool()` to disambiguate tools that share a name across multiple MCP servers. That workaround was silently broken: `as_mellea_tool()` used `self.name` both for the model-facing tool name *and* for the name sent to the server in `call_tool()`. A reassigned `.name` was therefore sent to the server, which only knows the original name, so the invocation failed.

This preserves the original server-side name at construction (`_server_tool_name`) and uses it for the actual tool invocation, leaving `.name` free for model-facing disambiguation. Adds a regression test and documents the supported reassignment behavior in the `MCPToolSpec` docstring.

Spun off from the design discussion on #1432, which resolved the tool-name-collision cases for component tools. That PR intentionally left user-supplied tools out of scope, on the basis that a user can rename their own function to avoid a conflict. MCP tools are the corner of that case: they are user-supplied, but their names come from the server rather than the user — so "rename it yourself" (reassigning `MCPToolSpec.name`, as noted on #1594) was the intended escape hatch. This PR makes that escape hatch actually work, by keeping the server-side name distinct from the reassignable model-facing name.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool
