### PR TITLE
fix(hf): forward string THINKING levels as reasoning_effort, not low_effort

### DIFF
--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -282,6 +282,13 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 
 _CHAT_TEMPLATE_THINKING_VARS: tuple[str, ...] = ("think", "thinking", "enable_thinking")
 
+# Granite 4.2's chat template exposes a boolean `low_effort` variable (see
+# chat_template.jinja) that is not one of the bool-valued THINKING vars above —
+# it is only ever set to True, triggered by a string THINKING level. Mirrors
+# the OpenAI backend's string-valued `reasoning_effort` handling
+# (_map_thinking_option in openai.py).
+_CHAT_TEMPLATE_LOW_EFFORT_VAR = "low_effort"
+
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
     """Names that `transformers`' `model.generate` accepts as keyword arguments.
@@ -2598,6 +2605,11 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         thinking_value = model_options.get(ModelOption.THINKING)
         if thinking_template_var is not None and type(thinking_value) is bool:
             backend_opts[thinking_template_var] = thinking_value
+        elif (
+            thinking_value == "low"
+            and _CHAT_TEMPLATE_LOW_EFFORT_VAR in self._chat_template_allowlist
+        ):
+            backend_opts[_CHAT_TEMPLATE_LOW_EFFORT_VAR] = True
         return {
             k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist
         }

--- a/mellea/backends/huggingface.py
+++ b/mellea/backends/huggingface.py
@@ -282,12 +282,13 @@ _HF_INTERNAL_TEMPLATE_VARS: frozenset[str] = frozenset(
 
 _CHAT_TEMPLATE_THINKING_VARS: tuple[str, ...] = ("think", "thinking", "enable_thinking")
 
-# Granite 4.2's chat template exposes a boolean `low_effort` variable (see
-# chat_template.jinja) that is not one of the bool-valued THINKING vars above —
-# it is only ever set to True, triggered by a string THINKING level. Mirrors
-# the OpenAI backend's string-valued `reasoning_effort` handling
-# (_map_thinking_option in openai.py).
-_CHAT_TEMPLATE_LOW_EFFORT_VAR = "low_effort"
+# A string THINKING level (e.g. "low") is forwarded verbatim as `reasoning_effort`
+# when the chat template declares that variable — this is the actual mechanism
+# Granite 4.2's chat template consumes (chat_template.jinja derives its boolean
+# `low_effort` from `reasoning_effort == "low"`) and what gpt-oss's HF chat
+# template reads directly. Mirrors the OpenAI backend's string-valued
+# `reasoning_effort` handling (_map_thinking_option in openai.py).
+_CHAT_TEMPLATE_REASONING_EFFORT_VAR = "reasoning_effort"
 
 
 def _compute_generate_kwargs_allowlist() -> frozenset[str]:
@@ -2606,10 +2607,10 @@ class LocalHFBackend(FormatterBackend, AdapterMixin):
         if thinking_template_var is not None and type(thinking_value) is bool:
             backend_opts[thinking_template_var] = thinking_value
         elif (
-            thinking_value == "low"
-            and _CHAT_TEMPLATE_LOW_EFFORT_VAR in self._chat_template_allowlist
+            isinstance(thinking_value, str)
+            and _CHAT_TEMPLATE_REASONING_EFFORT_VAR in self._chat_template_allowlist
         ):
-            backend_opts[_CHAT_TEMPLATE_LOW_EFFORT_VAR] = True
+            backend_opts[_CHAT_TEMPLATE_REASONING_EFFORT_VAR] = thinking_value
         return {
             k: v for k, v in backend_opts.items() if k in self._chat_template_allowlist
         }

--- a/mellea/backends/model_options.py
+++ b/mellea/backends/model_options.py
@@ -72,12 +72,14 @@ class ModelOption:
       `chat_template_kwargs`, while Ollama's /v1 endpoint (>= 0.33.1) honours
       `reasoning_effort` — and for models that default to thinking on (e.g.
       granite4.2) absent `reasoning_effort` means thinking stays on.
-    * `"low"` / `"medium"` / `"high"` — passed directly as `reasoning_effort`
-      (OpenAI-compatible backends only; no-op on vLLM).
+    * `"low"` / `"medium"` / `"high"` — OpenAI-compatible backends: passed
+      directly as `reasoning_effort` (no-op on vLLM). HuggingFace: forwarded
+      verbatim as the chat template's `reasoning_effort` variable if it
+      declares one (e.g. Granite 4.2, gpt-oss); a no-op otherwise.
 
-    HuggingFace supports boolean values only; a non-boolean value (e.g.
-    `"low"`) is silently ignored. If its chat template does not expose a
-    recognised thinking variable, the option is ignored regardless of value.
+    For HuggingFace, any value is ignored if the tokenizer's chat template
+    does not declare the corresponding variable (`think`/`thinking`/
+    `enable_thinking` for bools, `reasoning_effort` for strings).
     """
     SEED = "@@@seed@@@"
     STREAM = "@@@stream@@@"

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -345,6 +345,54 @@ def test_filter_for_chat_template_drops_thinking_effort_level() -> None:
     assert result == {}
 
 
