### PR TITLE
test: add integration-level test coverage for ModelOption.THINKING on OllamaModelBackend

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -456,8 +456,9 @@ Tests skip automatically when requirements are not met:
 | **On-demand nightly** | Not yet available | IBM internal LSF cluster | Comment-triggered nightly against a PR branch. Tracked in [#734](https://github.com/generative-computing/mellea/issues/734); ask a maintainer if you need pre-merge GPU validation today. |
 
 **PR CI** (`ci.yml` → `quality.yml`): pre-commit checks, then Ollama installed
-and `granite4:micro` + `granite4:micro-h` pulled, then `uv run -m pytest -v
---junit-xml=... test`. `docs/examples/` is not collected in PR CI.
+and `granite4.2:3b` + `granite4:micro-h` + the `granite-vision-4.1-4b` GGUF
+pulled, then `uv run -m pytest -v --junit-xml=... test`. `docs/examples/` is
+not collected in PR CI.
 
 **Nightly** (`test/scripts/run_tests_with_ollama_and_vllm.sh`): starts local
 Ollama and (when GPU present) a local vLLM server, then runs

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -358,7 +358,7 @@ async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
     assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
 
 
-@pytest.mark.slow
+@pytest.mark.slow  # generates a full think block, unlike its THINKING=False siblings
 async def test_thinking_enabled_mot_field_nonempty(session) -> None:
     """THINKING=True per call overrides a THINKING=False construction-time default,
     and mot.thinking should contain a non-empty reasoning trace.

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -328,5 +328,58 @@ def test_stop_sequences(session) -> None:
     )
 
 
+@pytest.fixture(scope="function")
+def thinking_on_session():
+    """Fresh Ollama session with THINKING enabled at construction time.
+
+    Unlike the `session` fixture (THINKING=False at construction), this lets
+    tests verify that a per-call `THINKING: False` actually overrides the
+    construction-time default, rather than merely agreeing with it.
+    """
+    thinking_on_session = start_session(
+        model_id=_ollama_model_for_eval(),
+        model_options={
+            ModelOption.CONTEXT_WINDOW: TEST_CONTEXT_WINDOW,
+            ModelOption.THINKING: True,
+        },
+    )
+    yield thinking_on_session
+    thinking_on_session.reset()
+
+
+async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
+    """THINKING=False per call overrides a THINKING=True construction-time default."""
+    mot, _ = await thinking_on_session.backend.generate_from_context(
+        CBlock("What is 1+1?"),
+        thinking_on_session.ctx,
+        model_options={ModelOption.THINKING: False},
+    )
+    await mot.avalue()
+    assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
+
+
+@pytest.mark.slow
+async def test_thinking_enabled_mot_field_nonempty(session) -> None:
+    """THINKING=True per call overrides a THINKING=False construction-time default,
+    and mot.thinking should contain a non-empty reasoning trace.
+    """
+    mot, _ = await session.backend.generate_from_context(
+        CBlock("What is 1+1?"), session.ctx, model_options={ModelOption.THINKING: True}
+    )
+    await mot.avalue()
+    assert mot.thinking, "Expected a thinking trace but mot.thinking was empty/None"
+
+
+async def test_construction_time_thinking_default_suppresses(session) -> None:
+    """Backend constructed with THINKING=False suppresses thinking on all calls
+    without per-call model_options.
+    """
+    mot, _ = await session.backend.generate_from_context(
+        CBlock("What is 1+1?"), session.ctx
+    )
+    await mot.avalue()
+    assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -357,11 +357,15 @@ async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
     assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
 
 
-# Runs only manually / in `-m slow` sweeps: PR CI (quality.yml) and the nightly
-# script both inherit pyproject.toml's default `-m "not slow"`, so this is the
-# only test in the module that would catch a regression in think-block capture
-# itself (the THINKING=False tests would pass vacuously in that case). A
-# regression in the merge/override plumbing is still caught by the other two.
+# Runs only manually / in `-m slow` sweeps. PR CI (quality.yml) never overrides
+# `-m`, so it inherits pyproject.toml's default `-m "not slow"` and never runs
+# this test. The nightly script committed here has the same default, but it's
+# driven by an external nightly.py not in this repo, so whether nightly
+# actually invokes `-m slow` is unverified rather than ruled out. Either way,
+# this is the only test in the module that would catch a regression in
+# think-block capture itself (the THINKING=False tests would pass vacuously in
+# that case). A regression in the merge/override plumbing is still caught by
+# the other two.
 @pytest.mark.slow  # generates a full think block, unlike its THINKING=False siblings
 async def test_thinking_enabled_mot_field_nonempty(session) -> None:
     """THINKING=True per call overrides a THINKING=False construction-time default."""

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -73,21 +73,39 @@ def _ensure_model_warm() -> None:
         pass  # best-effort; per-test failures will be clearer than a fixture abort
 
 
-@pytest.fixture(scope="function")
-def session():
-    """Fresh Ollama session for each test.
+def _start_ollama_session(*, thinking: bool):
+    """Start an Ollama session with a fixed context window and THINKING default.
 
     The model size is driven by GRANITE42_MODEL (see _ollama_model_for_eval).
     """
-    session = start_session(
+    return start_session(
         model_id=_ollama_model_for_eval(),
         model_options={
             ModelOption.CONTEXT_WINDOW: TEST_CONTEXT_WINDOW,
-            ModelOption.THINKING: False,
+            ModelOption.THINKING: thinking,
         },
     )
+
+
+@pytest.fixture(scope="function")
+def session():
+    """Fresh Ollama session for each test, with THINKING off at construction."""
+    session = _start_ollama_session(thinking=False)
     yield session
     session.reset()
+
+
+@pytest.fixture(scope="function")
+def thinking_on_session():
+    """Fresh Ollama session with THINKING on at construction time.
+
+    Unlike the `session` fixture (THINKING=False at construction), this lets
+    tests verify that a per-call `THINKING: False` actually overrides the
+    construction-time default, rather than merely agreeing with it.
+    """
+    thinking_on_session = _start_ollama_session(thinking=True)
+    yield thinking_on_session
+    thinking_on_session.reset()
 
 
 @pytest.mark.qualitative
@@ -328,25 +346,6 @@ def test_stop_sequences(session) -> None:
     )
 
 
-@pytest.fixture(scope="function")
-def thinking_on_session():
-    """Fresh Ollama session with THINKING enabled at construction time.
-
-    Unlike the `session` fixture (THINKING=False at construction), this lets
-    tests verify that a per-call `THINKING: False` actually overrides the
-    construction-time default, rather than merely agreeing with it.
-    """
-    thinking_on_session = start_session(
-        model_id=_ollama_model_for_eval(),
-        model_options={
-            ModelOption.CONTEXT_WINDOW: TEST_CONTEXT_WINDOW,
-            ModelOption.THINKING: True,
-        },
-    )
-    yield thinking_on_session
-    thinking_on_session.reset()
-
-
 async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
     """THINKING=False per call overrides a THINKING=True construction-time default."""
     mot, _ = await thinking_on_session.backend.generate_from_context(
@@ -358,16 +357,22 @@ async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
     assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
 
 
+# Runs only manually / in `-m slow` sweeps: PR CI (quality.yml) and the nightly
+# script both inherit pyproject.toml's default `-m "not slow"`, so this is the
+# only test in the module that would catch a regression in think-block capture
+# itself (the THINKING=False tests would pass vacuously in that case). A
+# regression in the merge/override plumbing is still caught by the other two.
 @pytest.mark.slow  # generates a full think block, unlike its THINKING=False siblings
 async def test_thinking_enabled_mot_field_nonempty(session) -> None:
-    """THINKING=True per call overrides a THINKING=False construction-time default,
-    and mot.thinking should contain a non-empty reasoning trace.
-    """
+    """THINKING=True per call overrides a THINKING=False construction-time default."""
     mot, _ = await session.backend.generate_from_context(
         CBlock("What is 1+1?"), session.ctx, model_options={ModelOption.THINKING: True}
     )
     await mot.avalue()
-    assert mot.thinking, "Expected a thinking trace but mot.thinking was empty/None"
+    assert mot.thinking, (
+        f"Expected a non-empty thinking trace from "
+        f"{_ollama_model_for_eval()!r} but mot.thinking was empty/None"
+    )
 
 
 async def test_construction_time_thinking_default_suppresses(session) -> None:

--- a/test/backends/test_ollama.py
+++ b/test/backends/test_ollama.py
@@ -96,16 +96,16 @@ def session():
 
 
 @pytest.fixture(scope="function")
-def thinking_on_session():
+def thinking_session():
     """Fresh Ollama session with THINKING on at construction time.
 
     Unlike the `session` fixture (THINKING=False at construction), this lets
     tests verify that a per-call `THINKING: False` actually overrides the
     construction-time default, rather than merely agreeing with it.
     """
-    thinking_on_session = _start_ollama_session(thinking=True)
-    yield thinking_on_session
-    thinking_on_session.reset()
+    thinking_session = _start_ollama_session(thinking=True)
+    yield thinking_session
+    thinking_session.reset()
 
 
 @pytest.mark.qualitative
@@ -346,27 +346,17 @@ def test_stop_sequences(session) -> None:
     )
 
 
-async def test_thinking_suppressed_per_call(thinking_on_session) -> None:
+async def test_thinking_suppressed_per_call(thinking_session) -> None:
     """THINKING=False per call overrides a THINKING=True construction-time default."""
-    mot, _ = await thinking_on_session.backend.generate_from_context(
+    mot, _ = await thinking_session.backend.generate_from_context(
         CBlock("What is 1+1?"),
-        thinking_on_session.ctx,
+        thinking_session.ctx,
         model_options={ModelOption.THINKING: False},
     )
     await mot.avalue()
     assert not mot.thinking, f"Expected no thinking trace, got: {mot.thinking!r}"
 
 
-# Runs only manually / in `-m slow` sweeps. PR CI (quality.yml) never overrides
-# `-m`, so it inherits pyproject.toml's default `-m "not slow"` and never runs
-# this test. The nightly script committed here has the same default, but it's
-# driven by an external nightly.py not in this repo, so whether nightly
-# actually invokes `-m slow` is unverified rather than ruled out. Either way,
-# this is the only test in the module that would catch a regression in
-# think-block capture itself (the THINKING=False tests would pass vacuously in
-# that case). A regression in the merge/override plumbing is still caught by
-# the other two.
-@pytest.mark.slow  # generates a full think block, unlike its THINKING=False siblings
 async def test_thinking_enabled_mot_field_nonempty(session) -> None:
     """THINKING=True per call overrides a THINKING=False construction-time default."""
     mot, _ = await session.backend.generate_from_context(


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1553

## Description

`ModelOption.THINKING` was only tested against a mocked backend — nothing
exercised it against a live model. That's a real gap: structured-output
examples using `@generative` stubs can intermittently fail because the parser
receives combined think+answer text, and only `THINKING: False` suppression
prevents it. Nothing was guarding that suppression from silently regressing.

**Adds three live-model tests** to `test/backends/test_ollama.py`:

| Test | What it proves |
|------|-----------------|
| `test_thinking_suppressed_per_call` | per-call `THINKING: False` overrides a `THINKING: True` construction-time default |
| `test_thinking_enabled_mot_field_nonempty` | per-call `THINKING: True` overrides a `THINKING: False` construction-time default (`slow` — generates a real think block) |
| `test_construction_time_thinking_default_suppresses` | construction-time `THINKING: False` holds with no per-call override |

Each override test flips the construction-time default in the *opposite*
direction from what it sets per-call, so it's actually falsifiable rather than
just agreeing with the default.

**Known gap, documented in-line:** `pyproject.toml`'s default `addopts`
excludes `slow` tests. **Verified:** PR CI (`quality.yml`) never overrides
`-m`, so it never runs the positive-direction test. **Unverified:** the
nightly script committed in this repo also has no override by default, but
it's driven by an external `nightly.py` not present here — I can't confirm
whether that driver passes `-m slow`, so nightly coverage is unknown rather
than ruled out. Worth a maintainer confirming.

A regression in think-block *capture itself* would only be caught by that one
test; a regression in the override *plumbing* is still caught by the other two
on every CI run. I ran the positive test manually for this PR (see Testing) —
that's its only verification unless nightly does invoke `-m slow`.

**Also included:** a one-line fix for `test/README.md`'s stale CI model list
(said `granite4:micro`; `quality.yml` actually pulls `granite4.2:3b` +
`granite4:micro-h` + the vision GGUF) — found while verifying the gap above.

### Testing

```
uv run pytest test/backends/test_ollama.py -v          # 12 pass, 1 xpass, 1 deselected
uv run pytest test/backends/test_ollama.py -m slow -v  # the deselected test, passes
```

Both run live against a warm `granite4.2:3b` on Ollama 0.33.2.
`ruff format --check`, `ruff check`, and `mypy` all clean.

- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
