### PR TITLE
test(telemetry): avoid requiring provider chunk intervals

### DIFF
--- a/test/telemetry/test_metrics_backend.py
+++ b/test/telemetry/test_metrics_backend.py
@@ -192,10 +192,6 @@ async def test_ollama_token_metrics_integration(
         },
     )
     ctx = ChatContext()
-    # A counting prompt reliably spans many output tokens, so the streaming
-    # branch always sees >=2 chunks (the time_per_output_chunk histogram only
-    # records inter-chunk intervals; a single-chunk reply like "Hello!" leaves
-    # it empty — observed in run 33163851256).
     ctx = ctx.add(Message(role="user", content="Count from 1 to 10 and nothing else"))
 
     model_options = {ModelOption.STREAM: True} if stream else {}
@@ -252,18 +248,6 @@ async def test_ollama_token_metrics_integration(
         )
         assert ttfb_dp is not None, "TTFB should be recorded for streaming requests"
         assert ttfb_dp.sum > 0, "TTFB should be > 0"
-
-        # With MELLEA_GENERATION_CHUNK_EVENTS enabled, each chunk after the
-        # first records an inter-chunk interval.
-        tpoc_dp = _find_histogram_data_point(
-            metrics_data, "gen_ai.client.operation.time_per_output_chunk"
-        )
-        assert tpoc_dp is not None, (
-            "time_per_output_chunk should be recorded when chunk events are enabled"
-        )
-        assert tpoc_dp.count >= 1, (
-            "at least one inter-chunk interval should be recorded"
-        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request

## Issue
Partly addresses #1566 (test case impact on other code)

## Description
The live Ollama telemetry test required `gen_ai.client.operation.time_per_output_chunk` to exist for every streamed response. That metric records inter-chunk intervals, so a valid one-chunk response has no interval and leaves the histogram empty. Provider chunk framing is not deterministic, even when the prompt produces several output tokens, so the assertion caused unrelated CI failures.

Remove that provider-dependent assertion while retaining the live checks for token usage, request duration, and time to first chunk. Deterministic unit coverage for interval recording remains unchanged. The broader producer-side telemetry correction stays scoped to issue #1566.

### Testing
- [x] Tests added to the respective file if code was changed
- [x] New code has 100% coverage if code was added
- [x] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

Verified locally:

```text
uv run pytest test/telemetry/test_metrics_plugins.py test/helpers/test_async_helpers.py -q
18 passed, 1 skipped
uv run ruff check test/telemetry/test_metrics_backend.py
All checks passed!
uv run ruff format --check test/telemetry/test_metrics_backend.py
1 file already formatted
```

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
