### PR TITLE
fix(rag): normalise model-returned JSON types

### DIFF
--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -22,6 +22,25 @@ from ..context import ChatContext
 logger = MelleaLogger.get_logger()
 
 
+def _normalise_span_id(raw: object, expected_count: int) -> int | None:
+    """Normalise a model-returned span identifier."""
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        span_id = raw
+    elif isinstance(raw, str) and raw.strip().isdigit():
+        span_id = int(raw.strip())
+    else:
+        return None
+
+    return span_id if 0 <= span_id < expected_count else None
+
+
+def _normalise_label(raw: object) -> str:
+    """Normalise a model-returned string label."""
+    return raw.strip() if isinstance(raw, str) else ""
+
+
 class GroundednessRequirement(Requirement):
     """Requirement that validates LLM responses are grounded by citations.
 
@@ -680,8 +699,8 @@ class GroundednessRequirement(Requirement):
             # Normalize each nested citation through the same substring
             # logic the flat path uses below, so near-miss labels like
             # "FULLY SUPPORTED" (space) aren't silently downgraded.
-            def _norm(raw: str | None) -> str:
-                raw = (raw or "").upper().strip()
+            def _norm(raw: object) -> str:
+                raw = _normalise_label(raw).upper()
                 if "FULLY" in raw and "SUPPORTED" in raw:
                     return "FULLY_SUPPORTED"
                 if "PARTIALLY" in raw and "SUPPORTED" in raw:
@@ -694,10 +713,10 @@ class GroundednessRequirement(Requirement):
                     logger.debug(f"Skipping non-dict judgment: {judgment}")
                     continue
 
-                span_id = judgment.get("span_id")
-                support_level_raw = (
-                    (judgment.get("support_level") or "").upper().strip()
-                )
+                span_id = _normalise_span_id(judgment.get("span_id"), expected_count)
+                support_level_raw = _normalise_label(
+                    judgment.get("support_level")
+                ).upper()
                 # Handle nested format: {"span_id": 0, "evidence": [{"support_level": "..."}]}
                 # Checks both "evidence" and "citations" (prior key, kept defensively).
                 if not support_level_raw:
@@ -787,16 +806,16 @@ class GroundednessRequirement(Requirement):
                 if not isinstance(judgment, dict):
                     continue
 
-                span_id = judgment.get("span_id")
-                needs_citation_flag = (
-                    (judgment.get("needs_citation") or "").lower().strip()
-                )
+                span_id = _normalise_span_id(judgment.get("span_id"), len(spans))
+                needs_citation_flag = _normalise_label(
+                    judgment.get("needs_citation")
+                ).lower()
 
                 logger.debug(
                     f"  Judgment: span_id={span_id}, needs_citation={needs_citation_flag}"
                 )
 
-                if span_id is not None and 0 <= span_id < len(spans):
+                if span_id is not None:
                     span = spans[span_id]
                     span_key = (span["begin"], span["end"])
                     # Handle variations: "yes", "true", "1" -> True

--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -21,6 +21,12 @@ from ..context import ChatContext
 
 logger = MelleaLogger.get_logger()
 
+_SUPPORT_LEVEL_RANK: dict[str, int] = {
+    "FULLY_SUPPORTED": 0,
+    "PARTIALLY_SUPPORTED": 1,
+    "NOT_SUPPORTED": 2,
+}
+
 
 def _normalise_span_id(raw: object, expected_count: int) -> int | None:
     """Normalise a model-returned span identifier."""
@@ -28,8 +34,11 @@ def _normalise_span_id(raw: object, expected_count: int) -> int | None:
         return None
     if isinstance(raw, int):
         span_id = raw
-    elif isinstance(raw, str) and raw.strip().isdigit():
-        span_id = int(raw.strip())
+    elif isinstance(raw, str):
+        try:
+            span_id = int(raw.strip())
+        except ValueError:
+            return None
     else:
         return None
 
@@ -39,6 +48,19 @@ def _normalise_span_id(raw: object, expected_count: int) -> int | None:
 def _normalise_label(raw: object) -> str:
     """Normalise a model-returned string label."""
     return raw.strip() if isinstance(raw, str) else ""
+
+
+def _normalise_needs_citation(raw: object) -> bool:
+    """Normalise a model-returned citation-necessity label."""
+    if not isinstance(raw, str):
+        return True
+
+    label = raw.strip().lower()
+    if label in ("yes", "true", "1"):
+        return True
+    if label in ("no", "false", "0"):
+        return False
+    return True
 
 
 class GroundednessRequirement(Requirement):
@@ -720,7 +742,7 @@ class GroundednessRequirement(Requirement):
                 # Handle nested format: {"span_id": 0, "evidence": [{"support_level": "..."}]}
                 # Checks both "evidence" and "citations" (prior key, kept defensively).
                 if not support_level_raw:
-                    nested_source: list = []
+                    nested_source: list[object] = []
                     for nested_key in ("evidence", "citations"):
                         nested_value = judgment.get(nested_key)
                         if isinstance(nested_value, list):
@@ -761,7 +783,13 @@ class GroundednessRequirement(Requirement):
                 else:
                     support_level = "NOT_SUPPORTED"
 
-                result[span_id] = support_level
+                existing_support = result.get(span_id)
+                if (
+                    existing_support is None
+                    or _SUPPORT_LEVEL_RANK[support_level]
+                    > _SUPPORT_LEVEL_RANK[existing_support]
+                ):
+                    result[span_id] = support_level
 
             # Ensure all expected spans have results (default to NOT_SUPPORTED if missing)
             for i in range(expected_count):
@@ -807,22 +835,19 @@ class GroundednessRequirement(Requirement):
                     continue
 
                 span_id = _normalise_span_id(judgment.get("span_id"), len(spans))
-                needs_citation_flag = _normalise_label(
+                needs_citation = _normalise_needs_citation(
                     judgment.get("needs_citation")
-                ).lower()
+                )
 
                 logger.debug(
-                    f"  Judgment: span_id={span_id}, needs_citation={needs_citation_flag}"
+                    f"  Judgment: span_id={span_id}, needs_citation={needs_citation}"
                 )
 
                 if span_id is not None:
                     span = spans[span_id]
                     span_key = (span["begin"], span["end"])
-                    # Handle variations: "yes", "true", "1" -> True
-                    span_necessity[span_key] = needs_citation_flag in (
-                        "yes",
-                        "true",
-                        "1",
+                    span_necessity[span_key] = (
+                        span_necessity.get(span_key, False) or needs_citation
                     )
 
             # Ensure all spans are in the result

--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -34,11 +34,13 @@ def _normalise_span_id(raw: object, expected_count: int) -> int | None:
         return None
     if isinstance(raw, int):
         span_id = raw
+    elif isinstance(raw, float) and raw.is_integer():
+        span_id = int(raw)
     elif isinstance(raw, str):
-        try:
-            span_id = int(raw.strip())
-        except ValueError:
+        match = re.fullmatch(r"[0-9]+", raw.strip())
+        if match is None:
             return None
+        span_id = int(match.group())
     else:
         return None
 
@@ -52,6 +54,10 @@ def _normalise_label(raw: object) -> str:
 
 def _normalise_needs_citation(raw: object) -> bool:
     """Normalise a model-returned citation-necessity label."""
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, int):
+        return bool(raw)
     if not isinstance(raw, str):
         return True
 
@@ -723,6 +729,8 @@ class GroundednessRequirement(Requirement):
             # "FULLY SUPPORTED" (space) aren't silently downgraded.
             def _norm(raw: object) -> str:
                 raw = _normalise_label(raw).upper()
+                if re.search(r"\b(?:NOT|UNSUPPORTED)\b", raw):
+                    return "NOT_SUPPORTED"
                 if "FULLY" in raw and "SUPPORTED" in raw:
                     return "FULLY_SUPPORTED"
                 if "PARTIALLY" in raw and "SUPPORTED" in raw:
@@ -736,6 +744,7 @@ class GroundednessRequirement(Requirement):
                     continue
 
                 span_id = _normalise_span_id(judgment.get("span_id"), expected_count)
+                nested_levels: set[str] = set()
                 support_level_raw = _normalise_label(
                     judgment.get("support_level")
                 ).upper()
@@ -772,18 +781,11 @@ class GroundednessRequirement(Requirement):
                     logger.debug("Skipping judgment with no span_id")
                     continue
 
-                # Normalize support level
-                if "FULLY" in support_level_raw and "SUPPORTED" in support_level_raw:
-                    support_level = "FULLY_SUPPORTED"
-                elif (
-                    "PARTIALLY" in support_level_raw
-                    and "SUPPORTED" in support_level_raw
-                ):
-                    support_level = "PARTIALLY_SUPPORTED"
-                else:
-                    support_level = "NOT_SUPPORTED"
+                support_level = _norm(support_level_raw) or "NOT_SUPPORTED"
 
                 existing_support = result.get(span_id)
+                # Duplicate judgments must remain conservative regardless of
+                # whether the model used flat or nested output.
                 if (
                     existing_support is None
                     or _SUPPORT_LEVEL_RANK[support_level]
@@ -834,13 +836,15 @@ class GroundednessRequirement(Requirement):
                 if not isinstance(judgment, dict):
                     continue
 
+                needs_citation_raw = judgment.get("needs_citation")
                 span_id = _normalise_span_id(judgment.get("span_id"), len(spans))
                 needs_citation = _normalise_needs_citation(
                     judgment.get("needs_citation")
                 )
 
                 logger.debug(
-                    f"  Judgment: span_id={span_id}, needs_citation={needs_citation}"
+                    f"  Judgment: span_id={span_id}, needs_citation_raw={needs_citation_raw!r}, "
+                    f"needs_citation={needs_citation}"
                 )
 
                 if span_id is not None:

--- a/mellea/stdlib/requirements/rag.py
+++ b/mellea/stdlib/requirements/rag.py
@@ -728,7 +728,11 @@ class GroundednessRequirement(Requirement):
             # logic the flat path uses below, so near-miss labels like
             # "FULLY SUPPORTED" (space) aren't silently downgraded.
             def _norm(raw: object) -> str:
-                raw = _normalise_label(raw).upper()
+                # Split camelCase boundaries and collapse separators to spaces
+                # so \b sees word edges around "NOT"/"UNSUPPORTED" regardless
+                # of delimiter style (underscore, hyphen, or camelCase).
+                label = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", _normalise_label(raw))
+                raw = re.sub(r"[^A-Za-z0-9]+", " ", label).upper().strip()
                 if re.search(r"\b(?:NOT|UNSUPPORTED)\b", raw):
                     return "NOT_SUPPORTED"
                 if "FULLY" in raw and "SUPPORTED" in raw:
@@ -745,9 +749,9 @@ class GroundednessRequirement(Requirement):
 
                 span_id = _normalise_span_id(judgment.get("span_id"), expected_count)
                 nested_levels: set[str] = set()
-                support_level_raw = _normalise_label(
-                    judgment.get("support_level")
-                ).upper()
+                # Case is preserved here (not upper-cased) so _norm can still
+                # see camelCase word boundaries like "notFullySupported".
+                support_level_raw = _normalise_label(judgment.get("support_level"))
                 # Handle nested format: {"span_id": 0, "evidence": [{"support_level": "..."}]}
                 # Checks both "evidence" and "citations" (prior key, kept defensively).
                 if not support_level_raw:

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -492,6 +492,47 @@ def test_parse_batch_support_output():
     assert result[1] == "PARTIALLY_SUPPORTED"
 
 
+def test_parse_batch_support_output_normalises_string_span_id():
+    """Quoted numeric span IDs must map to the integer result key.
+
+    Without this normalisation, a valid model judgment is stored under ``"0"``
+    and the caller falls back to NOT_SUPPORTED when looking up integer key 0.
+    """
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        '[{"span_id": "0", "support_level": "FULLY_SUPPORTED"}]', 1
+    )
+
+    assert result == {0: "FULLY_SUPPORTED"}
+
+
+def test_parse_batch_support_output_ignores_non_string_support_level():
+    """Unexpected support-level types must degrade conservatively."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output('[{"span_id": 0, "support_level": 5}]', 1)
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+def test_parse_necessity_output_normalises_model_types():
+    """Necessity parsing must tolerate quoted IDs and non-string labels."""
+    req = GroundednessRequirement()
+    spans = [
+        {"begin": 0, "end": 5, "text": "Fact."},
+        {"begin": 7, "end": 13, "text": "Other."},
+    ]
+
+    result = req._parse_necessity_output(
+        '[{"span_id": "0", "needs_citation": "yes"}, '
+        '{"span_id": 1, "needs_citation": 1}]',
+        spans,
+    )
+
+    assert result == {(0, 5): True, (7, 13): False}
+
+
 def test_parse_batch_support_output_nested_citations():
     """Test parsing batch support output when model nests support_level inside citations.
 

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -530,7 +530,7 @@ def test_parse_batch_support_output_ignores_non_string_nested_support_level(
     assert result == {0: "NOT_SUPPORTED"}
 
 
-@pytest.mark.parametrize("span_id", [True, -1, 1.5, "not-an-index", "2"])
+@pytest.mark.parametrize("span_id", [True, -1, 1.5, "not-an-index", "2", "²"])
 def test_parse_batch_support_output_ignores_invalid_span_id(span_id: object):
     """Invalid model-returned span IDs must not become result keys."""
     req = GroundednessRequirement()
@@ -543,7 +543,7 @@ def test_parse_batch_support_output_ignores_invalid_span_id(span_id: object):
 
 
 def test_parse_necessity_output_normalises_model_types():
-    """Necessity parsing must tolerate quoted IDs and non-string labels."""
+    """Necessity parsing must tolerate quoted IDs and default invalid labels safely."""
     req = GroundednessRequirement()
     spans = [
         {"begin": 0, "end": 5, "text": "Fact."},
@@ -556,7 +556,65 @@ def test_parse_necessity_output_normalises_model_types():
         spans,
     )
 
-    assert result == {(0, 5): True, (7, 13): False}
+    assert result == {(0, 5): True, (7, 13): True}
+
+
+@pytest.mark.parametrize(
+    "output_text",
+    [
+        (
+            '[{"span_id": 0, "needs_citation": "no"}, '
+            '{"span_id": "0", "needs_citation": "yes"}]'
+        ),
+        (
+            '[{"span_id": "0", "needs_citation": "yes"}, '
+            '{"span_id": 0, "needs_citation": "no"}]'
+        ),
+    ],
+)
+def test_parse_necessity_output_duplicate_ids_require_citations(output_text: str):
+    """Duplicate span judgments must retain the conservative result."""
+    req = GroundednessRequirement()
+    spans = [{"begin": 0, "end": 5, "text": "Fact."}]
+
+    result = req._parse_necessity_output(output_text, spans)
+
+    assert result == {(0, 5): True}
+
+
+@pytest.mark.parametrize(
+    "output_text",
+    [
+        (
+            '[{"span_id": 0, "support_level": "NOT_SUPPORTED"}, '
+            '{"span_id": "0", "support_level": "FULLY_SUPPORTED"}]'
+        ),
+        (
+            '[{"span_id": "0", "support_level": "FULLY_SUPPORTED"}, '
+            '{"span_id": 0, "support_level": "NOT_SUPPORTED"}]'
+        ),
+    ],
+)
+def test_parse_batch_support_output_duplicate_ids_are_pessimistic(output_text: str):
+    """Duplicate span judgments must retain the least-supported result."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(output_text, 1)
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+def test_malformed_necessity_label_keeps_span_subject_to_groundedness():
+    """Malformed necessity output must not let an unsupported span pass."""
+    req = GroundednessRequirement()
+    spans = [{"begin": 0, "end": 5, "text": "Fact."}]
+    necessity = req._parse_necessity_output(
+        '[{"span_id": 0, "needs_citation": 1}]', spans
+    )
+
+    passed, _ = req._build_groundedness_result("Fact.", [], necessity, {})
+
+    assert not passed
 
 
 def test_parse_batch_support_output_nested_citations():

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -495,8 +495,8 @@ def test_parse_batch_support_output():
 def test_parse_batch_support_output_normalises_string_span_id():
     """Quoted numeric span IDs must map to the integer result key.
 
-    Without this normalisation, a valid model judgment is stored under ``"0"``
-    and the caller falls back to NOT_SUPPORTED when looking up integer key 0.
+    Without this normalisation, a valid model judgment is stored under `"0"`
+    and the caller falls back to NOT_SUPPORTED when looking up integer key `0`.
     """
     req = GroundednessRequirement()
 

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mellea.backends.huggingface import LocalHFBackend
 from mellea.core.base import ModelOutputThunk
 from mellea.stdlib.components import Document, Message
 from mellea.stdlib.context import ChatContext
