### PR TITLE
fix(rag): stop mirroring output schema key in groundedness batch prompt

### DIFF
--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -556,32 +556,26 @@ class GroundednessRequirement(Requirement):
         Returns:
             Formatted prompt for LLM expecting JSON array output
         """
-        # Build structured list of spans with their citations
-        span_assessments = []
+        # json.dumps keeps this valid JSON even if text contains quotes/newlines.
+        spans_payload = []
         for i, span_info in enumerate(spans_to_assess):
             span_text = span_info["text"]
             span_citations = span_info["citations"]
 
-            # Format citations for this span
-            citations_lines = []
+            evidence_entries = []
             for j, citation in enumerate(span_citations):
                 citation_text = citation.get("citation_text", "")
                 doc_id = citation.get("citation_doc_id", "unknown")
-                citations_lines.append(
-                    f'    Citation {j} (from doc {doc_id}): "{citation_text}"'
+                evidence_entries.append(
+                    f'Evidence {j} (from doc {doc_id}): "{citation_text}"'
                 )
 
-            citations_formatted = "\n".join(citations_lines)
-
-            # Build span entry
-            span_entry = (
-                f'  {{"span_id": {i}, '
-                f'"text": "{span_text}", '
-                f'"citations": [\n{citations_formatted}\n  ]}}'
+            # "evidence" (not "citations") avoids echoing the output key name (#1316).
+            spans_payload.append(
+                {"span_id": i, "text": span_text, "evidence": evidence_entries}
             )
-            span_assessments.append(span_entry)
 
-        spans_formatted = ",\n".join(span_assessments)
+        spans_formatted = json.dumps(spans_payload, indent=2)
 
         # Build source documents section for context
         documents_section = ""
@@ -594,17 +588,17 @@ class GroundednessRequirement(Requirement):
             documents_section = "Source Documents:\n" + "\n\n".join(doc_lines) + "\n\n"
 
         prompt = (
-            "Assess the level of support for each response span based on provided citations "
-            "and source documents.\n\n"
-            "For each span, determine if the citations fully support, partially support, "
-            "or do not support the span. Consider the full context from the source documents "
-            "where the citations appear.\n\n"
+            "Assess the level of support for each response span based on its provided evidence "
+            "and the source documents.\n\n"
+            "For each span, determine if the evidence fully supports, partially supports, "
+            "or does not support the span. Consider the full context from the source documents "
+            "where the evidence appears.\n\n"
             "Respond with a flat JSON array (no nested arrays), with one object for each span. Example output:\n"
             '[{"span_id": 0, "support_level": "FULLY_SUPPORTED"}]\n\n'
             "Support levels must be ONLY one of: FULLY_SUPPORTED, PARTIALLY_SUPPORTED, or NOT_SUPPORTED.\n\n"
             f"{documents_section}"
             f"Response context:\n{response}\n\n"
-            f"Spans to assess:\n[\n{spans_formatted}\n]\n\n"
+            f"Spans to assess:\n{spans_formatted}\n\n"
             "JSON Output:\n"
         )
         return prompt
@@ -704,14 +698,17 @@ class GroundednessRequirement(Requirement):
                 support_level_raw = (
                     (judgment.get("support_level") or "").upper().strip()
                 )
-                # Handle nested format: {"span_id": 0, "citations": [{"support_level": "..."}]}
-                # This format appears when the model mirrors the input span structure from the prompt.
-                # Aggregate using pessimistic ordering (NOT_SUPPORTED beats PARTIALLY, etc.)
-                # so the result is deterministic regardless of citation order.
+                # Handle nested format: {"span_id": 0, "evidence": [{"support_level": "..."}]}
+                # Checks both "evidence" and "citations" (prior key, kept defensively).
                 if not support_level_raw:
+                    nested_source: list = []
+                    for nested_key in ("evidence", "citations"):
+                        nested_value = judgment.get(nested_key)
+                        if isinstance(nested_value, list):
+                            nested_source.extend(nested_value)
                     nested_levels = {
                         _norm(cit.get("support_level"))
-                        for cit in (judgment.get("citations") or [])
+                        for cit in nested_source
                         if isinstance(cit, dict)
                     }
                     nested_levels.discard("")

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -3,6 +3,7 @@
 
 """Tests for GroundednessRequirement."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -435,6 +436,42 @@ def test_build_batch_support_prompt(sample_docs):
     assert "The sky is blue" in prompt
     assert "Grass is green" in prompt
 
