### PR TITLE
fix: pin pillow to exclude broken 12.3.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ollama>=0.5.1",
     "requests>=2.32.3",
     "mistletoe>=1.4.0",
-    "pillow>=12.0.0", # Needed for Intrinsics (HF and OpenAI Backends).
+    "pillow>=12.2.0,!=12.3.0", # Needed for Intrinsics (HF and OpenAI Backends). 12.3.0 removed PIL._typing._Ink, breaking docling (issue#1640).
     "math_verify", # Needed for Majority Voting Sampling Strategies.
     "nltk>=3.9,!=3.10.1", # Needed for sentence tokenization in granite citation parsing.
     "rouge_score", # Needed for Majority Voting Sampling Strategies.

--- a/test/package/test_pillow_constraint.py
+++ b/test/package/test_pillow_constraint.py
@@ -1,0 +1,41 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that the core `pillow` dependency specifier excludes the broken 12.3.0 release.
+
+Pillow 12.3.0 removed `_Ink` from `PIL._typing`, which breaks `from PIL import
+ImageText` and cascades through `docling_core` into `RichDocument` (issue #1640).
+These tests assert the specifier in `pyproject.toml` cannot resolve 12.3.0 while
+still admitting the known-good releases.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _pillow_specifier():
+    """Return the `SpecifierSet` for the core `pillow` dependency in pyproject.toml."""
+    with PYPROJECT.open("rb") as f:
+        pyproject = tomllib.load(f)
+    for dep in pyproject["project"]["dependencies"]:
+        req = Requirement(dep)
+        if req.name == "pillow":
+            return req.specifier
+    raise AssertionError("pillow not found in core dependencies")
+
+
+def test_pillow_specifier_excludes_broken_1230():
+    """The pillow specifier must not admit the broken 12.3.0 release (issue #1640)."""
+    assert "12.3.0" not in _pillow_specifier()
+
+
+def test_pillow_specifier_allows_working_versions():
+    """The pillow specifier still admits the known-good 12.2.0 release."""
+    spec = _pillow_specifier()
+    assert "12.2.0" in spec

--- a/uv.lock
+++ b/uv.lock
@@ -3465,7 +3465,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.20.0" },
     { name = "packaging" },
     { name = "peft", marker = "extra == 'hf'", specifier = ">=0.18.1" },
-    { name = "pillow", specifier = ">=12.0.0" },
+    { name = "pillow", specifier = ">=12.2.0,!=12.3.0" },
     { name = "pyarrow", marker = "extra == 'granite-retriever'" },
     { name = "pydantic" },
     { name = "pyyaml" },


### PR DESCRIPTION
# Pull Request

## Issue
Fixes #1640

## Description
<!-- What does this PR do and why? -->
Skips pillow 12.3.0 due to removal of ink as required for RichDocument handling.

### Testing
- [ ] Tests added to the respective file if code was changed
- [ ] New code has 100% coverage if code was added
- [ ] Ensure existing tests and github automation passes (a maintainer will kick off the github automation when the rest of the PR is populated)

### Attribution
- [x] AI coding assistants used

---

### Adding a new component, requirement, sampling strategy, or tool?

If your PR adds or modifies one of the types below, check the matching box. A checklist of type-specific review items will be posted as a comment.

<!-- DO NOT DELETE THIS SECTION — managed by .github/workflows/pr-update.yml. Checking a box is fine; removing the boxes will break checklist updates. -->
<!-- If your PR implements more than one, please split it into separate PRs. -->

- [ ] Component
- [ ] Requirement
- [ ] Sampling Strategy
- [ ] Tool

NOTE: Please ensure you have an issue that has been acknowledged by a core contributor and routed you to open a pull request against this repository. Otherwise, please open an issue before continuing with this pull request.