@@ -20,6 +19,11 @@ from test.predicates import require_gpu
 @pytest.fixture
 def backend():
     """Provide HuggingFace backend for tests."""
+    try:
+        from mellea.backends.huggingface import LocalHFBackend
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
     with hf_skip():
         return LocalHFBackend(model_id="ibm-granite/granite-4.0-micro")
 
@@ -530,7 +534,9 @@ def test_parse_batch_support_output_ignores_non_string_nested_support_level(
     assert result == {0: "NOT_SUPPORTED"}
 
 
-@pytest.mark.parametrize("span_id", [True, -1, 1.5, "not-an-index", "2", "²"])
+@pytest.mark.parametrize(
+    "span_id", [True, -1, 1.5, "not-an-index", "2", "²", "1_0", "+1", "３"]
+)
 def test_parse_batch_support_output_ignores_invalid_span_id(span_id: object):
     """Invalid model-returned span IDs must not become result keys."""
     req = GroundednessRequirement()
@@ -540,6 +546,18 @@ def test_parse_batch_support_output_ignores_invalid_span_id(span_id: object):
     )
 
     assert result == {0: "NOT_SUPPORTED"}
+
+
+@pytest.mark.parametrize("span_id", [0.0, "0"])
+def test_parse_batch_support_output_accepts_integral_span_id(span_id: object):
+    """Integral numeric span IDs must resolve to the integer result key."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        json.dumps([{"span_id": span_id, "support_level": "FULLY_SUPPORTED"}]), 1
+    )
+
+    assert result == {0: "FULLY_SUPPORTED"}
 
 
 def test_parse_necessity_output_normalises_model_types():
@@ -557,6 +575,19 @@ def test_parse_necessity_output_normalises_model_types():
     )
 
     assert result == {(0, 5): True, (7, 13): True}
+
+
+@pytest.mark.parametrize("needs_citation", [False, 0, "false", "0", "no"])
+def test_parse_necessity_output_preserves_false_labels(needs_citation: object):
+    """False model-returned necessity labels must remain false."""
+    req = GroundednessRequirement()
+    spans = [{"begin": 0, "end": 5, "text": "Fact."}]
+
+    result = req._parse_necessity_output(
+        json.dumps([{"span_id": 0, "needs_citation": needs_citation}]), spans
+    )
+
+    assert result == {(0, 5): False}
 
 
 @pytest.mark.parametrize(
@@ -586,6 +617,28 @@ def test_parse_necessity_output_duplicate_ids_require_citations(output_text: str
     "output_text",
     [
         (
+            '[{"span_id": 0, "citations": [{"support_level": "NOT_SUPPORTED"}]}, '
+            '{"span_id": "0", "citations": [{"support_level": "FULLY_SUPPORTED"}]}]'
+        ),
+        (
+            '[{"span_id": "0", "citations": [{"support_level": "FULLY_SUPPORTED"}]}, '
+            '{"span_id": 0, "citations": [{"support_level": "NOT_SUPPORTED"}]}]'
+        ),
+    ],
+)
+def test_parse_batch_support_output_duplicate_ids_are_pessimistic(output_text: str):
+    """Nested duplicate span judgments must retain the least-supported result."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(output_text, 1)
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+@pytest.mark.parametrize(
+    "output_text",
+    [
+        (
             '[{"span_id": 0, "support_level": "NOT_SUPPORTED"}, '
             '{"span_id": "0", "support_level": "FULLY_SUPPORTED"}]'
         ),
@@ -595,11 +648,73 @@ def test_parse_necessity_output_duplicate_ids_require_citations(output_text: str
         ),
     ],
 )
