### PR TITLE
fix(backends): deep-merge extra_body.chat_template_kwargs in merge_model_options

### DIFF
--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -437,11 +437,10 @@ Toggling thinking per call is also possible via `model_options={"extra_body":
 ...}` on the call itself. The older pattern of setting a persistent default
 via `model_options={"extra_body": ...}` at **construction** time also works —
 `chat_template_kwargs` in a construction-time `model_options["extra_body"]` is
-deep-merged with any per-call `extra_body`, so it is no longer silently
-dropped by a call that happens to pass its own, unrelated per-call
-`extra_body` ([#1539](https://github.com/generative-computing/mellea/issues/1539)).
-Prefer `default_extra_body` regardless — it is the dedicated mechanism for
-values you want to persist across every call.
+deep-merged with any per-call `extra_body`, so a call that passes its own,
+unrelated per-call `extra_body` does not drop it. Prefer `default_extra_body`
+regardless — it is the dedicated mechanism for values you want to persist
+across every call.
 
 Note also that switching `enable_thinking` mid-session changes the rendered
 chat-template prefix on servers like vLLM, which can invalidate that

--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -434,11 +434,14 @@ thinking setting is not silently dropped when a call also activates an
 intrinsic adapter (which writes its own `chat_template_kwargs.adapter_name`).
 
 Toggling thinking per call is also possible via `model_options={"extra_body":
-...}` on the call itself, but not via `model_options={"extra_body": ...}` at
-**construction** time — that older pattern is not deep-merged and can be
-silently overwritten by an unrelated per-call `extra_body` on some other
-call in the same session ([#1539](https://github.com/generative-computing/mellea/issues/1539)).
-Use `default_extra_body` for anything you want to persist across every call.
+...}` on the call itself. The older pattern of setting a persistent default
+via `model_options={"extra_body": ...}` at **construction** time also works —
+`chat_template_kwargs` in a construction-time `model_options["extra_body"]` is
+deep-merged with any per-call `extra_body`, so it is no longer silently
+dropped by a call that happens to pass its own, unrelated per-call
+`extra_body` ([#1539](https://github.com/generative-computing/mellea/issues/1539)).
+Prefer `default_extra_body` regardless — it is the dedicated mechanism for
+values you want to persist across every call.
 
 Note also that switching `enable_thinking` mid-session changes the rendered
 chat-template prefix on servers like vLLM, which can invalidate that

--- a/mellea/backends/litellm.py
+++ b/mellea/backends/litellm.py
@@ -148,6 +148,18 @@ class LiteLLMBackend(FormatterBackend):
 
         self._past_event_loops: set[int] = set()
 
+        # Construction-time `extra_body` in the generic `model_options` dict must
+        # not outrank a per-call `ModelOption.THINKING`. Fold it into a dedicated
+        # lowest-priority tier now and exclude it from `self.model_options` in
+        # `_simplify_and_merge`, so it can no longer re-enter the per-call
+        # precedence chain as if it were caller-supplied `extra_body` (#1617).
+        construction_extra_body = self.model_options.get("extra_body")
+        self._default_extra_body: dict = (
+            dict(construction_extra_body)
+            if isinstance(construction_extra_body, dict)
+            else {}
+        )
+
     def __repr__(self) -> str:
         """Return a useful string representation for debugging."""
         base_url_repr = self._base_url if self._explicit_base_url else None
@@ -224,8 +236,13 @@ class LiteLLMBackend(FormatterBackend):
         Returns:
             a new dict
         """
+        # `extra_body` is excluded here: it was already folded into
+        # `_default_extra_body` at construction time (see `__init__`), so
+        # merging it again would let it re-enter the per-call precedence
+        # chain and outrank a per-call `ModelOption.THINKING`.
         backend_model_opts = ModelOption.replace_keys(
-            self.model_options, self.to_mellea_model_opts_map
+            {k: v for k, v in self.model_options.items() if k != "extra_body"},
+            self.to_mellea_model_opts_map,
         )
 
         if model_options is None:
@@ -373,6 +390,14 @@ class LiteLLMBackend(FormatterBackend):
         )
 
         extra_params: dict[str, Any] = {}
+        if self._default_extra_body:
+            # Seed from the construction-time tier (below the per-call
+            # THINKING resolution below, and below caller-supplied extra_body
+            # further down); `_merge_extra_body` gives back a fresh dict (and
+            # a fresh `chat_template_kwargs` sub-dict) safe to mutate below.
+            extra_params["extra_body"] = ModelOption._merge_extra_body(
+                {}, self._default_extra_body
+            )
         if _format is not None:
             extra_params["response_format"] = {
                 "type": "json_schema",

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -219,13 +219,60 @@ class ModelOption:
         return new_options
 
     @staticmethod
+    def _merge_extra_body(
+        base: dict[str, Any], overwrite: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Merge two `extra_body` dicts, deep-merging their `chat_template_kwargs`.
+
+        Every other key is a flat overwrite, matching `merge_model_options`.
+        `chat_template_kwargs` is special-cased because it commonly has more
+        than one independent writer (e.g. a thinking-mode default and an
+        adapter-activation call) that must not clobber each other. If either
+        side's `chat_template_kwargs` is present but not a dict (malformed
+        input), deep-merging is skipped and the flat-overwrite result is used
+        instead — `overwrite`'s value wins when present, else `base`'s.
+
+        Args:
+            base (dict[str, Any]): Lower-precedence `extra_body` dict.
+            overwrite (dict[str, Any]): Higher-precedence `extra_body` dict.
+
+        Returns:
+            dict[str, Any]: A new merged `extra_body` dict.
+        """
+        merged = dict(base)
+        base_ctk = merged.pop("chat_template_kwargs", None)
+
+        overwrite = dict(overwrite)
+        overwrite_ctk = overwrite.pop("chat_template_kwargs", None)
+
+        merged.update(overwrite)
+
+        base_ctk_ok = base_ctk is None or isinstance(base_ctk, dict)
+        overwrite_ctk_ok = overwrite_ctk is None or isinstance(overwrite_ctk, dict)
+
+        if base_ctk_ok and overwrite_ctk_ok:
+            if base_ctk is not None or overwrite_ctk is not None:
+                merged["chat_template_kwargs"] = {
+                    **(base_ctk or {}),
+                    **(overwrite_ctk or {}),
+                }
+        elif overwrite_ctk is not None:
+            merged["chat_template_kwargs"] = overwrite_ctk
+        elif base_ctk is not None:
+            merged["chat_template_kwargs"] = base_ctk
+        return merged
+
+    @staticmethod
     def merge_model_options(
         persistent_opts: dict[str, Any], overwrite_opts: dict[str, Any] | None
     ) -> dict[str, Any]:
         """Merge two model-options dicts, with `overwrite_opts` taking precedence on conflicts.
 
         Creates a new dict that contains all keys and values from persistent opts and overwrite opts.
-        If there are duplicate keys, overwrite opts key value pairs will be used.
+        If there are duplicate keys, overwrite opts key value pairs will be used, except for
+        `extra_body`: when both sides have a dict there, their `chat_template_kwargs` sub-dicts
+        are deep-merged (see `_merge_extra_body`) instead of one replacing the other, since
+        `extra_body` commonly carries independent writes from more than one source.
 
         Args:
             persistent_opts (dict[str, Any]): Base model options (lower precedence).
@@ -242,5 +289,12 @@ class ModelOption:
 
         if overwrite_opts is not None:
             for k, v in overwrite_opts.items():
-                new_options[k] = v
+                if (
+                    k == "extra_body"
+                    and isinstance(v, dict)
+                    and isinstance(new_options.get(k), dict)
+                ):
+                    new_options[k] = ModelOption._merge_extra_body(new_options[k], v)
+                else:
+                    new_options[k] = v
         return new_options

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -224,13 +224,10 @@ class ModelOption:
     ) -> dict[str, Any]:
         """Merge two `extra_body` dicts, deep-merging their `chat_template_kwargs`.
 
-        Every other key is a flat overwrite, matching `merge_model_options`.
-        `chat_template_kwargs` is special-cased because it commonly has more
-        than one independent writer (e.g. a thinking-mode default and an
-        adapter-activation call) that must not clobber each other. If either
-        side's `chat_template_kwargs` is present but not a dict (malformed
-        input), deep-merging is skipped and the flat-overwrite result is used
-        instead — `overwrite`'s value wins when present, else `base`'s.
+        Every other key is a flat overwrite, matching `merge_model_options`. If
+        either side's `chat_template_kwargs` is present but not a dict, the
+        deep-merge is skipped and `overwrite`'s value wins when present, else
+        `base`'s.
 
         Args:
             base (dict[str, Any]): Lower-precedence `extra_body` dict.
@@ -271,8 +268,7 @@ class ModelOption:
         Creates a new dict that contains all keys and values from persistent opts and overwrite opts.
         If there are duplicate keys, overwrite opts key value pairs will be used, except for
         `extra_body`: when both sides have a dict there, their `chat_template_kwargs` sub-dicts
-        are deep-merged (see `_merge_extra_body`) instead of one replacing the other, since
-        `extra_body` commonly carries independent writes from more than one source.
+        are deep-merged (see `_merge_extra_body`) instead of one replacing the other.
 
         Args:
             persistent_opts (dict[str, Any]): Base model options (lower precedence).

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -225,6 +225,19 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
         self.default_to_constraint_checking_alora = default_to_constraint_checking_alora
         self._default_extra_body: dict = default_extra_body or {}
 
+        # Construction-time `extra_body` passed via the generic `model_options`
+        # dict (as opposed to the dedicated `default_extra_body` param) must not
+        # outrank a per-call `ModelOption.THINKING` the way `default_extra_body`
+        # doesn't. Fold it into `_default_extra_body`'s tier now and exclude it
+        # from `self.model_options` in `_simplify_and_merge`, so it can no longer
+        # re-enter the per-call precedence chain as if it were caller-supplied
+        # `extra_body` (#1617).
+        construction_extra_body = self.model_options.get("extra_body")
+        if isinstance(construction_extra_body, dict):
+            self._default_extra_body = ModelOption._merge_extra_body(
+                construction_extra_body, self._default_extra_body
+            )
+
         self._provider: str = "openai"
 
         self._adapter_source = adapter_source
@@ -484,7 +497,13 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             remap_dict = self.to_mellea_model_opts_map_completions
 
         resolved_options = resolve_model_options(
-            backend_defaults=self.model_options,
+            # `extra_body` is excluded here: it was already folded into
+            # `_default_extra_body` at construction time (see `__init__`), so
+            # merging it again would let it re-enter the per-call precedence
+            # chain and outrank a per-call `ModelOption.THINKING`.
+            backend_defaults={
+                k: v for k, v in self.model_options.items() if k != "extra_body"
+            },
             remap=remap_dict,
             call_options=model_options,
         )

--- a/test/backends/test_litellm_thinking.py
+++ b/test/backends/test_litellm_thinking.py
@@ -459,6 +459,36 @@ async def test_no_api_base_forwarded_when_base_url_not_set() -> None:
     )
 
 
+async def test_construction_extra_body_thinking_does_not_outrank_per_call_thinking():
+    """Regression for #1617 review: a construction-time `enable_thinking` set via
+    the generic `model_options["extra_body"]` must not silently override a
+    per-call `ModelOption.THINKING`.
+
+    Before the fix, `_simplify_and_merge` merged this construction-time
+    `extra_body` together with any per-call `extra_body` via `merge_model_options`,
+    and the combined blob then unconditionally beat the correctly-resolved
+    per-call THINKING value later in `_generate_from_chat_context_standard`.
+    """
+    from mellea.backends import ModelOption
+
+    backend = LiteLLMBackend(
+        model_id="hosted_vllm/qwen3",
+        base_url="http://localhost:9997",
+        model_options={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}}
+        },
+    )
+
+    kwargs = await _call_and_capture(backend, {ModelOption.THINKING: False})
+
+    assert (
+        kwargs.get("extra_body", {})
+        .get("chat_template_kwargs", {})
+        .get("enable_thinking")
+        is False
+    ), "per-call THINKING=False must win over construction-time extra_body"
+
+
 async def test_extra_body_mutation_does_not_corrupt_caller_dict(
     chat_backend: LiteLLMBackend,
 ) -> None:

--- a/test/backends/test_model_options.py
+++ b/test/backends/test_model_options.py
@@ -129,5 +129,88 @@ def test_model_option_merge():
     assert expected_opts == processed_model_opts, "merged dict did not match expected"
 
 
+def test_model_option_merge_extra_body_unrelated_key_preserves_default():
+    """Issue #1539: an unrelated per-call extra_body must not clobber a backend-level default."""
+    default_model_opts = {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+    overwrite_opts = {"extra_body": {"some_unrelated_field": 123}}
+
+    processed_model_opts = ModelOption.merge_model_options(
+        default_model_opts, overwrite_opts
+    )
+    assert processed_model_opts["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "some_unrelated_field": 123,
+    }
+
+
+def test_model_option_merge_extra_body_deep_merges_chat_template_kwargs():
+    """A per-call chat_template_kwargs key must merge with, not replace, the default's."""
+    default_model_opts = {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+    overwrite_opts = {"extra_body": {"chat_template_kwargs": {"adapter_name": "foo"}}}
+
+    processed_model_opts = ModelOption.merge_model_options(
+        default_model_opts, overwrite_opts
+    )
+    assert processed_model_opts["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False, "adapter_name": "foo"}
+    }
+
+
+def test_model_option_merge_extra_body_overwrite_wins_on_conflict():
+    """Within chat_template_kwargs, the overwrite value wins on an actual key conflict."""
+    default_model_opts = {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+    overwrite_opts = {"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
+
+    processed_model_opts = ModelOption.merge_model_options(
+        default_model_opts, overwrite_opts
+    )
+    assert processed_model_opts["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": True}
+    }
+
+
+def test_model_option_merge_extra_body_does_not_mutate_inputs():
+    """Neither `base` nor `overwrite` dicts (nor their nested dicts) are modified."""
+    base = {"chat_template_kwargs": {"enable_thinking": False}}
+    overwrite = {"chat_template_kwargs": {"adapter_name": "answerability"}}
+
+    ModelOption._merge_extra_body(base, overwrite)
+
+    assert base == {"chat_template_kwargs": {"enable_thinking": False}}
+    assert overwrite == {"chat_template_kwargs": {"adapter_name": "answerability"}}
+
+
+def test_model_option_merge_extra_body_non_dict_chat_template_kwargs_falls_back():
+    """A malformed non-dict `chat_template_kwargs` on the base side must not raise."""
+    default_model_opts = {"extra_body": {"chat_template_kwargs": "not-a-dict"}}
+    overwrite_opts = {"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
+
+    processed_model_opts = ModelOption.merge_model_options(
+        default_model_opts, overwrite_opts
+    )
+    assert processed_model_opts["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": True}
+    }
+
+
+def test_model_option_merge_extra_body_overwrite_non_dict_chat_template_kwargs_wins():
+    """A malformed non-dict `chat_template_kwargs` on the overwrite side must not raise."""
+    default_model_opts = {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+    overwrite_opts = {"extra_body": {"chat_template_kwargs": "not-a-dict"}}
+
+    processed_model_opts = ModelOption.merge_model_options(
+        default_model_opts, overwrite_opts
+    )
+    assert processed_model_opts["extra_body"] == {"chat_template_kwargs": "not-a-dict"}
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/backends/test_model_options.py
+++ b/test/backends/test_model_options.py
@@ -130,7 +130,7 @@ def test_model_option_merge():
 
 
 def test_model_option_merge_extra_body_unrelated_key_preserves_default():
-    """Issue #1539: an unrelated per-call extra_body must not clobber a backend-level default."""
+    """An unrelated per-call extra_body must not clobber a backend-level default."""
     default_model_opts = {
         "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
     }

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -208,6 +208,47 @@ async def test_chat_template_kwargs_set():
     assert extra_body["chat_template_kwargs"]["adapter_name"] == "answerability"
 
 
+async def test_construction_time_extra_body_default_survives_intrinsic_call():
+    """Issue #1539: a construction-time `extra_body` default (e.g. a thinking
+    default) must survive an intrinsic call that supplies its own, unrelated
+    per-call `extra_body` — and both must still coexist with the adapter's own
+    `chat_template_kwargs.adapter_name` write.
+    """
+    backend = _make_backend_with_adapter(
+        _SIMPLE_CONFIG,
+        model_options={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+        },
+    )
+    ctx = _make_context()
+    mock_create = AsyncMock(return_value=_simple_chat_completion())
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with patch.object(
+        OpenAIBackend,
+        "_async_client",
+        new_callable=PropertyMock,
+        return_value=mock_client,
+    ):
+        mot, _ = await mfuncs.aact(
+            Intrinsic("answerability"),
+            ctx,
+            backend,
+            strategy=None,
+            model_options={"extra_body": {"some_unrelated_field": 123}},
+        )
+        await mot.avalue()
+
+    mock_create.assert_called_once()
+    extra_body = mock_create.call_args.kwargs.get("extra_body", {})
+
+    assert extra_body["some_unrelated_field"] == 123
+    assert extra_body["chat_template_kwargs"]["enable_thinking"] is False
+    assert extra_body["chat_template_kwargs"]["adapter_name"] == "answerability"
+
+
 async def test_result_processor_applied():
     """Full answerability config: likelihood + nest transforms produce the expected JSON."""
     backend = _make_backend_with_adapter(_ANSWERABILITY_CONFIG)

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -209,11 +209,9 @@ async def test_chat_template_kwargs_set():
 
 
 async def test_construction_time_extra_body_default_survives_intrinsic_call():
-    """Issue #1539: a construction-time `extra_body` default (e.g. a thinking
-    default) must survive an intrinsic call that supplies its own, unrelated
-    per-call `extra_body` — and both must still coexist with the adapter's own
-    `chat_template_kwargs.adapter_name` write.
-    """
+    """A construction-time extra_body default must survive an intrinsic call
+    that supplies its own unrelated per-call extra_body, alongside the
+    adapter's own chat_template_kwargs.adapter_name write."""
     backend = _make_backend_with_adapter(
         _SIMPLE_CONFIG,
         model_options={

--- a/test/backends/test_openai_unit.py
+++ b/test/backends/test_openai_unit.py
@@ -836,6 +836,71 @@ async def test_thinking_false_sends_reasoning_effort_none_and_disable():
     assert call_kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
 
 
+async def test_construction_time_extra_body_thinking_does_not_outrank_per_call_thinking():
+    """Regression for #1617 review: a construction-time `enable_thinking` set via
+    the generic `model_options["extra_body"]` (as opposed to `default_extra_body`)
+    must not silently override a per-call `ModelOption.THINKING`.
+
+    Before the fix, `_simplify_and_merge` merged this construction-time
+    `extra_body` together with any per-call `extra_body` via `merge_model_options`,
+    and the combined blob was then treated as highest-priority in
+    `_merge_user_extra_body` — beating the correctly-resolved per-call THINKING
+    value computed by `_map_thinking_option`.
+    """
+    from mellea.core.base import CBlock
+    from mellea.stdlib.context import ChatContext
+
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        model_options={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}}
+        },
+    )
+
+    with patch.object(
+        backend._async_client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = ChatCompletion(
+            id="test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion",
+        )
+        mot, _ = await backend.generate_from_chat_context(
+            CBlock(value="hello"),
+            ChatContext(),
+            model_options={ModelOption.THINKING: False},
+        )
+        await mot.avalue()
+
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_simplify_and_merge_excludes_construction_extra_body():
+    """Construction-time `extra_body` must not reappear in `_simplify_and_merge`'s
+    output — it is folded into `_default_extra_body` at `__init__` time instead,
+    so it can't re-enter the per-call precedence chain as `user_extra_body`."""
+    backend = OpenAIBackend(
+        model_id="gpt-4o",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        model_options={"extra_body": {"chat_template_kwargs": {"foo": "bar"}}},
+    )
+    result = backend._simplify_and_merge({}, is_chat_context=True)
+    assert "extra_body" not in result
+    assert backend._default_extra_body == {"chat_template_kwargs": {"foo": "bar"}}
+
+
 async def test_thinking_false_omits_reasoning_effort_against_real_openai():
     """THINKING=False must NOT send reasoning_effort="none" to api.openai.com.
 

--- a/test/backends/test_options.py
+++ b/test/backends/test_options.py
@@ -62,8 +62,8 @@ def test_resolve_model_options_unrelated_keys_are_preserved():
 
 
 def test_resolve_model_options_extra_body_default_survives_unrelated_call_extra_body():
-    """Issue #1539: a backend-level extra_body default must not be dropped by an
-    unrelated per-call extra_body (e.g. an intrinsic/adapter routing call)."""
+    """A backend-level extra_body default must survive an unrelated per-call
+    extra_body (e.g. an intrinsic/adapter routing call)."""
     resolved = resolve_model_options(
         backend_defaults={
             "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}

--- a/test/backends/test_options.py
+++ b/test/backends/test_options.py
@@ -59,3 +59,19 @@ def test_resolve_model_options_unrelated_keys_are_preserved():
         call_options={"call_only": 3},
     )
     assert resolved == {"backend_only": 1, "helper_only": 2, "call_only": 3}
+
+
+def test_resolve_model_options_extra_body_default_survives_unrelated_call_extra_body():
+    """Issue #1539: a backend-level extra_body default must not be dropped by an
+    unrelated per-call extra_body (e.g. an intrinsic/adapter routing call)."""
+    resolved = resolve_model_options(
+        backend_defaults={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+        },
+        remap={},
+        call_options={"extra_body": {"some_unrelated_field": 123}},
+    )
+    assert resolved["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "some_unrelated_field": 123,
+    }


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1539

## Description

### Impact

A backend-level `extra_body` default (e.g. a thinking-mode toggle set at construction time) gets **silently dropped, with no error or warning**, the moment a per-call `extra_body` is also present — even one that's about something else entirely:

```python
backend = OpenAIBackend(
    model_id="gpt-4o", base_url="...",
    model_options={"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
)
# ... later, any call that passes its own unrelated extra_body:
m.instruct("...", model_options={"extra_body": {"some_unrelated_field": 123}})
# -> enable_thinking is gone. The model thinks again, silently.
```

This isn't a rare edge case: it fires on **every** intrinsic/adapter call, because `OpenAIBackend._generate_from_intrinsic` always builds its own `extra_body` (to write `chat_template_kwargs["adapter_name"]`) — so a session that sets a thinking default and also uses any adapter loses that default the first time the adapter is called.

### Root cause

`merge_model_options` merges option dicts with a flat, top-level `dict.update`. That's correct for scalar options, but wrong for `extra_body`, whose value is itself a dict that different call sites write into independently.

### Fix

`merge_model_options` now special-cases `extra_body`: when both sides have a dict there, their `chat_template_kwargs` sub-dicts deep-merge instead of one replacing the other (new `ModelOption._merge_extra_body`, mirroring the deep-merge `OpenAIBackend._merge_user_extra_body` already does one layer down). Every other option key — and every other key inside `extra_body` — still flat-overwrites exactly as before; only the one broken case changes.

Also updates `docs/docs/integrations/openai.md`, which documented this exact clobbering as a known limitation — that caveat is now gone.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

**New tests:**
- `test_model_options.py`, `test_options.py` — unit coverage on the merge functions: unrelated-key preservation, `chat_template_kwargs` deep-merge, conflict resolution, non-mutation, non-dict fallback.
- `test_openai_intrinsics_unit.py::test_construction_time_extra_body_default_survives_intrinsic_call` — the impact scenario end to end through a real intrinsic call: a construction-time thinking default, an unrelated per-call `extra_body`, and the adapter's own `adapter_name` all survive together in the final request. Confirmed this test fails on pre-fix code (`KeyError: 'enable_thinking'`) and passes post-fix.

**Full run:** `uv run pytest test/ -m "not qualitative"` → 4286 passed, 20 skipped, 4 xpassed, 1 unrelated pre-existing flake (`test_tracing_backend.py::test_stream_e2e`, a live-Ollama timing assertion — passes on rerun). `ruff format`/`ruff check`/`mypy` clean; `markdownlint-cli2` clean on the docs change.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
