### PR TITLE
docs: document PR template system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,7 +440,21 @@ as it can corrupt state.
 6. **Run the test suite** to ensure everything passes
 7. **Update documentation** as needed
 8. **Push to your fork** and create a pull request to the main repository
-9. **Follow the automated PR workflow** instructions
+9. **Fill out the PR template and type checklist**
+   - GitHub prefills the body from [`.github/pull_request_template.md`](.github/pull_request_template.md).
+     Complete the `Issue`, `Description`, `Testing`, and `Attribution` sections.
+   - If your PR adds or modifies a **Component**, **Requirement**, **Sampling Strategy**, or
+     **Tool**, check that one box at the bottom. The `PR Bot` workflow
+     ([`.github/workflows/pr-update.yml`](.github/workflows/pr-update.yml)) then posts the
+     type-specific review checklist as a comment, usually within a few seconds. If your PR
+     covers more than one type, split it up; the bot only honors the first checked box.
+   - Work through that checklist comment before requesting review. Editing the comment is
+     fine (ticking boxes, adding notes), but leave the HTML marker on its first line alone,
+     otherwise the bot loses track of the comment and posts a duplicate.
+   - Keep the checkbox section in the body. The bot re-runs on every body edit: unchecking
+     the box deletes the checklist comment, and switching boxes replaces it with the new
+     checklist. Note that opening the PR outside the GitHub UI (`gh pr create --body`, or
+     via automation) skips the prefill entirely, so paste the template body in yourself.
 
 ### Review Assignment
 


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1086 

## Description
Expands step 9 of the Pull Request Process from a one-line pointer ("Follow the automated PR workflow instructions") into a description of what the PR template and `PR Bot` workflow actually do: the four type checkboxes, that the bot posts the matching review checklist as a comment, that the marker line in that comment must stay intact, and that the bot re-runs on body edits (unchecking deletes the comment, switching boxes replaces it).

Contributor-facing counterpart to the agent-facing docs added in #1585. 

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [ ] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