+    # Input spans are keyed "evidence", not "citations" (issue #1316).
+    assert '"evidence": [' in prompt
+    assert '"citations": [' not in prompt
+    assert "Evidence 0" in prompt
+
+
+def test_build_batch_support_prompt_escapes_special_characters(sample_docs):
+    """Text with quotes/newlines must not break the prompt's JSON structure."""
+    req = GroundednessRequirement()
+
+    response = 'He said "hello" to me.'
+    spans_to_assess = [
+        {
+            "text": 'He said "hello" to me',
+            "citations": [
+                {
+                    "citation_text": 'The greeting was "hello".\nA second line.',
+                    "citation_doc_id": "0",
+                }
+            ],
+        }
+    ]
+
+    prompt = req._build_batch_support_prompt(response, spans_to_assess, sample_docs)
+
+    spans_section = prompt[
+        prompt.index("Spans to assess:\n") + len("Spans to assess:\n") : prompt.index(
+            "\n\nJSON Output:"
+        )
+    ]
+    parsed = json.loads(spans_section)
+
+    assert parsed[0]["span_id"] == 0
+    assert parsed[0]["text"] == 'He said "hello" to me'
+    assert 'The greeting was "hello".\nA second line.' in parsed[0]["evidence"][0]
+
 
 def test_parse_batch_support_output():
     """Test parsing batch support output."""
@@ -495,6 +532,83 @@ def test_parse_batch_support_output_nested_citations():
 
     assert len(result) == 2
     assert result[0] == "FULLY_SUPPORTED"
+    assert result[1] == "NOT_SUPPORTED"
+
+
+def test_parse_batch_support_output_nested_evidence():
+    """Same as the 'citations' nesting test, but for the current 'evidence' key."""
+    req = GroundednessRequirement()
+
+    output_text = """
+    [
+        {
+            "span_id": 0,
+            "text": "The Eiffel Tower is located in Paris, France.",
+            "evidence": [
+                {
+                    "citation_id": 0,
+                    "source_document": 0,
+                    "support_level": "FULLY_SUPPORTED"
+                }
+            ]
+        },
+        {
+            "span_id": 1,
+            "text": "Another span.",
+            "evidence": [
+                {
+                    "citation_id": 0,
+                    "source_document": 0,
+                    "support_level": "NOT_SUPPORTED"
+                }
+            ]
+        }
+    ]
+    """
+
+    result = req._parse_batch_support_output(output_text, 2)
+
+    assert len(result) == 2
+    assert result[0] == "FULLY_SUPPORTED"
+    assert result[1] == "NOT_SUPPORTED"
+
+
+def test_parse_batch_support_output_nested_both_keys_union():
+    """Both keys present at once must union, not pick one and drop the other."""
+    req = GroundednessRequirement()
+
+    output_text = """
+    [
+        {
+            "span_id": 0,
+            "evidence": [{"support_level": "FULLY_SUPPORTED"}],
+            "citations": [{"support_level": "NOT_SUPPORTED"}]
+        }
+    ]
+    """
+
+    result = req._parse_batch_support_output(output_text, 1)
+
+    assert len(result) == 1
+    # pessimistic: NOT_SUPPORTED wins over FULLY_SUPPORTED from the other key
+    assert result[0] == "NOT_SUPPORTED"
+
+
+def test_parse_batch_support_output_nested_non_list_value():
+    """A non-list value must not raise - degrade to NOT_SUPPORTED instead."""
+    req = GroundednessRequirement()
+
+    output_text = """
+    [
+        {"span_id": 0, "evidence": 5},
+        {"span_id": 1, "citations": "not a list"}
+    ]
+    """
+
+    result = req._parse_batch_support_output(output_text, 2)
+
+    assert len(result) == 2
+    assert result[0] == "NOT_SUPPORTED"
     assert result[1] == "NOT_SUPPORTED"
 
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1316

## Description

The groundedness batch prompt showed the model each span with a `"citations"`
key, then asked for a flat output keyed `"support_level"`. granite-4.0-micro
would sometimes copy the input's nested shape into its output instead of
following the instructions — issue #1316 measured this at ~70%.

Fix: rename the input key to `"evidence"` so it no longer shares a name with
the shape the model mirrors. The existing fallback parser (from #1292) now
checks both the old and new key, so nothing regresses either way.

Two small bugs found in that same code while making this change, fixed here
since they're a few lines away:
- The fallback parser could silently drop a valid `NOT_SUPPORTED` judgment in
  favor of a `FULLY_SUPPORTED` one from the other key, and crashed on a
  non-list value. Now unions both keys safely.
- Span text containing a quote or newline produced invalid JSON in the
  prompt. Now built with `json.dumps`, so it's always valid.

**HPC validation:** ~70% mirroring reported in #1316, but couldn't reproduce
it on GPU hardware. Keeping the fix anyway — it's low-risk and addresses the
root cause.

Filed #1614 for a related but unconfirmed bug spotted in the same parser
(span_id type mismatch) — not included here, no reproduction yet.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

`test_groundedness_requirement.py`: 28 passed (4 new tests). Lint, format,
and mypy clean.

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