+def test_filter_for_chat_template_maps_low_effort_to_low_effort_variable() -> None:
+    """THINKING="low" maps to low_effort=True when the template declares it.
+
+    Regression test for issue #1636: Granite 4.2's chat template implements a
+    boolean `low_effort` variable (distinct from the bool-valued THINKING vars),
+    set via a string `reasoning_effort`/THINKING level rather than a bool.
+    """
+    b = _make_backend("{{ low_effort }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
+
+    assert result == {"low_effort": True}
+
+
+def test_filter_for_chat_template_drops_low_effort_without_template_variable() -> None:
+    """THINKING="low" is a no-op when the template does not declare low_effort."""
+    b = _make_backend("{{ thinking }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
+
+    assert "low_effort" not in result
+
+
+@pytest.mark.parametrize("thinking_value", ["medium", "high", "none"])
+def test_filter_for_chat_template_ignores_non_low_effort_levels(
+    thinking_value: str,
+) -> None:
+    """THINKING levels other than "low" remain no-ops, matching Granite's template.
+
+    Granite's chat template only has a low_effort branch — there is no "high"
+    branch on the model side (see issue #1636).
+    """
+    b = _make_backend("{{ low_effort }}{{ thinking }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: thinking_value})
+
+    assert result == {}
+
+
+def test_filter_for_chat_template_bool_thinking_does_not_set_low_effort() -> None:
+    """A bool THINKING value sets the bool template var, not low_effort."""
+    b = _make_backend("{{ low_effort }}{{ thinking }}")
+
+    result = b._filter_for_chat_template({ModelOption.THINKING: True})
+
+    assert result == {"thinking": True}
+
+
 def test_filter_for_chat_template_drops_thinking_effort_level_via_alias() -> None:
     """A recognised alias (`thinking`) folds into THINKING and is bool-gated too.
 
@@ -719,6 +767,43 @@ def test_granite_thinking_option_uses_detected_template_variable() -> None:
     assert b._filter_for_chat_template({ModelOption.THINKING: False}) == {
         expected_key: False
     }
+
+
+@pytest.mark.integration
+@pytest.mark.huggingface
+def test_granite_low_effort_option_reaches_real_template() -> None:
+    """Regression test for issue #1636 against the real Granite 4.2 chat template.
+
+    THINKING="low" must reach `low_effort=True` in the kwargs passed to
+    `apply_chat_template` — previously this was silently dropped because
+    `_filter_for_chat_template` only handled bool THINKING values.
+    """
+    tok = _try_load_granite_tokenizer(_GRANITE_THINKING_MODEL_ID)
+    if tok is None:
+        pytest.skip(
+            f"{_GRANITE_THINKING_MODEL_ID} not in local HF cache — "
+            "run the Granite 4.2 HF test lane first"
+        )
+
+    b: LocalHFBackend = LocalHFBackend.__new__(LocalHFBackend)
+    b._tokenizer = tok
+    b._model_id = _GRANITE_THINKING_MODEL_ID
+    b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
+
+    assert "low_effort" in b._chat_template_allowlist, (
+        f"'low_effort' missing from real Granite 4.2 allowlist; "
+        f"got: {sorted(b._chat_template_allowlist)}"
+    )
+    result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
+    assert result == {"low_effort": True}
+
+    # The template must actually render differently with this kwarg — proves
+    # the fix changes real model input, not just an internal dict.
+    messages = [{"role": "user", "content": "hi"}]
+    without_low_effort = tok.apply_chat_template(messages, tokenize=False)
+    with_low_effort = tok.apply_chat_template(messages, tokenize=False, **result)
+    assert "reasoning effort: low" in with_low_effort
+    assert "reasoning effort: low" not in without_low_effort
 
 
 if __name__ == "__main__":

--- a/test/backends/test_huggingface_filter_options.py
+++ b/test/backends/test_huggingface_filter_options.py
@@ -345,48 +345,60 @@ def test_filter_for_chat_template_drops_thinking_effort_level() -> None:
     assert result == {}
 
 
-def test_filter_for_chat_template_maps_low_effort_to_low_effort_variable() -> None:
-    """THINKING="low" maps to low_effort=True when the template declares it.
+@pytest.mark.parametrize("thinking_value", ["low", "medium", "high"])
+def test_filter_for_chat_template_forwards_string_thinking_as_reasoning_effort(
+    thinking_value: str,
+) -> None:
+    """A string THINKING level is forwarded verbatim as `reasoning_effort`.
 
-    Regression test for issue #1636: Granite 4.2's chat template implements a
-    boolean `low_effort` variable (distinct from the bool-valued THINKING vars),
-    set via a string `reasoning_effort`/THINKING level rather than a bool.
+    Regression test for issue #1636: Granite 4.2's chat template derives its
+    boolean `low_effort` variable from `reasoning_effort == "low"`
+    (chat_template.jinja), and gpt-oss's HF chat template reads
+    `reasoning_effort` directly — so the string must be forwarded as-is,
+    mirroring the OpenAI backend's `reasoning_effort` handling, rather than
+    translated into a template-specific boolean.
     """
-    b = _make_backend("{{ low_effort }}")
+    b = _make_backend("{{ reasoning_effort }}")
 
-    result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
+    result = b._filter_for_chat_template({ModelOption.THINKING: thinking_value})
 
-    assert result == {"low_effort": True}
+    assert result == {"reasoning_effort": thinking_value}
 
 
-def test_filter_for_chat_template_drops_low_effort_without_template_variable() -> None:
-    """THINKING="low" is a no-op when the template does not declare low_effort."""
+def test_filter_for_chat_template_drops_string_thinking_without_reasoning_effort_var() -> (
+    None
+):
+    """A string THINKING level is a no-op when the template has no reasoning_effort var."""
     b = _make_backend("{{ thinking }}")
 
     result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
 
-    assert "low_effort" not in result
+    assert "reasoning_effort" not in result
 
 
-@pytest.mark.parametrize("thinking_value", ["medium", "high", "none"])
-def test_filter_for_chat_template_ignores_non_low_effort_levels(
-    thinking_value: str,
-) -> None:
-    """THINKING levels other than "low" remain no-ops, matching Granite's template.
+def test_filter_for_chat_template_string_thinking_sentinel_overrides_raw_reasoning_effort() -> (
+    None
+):
+    """The resolved THINKING sentinel wins over an already-present raw `reasoning_effort` key.
 
-    Granite's chat template only has a low_effort branch — there is no "high"
-    branch on the model side (see issue #1636).
+    Regression guard: a caller passing both ModelOption.THINKING="low" and a
+    conflicting raw `reasoning_effort="high"` must not have the sentinel's
+    intent silently overridden — matching the existing bool-THINKING
+    precedence behaviour (see
+    test_filter_for_chat_template_sentinel_overrides_conflicting_alias_key).
     """
-    b = _make_backend("{{ low_effort }}{{ thinking }}")
+    b = _make_backend("{{ reasoning_effort }}")
 
-    result = b._filter_for_chat_template({ModelOption.THINKING: thinking_value})
+    result = b._filter_for_chat_template(
+        {ModelOption.THINKING: "low", "reasoning_effort": "high"}
+    )
 
-    assert result == {}
+    assert result == {"reasoning_effort": "low"}
 
 
-def test_filter_for_chat_template_bool_thinking_does_not_set_low_effort() -> None:
-    """A bool THINKING value sets the bool template var, not low_effort."""
-    b = _make_backend("{{ low_effort }}{{ thinking }}")
+def test_filter_for_chat_template_bool_thinking_does_not_set_reasoning_effort() -> None:
+    """A bool THINKING value sets the bool template var, not reasoning_effort."""
+    b = _make_backend("{{ reasoning_effort }}{{ thinking }}")
 
     result = b._filter_for_chat_template({ModelOption.THINKING: True})
 
@@ -771,12 +783,17 @@ def test_granite_thinking_option_uses_detected_template_variable() -> None:
 
 @pytest.mark.integration
 @pytest.mark.huggingface
-def test_granite_low_effort_option_reaches_real_template() -> None:
+def test_granite_reasoning_effort_option_reaches_real_template() -> None:
     """Regression test for issue #1636 against the real Granite 4.2 chat template.
 
-    THINKING="low" must reach `low_effort=True` in the kwargs passed to
+    THINKING="low" must reach `reasoning_effort="low"` in the kwargs passed to
     `apply_chat_template` — previously this was silently dropped because
-    `_filter_for_chat_template` only handled bool THINKING values.
+    `_filter_for_chat_template` only handled bool THINKING values. Forwarding
+    the string verbatim (rather than translating it into the template's
+    derived boolean `low_effort` variable) is the mechanism the template
+    itself expects (`{%- set low_effort = reasoning_effort == "low" %}` in
+    chat_template.jinja) and matches the OpenAI backend's `reasoning_effort`
+    handling.
     """
     tok = _try_load_granite_tokenizer(_GRANITE_THINKING_MODEL_ID)
     if tok is None:
@@ -790,20 +807,20 @@ def test_granite_low_effort_option_reaches_real_template() -> None:
     b._model_id = _GRANITE_THINKING_MODEL_ID
     b.from_mellea_model_opts_map = {ModelOption.MAX_NEW_TOKENS: "max_new_tokens"}
 
-    assert "low_effort" in b._chat_template_allowlist, (
-        f"'low_effort' missing from real Granite 4.2 allowlist; "
+    assert "reasoning_effort" in b._chat_template_allowlist, (
+        f"'reasoning_effort' missing from real Granite 4.2 allowlist; "
         f"got: {sorted(b._chat_template_allowlist)}"
     )
     result = b._filter_for_chat_template({ModelOption.THINKING: "low"})
-    assert result == {"low_effort": True}
+    assert result == {"reasoning_effort": "low"}
 
     # The template must actually render differently with this kwarg — proves
     # the fix changes real model input, not just an internal dict.
     messages = [{"role": "user", "content": "hi"}]
-    without_low_effort = tok.apply_chat_template(messages, tokenize=False)
-    with_low_effort = tok.apply_chat_template(messages, tokenize=False, **result)
-    assert "reasoning effort: low" in with_low_effort
-    assert "reasoning effort: low" not in without_low_effort
+    without_reasoning_effort = tok.apply_chat_template(messages, tokenize=False)
+    with_reasoning_effort = tok.apply_chat_template(messages, tokenize=False, **result)
+    assert "reasoning effort: low" in with_reasoning_effort
+    assert "reasoning effort: low" not in without_reasoning_effort
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this fixes

If you passed `ModelOption.THINKING="low"` to a `LocalHFBackend` session (e.g. Granite 4.2), it was silently ignored — the model reasoned at full length anyway, with no error or warning. In practice this could burn your whole token budget on reasoning and never produce an answer.

After this fix, `THINKING="low"` genuinely engages Granite's low-effort reasoning mode, producing a short reasoning trace and reaching an answer within the token budget. The same fix also makes `THINKING="low"/"medium"/"high"` work for `openai/gpt-oss-20b` and `gpt-oss-120b` on `LocalHFBackend`, which had the same gap.

## Why it was broken

`LocalHFBackend` only forwarded `THINKING` to the chat template when it was a bool (`True`/`False`). A string level like `"low"` failed that check and was dropped before it ever reached the template.

## How it's fixed

Granite 4.2's chat template computes its low-effort behaviour from a `reasoning_effort` variable: `{%- set low_effort = reasoning_effort == "low" %}`. The fix forwards a string `THINKING` value verbatim as `reasoning_effort` whenever the tokenizer's chat template declares that variable — the same mechanism the OpenAI backend already uses (`_map_thinking_option` in `openai.py`). This also preserves the existing precedence rule: an explicit `ModelOption.THINKING` always wins over a raw `reasoning_effort` key set some other way.

The `ModelOption.THINKING` docstring is also corrected — it previously said HuggingFace only supports boolean values, which is no longer true.

## Verification

- Live end-to-end: ran the issue's exact repro against `ibm-granite/granite-4.2-3b`. Before: `THINKING="low"` produced full-length reasoning and exhausted a 400-token budget with no answer. After: short reasoning, correct answer, well within budget.
- Integration test against the real `ibm-granite/granite-4.2-3b` tokenizer/chat-template, confirming the rendered prompt text actually changes (`{reasoning effort: low}` appears/disappears).
- Unit tests covering: string levels forward correctly when the template declares `reasoning_effort`, are a no-op when it doesn't, an explicit `THINKING` sentinel wins over a conflicting raw `reasoning_effort` key, and bool `THINKING` values are unaffected.
- `uv run pytest test/backends/test_huggingface_filter_options.py` — 41 passed, 3 skipped (pre-existing skips, unrelated model not cached locally).
- Full suite (`uv sync --all-extras --all-groups`; `uv run pytest test/ -m "not qualitative"`) — 3629+ passed, no failures from this change.
- `ruff format --check` / `ruff check` / `mypy` — all clean.

Fixes #1636

Assisted-by: Claude Code