### PR TITLE
fix: validation

### DIFF
--- a/docs/docs/advanced/lora-and-alora-adapters.md
+++ b/docs/docs/advanced/lora-and-alora-adapters.md
@@ -188,6 +188,21 @@ directly (bypassing the normal `validate()` call), use `ALoraRequirement` from
 but still requires a matching adapter to actually be registered. If none is found,
 Mellea logs a warning and falls back to regular generation rather than erroring.
 
+### What the adapter sees
+
+The `requirement-check` adapter judges the last assistant turn of the conversation it is
+given, so the routing above only produces useful verdicts if that conversation actually
+reaches it. Mellea builds the adapter's message list from the validation context's
+`view_for_generation()`, and validation runs over the post-generation context — the same
+conversation the model generated into, with the generated output last. No extra setup is
+needed for that; it is the default.
+
+One consequence is worth knowing: a context whose generation view is empty gives the
+adapter nothing to judge. `SimpleContext` is the case to watch — it retains
+`last_output()` but its `view_for_generation()` is always empty by design. Adapter-backed
+requirements need a context that renders the assistant turn, such as `ChatContext`.
+See [What the validator sees](../concepts/requirements-system.md#what-the-validator-sees).
+
 ## Disable adapter validation
 
 To run without adapter validation (for benchmarking or debugging):

--- a/docs/docs/concepts/requirements-system.md
+++ b/docs/docs/concepts/requirements-system.md
@@ -296,6 +296,49 @@ reserve LLM-based requirements for subjective criteria that cannot be coded dire
 
 For a full walkthrough of using LLM-as-a-judge for output quality evaluation, see [Evaluate with LLM-as-a-Judge](../how-to/evaluate-with-llm-as-a-judge).
 
+## What the validator sees
+
+Validation runs over the **post-generation context** — the same conversation the model
+just generated into, with the generated output as its last entry. This matters for all
+three validation approaches:
+
+- A `validation_fn` receives that context, so `ctx.last_output()` is the output under
+  judgement and `ctx.as_list()` is the conversation that produced it.
+- An LLM-as-a-judge requirement sends that conversation to the model, followed by the
+  specific output to judge. The judge prompt scopes the verdict to that output, while
+  telling the model the conversation is there to help it interpret the requirement —
+  which is what makes conversation-dependent requirements ("must answer the question
+  that was asked") judgeable at all.
+- An `ALoraRequirement` needs the conversation to reach the adapter at all — the
+  `requirement-check` adapter judges the last assistant turn of the conversation it is
+  given. See [LoRA and aLoRA Adapters](../advanced/lora-and-alora-adapters.md).
+
+The output under judgement is passed as the `ModelOutputThunk` itself, not a detached
+string copy, so its `parsed_repr` and any structured representation survive into the
+judge prompt.
+
+### Overriding the validation context
+
+`SamplingStrategy.sample()` takes an optional `validation_ctx` for validating over
+something other than the post-generation context — for example, a trimmed context that
+excludes long retrieved documents. When it is given, the sampled output is appended to it
+so it is still the validation target; when it is `None`, each attempt is validated over its
+own post-generation context.
+
+`instruct()`, `act()`, and their async counterparts always pass `None`, so the
+post-generation context is what you get unless you drive a strategy's `sample()` directly.
+
+`validate()` and `avalidate()` follow the same rule at a lower level: they validate over
+the `context` you hand them, in your own context type. Their `output` argument designates
+*which* output is under judgement rather than replacing the context — it is appended only
+when it is not already the context's last output.
+
+> **Deprecated:** the `input` parameter of `validate()` / `avalidate()` is deprecated and
+> will be removed in a future release. Pass a context that already contains the input.
+
+Preconditions are the one case that never sees the conversation: `precondition_requirements`
+are judged over the function arguments alone, in a fresh context.
+
 ## Composing requirements
 
 Requirements are composable: mix strings, `req()`, `check()`, and `Requirement`

--- a/docs/docs/how-to/write-custom-verifiers.md
+++ b/docs/docs/how-to/write-custom-verifiers.md
@@ -77,6 +77,34 @@ result = m.instruct(
 print(str(result))
 ```
 
+### Which context your function receives
+
+The `ctx` argument is the **post-generation context**: the conversation the model just
+generated into, with the output under judgement as its last entry. So `ctx.last_output()`
+is the output to check, and `ctx.as_list()` gives you the turns that produced it — useful
+when a verdict depends on what was asked, not just what was answered:
+
+```python
+from mellea.core import Context, ValidationResult
+
+
+def validate_answers_the_question(ctx: Context) -> ValidationResult:
+    """Fail if the output repeats the user's question back instead of answering it."""
+    turns = ctx.as_list()
+    output = ctx.last_output()
+    text = output.value if output and output.value else ""
+
+    prior = [str(turn) for turn in turns[:-1]]
+    if prior and text.strip() in prior[-1]:
+        return ValidationResult(False, reason="The response echoes the question.")
+    return ValidationResult(True)
+```
+
+Under `instruct()` and `act()` this is always the post-generation context. Driving a
+sampling strategy's `sample()` directly lets you pass a `validation_ctx` to validate over
+something else instead — see
+[Overriding the validation context](../concepts/requirements-system.md#overriding-the-validation-context).
+
 ## Common validation patterns
 
 ### JSON validity

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -505,6 +505,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
             tool_calls (bool): If `True`, expose available tools to the model and
                 parse tool-call responses.
 
+        Raises:
+            ValueError: If `action` is an `ALoraRequirement` but `ctx` renders no
+                conversation, leaving the requirement-check adapter nothing to judge.
+
         Returns:
             tuple[ModelOutputThunk[C], Context]: A thunk holding the (lazy) model output
                 and an updated context that includes `action` and the new output.
@@ -548,6 +552,31 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
                     reroute_to_alora = False
 
                 if issubclass(type(action), LLMaJRequirement):
+                    reroute_to_alora = False
+
+                # The requirement-check adapter judges the last assistant turn of the
+                # conversation it is given, and this path never renders the requirement
+                # template -- so unlike LLM-as-a-judge it has no inlined copy of the output
+                # to fall back on. A context that renders nothing leaves it nothing to judge.
+                if reroute_to_alora and not ctx.view_for_generation():
+                    if isinstance(action, ALoraRequirement):
+                        raise ValueError(
+                            f"cannot validate an ALoraRequirement over a "
+                            f"{type(ctx).__name__}: it renders no conversation, so the "
+                            f"{adapter_name} adapter has no assistant turn to judge. "
+                            "Validate over a context that renders history (e.g. ChatContext), "
+                            "or use a plain Requirement, which falls back to LLM-as-a-judge."
+                        )
+                    # Auto-rerouting a plain Requirement is an optimisation, not a request:
+                    # fall back to LLM-as-a-judge, which inlines the output and still works.
+                    warn_key = f"alora_reroute_empty_view_{type(ctx).__name__}"
+                    if warn_key not in self._warned_about:
+                        self._warned_about.add(warn_key)
+                        MelleaLogger.get_logger().warning(
+                            f"not rerouting requirements to the {adapter_name} adapter: "
+                            f"{type(ctx).__name__} renders no conversation for the adapter "
+                            "to judge; using LLM-as-a-judge instead."
+                        )
                     reroute_to_alora = False
 
                 if reroute_to_alora:

--- a/mellea/backends/openai.py
+++ b/mellea/backends/openai.py
@@ -591,6 +591,10 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
             tool_calls (bool): If `True`, expose available tools to the model and
                 parse tool-call responses.
 
+        Raises:
+            ValueError: If `action` is an `ALoraRequirement` but `ctx` renders no
+                conversation, leaving the requirement-check adapter nothing to judge.
+
         Returns:
             tuple[ModelOutputThunk[C], Context]: A thunk holding the (lazy) model output
                 and an updated context that includes `action` and the new output.
@@ -633,6 +637,31 @@ class OpenAIBackend(FormatterBackend, AdapterMixin):
                     reroute_to_alora = False
 
                 if issubclass(type(action), LLMaJRequirement):
+                    reroute_to_alora = False
+
+                # The requirement-check adapter judges the last assistant turn of the
+                # conversation it is given, and this path never renders the requirement
+                # template -- so unlike LLM-as-a-judge it has no inlined copy of the output
+                # to fall back on. A context that renders nothing leaves it nothing to judge.
+                if reroute_to_alora and not ctx.view_for_generation():
+                    if isinstance(action, ALoraRequirement):
+                        raise ValueError(
+                            f"cannot validate an ALoraRequirement over a "
+                            f"{type(ctx).__name__}: it renders no conversation, so the "
+                            f"{adapter_name} adapter has no assistant turn to judge. "
+                            "Validate over a context that renders history (e.g. ChatContext), "
+                            "or use a plain Requirement, which falls back to LLM-as-a-judge."
+                        )
+                    # Auto-rerouting a plain Requirement is an optimisation, not a request:
+                    # fall back to LLM-as-a-judge, which inlines the output and still works.
+                    warn_key = f"alora_reroute_empty_view_{type(ctx).__name__}"
+                    if warn_key not in self._warned_about:
+                        self._warned_about.add(warn_key)
+                        MelleaLogger.get_logger().warning(
+                            f"not rerouting requirements to the {adapter_name} adapter: "
+                            f"{type(ctx).__name__} renders no conversation for the adapter "
+                            "to judge; using LLM-as-a-judge instead."
+                        )
                     reroute_to_alora = False
 
                 if reroute_to_alora:

--- a/mellea/core/base.py
+++ b/mellea/core/base.py
@@ -1976,7 +1976,14 @@ class TemplateRepresentation:
     obj: Any
     args: dict[
         str,
-        str | Component | CBlock | Iterable | Mapping | TemplateRepresentation | None,
+        str
+        | Component
+        | CBlock
+        | ModelOutputThunk
+        | Iterable
+        | Mapping
+        | TemplateRepresentation
+        | None,
     ]
     tools: dict[str, AbstractMelleaTool] | None = (
         None  # the key must be the name of the function.

--- a/mellea/core/requirement.py
+++ b/mellea/core/requirement.py
@@ -243,8 +243,25 @@ class Requirement(Component[str]):
         self.validation_fn = validation_fn
         self.check_only = check_only
 
-        # Used for validation. Do not manually populate.
-        self._output: str | None = None
+        # The span under judgement. Bound only on the transient copy created inside
+        # `validate` (see `_bind_validation_target`). Do not manually populate.
+        self._validation_target: Span | None = None
+
+    def _bind_validation_target(self, target: Span) -> "Requirement":
+        """Return a shallow copy of this requirement bound to the span under judgement.
+
+        Binding happens on a copy so that a `Requirement` object can be reused across
+        validation calls (and across sampling iterations) without accumulating state.
+
+        Args:
+            target: The `Component`, `CBlock`, or `ModelOutputThunk` being validated.
+
+        Returns:
+            Requirement: A copy of this requirement whose `_validation_target` is `target`.
+        """
+        bound = copy(self)
+        bound._validation_target = target
+        return bound
 
     async def validate(
         self,
@@ -287,10 +304,10 @@ class Requirement(Component[str]):
                 " Context has no appropriate last output"
             )
 
-            # Create a copy of the requirement that holds the output
-            # and its template gets populated with the output correctly.
-            req_copy = copy(self)
-            req_copy._output = last_output.value
+            # Bind the output being judged to a copy of this requirement, so that the
+            # judgement request carries the output itself -- not a detached string copy
+            # of it -- and so that `self` is left unmodified.
+            req_copy = self._bind_validation_target(last_output)
             llm_as_a_judge_result, val_ctx = await backend.generate_from_context(
                 req_copy, ctx, format=format, model_options=model_options
             )
@@ -367,29 +384,43 @@ class Requirement(Component[str]):
     def parts(self) -> list[Span]:
         """Returns all of the constituent parts of a Requirement.
 
+        Once a validation target has been bound (inside a `validate` call), that target is
+        the requirement's sole part. Exposing it here is what allows `generate_walk` to
+        await it if it has not been computed yet.
+
         Returns:
-            List of constituent components. Empty by default; subclasses override
-            to expose their internal structure.
+            List of constituent components. Empty unless a validation target is bound.
         """
-        return []
+        return [] if self._validation_target is None else [self._validation_target]
 
     def format_for_llm(self) -> TemplateRepresentation | str:
         """Returns a `TemplateRepresentation` for LLM-as-a-Judge evaluation of this requirement.
 
-        Populates the template with the requirement's `description` and the stored model
-        `_output`. Must only be called from within a `validate` call for this same requirement,
-        after `_output` has been set.
+        Populates the template with the requirement's `description` and the bound validation
+        target. Must only be called from within a `validate` call for this same requirement,
+        after the target has been bound by `_bind_validation_target`.
+
+        When the target is a `ModelOutputThunk` with a `Component` `parsed_repr`, the parsed
+        representation is used so that the judge sees the structured output rather than the
+        raw generated string.
 
         Returns:
             TemplateRepresentation | str: A `TemplateRepresentation` containing the description
             and the model output to be judged.
         """
-        assert self._output is not None, (
+        assert self._validation_target is not None, (
             "Object protocol error: should never try to templatize a Requirement except inside of a validate call for that same requirement."
         )
+
+        target: Span = self._validation_target
+        if isinstance(target, ModelOutputThunk) and isinstance(
+            target.parsed_repr, Component
+        ):
+            target = target.parsed_repr
+
         return TemplateRepresentation(
             obj=self,
-            args={"description": self.description, "output": self._output},
+            args={"description": self.description, "output": target},
             tools=None,
             template_order=["*", "Requirement"],
         )

--- a/mellea/core/sampling.py
+++ b/mellea/core/sampling.py
@@ -148,7 +148,8 @@ class SamplingStrategy(abc.ABC):
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
-            validation_ctx: Optional context to use for validation. If None, validation_ctx = ctx.
+            validation_ctx: Optional context to validate over. If None, each sample is validated
+                over its own post-generation context.
             format: output format for structured outputs.
             model_options: model options to pass to the backend during generation / validation.
             tool_calls: True if tool calls should be used during this sampling strategy.

--- a/mellea/stdlib/components/genstub.py
+++ b/mellea/stdlib/components/genstub.py
@@ -29,6 +29,7 @@ from ...core import (
     ValidationResult,
 )
 from ...helpers.annotation_helpers import resolve_signature_annotations
+from ..context import ChatContext
 from ..requirements.requirement import reqify
 from ..session import MelleaSession
 
@@ -625,23 +626,20 @@ class SyncGenerativeStub(GenerativeStub, Generic[P, R]):
 
         # Do precondition validation first.
         if stub_copy._arguments is not None:
-            if extracted.m is not None:
-                val_results = extracted.m.validate(
-                    reqs=stub_copy.precondition_requirements,
-                    model_options=extracted.model_options,
-                    output=ModelOutputThunk(stub_copy._arguments.value),
-                )
-            else:
-                # We know these aren't None from the `extract_args_and_kwargs` function.
-                assert extracted.context is not None
-                assert extracted.backend is not None
-                val_results = mfuncs.validate(
-                    reqs=stub_copy.precondition_requirements,
-                    context=extracted.context,
-                    backend=extracted.backend,
-                    model_options=extracted.model_options,
-                    output=ModelOutputThunk(stub_copy._arguments.value),
-                )
+            # Preconditions are judged over the arguments alone, so they get a fresh
+            # context rather than the caller's/session's conversation history.
+            precondition_backend = (
+                extracted.m.backend if extracted.m is not None else extracted.backend
+            )
+            # We know this isn't None from the `extract_args_and_kwargs` function.
+            assert precondition_backend is not None
+            val_results = mfuncs.validate(
+                reqs=stub_copy.precondition_requirements,
+                context=ChatContext(),
+                backend=precondition_backend,
+                model_options=extracted.model_options,
+                output=ModelOutputThunk(stub_copy._arguments.value),
+            )
 
             # No retries if precondition validation fails.
             if not all(bool(val_result) for val_result in val_results):
@@ -771,23 +769,22 @@ class AsyncGenerativeStub(GenerativeStub, Generic[P, R]):
 
             # Do precondition validation first.
             if stub_copy._arguments is not None:
-                if extracted.m is not None:
-                    val_results = await extracted.m.avalidate(
-                        reqs=stub_copy.precondition_requirements,
-                        model_options=extracted.model_options,
-                        output=ModelOutputThunk(stub_copy._arguments.value),
-                    )
-                else:
-                    # We know these aren't None from the `extract_args_and_kwargs` function.
-                    assert extracted.context is not None
-                    assert extracted.backend is not None
-                    val_results = await mfuncs.avalidate(
-                        reqs=stub_copy.precondition_requirements,
-                        context=extracted.context,
-                        backend=extracted.backend,
-                        model_options=extracted.model_options,
-                        output=ModelOutputThunk(stub_copy._arguments.value),
-                    )
+                # Preconditions are judged over the arguments alone, so they get a fresh
+                # context rather than the caller's/session's conversation history.
+                precondition_backend = (
+                    extracted.m.backend
+                    if extracted.m is not None
+                    else extracted.backend
+                )
+                # We know this isn't None from the `extract_args_and_kwargs` function.
+                assert precondition_backend is not None
+                val_results = await mfuncs.avalidate(
+                    reqs=stub_copy.precondition_requirements,
+                    context=ChatContext(),
+                    backend=precondition_backend,
+                    model_options=extracted.model_options,
+                    output=ModelOutputThunk(stub_copy._arguments.value),
+                )
 
                 # No retries if precondition validation fails.
                 if not all(bool(val_result) for val_result in val_results):

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-import warnings
 from collections.abc import Coroutine, Iterable
 from typing import Any, Literal, overload
 
@@ -365,10 +364,9 @@ def validate(
         format: Optional Pydantic model for constrained decoding.
         model_options: Additional model options to merge with backend defaults.
         generate_logs: Optional list to append generation logs to.
-        input: Deprecated. Optional input to prepend to the validation context. Pass a
-            context that already contains the input instead. Passing it raises a
-            `DeprecationWarning` from `avalidate`, so the reported source location is this
-            wrapper rather than the caller.
+        input: Optional input to prepend to the validation context, for judging an output
+            against a specific input rather than the whole conversation. See `avalidate`
+            for the visibility caveat on contexts that render no history.
 
     Returns:
         List of `ValidationResult` objects, one per requirement.
@@ -1053,8 +1051,11 @@ async def avalidate(
         format: Optional Pydantic model for constrained decoding.
         model_options: Additional model options to merge with backend defaults.
         generate_logs: Optional list to append generation logs to.
-        input: Deprecated. Optional input to prepend to the validation context. Pass a
-            context that already contains the input instead.
+        input: Optional input to prepend to the validation context, for judging an output
+            against a specific input rather than the whole conversation. It is added ahead
+            of `output`, so the judge sees the pair in order. It only reaches the model if
+            the context renders history: on a context whose `view_for_generation()` is empty
+            (`SimpleContext`), nothing added here is visible to the judge.
 
     Returns:
         List of `ValidationResult` objects, one per requirement.
@@ -1068,13 +1069,6 @@ async def avalidate(
     validation_target_ctx = context
 
     if input is not None:
-        warnings.warn(
-            "The `input` parameter of validate/avalidate is deprecated and will be removed "
-            "in a future release. Pass a validation context that already contains the input "
-            "instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         validation_target_ctx = validation_target_ctx.add(input)
 
     # `output` designates the validation target rather than replacing the context. Adding it
@@ -1082,6 +1076,21 @@ async def avalidate(
     # so the thunk passed here *is* the one already in the context.
     if output is not None and validation_target_ctx.last_output() is not output:
         validation_target_ctx = validation_target_ctx.add(output)
+
+    # A context that renders no history hands the judge nothing but the requirement and the
+    # inlined output, so anything conversational -- `input`, earlier turns, and the whole
+    # premise of adapter-backed requirement checking -- is silently dropped. Say so rather
+    # than letting the caller infer working validation from a plausible-looking verdict.
+    if (
+        not validation_target_ctx.view_for_generation()
+        and validation_target_ctx.as_list()
+    ):
+        MelleaLogger.get_logger().warning(
+            f"validating over a {type(validation_target_ctx).__name__} whose"
+            " view_for_generation() is empty: the judge sees only the requirement and the"
+            " inlined output, not the conversation that produced it. Pass a context that"
+            " renders history (e.g. ChatContext) to validate against the input."
+        )
 
     # --- validation_pre_check hook ---
     if has_plugins(HookType.VALIDATION_PRE_CHECK):

--- a/mellea/stdlib/functional.py
+++ b/mellea/stdlib/functional.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+import warnings
 from collections.abc import Coroutine, Iterable
 from typing import Any, Literal, overload
 
@@ -343,24 +344,31 @@ def validate(
     context: Context,
     backend: Backend,
     *,
-    output: CBlock | ModelOutputThunk | None = None,
+    output: ModelOutputThunk | None = None,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
     generate_logs: list[GenerateLog]
     | None = None,  # TODO: Can we get rid of gen logs here and in act?
     input: CBlock | ModelOutputThunk | None = None,
 ) -> list[ValidationResult]:
-    """Validates a set of requirements over the output (if provided) or the current context (if the output is not provided).
+    """Validates a set of requirements over the given context.
+
+    Validation always runs over `context`, in the caller's own context type. `output`
+    designates *which* output is under judgement; see `avalidate` for details.
 
     Args:
         reqs: A single `Requirement` or a list of them to validate.
-        context: The current conversation context.
+        context: The context to validate over.
         backend: The backend used for LLM-as-a-judge requirements.
-        output: Optional model output to validate against instead of the context.
+        output: Optional model output designating the validation target. When `None`, the
+            context's last output is validated.
         format: Optional Pydantic model for constrained decoding.
         model_options: Additional model options to merge with backend defaults.
         generate_logs: Optional list to append generation logs to.
-        input: Optional input to include alongside `output` when validating.
+        input: Deprecated. Optional input to prepend to the validation context. Pass a
+            context that already contains the input instead. Passing it raises a
+            `DeprecationWarning` from `avalidate`, so the reported source location is this
+            wrapper rather than the caller.
 
     Returns:
         List of `ValidationResult` objects, one per requirement.
@@ -1023,23 +1031,30 @@ async def avalidate(
     context: Context,
     backend: Backend,
     *,
-    output: CBlock | ModelOutputThunk | None = None,
+    output: ModelOutputThunk | None = None,
     format: type[BaseModelSubclass] | None = None,
     model_options: dict | None = None,
     generate_logs: list[GenerateLog] | None = None,
     input: CBlock | ModelOutputThunk | None = None,
 ) -> list[ValidationResult]:
-    """Asynchronous version of .validate; validates a set of requirements over the output (if provided) or the current context (if the output is not provided).
+    """Asynchronous version of .validate; validates a set of requirements over the given context.
+
+    Validation always runs over `context`, in the caller's own context type, so requirements
+    (including adapter-backed ones) see the same conversation the model saw. `output`
+    designates *which* output is under judgement: it is appended to `context` when it is not
+    already the context's last output, and the requirement then validates that output.
 
     Args:
         reqs: A single `Requirement` or a list of them to validate.
-        context: The current conversation context.
+        context: The context to validate over.
         backend: The backend used for LLM-as-a-judge requirements.
-        output: Optional model output to validate against instead of the context.
+        output: Optional model output designating the validation target. When `None`, the
+            context's last output is validated.
         format: Optional Pydantic model for constrained decoding.
         model_options: Additional model options to merge with backend defaults.
         generate_logs: Optional list to append generation logs to.
-        input: Optional input to include alongside `output` when validating.
+        input: Deprecated. Optional input to prepend to the validation context. Pass a
+            context that already contains the input instead.
 
     Returns:
         List of `ValidationResult` objects, one per requirement.
@@ -1050,14 +1065,22 @@ async def avalidate(
 
     validation_id = str(uuid.uuid4())
 
-    if output is None:
-        validation_target_ctx = context
-    else:
-        validation_target_ctx = SimpleContext()
+    validation_target_ctx = context
 
-        # Add the input/output to the validation context
-        if input is not None:
-            validation_target_ctx = validation_target_ctx.add(input)
+    if input is not None:
+        warnings.warn(
+            "The `input` parameter of validate/avalidate is deprecated and will be removed "
+            "in a future release. Pass a validation context that already contains the input "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        validation_target_ctx = validation_target_ctx.add(input)
+
+    # `output` designates the validation target rather than replacing the context. Adding it
+    # is a no-op for the sampling path: ComputedModelOutputThunk reassigns __class__ in place,
+    # so the thunk passed here *is* the one already in the context.
+    if output is not None and validation_target_ctx.last_output() is not output:
         validation_target_ctx = validation_target_ctx.add(output)
 
     # --- validation_pre_check hook ---

--- a/mellea/stdlib/requirements/requirement.py
+++ b/mellea/stdlib/requirements/requirement.py
@@ -13,6 +13,7 @@ from ...core import (
     MelleaLogger,
     ModelOutputThunk,
     Requirement,
+    TemplateRepresentation,
     ValidationResult,
 )
 from ..components.intrinsic import Intrinsic

--- a/mellea/stdlib/sampling/base.py
+++ b/mellea/stdlib/sampling/base.py
@@ -222,7 +222,8 @@ class BaseSamplingStrategy(SamplingStrategy):
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
-            validation_ctx: Optional context to use for validation. If None, validation_ctx = ctx.
+            validation_ctx: Optional context to validate over. If None, each sample is validated
+                over its own post-generation context.
             format: output format for structured outputs.
             model_options: model options to pass to the backend during generation / validation.
             tool_calls: True if tool calls should be used during this sampling strategy.
@@ -240,8 +241,6 @@ class BaseSamplingStrategy(SamplingStrategy):
                 the first non-cancellation exception is re-raised (e.g. a
                 backend error).
         """
-        validation_ctx = validation_ctx if validation_ctx is not None else context
-
         flog = MelleaLogger.get_logger()
 
         with log_context(strategy=type(self).__name__, loop_budget=self.loop_budget):
@@ -490,7 +489,8 @@ class BaseSamplingStrategy(SamplingStrategy):
         Yields a :class:`_SamplingResultSlice` per attempt and ends early after the first successful slice.
         `subsample_index` (0-based) identifies this subsample within the parent `sample()` call; it is used to derive a
         globally unique iteration counter for telemetry and hooks. `sampling_id` is passed through to the
-        iteration and repair hooks this subsample fires.
+        iteration and repair hooks this subsample fires. When `validation_ctx` is `None`, each attempt is
+        validated over its own post-generation context.
         """
         flog = MelleaLogger.get_logger()
         sampled_results: list[ComputedModelOutputThunk[S]] = []
@@ -533,10 +533,13 @@ class BaseSamplingStrategy(SamplingStrategy):
                     else result.value  # type: ignore[assignment]
                 )
 
-                # validation pass
+                # validation pass; validate over the caller's validation context if they
+                # supplied one, otherwise over this attempt's post-generation context.
                 val_scores_co = mfuncs.avalidate(
                     reqs=requirements,
-                    context=result_ctx,
+                    context=validation_ctx
+                    if validation_ctx is not None
+                    else result_ctx,
                     backend=backend,
                     output=result,
                     format=None,

--- a/mellea/stdlib/sampling/budget_forcing.py
+++ b/mellea/stdlib/sampling/budget_forcing.py
@@ -117,7 +117,8 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
-            validation_ctx: Optional context to use for validation. If None, validation_ctx = ctx.
+            validation_ctx: Optional context to validate over. If None, each sample is validated
+                over its own post-generation context.
             format: output format for structured outputs.
             model_options: model options to pass to the backend during generation / validation.
             tool_calls: True if tool calls should be used during this sampling strategy.
@@ -129,8 +130,6 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
         Raises:
             AssertionError: Asserts that all required components (repair, select_from_failure, validate, and generate) are provided before proceeding with the sampling.
         """
-        validation_ctx = validation_ctx if validation_ctx is not None else context
-
         flog = MelleaLogger.get_logger()
 
         with log_context(strategy=type(self).__name__, loop_budget=self.loop_budget):
@@ -211,10 +210,13 @@ class BudgetForcingSamplingStrategy(RejectionSamplingStrategy):
                     else result.value
                 )
 
-                # validation pass
+                # validation pass; validate over the caller's validation context if they
+                # supplied one, otherwise over this attempt's post-generation context.
                 val_scores_co = mfuncs.avalidate(
                     reqs=reqs,
-                    context=result_ctx,
+                    context=validation_ctx
+                    if validation_ctx is not None
+                    else result_ctx,
                     backend=backend,
                     output=result,
                     format=format,

--- a/mellea/stdlib/sampling/majority_voting.py
+++ b/mellea/stdlib/sampling/majority_voting.py
@@ -154,7 +154,8 @@ class BaseMBRDSampling(RejectionSamplingStrategy):
             context: The context to be passed to the sampling strategy.
             backend: The backend used for generating samples.
             requirements: List of requirements to test against (merged with global requirements).
-            validation_ctx: Optional context to use for validation. If None, validation_ctx = ctx.
+            validation_ctx: Optional context to validate over. If None, each sample is validated
+                over its own post-generation context.
             format: output format for structured outputs; ignored for this sampling strategy.
             model_options: model options to pass to the backend during generation / validation.
             tool_calls: True if tool calls should be used during this sampling strategy.

--- a/mellea/stdlib/sampling/sofai.py
+++ b/mellea/stdlib/sampling/sofai.py
@@ -520,6 +520,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
         format: type[BaseModelSubclass] | None,
         model_options: dict | None,
         tool_calls: bool,
+        validation_ctx: Context | None = None,
     ) -> tuple[
         ComputedModelOutputThunk, Context, list[tuple[Requirement, ValidationResult]]
     ]:
@@ -534,6 +535,8 @@ class SOFAISamplingStrategy(SamplingStrategy):
             format: Output format for structured outputs.
             model_options: Model options for generation.
             tool_calls: Whether to use tool calls.
+            validation_ctx: Optional context to validate over. If None, validation runs over
+                the post-generation context.
 
         Returns:
             Tuple of (result, result_context, validation_scores).
@@ -560,7 +563,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
         )
         val_scores = await mfuncs.avalidate(
             reqs=reqs_for_validation,
-            context=result_ctx,
+            context=validation_ctx if validation_ctx is not None else result_ctx,
             backend=session_backend,
             output=computed_result,
             format=None,
@@ -610,7 +613,8 @@ class SOFAISamplingStrategy(SamplingStrategy):
             context: The session context (must be ChatContext).
             backend: Session backend (used for validation fallback).
             requirements: Requirements to validate against.
-            validation_ctx: Optional separate validation context (unused).
+            validation_ctx: Optional context to validate over. If None, each sample is validated
+                over its own post-generation context.
             format: Output format for structured outputs.
             model_options: Model options to pass to backends.
             tool_calls: True if tool calls should be used.
@@ -683,6 +687,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
                     format=format,
                     model_options=model_options,
                     tool_calls=tool_calls,
+                    validation_ctx=validation_ctx,
                 )
 
                 # Store attempt
@@ -771,6 +776,7 @@ class SOFAISamplingStrategy(SamplingStrategy):
                 format=format,
                 model_options=model_options,
                 tool_calls=tool_calls,
+                validation_ctx=validation_ctx,
             )
 
             # Store S2 attempt

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -726,21 +726,22 @@ class MelleaSession:
         self,
         reqs: Requirement | list[Requirement],
         *,
-        output: CBlock | ModelOutputThunk | None = None,
+        output: ModelOutputThunk | None = None,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
         generate_logs: list[GenerateLog] | None = None,
         input: CBlock | ModelOutputThunk | None = None,
     ) -> list[ValidationResult]:
-        """Validates a set of requirements over the output (if provided) or the current context (if the output is not provided).
+        """Validates a set of requirements over this session's context.
 
         Args:
             reqs: A single `Requirement` or a list of them to validate.
-            output: Optional model output to validate against instead of the context.
+            output: Optional model output designating the validation target. When `None`,
+                the context's last output is validated.
             format: Optional Pydantic model for constrained decoding.
             model_options: Additional model options to merge with backend defaults.
             generate_logs: Optional list to append generation logs to.
-            input: Optional input to include alongside `output` when validating.
+            input: Deprecated. Optional input to prepend to the validation context.
 
         Returns:
             List of `ValidationResult` objects, one per requirement.
@@ -1142,21 +1143,22 @@ class MelleaSession:
         self,
         reqs: Requirement | list[Requirement],
         *,
-        output: CBlock | ModelOutputThunk | None = None,
+        output: ModelOutputThunk | None = None,
         format: type[BaseModelSubclass] | None = None,
         model_options: dict | None = None,
         generate_logs: list[GenerateLog] | None = None,
         input: CBlock | ModelOutputThunk | None = None,
     ) -> list[ValidationResult]:
-        """Validates a set of requirements over the output (if provided) or the current context (if the output is not provided).
+        """Validates a set of requirements over this session's context.
 
         Args:
             reqs: A single `Requirement` or a list of them to validate.
-            output: Optional model output to validate against instead of the context.
+            output: Optional model output designating the validation target. When `None`,
+                the context's last output is validated.
             format: Optional Pydantic model for constrained decoding.
             model_options: Additional model options to merge with backend defaults.
             generate_logs: Optional list to append generation logs to.
-            input: Optional input to include alongside `output` when validating.
+            input: Deprecated. Optional input to prepend to the validation context.
 
         Returns:
             List of `ValidationResult` objects, one per requirement.

--- a/mellea/stdlib/session.py
+++ b/mellea/stdlib/session.py
@@ -741,7 +741,8 @@ class MelleaSession:
             format: Optional Pydantic model for constrained decoding.
             model_options: Additional model options to merge with backend defaults.
             generate_logs: Optional list to append generation logs to.
-            input: Deprecated. Optional input to prepend to the validation context.
+            input: Optional input to prepend to the validation context, for judging an
+                output against a specific input rather than the whole conversation.
 
         Returns:
             List of `ValidationResult` objects, one per requirement.
@@ -1158,7 +1159,8 @@ class MelleaSession:
             format: Optional Pydantic model for constrained decoding.
             model_options: Additional model options to merge with backend defaults.
             generate_logs: Optional list to append generation logs to.
-            input: Deprecated. Optional input to prepend to the validation context.
+            input: Optional input to prepend to the validation context, for judging an
+                output against a specific input rather than the whole conversation.
 
         Returns:
             List of `ValidationResult` objects, one per requirement.

--- a/mellea/templates/prompts/default/Requirement.jinja2
+++ b/mellea/templates/prompts/default/Requirement.jinja2
@@ -1,4 +1,5 @@
-Please check the following requirement against the following output.
+Check whether the output below satisfies the requirement below.
+The conversation is provided so that you can interpret the requirement; judge only the output.
 Reply with 'yes' if the requirement is satisfied and 'no' otherwise.
 Do not include any other text in your response.
 

--- a/test/backends/test_openai_intrinsics_unit.py
+++ b/test/backends/test_openai_intrinsics_unit.py
@@ -13,6 +13,7 @@ Mocks the OpenAI async client to verify that `_generate_from_intrinsic` correctl
 """
 
 import json
+import logging
 import pathlib
 from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -30,9 +31,11 @@ from openai.types.completion_usage import CompletionUsage
 from mellea.backends import ModelOption
 from mellea.backends.adapters.adapter import EmbeddedIntrinsicAdapter
 from mellea.backends.openai import OpenAIBackend
+from mellea.core import ModelOutputThunk, Requirement
 from mellea.stdlib import functional as mfuncs
 from mellea.stdlib.components import Intrinsic, Message
-from mellea.stdlib.context import ChatContext
+from mellea.stdlib.context import ChatContext, SimpleContext
+from mellea.stdlib.requirements import ALoraRequirement
 
 _TEST_DIR = pathlib.Path(__file__).parent
 _INTRINSICS_DATA = _TEST_DIR / "test_adapters" / "intrinsics-data"
@@ -744,3 +747,80 @@ async def test_tools_passed_to_api():
     assert tools is not None
     assert len(tools) == 1
     assert tools[0]["function"]["name"] == "get_temperature"
+
+
+# ---------------------------------------------------------------------------
+# Requirement rerouting requires a context the adapter can actually judge
+# ---------------------------------------------------------------------------
+
+
+def _make_backend_with_requirement_adapter() -> OpenAIBackend:
+    """Return a backend whose `requirement-check` aLoRA would capture Requirements."""
+    backend = OpenAIBackend(
+        model_id="granite-switch",
+        api_key="fake-key",
+        base_url="http://localhost:9999/v1",
+    )
+    backend.add_adapter(
+        EmbeddedIntrinsicAdapter(
+            intrinsic_name="requirement-check",
+            config=deepcopy(_SIMPLE_CONFIG),
+            technology="alora",
+        )
+    )
+    return backend
+
+
+async def test_alora_requirement_over_a_context_that_renders_nothing_raises():
+    """An explicit `ALoraRequirement` cannot be honoured over an empty generation view.
+
+    The `requirement-check` adapter judges the last assistant turn of the conversation it
+    is handed, and this path never renders the requirement template, so there is no inlined
+    output to fall back on. Asking for the adapter anyway is a caller error, not something
+    to silently downgrade.
+    """
+    backend = _make_backend_with_requirement_adapter()
+    ctx = SimpleContext().add(ModelOutputThunk("The capital of France is Paris."))
+
+    with pytest.raises(ValueError, match="renders no conversation"):
+        await ALoraRequirement("must mention Paris").validate(backend, ctx)
+
+
+async def test_plain_requirement_over_empty_view_falls_back_to_llmaj(caplog):
+    """Auto-rerouting is an optimisation, so a plain `Requirement` degrades instead.
+
+    The reroute is mellea's choice rather than the caller's, so an unusable adapter must
+    not break validation: it falls through to LLM-as-a-judge, whose template inlines the
+    output and therefore still works over a context that renders nothing.
+    """
+    backend = _make_backend_with_requirement_adapter()
+    ctx = SimpleContext().add(ModelOutputThunk("The capital of France is Paris."))
+
+    mock_create = AsyncMock(return_value=_simple_chat_completion("yes"))
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = mock_create
+
+    with (
+        patch.object(
+            OpenAIBackend,
+            "_async_client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ),
+        patch.object(
+            OpenAIBackend, "_generate_from_intrinsic", new_callable=AsyncMock
+        ) as mock_intrinsic,
+        caplog.at_level(logging.WARNING),
+    ):
+        await Requirement("must mention Paris").validate(backend, ctx)
+
+    mock_intrinsic.assert_not_called()
+    assert mock_create.await_count == 1, (
+        "should fall through to ordinary chat generation"
+    )
+    sent = mock_create.await_args.kwargs["messages"]
+    assert any("The capital of France is Paris." in str(m) for m in sent), (
+        "the LLMaJ template must inline the output, which is what makes validation still"
+        " work over a context that renders no history"
+    )
+    assert "not rerouting requirements" in caplog.text

--- a/test/core/test_stream_validate.py
+++ b/test/core/test_stream_validate.py
@@ -66,13 +66,13 @@ async def test_subclass_can_return_fail():
 async def test_does_not_mutate_requirement():
     req = Requirement(description="original description")
     original_description = req.description
-    original_output = req._output
+    original_target = req._validation_target
     original_validation_fn = req.validation_fn
 
     await req.stream_validate("some chunk", backend=None, ctx=None)  # type: ignore[arg-type]
 
     assert req.description == original_description
-    assert req._output == original_output
+    assert req._validation_target == original_target
     assert req.validation_fn == original_validation_fn
 
 
@@ -83,7 +83,7 @@ async def test_stream_validate_idempotent():
     result2 = await req.stream_validate("chunk two", backend=None, ctx=None)  # type: ignore[arg-type]
     assert result1.success == "unknown"
     assert result2.success == "unknown"
-    assert req._output is None
+    assert req._validation_target is None
 
 
 @pytest.mark.asyncio

--- a/test/stdlib/requirements/test_requirement.py
+++ b/test/stdlib/requirements/test_requirement.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mellea.backends.adapters import AdapterSchemaMismatchError
-from mellea.core import ModelOutputThunk, Requirement
+from mellea.core import ModelOutputThunk, Requirement, TemplateRepresentation
+from mellea.formatters.template_formatter import TemplateFormatter
+from mellea.stdlib.components import Message
 from mellea.stdlib.context import ChatContext
 from mellea.stdlib.requirements import LLMaJRequirement, simple_validate
 from mellea.stdlib.requirements.requirement import (
@@ -28,11 +30,11 @@ ctx = ctx.add(ModelOutputThunk("test"))
 async def test_llmaj_validation_req_output_field():
     m = start_session(ctx=ctx)
     req = Requirement("Must output test.")
-    assert req._output is None
+    assert req._validation_target is None
 
     _ = await req.validate(m.backend, ctx=ctx)
-    assert req._output is None, (
-        "requirement's output shouldn't be updated during/after validation"
+    assert req._validation_target is None, (
+        "requirement's validation target shouldn't be bound during/after validation"
     )
 
 
@@ -41,11 +43,11 @@ async def test_llmaj_validation_req_output_field():
 async def test_llmaj_requirement_uses_requirement_template():
     m = start_session(ctx=ctx)
     req = LLMaJRequirement("Must output test.")
-    assert req._output is None
+    assert req._validation_target is None
 
     _ = await req.validate(m.backend, ctx=ctx)
-    assert req._output is None, (
-        "requirement's output shouldn't be updated during/after validation"
+    assert req._validation_target is None, (
+        "requirement's validation target shouldn't be bound during/after validation"
     )
 
 
@@ -203,6 +205,117 @@ def test_simple_validate_none_output():
     validation_func = simple_validate(lambda x: True)
     result = validation_func(empty_ctx)
     assert result.as_bool() is False
+
+
+# --- validation target binding (issue #426) ---
+
+
+def test_parts_empty_until_target_bound():
+    r = Requirement("must mention Paris")
+    assert r.parts() == [], "an unbound requirement has no parts"
+
+
+def test_bind_validation_target_leaves_original_unbound():
+    """Binding happens on a copy so a requirement can be reused across validations."""
+    r = Requirement("must mention Paris")
+    target = ModelOutputThunk("The capital of France is Paris.")
+
+    bound = r._bind_validation_target(target)
+
+    assert bound is not r
+    assert r._validation_target is None
+    assert bound._validation_target is target
+    assert bound.parts() == [target], (
+        "the bound target must be exposed as a part so generate_walk can await it"
+    )
+
+
+def test_format_for_llm_carries_the_target_span():
+    """The judge prompt gets the thunk itself, not a detached string copy of it."""
+    r = Requirement("must mention Paris")
+    target = ModelOutputThunk("The capital of France is Paris.")
+
+    representation = r._bind_validation_target(target).format_for_llm()
+
+    assert isinstance(representation, TemplateRepresentation)
+    assert representation.args["output"] is target
+    assert representation.args["description"] == "must mention Paris"
+
+
+def test_format_for_llm_prefers_component_parsed_repr():
+    """A parsed `Component` repr beats the raw generated string."""
+    r = Requirement("must be polite")
+    parsed = Message("assistant", "parsed message content")
+    target = ModelOutputThunk("raw string value")
+    target.parsed_repr = parsed
+
+    representation = r._bind_validation_target(target).format_for_llm()
+
+    assert isinstance(representation, TemplateRepresentation)
+    assert representation.args["output"] is parsed
+
+
+def test_format_for_llm_without_bound_target_raises():
+    with pytest.raises(AssertionError, match="Object protocol error"):
+        Requirement("must mention Paris").format_for_llm()
+
+
+# --- judge prompt rendering ---
+
+
+@pytest.fixture
+def formatter():
+    return TemplateFormatter(model_id="ibm-granite/granite-3.3-8b-instruct")
+
+
+def test_requirement_prompt_inlines_the_output(formatter):
+    r = Requirement("must mention Paris")
+    target = ModelOutputThunk("The capital of France is Paris.")
+
+    rendered = formatter.print(r._bind_validation_target(target))
+
+    assert "The capital of France is Paris." in rendered
+    assert "must mention Paris" in rendered
+
+
+# --- the judgement request carries the conversation (issue #426, defect 4) ---
+
+
+async def test_validate_hands_the_backend_a_context_that_renders_the_output():
+    """The context reaching the backend must render the output under judgement.
+
+    This is what makes adapter-backed requirement checking work at all:
+    `_generate_from_intrinsic` builds the `requirement-check` conversation from
+    `ctx.view_for_generation()`. Under the old throwaway `SimpleContext` that view was
+    empty, so the adapter was handed only the injected requirement-check message and
+    never saw the assistant turn it was supposed to judge.
+    """
+    seen: list = []
+    target = ModelOutputThunk("The capital of France is Paris.")
+    validation_ctx = (
+        ChatContext().add(Message("user", "capital of France?")).add(target)
+    )
+
+    async def capture(action, ctx, **kwargs):
+        seen.append((action, ctx))
+        # A thunk constructed with a value is already computed.
+        return ModelOutputThunk("yes"), ctx
+
+    backend = MagicMock()
+    backend.generate_from_context = capture
+
+    result = await Requirement("must mention Paris").validate(backend, validation_ctx)
+
+    assert result.as_bool() is True
+    bound_req, passed_ctx = seen[0]
+    view = passed_ctx.view_for_generation()
+    assert view is not None and target in view, (
+        "the judged output must be visible to the model, not merely present in as_list()"
+    )
+    assert any("capital of France?" in str(node) for node in view), (
+        "the conversation that produced the output must reach the judge too"
+    )
+    assert bound_req._validation_target is target
 
 
 # --- LLMaJRequirement ---

--- a/test/stdlib/sampling/test_sampling_base_unit.py
+++ b/test/stdlib/sampling/test_sampling_base_unit.py
@@ -258,6 +258,103 @@ async def test_multi_turn_strategy_with_concurrency(mocked_context_backend):
     )
 
 
+# --- validation_ctx is actually used (issues #426, #668) ---
+
+
+def _ctx_capturing_requirement() -> tuple[Requirement, list[Context]]:
+    """A passing requirement that records every context it is validated over."""
+    seen: list[Context] = []
+
+    def capture(ctx: Context) -> ValidationResult:
+        seen.append(ctx)
+        return ValidationResult(result=True)
+
+    return Requirement("capture", validation_fn=capture), seen
+
+
+async def test_explicit_validation_ctx_is_used_for_validation(mocked_context_backend):
+    """An explicit `validation_ctx` — not the generation context — is validated over.
+
+    Regression test for #668: `validation_ctx` was accepted, defaulted, and threaded
+    through the strategy, then never passed to `avalidate`.
+    """
+    req, seen = _ctx_capturing_requirement()
+    validation_ctx = ChatContext().add(Message("user", "VALIDATION MARKER"))
+
+    await RejectionSamplingStrategy(loop_budget=1).sample(
+        action=Instruction(description="write something"),
+        context=ChatContext().add(Message("user", "GENERATION MARKER")),
+        backend=mocked_context_backend,
+        requirements=[req],
+        validation_ctx=validation_ctx,
+    )
+
+    assert len(seen) == 1
+    rendered = [str(node) for node in seen[0].as_list()]
+    assert any("VALIDATION MARKER" in r for r in rendered), (
+        "the caller's validation context must reach the requirement"
+    )
+    assert not any("GENERATION MARKER" in r for r in rendered), (
+        "the generation context must not leak into an explicit validation context"
+    )
+    assert seen[0].last_output() is not None, (
+        "the sampled output is appended so it is the validation target"
+    )
+
+
+async def test_validation_ctx_defaults_to_post_generation_context(
+    mocked_context_backend,
+):
+    """Without `validation_ctx`, each attempt validates over its own post-generation context."""
+    req, seen = _ctx_capturing_requirement()
+
+    result = await RejectionSamplingStrategy(loop_budget=1).sample(
+        action=Instruction(description="write something"),
+        context=ChatContext().add(Message("user", "GENERATION MARKER")),
+        backend=mocked_context_backend,
+        requirements=[req],
+    )
+
+    assert len(seen) == 1
+    # ComputedModelOutputThunk reassigns __class__ in place, so the sampled result *is*
+    # the thunk already in the post-generation context -- `avalidate` appends nothing.
+    assert seen[0] is result.sample_contexts[0], (
+        "validation should run over the attempt's post-generation context unchanged"
+    )
+    assert seen[0].last_output() is result.result, (
+        "the validation target is the generation under judgement"
+    )
+    rendered = [str(node) for node in seen[0].as_list()]
+    assert any("GENERATION MARKER" in r for r in rendered)
+
+
+async def test_validation_ctx_sees_the_output_in_its_generation_view(
+    mocked_context_backend,
+):
+    """The judged output must be visible to the model, not just present in `as_list()`.
+
+    This is what makes adapter-backed requirement checking work: `_generate_from_intrinsic`
+    builds its conversation from `view_for_generation()`, which was empty under the old
+    throwaway `SimpleContext`.
+    """
+    req, seen = _ctx_capturing_requirement()
+
+    result = await RejectionSamplingStrategy(loop_budget=1).sample(
+        action=Instruction(description="write something"),
+        context=ChatContext(),
+        backend=mocked_context_backend,
+        requirements=[req],
+    )
+
+    view = seen[0].view_for_generation()
+    assert view is not None and len(view) > 0, (
+        "the validation context must render something for the model"
+    )
+    assert result.result in view, (
+        "the generation under judgement must appear in the validation context's generation view"
+    )
+
+
 # --- Constructor validation ---
 
 

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -13,7 +13,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from PIL import Image as PILImage
 
-from mellea.core import AudioBlock, Context, ImageBlock, ModelToolCall
+from mellea.core import (
+    AudioBlock,
+    Context,
+    ImageBlock,
+    ModelOutputThunk,
+    ModelToolCall,
+    Requirement,
+    ValidationResult,
+)
 from mellea.stdlib.components import (
     Document,
     Instruction,
@@ -27,6 +35,7 @@ from mellea.stdlib.functional import (
     aact,
     achat,
     ainstruct,
+    avalidate,
     chat,
     instruct,
 )
@@ -490,6 +499,89 @@ async def test_atransform_persists_chosen_tool_message_in_context(
     _, new_ctx = await atransform(MObject(), "transform it", ctx, MagicMock())
 
     _assert_tool_message_persisted_after(ctx, new_ctx, [prior_message], tool_message)
+
+
+# --- avalidate context handling (issue #426) ---
+
+
+def _ctx_capturing_requirement() -> tuple[Requirement, list[Context]]:
+    """A passing requirement that records every context it is validated over."""
+    seen: list[Context] = []
+
+    def capture(ctx: Context) -> ValidationResult:
+        seen.append(ctx)
+        return ValidationResult(result=True)
+
+    return Requirement("capture", validation_fn=capture), seen
+
+
+async def test_avalidate_validates_over_the_callers_context():
+    """Validation runs over the caller's own context, not a throwaway `SimpleContext`.
+
+    Before #426 was fixed, `avalidate` built a fresh `SimpleContext` whose
+    `view_for_generation()` is always empty, so nothing the caller passed ever reached
+    the model.
+    """
+    req, seen = _ctx_capturing_requirement()
+    caller_ctx = ChatContext().add(Message("user", "hello")).add(ModelOutputThunk("hi"))
+
+    await avalidate(reqs=[req], context=caller_ctx, backend=MagicMock())
+
+    assert seen == [caller_ctx], (
+        "the caller's context object must be handed to the requirement untouched"
+    )
+    assert isinstance(seen[0], ChatContext), (
+        "validation must run in the caller's context type"
+    )
+
+
+async def test_avalidate_appends_output_when_not_already_last():
+    """`output` designates the validation target and is appended when it is not last."""
+    req, seen = _ctx_capturing_requirement()
+    caller_ctx = ChatContext().add(Message("user", "hello"))
+    target = ModelOutputThunk("the output under judgement")
+
+    await avalidate(reqs=[req], context=caller_ctx, backend=MagicMock(), output=target)
+
+    assert seen[0] is not caller_ctx
+    assert seen[0].last_output() is target
+    assert target in seen[0].view_for_generation()  # type: ignore[operator]
+    assert any("hello" in str(node) for node in seen[0].as_list()), (
+        "appending the target must not discard the caller's history"
+    )
+
+
+async def test_avalidate_does_not_double_add_the_context_last_output():
+    """Passing the context's own last output as `output` is a no-op.
+
+    This is the sampling path: `ComputedModelOutputThunk` reassigns `__class__` in
+    place, so the thunk handed to `avalidate` *is* the one already in the context.
+    """
+    req, seen = _ctx_capturing_requirement()
+    target = ModelOutputThunk("already in the context")
+    caller_ctx = ChatContext().add(Message("user", "hello")).add(target)
+
+    await avalidate(reqs=[req], context=caller_ctx, backend=MagicMock(), output=target)
+
+    assert seen == [caller_ctx]
+    assert len(seen[0].as_list()) == 2, "the target must not be appended twice"
+
+
+async def test_avalidate_input_is_deprecated():
+    req, seen = _ctx_capturing_requirement()
+    caller_ctx = ChatContext().add(ModelOutputThunk("hi"))
+
+    with pytest.warns(DeprecationWarning, match="`input` parameter"):
+        await avalidate(
+            reqs=[req],
+            context=caller_ctx,
+            backend=MagicMock(),
+            input=Message("user", "the deprecated input"),
+        )
+
+    assert any("the deprecated input" in str(node) for node in seen[0].as_list()), (
+        "the deprecated `input` should still be honoured for one more release"
+    )
 
 
 if __name__ == "__main__":

--- a/test/stdlib/test_functional_unit.py
+++ b/test/stdlib/test_functional_unit.py
@@ -8,6 +8,7 @@ Covers image preprocessing plus chat()/instruct() forwarding of multimodal input
 
 import base64
 import io
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,6 +16,7 @@ from PIL import Image as PILImage
 
 from mellea.core import (
     AudioBlock,
+    CBlock,
     Context,
     ImageBlock,
     ModelOutputThunk,
@@ -567,21 +569,46 @@ async def test_avalidate_does_not_double_add_the_context_last_output():
     assert len(seen[0].as_list()) == 2, "the target must not be appended twice"
 
 
-async def test_avalidate_input_is_deprecated():
+async def test_avalidate_input_reaches_the_judges_view():
+    """`input` is supported: it lands in the context the judge actually sees."""
     req, seen = _ctx_capturing_requirement()
     caller_ctx = ChatContext().add(ModelOutputThunk("hi"))
 
-    with pytest.warns(DeprecationWarning, match="`input` parameter"):
+    await avalidate(
+        reqs=[req],
+        context=caller_ctx,
+        backend=MagicMock(),
+        input=CBlock("the specific input"),
+    )
+
+    view = seen[0].view_for_generation()
+    assert view is not None and any(
+        "the specific input" in str(node) for node in view
+    ), (
+        "`input` must reach view_for_generation(), not merely as_list() -- only the"
+        " generation view is sent to the model"
+    )
+
+
+async def test_avalidate_warns_when_the_context_renders_nothing(caplog):
+    """A context with an empty generation view must not fail silently."""
+    req, _seen = _ctx_capturing_requirement()
+    # SimpleContext retains as_list()/last_output() but renders no history.
+    caller_ctx = SimpleContext().add(ModelOutputThunk("hi"))
+
+    with caplog.at_level(logging.WARNING):
         await avalidate(
             reqs=[req],
             context=caller_ctx,
             backend=MagicMock(),
-            input=Message("user", "the deprecated input"),
+            input=CBlock("invisible to the judge"),
         )
 
-    assert any("the deprecated input" in str(node) for node in seen[0].as_list()), (
-        "the deprecated `input` should still be honoured for one more release"
+    assert "view_for_generation() is empty" in caplog.text, (
+        "validating over a context that renders nothing should warn, since `input` and the"
+        " conversation are dropped without any other signal"
     )
+    assert "SimpleContext" in caplog.text, "the warning should name the context type"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #426 

## Description
I believe I covered all the parts of the initial issue.

1. Dead validation context — avalidate's throwaway SimpleContext() deleted. Validation runs over the caller's context, in their own context type. output now designates the target and is appended only when context.last_output() is not output
2. Provenance loss — Requirement._output: str → _validation_target: Span, bound on a copy via _bind_validation_target, exposed through parts() so generate_walk can await it, rendered preferring a Component parsed_repr over the raw string.
3. Dead validation_ctx (#668) — honored in sampling/base.py, budget_forcing.py, sofai.py; majority_voting.py verified. The old validation_ctx or context default was itself wrong (pre-generation context)
4. Judge prompt reworded — Requirement.jinja2, scoping the verdict to the output while telling the model the conversation is there to interpret the requirement. Got better results and fewer tokens across several models (granite 4.2 as well)
5. genstub preconditions judged over a fresh ChatContext() instead of leaking session history

6. Fixing alora requirement validation especially when auto-routing: when a reroute would happen but the context renders nothing, an explicit ALoraRequirement raises ValueError naming the context, the adapter, and both ways out; an auto-rerouted plain Requirement disables the reroute and falls back to LLMaJ with a warn-once


### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