-def test_parse_batch_support_output_duplicate_ids_are_pessimistic(output_text: str):
-    """Duplicate span judgments must retain the least-supported result."""
+def test_parse_batch_support_output_duplicate_flat_ids_are_pessimistic(
+    output_text: str,
+):
+    """Duplicate flat rows must retain the least-supported result."""
     req = GroundednessRequirement()
 
     result = req._parse_batch_support_output(output_text, 1)
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+@pytest.mark.parametrize(
+    "output_text",
+    [
+        (
+            '[{"span_id": 0, "support_level": "FULLY_SUPPORTED"}, '
+            '{"span_id": 0, "evidence": [{"support_level": "NOT_SUPPORTED"}]}]'
+        ),
+        (
+            '[{"span_id": 0, "evidence": [{"support_level": "NOT_SUPPORTED"}]}, '
+            '{"span_id": 0, "support_level": "FULLY_SUPPORTED"}]'
+        ),
+    ],
+)
+def test_parse_batch_support_output_mixed_duplicate_ids_are_pessimistic(
+    output_text: str,
+):
+    """Mixed output shapes must retain the least-supported result."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(output_text, 1)
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+@pytest.mark.parametrize("support_level", ["NOT FULLY SUPPORTED", "FULLY UNSUPPORTED"])
+def test_parse_batch_support_output_negated_labels_are_not_supported(
+    support_level: str,
+):
+    """Negated support labels must not be classified as fully supported."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        json.dumps([{"span_id": 0, "support_level": support_level}]), 1
+    )
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+def test_parse_batch_support_output_positive_unambiguous_label_is_supported():
+    """Positive labels containing unrelated `UN` text must remain supported."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        '[{"span_id": 0, "support_level": "FULLY SUPPORTED (UNAMBIGUOUS)"}]', 1
+    )
+
+    assert result == {0: "FULLY_SUPPORTED"}
+
+
+def test_parse_batch_support_output_nested_negated_label_is_not_supported():
+    """Negated nested support labels must not be classified as fully supported."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        '[{"span_id": 0, "evidence": [{"support_level": "not fully supported"}]}]', 1
+    )
 
     assert result == {0: "NOT_SUPPORTED"}
 

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -516,6 +516,32 @@ def test_parse_batch_support_output_ignores_non_string_support_level():
     assert result == {0: "NOT_SUPPORTED"}
 
 
+@pytest.mark.parametrize("nested_key", ["evidence", "citations"])
+def test_parse_batch_support_output_ignores_non_string_nested_support_level(
+    nested_key: str,
+):
+    """Unexpected nested support-level types must not crash validation."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        f'[{{"span_id": 0, "{nested_key}": [{{"support_level": 5}}]}}]', 1
+    )
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
+@pytest.mark.parametrize("span_id", [True, -1, 1.5, "not-an-index", "2"])
+def test_parse_batch_support_output_ignores_invalid_span_id(span_id: object):
+    """Invalid model-returned span IDs must not become result keys."""
+    req = GroundednessRequirement()
+
+    result = req._parse_batch_support_output(
+        json.dumps([{"span_id": span_id, "support_level": "FULLY_SUPPORTED"}]), 1
+    )
+
+    assert result == {0: "NOT_SUPPORTED"}
+
+
 def test_parse_necessity_output_normalises_model_types():
     """Necessity parsing must tolerate quoted IDs and non-string labels."""
     req = GroundednessRequirement()

--- a/test/stdlib/requirements/test_groundedness_requirement.py
+++ b/test/stdlib/requirements/test_groundedness_requirement.py
@@ -683,7 +683,18 @@ def test_parse_batch_support_output_mixed_duplicate_ids_are_pessimistic(
     assert result == {0: "NOT_SUPPORTED"}
 
 
-@pytest.mark.parametrize("support_level", ["NOT FULLY SUPPORTED", "FULLY UNSUPPORTED"])
+@pytest.mark.parametrize(
+    "support_level",
+    [
+        "NOT FULLY SUPPORTED",
+        "FULLY UNSUPPORTED",
+        "NOT_FULLY_SUPPORTED",
+        "FULLY_UNSUPPORTED",
+        "not_fully_supported",
+        "NotFullySupported",
+        "notFullySupported",
+    ],
+)
 def test_parse_batch_support_output_negated_labels_are_not_supported(
     support_level: str,
 ):


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1614

## Description
`GroundednessRequirement` should use a valid model judgment as returned. For
example, the model may return:

```json
[{"span_id": "0", "support_level": "FULLY_SUPPORTED"}]
```

Before this fix, the parser preserved `"0"` as a string key:

```text
stored result: {"0": "FULLY_SUPPORTED"}
caller lookup: results.get(0) -> "NOT_SUPPORTED"
```

The parser now converts the ID to integer `0` before storing it:

```text
stored result: {0: "FULLY_SUPPORTED"}
caller lookup: results.get(0) -> "FULLY_SUPPORTED"
```

The parser now normalises model-returned IDs and labels for both citation
support and citation necessity. Invalid values retain conservative behaviour,
and duplicate judgments are aggregated pessimistically.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Focused verification:

- `uv run --extra hf pytest test/stdlib/requirements/test_groundedness_requirement.py -q` — 39 passed, 5 skipped
- `uv run ruff check mellea/stdlib/requirements/rag.py test/stdlib/requirements/test_groundedness_requirement.py`
- `uv run mypy mellea/stdlib/requirements/rag.py`
- Full non-qualitative suite: 4,258 passed; 13 unrelated Granite formatter e2e failures caused by local Torch/clang compilation on macOS

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
